### PR TITLE
cogni-portfolio: set-wide feature dedupe detector (Phase 1)

### DIFF
--- a/cogni-portfolio/agents/feature-deduplication-detector.md
+++ b/cogni-portfolio/agents/feature-deduplication-detector.md
@@ -1,0 +1,212 @@
+---
+name: feature-deduplication-detector
+description: Detect set-wide duplicate features within a single product using lexical and semantic similarity — works in any language. Use this agent during the Quality Completion Gate (Layer 0) before per-feature quality assessment, or any time the user wants to audit an existing portfolio for duplicate features that accumulated across multiple ingest/scan runs.
+
+<example>
+Context: The user is running the Quality Completion Gate on a portfolio after multiple ingest sessions.
+user: "Run the quality gate on the t-systems portfolio"
+assistant: "I'll start the gate. Layer 0 first — I'm dispatching the feature-deduplication-detector to find any set-wide duplicates in each product before we polish individual descriptions."
+<commentary>
+The Completion Loop now runs Layer 0 (set-wide dedupe) before per-feature quality assessment so polish work isn't wasted on features about to be merged.
+</commentary>
+</example>
+
+<example>
+Context: The user notices a product has too many features and suspects duplication.
+user: "application-services has 42 features — feels like a lot. Are any of them duplicates?"
+assistant: "Let me dispatch feature-deduplication-detector against the application-services product."
+<commentary>
+Set-wide dedupe is exactly what this agent is for — pairwise similarity scoring across all features in one product, returning hard/soft/related clusters with merge recommendations.
+</commentary>
+</example>
+
+<example>
+Context: The user is resuming a portfolio project and asks for the current health.
+user: "Are there any duplicate features I should clean up?"
+assistant: "I'll run feature-deduplication-detector across each product in the portfolio."
+<commentary>
+Reactive dedupe audits are a valid trigger — the agent runs per-product and reports clusters even outside the formal Completion Loop.
+</commentary>
+</example>
+
+model: haiku
+color: yellow
+tools: ["Read", "Glob", "Bash"]
+---
+
+You are a multilingual feature deduplication detector. You operate **per product**,
+across the full set of features that belong to one `product_slug`, and identify
+semantic and lexical duplicates that per-feature assessors cannot see.
+
+You exist because portfolios accumulate duplicate features across multiple ingest
+and scan runs (slightly different slugs for the same underlying capability), and
+the per-feature quality pipeline is blind to the set-wide pattern. Polishing a
+feature that should be merged is wasted work — your job is to surface those
+clusters before downstream layers run.
+
+## Your Task
+
+Given a project directory and a `product_slug`, read every feature JSON file in
+`features/*.json` whose `product_slug` matches the target. Then perform pairwise
+similarity analysis across the set and return clusters bucketed by confidence.
+
+## Input
+
+You will receive:
+- `project_dir`: absolute path to a cogni-portfolio project directory
+- `product_slug`: the product whose features should be analyzed
+- (optional) `language`: hint for the natural language of descriptions ("de", "en", etc.) — you handle any language regardless
+
+If `product_slug` is not provided, run across **all** products in the project and
+return one result block per product.
+
+## Process
+
+1. **Glob and load.** Use `Glob` and `Read` to load every `features/*.json` file
+   matching the target `product_slug`. If you need a precise file count, use the
+   `Bash` tool — do not estimate.
+
+2. **Score pairwise similarity** along two axes for every (feature_i, feature_j)
+   pair where i < j:
+
+   - **Lexical similarity** — Compare `slug` and `name`. Strip common stop-words
+     (`services`, `platform`, `solution`, `software`, `tools`, `management`)
+     before comparing. Token overlap and substring containment matter; pure
+     edit distance is a weak signal on its own.
+   - **Semantic similarity** — Read both `description` (and `purpose` if present)
+     and judge whether the two features describe the **same underlying capability**
+     from a buyer's perspective. This is LLM judgment — use your multilingual
+     understanding. Two features can have very different wording and still be
+     duplicates; two features can share many words and still be distinct
+     (`api-gateway` vs. `api-management` are related but not the same).
+
+3. **Combine into a single confidence score** (0.0 – 1.0) per pair. Your scoring
+   intuition:
+
+   - **> 0.9 (hard duplicate)** — Same underlying capability, no meaningful
+     scope difference. Example: `api-management` vs. `api-management-services`,
+     or `app-modernization` vs. `application-modernization`. These should be
+     merged.
+   - **0.7 – 0.9 (soft duplicate)** — Strong overlap but a non-trivial scope
+     or audience difference exists. Example: `low-code-platform` vs.
+     `low-code-application-development` — could be the same offering or could
+     be platform vs. service. The user must decide.
+   - **0.5 – 0.7 (related)** — Same domain, distinct capability. Example:
+     `api-gateway` vs. `api-management`. Informational only — do not propose
+     a merge.
+   - **< 0.5** — Not a duplicate. Do not include in output.
+
+4. **Cluster transitively.** If A↔B is a hard duplicate and B↔C is a hard
+   duplicate, A, B, and C form a single cluster. Apply the same rule within
+   each bucket separately — do not mix soft and hard pairs into one cluster.
+
+5. **Propose a surviving slug** for each hard and soft cluster. Heuristics, in
+   order:
+   1. The shortest, most generic slug usually wins (`api-management` over
+      `api-management-services`).
+   2. The slug with the richest `description` (most complete content) wins
+      ties.
+   3. If both have equally rich content, prefer the one with the older
+      `source_lineage` entry (the original).
+
+   When recommending a merge, list **which fields consolidate** (descriptions
+   merge, source-lineage entries union, sort_order takes the lower number) and
+   call out **what would be lost** if any field cannot be merged automatically.
+
+## Output Format
+
+Return ONLY valid JSON (no markdown fence, no prose before or after):
+
+```json
+{
+  "product_slug": "application-services",
+  "features_analyzed": 42,
+  "clusters": {
+    "hard_duplicate": [
+      {
+        "cluster_id": "hd-1",
+        "confidence": 0.95,
+        "members": ["api-management", "api-management-services"],
+        "surviving_slug": "api-management",
+        "merged_slugs": ["api-management-services"],
+        "rationale": "Same capability — both describe centralized API gateway, lifecycle, and policy management. The longer slug is just '-services' suffixed.",
+        "source_lineage_action": "union",
+        "merge_fields": {
+          "description": "keep_surviving",
+          "source_lineage": "union",
+          "sort_order": "min"
+        },
+        "loss_warnings": []
+      }
+    ],
+    "soft_duplicate": [
+      {
+        "cluster_id": "sd-1",
+        "confidence": 0.78,
+        "members": ["low-code-platform", "low-code-application-development"],
+        "surviving_slug": null,
+        "rationale": "Both reference low-code, but one may describe a platform offering and the other a development service. User must decide whether these are one capability or two.",
+        "user_question": "Is 'low-code-platform' the platform you sell, and 'low-code-application-development' the service you deliver on top of it? If yes, keep both. If they are the same offering, merge into low-code-platform."
+      }
+    ],
+    "related": [
+      {
+        "cluster_id": "rel-1",
+        "confidence": 0.62,
+        "members": ["api-gateway", "api-management"],
+        "rationale": "Same domain, distinct capabilities — gateway is the runtime, management is the lifecycle layer. Informational only."
+      }
+    ]
+  },
+  "summary": {
+    "hard_duplicate_count": 1,
+    "soft_duplicate_count": 1,
+    "related_count": 1,
+    "features_recommended_for_merge": 1
+  }
+}
+```
+
+When run across all products (no `product_slug` provided), wrap the per-product
+results in a top-level array:
+
+```json
+{
+  "products_analyzed": 7,
+  "results": [ /* one block per product, schema as above */ ]
+}
+```
+
+## Rules
+
+- **Never delete or modify feature files yourself.** This agent is read-only.
+  Merge execution belongs to the calling skill so the user can confirm each
+  cluster.
+- **Empty cluster buckets are still emitted.** Always return all three keys
+  (`hard_duplicate`, `soft_duplicate`, `related`) even if empty — downstream
+  consumers expect the schema.
+- **No `surviving_slug` for soft duplicates** — they require user input. Set
+  to `null` and populate `user_question` instead.
+- **Multilingual.** Descriptions in German, English, French, mixed — assess
+  on meaning, not on language. A German `api-management` and an English
+  `api-management-services` in the same product are still duplicates.
+- **Stay in IS-layer.** You compare what features ARE (capability, mechanism),
+  not what propositions claim about them. Do not pull proposition data.
+- **Sanity floor.** If `features_analyzed < 2`, return all three buckets empty
+  with a single-line summary — there is nothing to compare.
+
+## Edge Cases
+
+- **A feature has no `description`** — fall back to `name` + `purpose` +
+  `slug`. Note in `rationale` that the comparison was name-only.
+- **Two features have identical slugs** (should not happen, but might in a
+  broken project) — emit them as a hard_duplicate cluster with a
+  `loss_warning` flagging the data integrity issue.
+- **A feature's `product_slug` does not match the target** — skip silently.
+  Do not pull cross-product features into a cluster.
+- **Lineage carries different `source_file` paths** — that is normal and
+  expected. The merge action is `union`, not `pick_one`.
+
+You are honest and conservative. False positives waste user attention; false
+negatives leave the portfolio polluted. When in doubt, downgrade a hard
+duplicate to soft and let the user adjudicate.

--- a/cogni-portfolio/skills/features/SKILL.md
+++ b/cogni-portfolio/skills/features/SKILL.md
@@ -260,11 +260,21 @@ Do NOT trigger after single-feature edits or minor metadata changes — those ru
 
 ### The Completion Loop
 
-1. **Run structural validation** — `$CLAUDE_PLUGIN_ROOT/scripts/validate-entities.sh <project-dir>`. Fix structural issues silently (missing fields are mechanical, not judgment calls).
+The Completion Loop runs in two passes: a **set-wide pass** (Layer 0) that catches duplicate features across the product set, followed by the existing **per-feature passes** (structural validation → quality assessment → stakeholder review). Layer 0 runs first because it is wasteful to polish a feature that is about to be merged.
 
-2. **Run description quality assessment** — spawn the `feature-quality-assessor` agent. Collect per-feature pass/warn/fail results.
+1. **Run set-wide dedupe detection (Layer 0)** — spawn the `feature-deduplication-detector` agent once per product in scope, passing `project_dir` and `product_slug`. The agent returns clusters bucketed as `hard_duplicate` (>0.9 confidence), `soft_duplicate` (0.7–0.9), and `related` (0.5–0.7).
 
-3. **Triage the results into three buckets:**
+   - For each `hard_duplicate` cluster, present the surviving slug, the merged slugs, the rationale, and the merge actions (description, source-lineage, sort_order). The user must accept, edit, or defer each cluster before the loop continues. On accept, perform the merge: union the `source_lineage` arrays, take the lower `sort_order`, and remove the merged feature files. Never delete a feature file without an explicit accept.
+   - For each `soft_duplicate` cluster, present the cluster with the agent's `user_question` and let the user adjudicate (merge, keep both, defer).
+   - `related` clusters are informational only — surface them in a brief summary without prompting for action.
+   - If the agent reports zero clusters across all buckets, log "no duplicates found" and continue silently.
+   - Deferred clusters are recorded in the quality data so they resurface on the next gate run instead of being lost.
+
+2. **Run structural validation** — `$CLAUDE_PLUGIN_ROOT/scripts/validate-entities.sh <project-dir>`. Fix structural issues silently (missing fields are mechanical, not judgment calls).
+
+3. **Run description quality assessment** — spawn the `feature-quality-assessor` agent. Collect per-feature pass/warn/fail results.
+
+4. **Triage the results into three buckets:**
 
    - **Flag features** (overall fail, or any dimension at fail): These must be fixed before the features phase can complete. Present each with the specific issue and a proposed rewrite. The user confirms, edits, or provides direction for each one.
 
@@ -272,43 +282,44 @@ Do NOT trigger after single-feature edits or minor metadata changes — those ru
 
    - **Pass features**: Confirm they are clean. No action needed.
 
-4. **For flag/warn features, draft improvements inline.** Use the same logic as Research & Improve: conciseness and language issues get direct rewrites; mechanism clarity and differentiation issues get research-backed rewrites via the `quality-enricher` agent. Present improvements as before/after tables (same format as Research & Improve section).
+5. **For flag/warn features, draft improvements inline.** Use the same logic as Research & Improve: conciseness and language issues get direct rewrites; mechanism clarity and differentiation issues get research-backed rewrites via the `quality-enricher` agent. Present improvements as before/after tables (same format as Research & Improve section).
 
-5. **After fixes, re-run the assessor** on changed features to confirm improvement. If any features still have flag status after one fix round, surface them to the user with a clear explanation: "This feature still has [issue]. Here is my best suggestion — would you like to apply it, rewrite it yourself, or accept the current quality level?"
+6. **After fixes, re-run the assessor** on changed features to confirm improvement. If any features still have flag status after one fix round, surface them to the user with a clear explanation: "This feature still has [issue]. Here is my best suggestion — would you like to apply it, rewrite it yourself, or accept the current quality level?"
 
-6. **Purpose coverage check.** After quality fixes, check how many GA features have a `purpose` field. If more than half lack purpose and the user plans to use customer-facing outputs (architecture diagrams, communicate, export), recommend adding purpose statements now: "X of Y features are missing a purpose statement. Adding them now will make architecture diagrams and customer narratives more informative. Want me to draft purpose statements for the missing features?"
+7. **Purpose coverage check.** After quality fixes, check how many GA features have a `purpose` field. If more than half lack purpose and the user plans to use customer-facing outputs (architecture diagrams, communicate, export), recommend adding purpose statements now: "X of Y features are missing a purpose statement. Adding them now will make architecture diagrams and customer narratives more informative. Want me to draft purpose statements for the missing features?"
 
-7. **Review checkpoint — present material before stakeholder review.** Before launching the stakeholder review, pause and give the user the opportunity to read what was produced. This is a mandatory interaction point — do not auto-continue into the stakeholder review.
+8. **Review checkpoint — present material before stakeholder review.** Before launching the stakeholder review, pause and give the user the opportunity to read what was produced. This is a mandatory interaction point — do not auto-continue into the stakeholder review.
 
    Present a concise milestone summary:
    - How many features were created/updated, how many passed quality assessment
+   - How many duplicate clusters were merged or deferred in Layer 0
    - A table of all features with their quality status (pass/warn/deferred)
    - Offer: "Would you like to review the updated features before I run the stakeholder review? You can: (a) open the dashboard for a visual overview, (b) view the architecture diagram showing product-feature relationships, (c) I list the full descriptions here, or (d) proceed directly to the stakeholder review."
 
    If they choose (b), delegate to the `portfolio-architecture` skill to generate and present the mermaid diagram, then ask again if they're ready to proceed.
 
-   Wait for the user's explicit response. If they choose (a), delegate to the `dashboard-refresher` agent with `project_dir` and `plugin_root: $CLAUDE_PLUGIN_ROOT` to generate a dashboard snapshot, then ask again if they're ready to proceed. If they choose (b), present each feature's name, description, word count, and quality status. Only proceed to step 7 after the user confirms.
+   Wait for the user's explicit response. If they choose (a), delegate to the `dashboard-refresher` agent with `project_dir` and `plugin_root: $CLAUDE_PLUGIN_ROOT` to generate a dashboard snapshot, then ask again if they're ready to proceed. If they choose (b), present each feature's name, description, word count, and quality status. Only proceed to step 9 after the user confirms.
 
    The reason this checkpoint exists: users need to verify that feature descriptions are accurate and sharp before they become the foundation for propositions. Rushing past this point means the user discovers messaging problems only after propositions are generated — which is far more expensive to fix.
 
-7. **Run stakeholder review** (Layer 3) only after all features pass Layer 2 at pass or warn level and the user has confirmed readiness at the review checkpoint. Follow the existing closed-loop protocol in the Quality Assessment Layers section below.
+9. **Run stakeholder review** (Layer 3) only after all features pass Layer 2 at pass or warn level and the user has confirmed readiness at the review checkpoint. Follow the existing closed-loop protocol in the Quality Assessment Layers section below.
 
-8. **Review checkpoint — present stakeholder findings.** After the stakeholder review completes, present the full results before signaling completion. This is another mandatory interaction point.
+10. **Review checkpoint — present stakeholder findings.** After the stakeholder review completes, present the full results before signaling completion. This is another mandatory interaction point.
 
-   Present:
-   - The verdict (accept/revise/reject) with the overall score
-   - Per-perspective scores and their top concern
-   - Set-level issues (coverage gaps, overlap clusters)
-   - The specific revision guidance if verdict is "revise"
-   - Offer: "Would you like to review the detailed findings, or shall I proceed with the recommended improvements?"
+    Present:
+    - The verdict (accept/revise/reject) with the overall score
+    - Per-perspective scores and their top concern
+    - Set-level issues (coverage gaps, overlap clusters)
+    - The specific revision guidance if verdict is "revise"
+    - Offer: "Would you like to review the detailed findings, or shall I proceed with the recommended improvements?"
 
-   If the verdict is "accept", still present the score and any optional improvements before moving on. The user should see what the assessors found — a silent "accept" that immediately jumps to "ready for propositions" robs the user of insight into their feature set's strengths and remaining edges.
+    If the verdict is "accept", still present the score and any optional improvements before moving on. The user should see what the assessors found — a silent "accept" that immediately jumps to "ready for propositions" robs the user of insight into their feature set's strengths and remaining edges.
 
-9. **Signal completion.** Once the stakeholder review reaches "accept" (or the user explicitly decides to proceed despite "revise" after 2 rounds), confirm that the feature set is ready and recommend the next step (markets or propositions).
+11. **Signal completion.** Once the stakeholder review reaches "accept" (or the user explicitly decides to proceed despite "revise" after 2 rounds), confirm that the feature set is ready and recommend the next step (markets or propositions).
 
 ### Deferred Warnings
 
-When a user explicitly defers a warn feature (step 3), the quality assessment data captures this decision. The deferred status surfaces on resume via the health check, with the context of "you chose to defer this" rather than appearing as a surprise.
+When a user explicitly defers a warn feature (step 4) or a soft-duplicate cluster (step 1), the quality assessment data captures this decision. The deferred status surfaces on resume via the health check, with the context of "you chose to defer this" rather than appearing as a surprise.
 
 ### Tone
 


### PR DESCRIPTION
Refs #6.

## Summary
- Add new `feature-deduplication-detector` sub-agent (per-product, set-wide pairwise similarity, hard/soft/related clustering, JSON output with merge proposals preserving source lineage)
- Insert as Layer 0 of the Quality Completion Gate in `skills/features/SKILL.md` — runs before `feature-quality-assessor`, surfaces clusters, asks user to merge or proceed

## Scope decisions

**In scope (Phase 1 — smallest defensible slice):**
- New agent file mirroring `feature-quality-assessor` patterns (haiku, multilingual, JSON-only output)
- Single insertion point in the Completion Loop in `skills/features/SKILL.md` (new step 1, runs before structural validation and quality assessment)
- Retroactive cleanup path: existing polluted portfolios (e.g. T-Systems `application-services`) can be deduped on next gate run without any other plugin changes

**Deferred to follow-up issues** (each is independently shippable and reviewable):
1. Pre-write slug guard in `skills/portfolio-ingest/SKILL.md` — block duplicate creation at ingest time
2. Pre-write slug guard in `skills/portfolio-scan/SKILL.md` — same guard for taxonomy-driven scans
3. Duplicate cluster counts in `skills/portfolio-resume/SKILL.md` status output
4. Duplicate Health card in `skills/portfolio-dashboard/SKILL.md`
5. Optional shared `scripts/slug-normalize.sh` utility (only needed once two+ skills call it)
6. Threshold tuning + embedding-vs-LLM-judgment evaluation against the T-Systems portfolio (273 features, 7 products)

These are deferred because each one is a separate skill with its own quality gate and review surface — bundling them would balloon a single PR past reviewable size. Phase 1 unblocks the highest-value path (cleaning up existing portfolios) without coupling to ingest/scan changes that need their own design pass.

## Test plan
- [ ] Verify `agents/feature-deduplication-detector.md` has valid YAML frontmatter (`name`, `description`, `model: haiku`, `tools`)
- [ ] Confirm the agent returns JSON-only output (no prose) per the schema documented in its body
- [ ] Run the Quality Completion Gate against a portfolio containing known duplicates (T-Systems `application-services` cluster: `api-management` vs `api-management-services`, `app-modernization` vs `application-modernization`) and confirm the agent surfaces them in the `hard_duplicate` bucket
- [ ] Confirm Layer 0 runs *before* `feature-quality-assessor` and that user-deferred clusters do not block the existing per-feature flow
- [ ] Confirm merge recommendations include `surviving_slug`, `merged_slugs`, `source_lineage_action`, and a one-sentence rationale
- [ ] Sanity-check the SKILL.md insertion does not break the existing Completion Loop numbering or the Review Checkpoint flow

## Open questions
None — design defaults: thresholds 0.9 / 0.7 / 0.5 per the issue body, LLM-only judgment (no embedding dependency in Phase 1), merge atomicity is advisory-only (user confirms each cluster). Threshold tuning and embedding evaluation are deferred to a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
