### PR TITLE
cogni-research: revisor honors project report_source in expansion passes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -165,7 +165,7 @@
     {
       "name": "cogni-research",
       "source": "./cogni-research",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "maturity": "preview",
       "description": "Multi-agent research report generator with localized search across 10 markets (DACH, DE, FR, IT, PL, NL, ES, US, UK, EU) — intent-based bilingual search, per-market authority sources, and configurable output language. STORM-inspired editorial workflow: parallel section research, claims-verified review loops, and five report types (basic, detailed, deep, outline, resource). Supports web, local, wiki, and hybrid source modes. Integrates with cogni-claims for source verification and cogni-wiki for compiled knowledge querying.",
       "keywords": [

--- a/cogni-research/.claude-plugin/plugin.json
+++ b/cogni-research/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-research",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Multi-agent research report generator with localized search across 10 markets (DACH, DE, FR, IT, PL, NL, ES, US, UK, EU) — intent-based bilingual search, per-market authority sources, and configurable output language. STORM-inspired editorial workflow: parallel section research, claims-verified review loops, and five report types (basic, detailed, deep, outline, resource). Supports web, local, wiki, and hybrid source modes. Integrates with cogni-claims for source verification and cogni-wiki for compiled knowledge querying.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-research/agents/revisor.md
+++ b/cogni-research/agents/revisor.md
@@ -3,7 +3,7 @@ name: revisor
 description: Incorporate reviewer feedback and claims deviation data into a revised draft.
 model: sonnet
 color: green
-tools: ["Read", "Write", "WebSearch", "WebFetch", "Bash", "Glob"]
+tools: ["Read", "Write", "WebSearch", "WebFetch", "Bash", "Glob", "Grep"]
 ---
 
 # Revisor Agent
@@ -33,11 +33,20 @@ Phase 0 → Phase 1 → Phase 2 → Phase 3
 
 Reading ALL previous verdicts — not just the current one — is critical for preventing oscillation. Without the full history, the revisor may "fix" an issue by reverting to text that a prior review already rejected, creating an infinite loop. The verdict chain reveals which issues are persistent (need a fundamentally different approach) versus which are new (introduced by the last revision).
 
+Resolving the project's source mode in Phase 0 — not halfway through Phase 2 — is equally critical. The revisor has WebSearch and WebFetch in its toolbelt, and without an explicit source-mode check it will silently default to the open web even when the project is configured to research a cogni-wiki or a local document corpus. That asymmetry breaks the source-mode contract that Phase 2 researchers honor: Phase 4.5 and Phase 5 expansion passes on a hybrid/wiki/local project would reach for generic web sources instead of the domain-specific evidence the project was configured around. Load the source mode here so every downstream decision in Phase 2 routes through the Source-Mode Evidence Gathering helper (see below the phase blocks).
+
 1. Read the current draft
 2. Read the reviewer verdict (issues, deviations, scores)
 3. Read ALL previous verdicts from `.metadata/review-verdicts/` to understand full issue history
 4. Read relevant source and claim entities for context
 5. Read `.metadata/user-claims-review.json` if present — contains the user's explicit decisions on claims (fix, drop, accept)
+6. **Resolve source mode from `.metadata/project-config.json`.** Read the config file and extract:
+   - `report_source` — one of `web`, `local`, `wiki`, `hybrid`. Default to `web` if absent.
+   - `wiki_paths` — list of cogni-wiki root paths (only meaningful when `report_source` is `wiki` or `hybrid`)
+   - `document_paths` — list of local file/glob paths (only meaningful when `report_source` is `local` or `hybrid`)
+   - `source_urls` — list of user-provided URLs to prefer when using WebFetch
+   - `query_domains` — list of domains to restrict WebSearch to
+   Store these values for use by the Source-Mode Evidence Gathering helper below. Do not hardcode WebSearch/WebFetch as the only expansion channel — route every evidence-gathering call through the helper so the revisor matches the researcher fan-out the project was configured for.
 
 ### Phase 1: Triage Issues
 
@@ -63,7 +72,7 @@ For each issue:
 1. Read the original source entity to understand what the source actually says
 2. Rewrite the claim to accurately reflect the source
 3. If the source is genuinely ambiguous, add hedging language
-4. If additional evidence is needed, use WebSearch + WebFetch to find corroborating sources
+4. If additional evidence is needed, invoke the **Source-Mode Evidence Gathering** helper below — do not hardcode WebSearch. The helper routes to wiki-query, local-query, or web-query based on the `report_source` resolved in Phase 0.
 5. Create new source entities for any new URLs via `scripts/create-entity.sh`
 
 **Structural improvements:**
@@ -82,7 +91,7 @@ For each issue:
 
 - **Default mode** — when the verdict has no high-severity word-deficit issue: track words added vs. removed. If the revision pushes the report beyond the original draft length + 20%, trim lower-priority additions. The writer agent already calibrated report length to the available context — unbounded growth signals scope creep, not quality improvement.
 - **Expansion mode** — when the verdict's issues list contains a high-severity issue whose text begins with `word deficit` or `Word deficit` (the exact phrase the reviewer emits from its Word Count Gate): the +20% cap is lifted. Grow the draft toward the report-type minimum (basic 3000 / detailed 5000 / deep 8000 / outline 1000 / resource 1500). Target for expansion is `max(report_type_minimum, original_words × 1.2)`. If the verdict names specific sections as under budget, bias new content toward those sections first.
-  - Expansion mode is still bound by the anti-fabrication rules in Phase 2 and the grounding rules below. Every new finding must cite an existing source entity or a new WebSearch-backed source. Prefer reusing already-curated sources before pulling in new ones — the aim is evidence density, not new topics.
+  - Expansion mode is still bound by the anti-fabrication rules in Phase 2 and the grounding rules below. Every new finding must cite an existing source entity or a new source discovered via the **Source-Mode Evidence Gathering** helper (wiki page, local document excerpt, or WebSearch result, as appropriate to `report_source`). Prefer reusing already-curated sources from `02-sources/data/` before pulling in new ones — use `Grep` on that directory for key terms from the evidence gap before dispatching a fresh channel query. The aim is evidence density, not new topics.
   - Do not add new top-level sections in expansion mode unless the verdict explicitly names a missing section. Deepen existing sections with cross-source comparison, implications, methodological context, and concrete examples from the research tree.
   - If after expansion you still cannot reach the floor without filler, stop short of the floor and let the orchestrator's Phase 4 gate log the deficit rather than padding.
 
@@ -109,6 +118,73 @@ On failure:
 {"ok": false, "error": "Draft file not found at output/draft-v1.md"}
 ```
 
+## Source-Mode Evidence Gathering
+
+This helper is the single point of control for every new-evidence call the revisor makes during Phase 2. It exists because the revisor has WebSearch/WebFetch in its toolbelt and would otherwise silently treat every project as `report_source=web`, breaking the source-mode contract that Phase 2 researchers honor. On a hybrid/wiki/local project, the wiki and local document corpora are different evidence universes from the open web — the whole reason those source modes exist is that they contain domain-specific material the open web does not surface. A revisor that only queries the web cannot honestly satisfy a citation-density expansion on those projects; it will under-cite, over-cite with generic web sources, or fabricate.
+
+**Always route through the helper.** Do not call WebSearch/WebFetch, Read, or Grep for evidence gathering directly from Phase 2 — funnel every evidence-gathering decision through this section so the source mode resolved in Phase 0 is honored consistently.
+
+### Mode resolution
+
+From the `report_source` value you stored in Phase 0:
+
+| `report_source` | Primary channel | Fallback | Notes |
+|---|---|---|---|
+| `web` (default) | web-query | — | No fallback needed; web is the only channel configured |
+| `wiki` | wiki-query over `wiki_paths` | web-query | Web fallback only after the wiki coverage for the current evidence gap is exhausted |
+| `local` | local-query over `document_paths` | web-query | Web fallback only after local coverage for the current evidence gap is exhausted |
+| `hybrid` | wiki-query → local-query → web-query (in order) | — | Query each configured channel in preference order; only move to the next channel after the prior one is exhausted for this evidence gap |
+
+**Exhaustion discipline.** "Exhausted" means you have honestly tried the primary channel and found no more relevant evidence — not that the first page or first Grep match didn't contain what you wanted. On wiki/hybrid projects, reading 2–3 index-matched pages counts as exhaustion only if none of them address the gap; on local/hybrid projects, at least one Grep pass with a multi-word phrase plus a surrounding-context Read counts as exhaustion only if no match contains the needed evidence.
+
+### Web query (web mode, hybrid fallback)
+
+1. Use `WebSearch` to find candidate sources, then `WebFetch` to pull the full content of the top candidates. This is the existing path and is unchanged on `report_source=web` projects.
+2. Honor `source_urls` from project-config.json: if non-empty, pre-fetch those URLs with `WebFetch` first before running any fresh `WebSearch` — the user has already decided these sources are load-bearing for the project.
+3. Honor `query_domains` from project-config.json: if non-empty, restrict `WebSearch` queries to the listed domains using the `site:` operator or the `WebSearch` tool's domain filter. Do not silently search the open web when the project has declared a domain allow-list.
+4. Honor `MARKET` for intent-based query routing via `${CLAUDE_PLUGIN_ROOT}/references/market-sources.json`, same as section-researcher — local-language for regulatory/association sources, English for academic/consulting. The market is already a required input parameter.
+5. Create source entities for any new URLs via `scripts/create-entity.sh` with the standard `https://` provenance.
+
+### Wiki query (wiki mode, hybrid primary)
+
+Borrowed from `agents/wiki-researcher.md` Phase 1–2 — the same index-first discovery pattern that Phase 2 wiki researchers use, so the revisor's wiki evidence matches what Phase 2 would have pulled. Do not invent a new wiki access pattern.
+
+1. For each path in `wiki_paths`, verify `.cogni-wiki/config.json` and `wiki/index.md` both exist and are readable. Skip wikis that fail this check.
+2. Read `wiki/index.md` fully. This is the content catalog with one-line summaries per page.
+3. From the index entries, select pages whose summaries address the evidence gap you are trying to fill. Match on semantic relevance to the reviewer's flagged issue (missing section, under-cited claim, coherence gap). Bias toward pages whose tags or titles match domain terms from the gap.
+4. If fewer than 2 clear matches from the index, supplement with `Grep` on `wiki/pages/` for key nouns extracted from the gap description. Add matching pages to the candidate set.
+5. Cap at 12 pages per wiki to prevent context overload, and track cumulative extracted-word count across pages read — stop deep analysis above 15,000 words for the current evidence gap. Rank candidates by estimated relevance (index-matched first, then grep-discovered).
+6. Read each candidate page fully via `Read`. Note the page's YAML frontmatter (`id`, `title`, `type`, `tags`, `status`, `sources`, `updated`). Extract publication metadata from the page body for citation:
+   - **Author**: look for `**Autoren**:`, `**Author**:`, `**Autor**:`, `**Verfasser**:`, `**Herausgeber**:`, or `by <name>` patterns; extract surnames
+   - **Year**: look for `**Erschienen**:`, `**Published**:`, `**Jahr**:`, or a four-digit year in publication context; also check the page title
+   - **Original URL**: scan the `sources:` frontmatter array and body for `https://` URLs pointing to the original publication; record as `original_url` if found
+
+   Follow `[[wikilinks]]` to directly relevant related pages, up to 3 per wiki, counted against the 12-page cap — the wiki-researcher does this in Phase 2 and the revisor's coverage should match.
+7. Extract findings relevant to the evidence gap. Preserve the page's own source traceability (`sources:` frontmatter). If two pages disagree on the gap-relevant fact, record both positions with their page references rather than silently picking one — the anti-fabrication contract requires surfacing contradictions, not smoothing them over.
+8. Create source entities for each wiki page that yielded findings. `quality_score` defaults to `0.90` because wiki pages are pre-curated and synthesized; downgrade to `0.80` when the page's `status` frontmatter is `draft` or `stale`:
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/create-entity.sh" \
+     --project-path "${PROJECT_PATH}" \
+     --entity-type source \
+     --data '{"frontmatter": {"url": "wiki://<wiki-slug>/<page-slug>", "title": "<page title>", "publisher": "cogni-wiki:<wiki-slug>", "author": "<extracted surname or empty>", "year": "<extracted year or empty>", "original_url": "<https URL or empty>", "fetch_method": "Read", "fetched_at": "<ISO timestamp>", "quality_score": 0.90}, "content": ""}' \
+     --json
+   ```
+9. Cite the new finding using the writer's wiki citation format (see `agents/writer.md` — `https://` sources are clickable, `wiki://` and `file://` sources use the same inline format minus the markdown link unless an `original_url` is present). The revised draft should read identically whether the wiki citation came from Phase 2 or from the revisor — readers should not be able to tell the difference.
+10. Only after exhausting wiki coverage for the current evidence gap may you fall back to web-query. Falling back before exhaustion is a violation the reviewer will flag (and on hybrid projects the downstream quality pass from #25 will catch it explicitly).
+
+### Local query (local mode, hybrid primary)
+
+1. For each path in `document_paths`, `Glob` to enumerate candidate files (the paths may be glob patterns — PDFs, markdown, CSVs, plain text, JSON).
+2. Use `Grep` to search for evidence matching the gap. Prefer **exact multi-word phrases** over single keywords — a four-word phrase from the reviewer's flagged issue has much higher precision than a single common noun and cuts false matches dramatically. Only fall back to keyword search if multi-word matches return nothing.
+3. For each `Grep` match, `Read` the full containing paragraph plus the surrounding section header — do not quote from the grep line alone. Local documents are often dense and mis-quoting a line out of context is exactly the failure mode the anti-fabrication rules exist to prevent.
+4. Extract findings with proper local provenance. Create source entities via `scripts/create-entity.sh` with `url: "file://<absolute-path>"`, `publisher: "local-document:<filename>"`, `fetch_method: "Read"`.
+5. Cite the new finding using the writer's local-document citation format (same as wiki citations — unlinked `(publisher, year)` unless an `original_url` field is present on the source entity).
+6. Only after exhausting local coverage may you fall back to web-query.
+
+### Reuse-before-new discipline
+
+Before dispatching any channel query (web, wiki, or local), `Grep` the project's already-curated sources at `02-sources/data/` and `01-contexts/data/` for key terms from the evidence gap. If a prior Phase 2 research pass already pulled evidence that addresses the gap, cite the existing source entity rather than creating a new one. This is meaningfully cheaper than a fresh channel query and keeps the source set coherent across drafts.
+
 ## Revision Guidelines
 
 - Do not rewrite the entire report — make targeted fixes
@@ -127,21 +203,22 @@ You have explicit permission — and a strict obligation — to say "I don't kno
 
 ### Anti-Fabrication Rules
 
-1. Every new finding added during revision MUST cite a source URL from actual WebSearch/WebFetch results
+1. Every new finding added during revision MUST cite a source URL from an actual evidence-gathering result — a `WebFetch` result (web mode), a wiki page actually read via the wiki-query helper (wiki/hybrid mode), or a local document excerpt actually read via the local-query helper (local/hybrid mode). Never fabricate URLs, wiki page slugs, or local file paths.
 2. Never fabricate URLs, titles, or content
-3. Never claim a finding exists if no search result supports it
+3. Never claim a finding exists if no channel query supports it
 4. When correcting a deviated claim, prefer the source's exact wording over paraphrasing
-5. If WebSearch returns no useful results for a correction, use hedging language ("reports suggest", "available evidence indicates") rather than asserting certainty
+5. If the primary channel (wiki, local, or web per `report_source`) returns no useful results for a correction, use hedging language ("reports suggest", "available evidence indicates") rather than asserting certainty — do not silently fall through to web-query on a wiki/local project just to fill the gap
 6. Never round or adjust numbers — use the exact figure from the source
 
 ### Self-Audit Before Output
 
 Before writing the revised draft, review each change:
 
-1. Does every new finding have a supporting source URL from actual search results?
+1. Does every new finding have a supporting source URL from an actual channel result matching the project `report_source` (WebFetch for web mode, a wiki page for wiki/hybrid, a local document excerpt for local/hybrid)?
 2. Does every corrected claim accurately reflect what the source reported?
 3. Have any unsupported claims been introduced during revision?
 4. **Remove unsourced additions** rather than including them — the reviewer will catch them in the next pass anyway
+5. On a hybrid/wiki/local project, have you honestly exhausted the primary channel before falling back to web-query? A Phase 5 expansion pass that cites only web sources when the project has a configured wiki or document corpus is a violation the reviewer and the downstream quality pass will flag.
 
 ### Confidence Assessment
 


### PR DESCRIPTION
Closes #26. Related: #23, #24, #25.

## Summary

- Add `Grep` to `agents/revisor.md` frontmatter tools array so the revisor can search local documents in local/hybrid projects and the project's already-curated source set before dispatching fresh channel queries.
- Extend Phase 0 (Load Inputs) to read `.metadata/project-config.json` and resolve `report_source` (web / local / wiki / hybrid), `wiki_paths`, `document_paths`, `source_urls`, and `query_domains` before any evidence gathering.
- Add a new **Source-Mode Evidence Gathering** helper section after Phase 3 with three sub-patterns:
  - **web-query** — existing WebSearch + WebFetch path, now explicitly honoring `source_urls` (pre-fetch first) and `query_domains` (restrict searches) from project-config.json
  - **wiki-query** — index-first discovery borrowed verbatim from `agents/wiki-researcher.md` Phase 1–2 (read `wiki/index.md`, select by relevance, supplement via Grep, cap at 12 pages, extract author/year/original_url, emit `wiki://<slug>/<page>` provenance with `cogni-wiki:<slug>` publisher)
  - **local-query** — Glob + Grep over `document_paths` with multi-word exact-phrase preference, surrounding-context Read discipline, and `file://` provenance
- Hybrid mode queries channels in preference order **wiki → local → web** and falls back to web-query only after the primary channel is exhausted for the current evidence gap. "Exhausted" is defined explicitly (2–3 index-matched pages read, or a multi-word Grep pass with surrounding-context Read) so the revisor can't fall back on the first non-match.
- Add a **reuse-before-new** discipline: Grep `02-sources/data/` and `01-contexts/data/` for evidence-gap terms before dispatching any fresh channel query. Cite existing source entities when they already address the gap.
- Tighten Anti-Fabrication Rule 1 and Self-Audit item 1 to reference the channel the project was actually configured for, not just WebSearch/WebFetch.
- Preserve every existing behavior on `report_source=web` projects — this is strictly additive for the web path.
- Bump `cogni-research` 0.7.0 → 0.7.2 in both `plugin.json` and the mirrored `marketplace.json` entry.

## Why this matters

Without this fix, the revisor silently treats every project as `report_source=web`. On the KI-Adoption v0.7.1-test hybrid run:

- `project-config.json` declared `"report_source": "hybrid"` with `"wiki_paths": [".../cogni-wiki/smarter-service"]`
- Phase 2 correctly fanned out 22 researchers (web + wiki) and half the 19 deduped contexts came from the wiki
- Phase 4 writer correctly used both channels because `merge-context.py` had already merged them into `aggregated-context.json`
- **Phase 5 revisor passes (draft-v1 → v2 → v3) had zero wiki access.** New citations biased toward MIT Blog / McKinsey MGI / NVIDIA press releases — none from the Mittelstand-specific smarter-service wiki
- The same asymmetry breaks any `report_source=local` or `report_source=wiki` project

This issue is a **prerequisite for #24** (revisor citation density parity) to land honestly. A density-aware revisor with only WebSearch/WebFetch would under-cite, over-cite with generic sources, or fabricate. #24 and #26 need to land together.

## Scope decisions

- **In scope:** single-file revisor.md prompt + frontmatter edit; version bump in plugin.json and marketplace.json.
- **Out of scope:** no changes to wiki-researcher.md, local-researcher.md, section-researcher.md, the orchestrator, or the writer — none of them have this bug. The wiki-query pattern is borrowed by copying the prose from wiki-researcher.md into the revisor's new helper section, not by factoring out a shared reference file.
- **Out of scope:** no schema changes to project-config.json; the fields already exist and are already populated by research-setup.
- **Deferred:** none — the issue body is self-contained and the fix is single-file.

## Version ordering note

This PR branches from `origin/main` where `cogni-research` is at **0.7.0** and `marketplace.json` also lists `0.7.0`. **PR #27** (`fix/cogni-research-23-revert-section-sharding`) is in review and bumps to **0.7.1**. This PR bumps **0.7.0 → 0.7.2**, deliberately skipping 0.7.1 so the diff contains only the revisor fix and does not collide with PR #27's 400-line revert commit.

- **If PR #27 merges first** (expected): rebase this PR onto main; the bump line in `plugin.json` and `marketplace.json` will resolve naturally to `0.7.1 → 0.7.2`. The revisor.md edit has no conflict surface with PR #27 (which only touches SKILL.md, writer.md, reviewer.md, CLAUDE.md, assemble-draft.sh, merge-context.py, and the version manifests).
- **If this PR merges first** (unlikely): `0.7.0 → 0.7.2` is still valid semver; PR #27 will rebase its bump line to `0.7.2 → 0.7.3`.

**Reviewer: please merge PR #27 before this one when both are ready.**

## Test plan

- [ ] `git diff origin/main -- cogni-research/agents/revisor.md` shows (a) `Grep` added to frontmatter tools array, (b) new Phase 0 step 6 reading `.metadata/project-config.json` and resolving `report_source`, (c) new Source-Mode Evidence Gathering section with web-query / wiki-query / local-query sub-patterns, (d) Phase 2 factual-corrections step 4 and word-budget expansion bullet updated to reference the helper instead of WebSearch-only, (e) Anti-Fabrication Rule 1 and Self-Audit item 1 updated.
- [ ] `cogni-research/.claude-plugin/plugin.json` version is `0.7.2`.
- [ ] `.claude-plugin/marketplace.json` cogni-research entry version is `0.7.2`.
- [ ] Re-run the v0.7.1-test expansion on `business-model/cogni-research/kiadoption-im-anlagen-und-maschinenbaumi-2026-04-14` (`report_source=hybrid`, `wiki_paths=[".../cogni-wiki/smarter-service"]`) and verify `draft-v2.md` and `draft-v3.md` contain at least one new citation with `wiki://smarter-service/...` provenance from the Phase 5 expansion pass — i.e., not just wiki citations already present in `draft-v1` from Phase 2 research, but new ones the revisor pulled from the wiki during expansion.
- [ ] Dry-run on a `report_source=web` project (any existing DACH research project) and confirm the revisor's behavior is unchanged — new citations still come from WebSearch/WebFetch, no regressions.
- [ ] `plugin-dev:agent-development` validation passes on revisor.md (frontmatter schema, tool names, required sections).
- [ ] Read the new Source-Mode Evidence Gathering section end-to-end and confirm the wiki-query sub-section's instructions are faithful to `wiki-researcher.md` Phase 1–2 (same index-first pattern, same 12-page cap, same provenance format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
