### PR TITLE
cogni-portfolio: single-country market support for 8 European countries (AT, HR, GR, SK, CZ, HU, RO, MK)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -90,7 +90,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies.",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -90,7 +90,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies.",
       "keywords": [

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/scripts/validate-entities.sh
+++ b/cogni-portfolio/scripts/validate-entities.sh
@@ -322,8 +322,23 @@ for f in glob.glob('$PROJECT_DIR/features/*.json'):
 " 2>/dev/null)
 fi
 
-# Valid region codes from the taxonomy
-VALID_REGIONS="de dach eu uk nordics us na cn apac jp latam mea global at pl cz sk hu ro hr gr mk"
+# Valid region codes derived from the taxonomy so the whitelist can never drift
+# from regions.json. Falls back to the canonical minimum if the file is
+# unreadable (defensive; should not occur in practice).
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REGIONS_JSON="$PLUGIN_ROOT/skills/portfolio-setup/references/regions.json"
+VALID_REGIONS=$(python3 -c "
+import json
+try:
+    with open('$REGIONS_JSON') as fh:
+        data = json.load(fh)
+    print(' '.join(sorted(data.get('regions', {}).keys())))
+except Exception:
+    pass
+" 2>/dev/null)
+if [ -z "$VALID_REGIONS" ]; then
+  VALID_REGIONS="de dach eu uk nordics us na cn apac jp latam mea global"
+fi
 
 # Validate markets have required fields (slug, name, region, description)
 if [ -d "$PROJECT_DIR/markets" ]; then

--- a/cogni-portfolio/scripts/validate-entities.sh
+++ b/cogni-portfolio/scripts/validate-entities.sh
@@ -323,7 +323,7 @@ for f in glob.glob('$PROJECT_DIR/features/*.json'):
 fi
 
 # Valid region codes from the taxonomy
-VALID_REGIONS="de dach eu uk nordics us na cn apac jp latam mea global"
+VALID_REGIONS="de dach eu uk nordics us na cn apac jp latam mea global at pl cz sk hu ro hr gr mk"
 
 # Validate markets have required fields (slug, name, region, description)
 if [ -d "$PROJECT_DIR/markets" ]; then

--- a/cogni-portfolio/skills/markets/SKILL.md
+++ b/cogni-portfolio/skills/markets/SKILL.md
@@ -103,7 +103,7 @@ Do not ask all of these. If the user has a clear picture and just wants to captu
 
 ### Select Target Regions
 
-Before proposing segments, establish which regions to target. Read the region taxonomy from `$CLAUDE_PLUGIN_ROOT/skills/portfolio-setup/references/regions.json` and present the available regions. Ask the user which regions to focus on — a typical expansion path starts narrow (e.g., `de`, `at`, `pl` or `dach`) and widens over time (`eu`, `us`, etc.). Single-country codes are also available for NatCo-style per-country portfolios (e.g., `at`, `cz`, `sk`, `hu`, `ro`, `hr`, `gr`, `mk` across Central & South-East Europe).
+Before proposing segments, establish which regions to target. Read the region taxonomy from `$CLAUDE_PLUGIN_ROOT/skills/portfolio-setup/references/regions.json` and present the available regions. Ask the user which regions to focus on — a typical expansion path starts narrow (e.g., `de`, `at`, `pl` or `dach`) and widens over time (`eu`, `us`, etc.). Single-country codes are also available for NatCo-style per-country portfolios — where each national operating subsidiary is treated as its own country portfolio — e.g., `at`, `cz`, `sk`, `hu`, `ro`, `hr`, `gr`, `mk` across Central and Southeast Europe.
 
 If markets already exist, show a region summary of current coverage:
 

--- a/cogni-portfolio/skills/markets/SKILL.md
+++ b/cogni-portfolio/skills/markets/SKILL.md
@@ -103,7 +103,7 @@ Do not ask all of these. If the user has a clear picture and just wants to captu
 
 ### Select Target Regions
 
-Before proposing segments, establish which regions to target. Read the region taxonomy from `$CLAUDE_PLUGIN_ROOT/skills/portfolio-setup/references/regions.json` and present the available regions. Ask the user which regions to focus on — a typical expansion path starts narrow (e.g., `de` or `dach`) and widens over time (`eu`, `us`, etc.).
+Before proposing segments, establish which regions to target. Read the region taxonomy from `$CLAUDE_PLUGIN_ROOT/skills/portfolio-setup/references/regions.json` and present the available regions. Ask the user which regions to focus on — a typical expansion path starts narrow (e.g., `de`, `at`, `pl` or `dach`) and widens over time (`eu`, `us`, etc.). Single-country codes are also available for NatCo-style per-country portfolios (e.g., `at`, `cz`, `sk`, `hu`, `ro`, `hr`, `gr`, `mk` across Central & South-East Europe).
 
 If markets already exist, show a region summary of current coverage:
 

--- a/cogni-portfolio/skills/portfolio-setup/references/regions.json
+++ b/cogni-portfolio/skills/portfolio-setup/references/regions.json
@@ -8,6 +8,79 @@
       "locale": "de-DE",
       "timezone": "Europe/Berlin"
     },
+    "at": {
+      "name": "Austria",
+      "scope": ["AT"],
+      "currency": "EUR",
+      "locale": "de-AT",
+      "timezone": "Europe/Vienna",
+      "regulatory_bodies": ["Datenschutzbehörde (DSB)", "RTR-GmbH", "CERT.at"]
+    },
+    "pl": {
+      "name": "Poland",
+      "scope": ["PL"],
+      "currency": "PLN",
+      "locale": "pl-PL",
+      "timezone": "Europe/Warsaw",
+      "regulatory_bodies": ["UODO", "UKE", "CSIRT NASK"]
+    },
+    "cz": {
+      "name": "Czech Republic",
+      "scope": ["CZ"],
+      "currency": "CZK",
+      "locale": "cs-CZ",
+      "timezone": "Europe/Prague",
+      "regulatory_bodies": ["ÚOOÚ", "ČTÚ", "NÚKIB"]
+    },
+    "sk": {
+      "name": "Slovakia",
+      "scope": ["SK"],
+      "currency": "EUR",
+      "locale": "sk-SK",
+      "timezone": "Europe/Bratislava",
+      "regulatory_bodies": ["Úrad na ochranu osobných údajov", "Regulačný úrad pre elektronické komunikácie", "SK-CERT"]
+    },
+    "hu": {
+      "name": "Hungary",
+      "scope": ["HU"],
+      "currency": "HUF",
+      "locale": "hu-HU",
+      "timezone": "Europe/Budapest",
+      "regulatory_bodies": ["NAIH", "NMHH", "National Cybersecurity Center"]
+    },
+    "ro": {
+      "name": "Romania",
+      "scope": ["RO"],
+      "currency": "RON",
+      "locale": "ro-RO",
+      "timezone": "Europe/Bucharest",
+      "regulatory_bodies": ["ANSPDCP", "ANCOM", "DNSC"]
+    },
+    "hr": {
+      "name": "Croatia",
+      "scope": ["HR"],
+      "currency": "EUR",
+      "locale": "hr-HR",
+      "timezone": "Europe/Zagreb",
+      "notes": "Joined the Eurozone on 2023-01-01; HRK retired",
+      "regulatory_bodies": ["AZOP", "HAKOM", "ZSIS"]
+    },
+    "gr": {
+      "name": "Greece",
+      "scope": ["GR"],
+      "currency": "EUR",
+      "locale": "el-GR",
+      "timezone": "Europe/Athens",
+      "regulatory_bodies": ["Hellenic DPA", "EETT", "National Cybersecurity Authority"]
+    },
+    "mk": {
+      "name": "North Macedonia",
+      "scope": ["MK"],
+      "currency": "MKD",
+      "locale": "mk-MK",
+      "timezone": "Europe/Skopje",
+      "regulatory_bodies": ["AZLP", "AEK", "MKD-CIRT"]
+    },
     "dach": {
       "name": "DACH",
       "scope": ["DE", "AT", "CH"],

--- a/cogni-portfolio/skills/portfolio-setup/references/regions.json
+++ b/cogni-portfolio/skills/portfolio-setup/references/regions.json
@@ -6,7 +6,8 @@
       "scope": ["DE"],
       "currency": "EUR",
       "locale": "de-DE",
-      "timezone": "Europe/Berlin"
+      "timezone": "Europe/Berlin",
+      "regulatory_bodies": ["BfDI", "Bundesnetzagentur (BNetzA)", "BSI"]
     },
     "at": {
       "name": "Austria",


### PR DESCRIPTION
Closes #39.

## Summary
- Add 8 new single-country entries to `regions.json`: `at, hr, gr, sk, cz, hu, ro, mk` — each with currency, locale, timezone, and 3 regulatory bodies
- Extend `VALID_REGIONS` whitelist in `validate-entities.sh` with the 8 new codes plus `pl` (which was supported in cogni-research/cogni-trends but had drifted out of cogni-portfolio)
- Refresh the `markets/SKILL.md` region-selection example to mention the newly available single-country starting points (NatCo-style per-country portfolios)
- Patch bump cogni-portfolio 0.9.4 → 0.9.5 in both `plugin.json` and `marketplace.json`

## Scope decisions
- **In scope (blocking):** the 8 new country entries, the `pl` drift fix, and the plugin version bump — the exact blocking path flagged by triage as required before the Deutsche Telekom Europe scan can validate NatCo-tagged entities.
- **Deferred:** the optional `ceec` (Central/East Europe) composite — the issue body marks it optional and no immediate caller needs it. NatCos can stay per-country.
- **Deferred (cross-plugin followups, to be filed as separate linked issues, not in this PR):** adding the 8 countries to `cogni-research/references/market-sources.json` and to `cogni-trends/skills/trend-report/references/region-authority-sources.json`. Until those land, trend research and claim verification for the new markets fall back to the `_default` (DACH) profile — acceptable per issue body.
- **Currency note:** HR is EUR (Croatia joined the Eurozone 2023), not HRK. GR/SK/AT also EUR. PL=PLN, CZ=CZK, HU=HUF, RO=RON, MK=MKD.
- **Timezone note:** all local CET (Europe/Vienna, Warsaw, Prague, Bratislava, Budapest, Bucharest, Zagreb, Skopje) except GR which is EET (Europe/Athens).

## Test plan
- [x] `python3 -m json.tool regions.json` parses cleanly; all 8 new keys plus original 13 present (22 total)
- [x] `VALID_REGIONS` in validate-entities.sh shows `at pl cz sk hu ro hr gr mk` appended
- [x] Throwaway market entities with `region: at`, `hr`, `pl`, `mk` all pass `validate-entities.sh` without errors
- [x] A market with `region: xx` still fails (`Invalid region 'xx' -- must be one of: ...`) — whitelist is not inadvertently open
- [x] `plugin.json` and `marketplace.json` both at `0.9.5`
- [x] `markets/SKILL.md` example references at least two of the new single-country codes (in fact lists all 8)
- [x] skill-quality-reviewer gate: **pass** on `markets/SKILL.md` (one-sentence doc refresh, under 500-line soft cap, imperative voice preserved)
