### PR TITLE
cogni-research: localized market-sources for 8 single-country markets

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -165,7 +165,7 @@
     {
       "name": "cogni-research",
       "source": "./cogni-research",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "maturity": "preview",
       "description": "Multi-agent research report generator with localized search across 10 markets (DACH, DE, FR, IT, PL, NL, ES, US, UK, EU) — intent-based bilingual search, per-market authority sources, and configurable output language. STORM-inspired editorial workflow: parallel section research, claims-verified review loops, and five report types (basic, detailed, deep, outline, resource). Supports web, local, wiki, and hybrid source modes. Integrates with cogni-claims for source verification and cogni-wiki for compiled knowledge querying.",
       "keywords": [

--- a/cogni-research/.claude-plugin/plugin.json
+++ b/cogni-research/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-research",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Multi-agent research report generator with localized search across 10 markets (DACH, DE, FR, IT, PL, NL, ES, US, UK, EU) — intent-based bilingual search, per-market authority sources, and configurable output language. STORM-inspired editorial workflow: parallel section research, claims-verified review loops, and five report types (basic, detailed, deep, outline, resource). Supports web, local, wiki, and hybrid source modes. Integrates with cogni-claims for source verification and cogni-wiki for compiled knowledge querying.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-research/references/market-sources.json
+++ b/cogni-research/references/market-sources.json
@@ -297,6 +297,166 @@
     "currency": "EUR"
   },
 
+  "at": {
+    "default_output_language": "de",
+    "local_language": "de",
+    "region_qualifiers": {"en": "Austria", "local": "Österreich"},
+    "local_query_tips": {
+      "compound_nouns": ["Digitalisierung", "künstliche Intelligenz", "Cybersicherheit", "Breitbandausbau", "Datenschutz", "Industrie 4.0", "digitale Transformation", "E-Government"],
+      "keep_english": ["Cloud", "IoT", "AI", "SaaS", "API", "5G", "Machine Learning"],
+      "geographic_modifiers": ["Österreich", "österreichisch", "Austria", "AT"]
+    },
+    "authority_sources": [
+      {"domain": "statistik.at", "category": "statistics", "authority": 5, "search_pattern": "site:statistik.at {TOPIC_LOCAL} Statistik {YEAR}"},
+      {"domain": "oeaw.ac.at", "category": "research", "authority": 5, "search_pattern": "site:oeaw.ac.at {TOPIC_LOCAL} Forschung {YEAR}"},
+      {"domain": "rtr.at", "category": "government", "authority": 5, "search_pattern": "site:rtr.at {TOPIC_LOCAL} Telekom Regulierung {YEAR}"},
+      {"domain": "wko.at", "category": "association", "authority": 4, "search_pattern": "site:wko.at {TOPIC_LOCAL} Wirtschaft Digitalisierung {YEAR}"},
+      {"domain": "derstandard.at", "category": "media", "authority": 3, "search_pattern": "site:derstandard.at {TOPIC_LOCAL} {YEAR}"}
+    ],
+    "regulatory_bodies": ["EUR-Lex (EU)", "Datenschutzbehörde (DSB)", "RTR-GmbH", "CERT.at"],
+    "currency": "EUR"
+  },
+
+  "cz": {
+    "default_output_language": "cs",
+    "local_language": "cs",
+    "region_qualifiers": {"en": "Czech Republic Czechia", "local": "Česká republika Česko"},
+    "local_query_tips": {
+      "compound_nouns": ["digitalizace", "umělá inteligence", "kybernetická bezpečnost", "digitální transformace", "ochrana osobních údajů", "průmysl 4.0", "datová ekonomika"],
+      "keep_english": ["Cloud", "IoT", "AI", "SaaS", "API", "5G", "Machine Learning"],
+      "geographic_modifiers": ["Česká republika", "Česko", "český", "česká", "Czechia"]
+    },
+    "authority_sources": [
+      {"domain": "czso.cz", "category": "statistics", "authority": 5, "search_pattern": "site:czso.cz {TOPIC_LOCAL} statistika {YEAR}"},
+      {"domain": "avcr.cz", "category": "research", "authority": 5, "search_pattern": "site:avcr.cz {TOPIC_LOCAL} výzkum {YEAR}"},
+      {"domain": "ctu.cz", "category": "government", "authority": 5, "search_pattern": "site:ctu.cz {TOPIC_LOCAL} telekomunikace regulace {YEAR}"},
+      {"domain": "uoou.cz", "category": "government", "authority": 5, "search_pattern": "site:uoou.cz {TOPIC_LOCAL} ochrana údajů {YEAR}"},
+      {"domain": "ihned.cz", "category": "media", "authority": 3, "search_pattern": "site:ihned.cz {TOPIC_LOCAL} {YEAR}"}
+    ],
+    "regulatory_bodies": ["EUR-Lex (EU)", "ÚOOÚ", "ČTÚ", "NÚKIB"],
+    "currency": "CZK"
+  },
+
+  "sk": {
+    "default_output_language": "sk",
+    "local_language": "sk",
+    "region_qualifiers": {"en": "Slovakia Slovak Republic", "local": "Slovensko Slovenská republika"},
+    "local_query_tips": {
+      "compound_nouns": ["digitalizácia", "umelá inteligencia", "kybernetická bezpečnosť", "digitálna transformácia", "ochrana osobných údajov", "priemysel 4.0"],
+      "keep_english": ["Cloud", "IoT", "AI", "SaaS", "API", "5G", "Machine Learning"],
+      "geographic_modifiers": ["Slovensko", "slovenský", "slovenská", "Slovakia"]
+    },
+    "authority_sources": [
+      {"domain": "statistics.sk", "category": "statistics", "authority": 5, "search_pattern": "site:statistics.sk {TOPIC_LOCAL} štatistika {YEAR}"},
+      {"domain": "sav.sk", "category": "research", "authority": 5, "search_pattern": "site:sav.sk {TOPIC_LOCAL} výskum {YEAR}"},
+      {"domain": "teleoff.gov.sk", "category": "government", "authority": 5, "search_pattern": "site:teleoff.gov.sk {TOPIC_LOCAL} telekomunikácie {YEAR}"},
+      {"domain": "dataprotection.gov.sk", "category": "government", "authority": 5, "search_pattern": "site:dataprotection.gov.sk {TOPIC_LOCAL} ochrana údajov {YEAR}"},
+      {"domain": "hnonline.sk", "category": "media", "authority": 3, "search_pattern": "site:hnonline.sk {TOPIC_LOCAL} {YEAR}"}
+    ],
+    "regulatory_bodies": ["EUR-Lex (EU)", "Úrad na ochranu osobných údajov SR", "Regulačný úrad pre elektronické komunikácie", "SK-CERT"],
+    "currency": "EUR"
+  },
+
+  "hu": {
+    "default_output_language": "hu",
+    "local_language": "hu",
+    "region_qualifiers": {"en": "Hungary", "local": "Magyarország"},
+    "local_query_tips": {
+      "compound_nouns": ["digitalizáció", "mesterséges intelligencia", "kiberbiztonság", "digitális átalakulás", "adatvédelem", "ipar 4.0", "szélessávú hálózat"],
+      "keep_english": ["Cloud", "IoT", "AI", "SaaS", "API", "5G", "Machine Learning"],
+      "geographic_modifiers": ["Magyarország", "magyar", "Hungary"]
+    },
+    "authority_sources": [
+      {"domain": "ksh.hu", "category": "statistics", "authority": 5, "search_pattern": "site:ksh.hu {TOPIC_LOCAL} statisztika {YEAR}"},
+      {"domain": "mta.hu", "category": "research", "authority": 5, "search_pattern": "site:mta.hu {TOPIC_LOCAL} kutatás {YEAR}"},
+      {"domain": "nmhh.hu", "category": "government", "authority": 5, "search_pattern": "site:nmhh.hu {TOPIC_LOCAL} távközlés szabályozás {YEAR}"},
+      {"domain": "naih.hu", "category": "government", "authority": 5, "search_pattern": "site:naih.hu {TOPIC_LOCAL} adatvédelem {YEAR}"},
+      {"domain": "portfolio.hu", "category": "media", "authority": 3, "search_pattern": "site:portfolio.hu {TOPIC_LOCAL} {YEAR}"}
+    ],
+    "regulatory_bodies": ["EUR-Lex (EU)", "NAIH", "NMHH", "National Cybersecurity Center"],
+    "currency": "HUF"
+  },
+
+  "ro": {
+    "default_output_language": "ro",
+    "local_language": "ro",
+    "region_qualifiers": {"en": "Romania", "local": "România"},
+    "local_query_tips": {
+      "compound_nouns": ["digitalizare", "inteligență artificială", "securitate cibernetică", "transformare digitală", "protecția datelor", "industria 4.0", "bandă largă"],
+      "keep_english": ["Cloud", "IoT", "AI", "SaaS", "API", "5G", "Machine Learning"],
+      "geographic_modifiers": ["România", "român", "română", "Romania"]
+    },
+    "authority_sources": [
+      {"domain": "insse.ro", "category": "statistics", "authority": 5, "search_pattern": "site:insse.ro {TOPIC_LOCAL} statistică {YEAR}"},
+      {"domain": "academiaromana.ro", "category": "research", "authority": 5, "search_pattern": "site:academiaromana.ro {TOPIC_LOCAL} cercetare {YEAR}"},
+      {"domain": "ancom.ro", "category": "government", "authority": 5, "search_pattern": "site:ancom.ro {TOPIC_LOCAL} comunicații reglementare {YEAR}"},
+      {"domain": "dataprotection.ro", "category": "government", "authority": 5, "search_pattern": "site:dataprotection.ro {TOPIC_LOCAL} date personale {YEAR}"},
+      {"domain": "zf.ro", "category": "media", "authority": 3, "search_pattern": "site:zf.ro {TOPIC_LOCAL} {YEAR}"}
+    ],
+    "regulatory_bodies": ["EUR-Lex (EU)", "ANSPDCP", "ANCOM", "DNSC"],
+    "currency": "RON"
+  },
+
+  "hr": {
+    "default_output_language": "hr",
+    "local_language": "hr",
+    "region_qualifiers": {"en": "Croatia", "local": "Hrvatska"},
+    "local_query_tips": {
+      "compound_nouns": ["digitalizacija", "umjetna inteligencija", "kibernetička sigurnost", "digitalna transformacija", "zaštita podataka", "industrija 4.0", "širokopojasni pristup"],
+      "keep_english": ["Cloud", "IoT", "AI", "SaaS", "API", "5G", "Machine Learning"],
+      "geographic_modifiers": ["Hrvatska", "hrvatski", "hrvatska", "Croatia"]
+    },
+    "authority_sources": [
+      {"domain": "dzs.hr", "category": "statistics", "authority": 5, "search_pattern": "site:dzs.hr {TOPIC_LOCAL} statistika {YEAR}"},
+      {"domain": "hazu.hr", "category": "research", "authority": 5, "search_pattern": "site:hazu.hr {TOPIC_LOCAL} znanost istraživanje {YEAR}"},
+      {"domain": "hakom.hr", "category": "government", "authority": 5, "search_pattern": "site:hakom.hr {TOPIC_LOCAL} elektroničke komunikacije {YEAR}"},
+      {"domain": "azop.hr", "category": "government", "authority": 5, "search_pattern": "site:azop.hr {TOPIC_LOCAL} zaštita podataka {YEAR}"},
+      {"domain": "poslovni.hr", "category": "media", "authority": 3, "search_pattern": "site:poslovni.hr {TOPIC_LOCAL} {YEAR}"}
+    ],
+    "regulatory_bodies": ["EUR-Lex (EU)", "AZOP", "HAKOM", "ZSIS"],
+    "currency": "EUR"
+  },
+
+  "gr": {
+    "default_output_language": "el",
+    "local_language": "el",
+    "region_qualifiers": {"en": "Greece Hellenic Republic", "local": "Ελλάδα Ελληνική Δημοκρατία"},
+    "local_query_tips": {
+      "compound_nouns": ["ψηφιοποίηση", "τεχνητή νοημοσύνη", "κυβερνοασφάλεια", "ψηφιακός μετασχηματισμός", "προστασία δεδομένων", "βιομηχανία 4.0", "ευρυζωνικότητα"],
+      "keep_english": ["Cloud", "IoT", "AI", "SaaS", "API", "5G", "Machine Learning"],
+      "geographic_modifiers": ["Ελλάδα", "ελληνικός", "ελληνική", "Greece", "Hellenic"]
+    },
+    "authority_sources": [
+      {"domain": "statistics.gr", "category": "statistics", "authority": 5, "search_pattern": "site:statistics.gr {TOPIC_LOCAL} στατιστική {YEAR}"},
+      {"domain": "academyofathens.gr", "category": "research", "authority": 5, "search_pattern": "site:academyofathens.gr {TOPIC_LOCAL} έρευνα {YEAR}"},
+      {"domain": "eett.gr", "category": "government", "authority": 5, "search_pattern": "site:eett.gr {TOPIC_LOCAL} τηλεπικοινωνίες {YEAR}"},
+      {"domain": "dpa.gr", "category": "government", "authority": 5, "search_pattern": "site:dpa.gr {TOPIC_LOCAL} προστασία δεδομένων {YEAR}"},
+      {"domain": "kathimerini.gr", "category": "media", "authority": 3, "search_pattern": "site:kathimerini.gr {TOPIC_LOCAL} {YEAR}"}
+    ],
+    "regulatory_bodies": ["EUR-Lex (EU)", "Hellenic DPA", "EETT", "National Cybersecurity Authority"],
+    "currency": "EUR"
+  },
+
+  "mk": {
+    "default_output_language": "mk",
+    "local_language": "mk",
+    "region_qualifiers": {"en": "North Macedonia", "local": "Северна Македонија"},
+    "local_query_tips": {
+      "compound_nouns": ["дигитализација", "вештачка интелигенција", "сајбер безбедност", "дигитална трансформација", "заштита на податоци", "индустрија 4.0"],
+      "keep_english": ["Cloud", "IoT", "AI", "SaaS", "API", "5G", "Machine Learning"],
+      "geographic_modifiers": ["Северна Македонија", "македонски", "North Macedonia"]
+    },
+    "authority_sources": [
+      {"domain": "stat.gov.mk", "category": "statistics", "authority": 5, "search_pattern": "site:stat.gov.mk {TOPIC_LOCAL} статистика {YEAR}"},
+      {"domain": "manu.edu.mk", "category": "research", "authority": 5, "search_pattern": "site:manu.edu.mk {TOPIC_LOCAL} наука {YEAR}"},
+      {"domain": "aek.mk", "category": "government", "authority": 5, "search_pattern": "site:aek.mk {TOPIC_LOCAL} комуникации {YEAR}"},
+      {"domain": "azlp.mk", "category": "government", "authority": 5, "search_pattern": "site:azlp.mk {TOPIC_LOCAL} лични податоци {YEAR}"},
+      {"domain": "kapital.mk", "category": "media", "authority": 3, "search_pattern": "site:kapital.mk {TOPIC_LOCAL} {YEAR}"}
+    ],
+    "regulatory_bodies": ["AZLP", "AEK", "MKD-CIRT"],
+    "currency": "MKD"
+  },
+
   "eu": {
     "_note": "Composite market — orchestrator expands to per-country researchers for market-specific sub-questions. This entry provides EU-wide sources and cross-market defaults.",
     "default_output_language": "en",

--- a/cogni-research/references/market-sources.json
+++ b/cogni-research/references/market-sources.json
@@ -331,7 +331,7 @@
       {"domain": "avcr.cz", "category": "research", "authority": 5, "search_pattern": "site:avcr.cz {TOPIC_LOCAL} výzkum {YEAR}"},
       {"domain": "ctu.cz", "category": "government", "authority": 5, "search_pattern": "site:ctu.cz {TOPIC_LOCAL} telekomunikace regulace {YEAR}"},
       {"domain": "uoou.cz", "category": "government", "authority": 5, "search_pattern": "site:uoou.cz {TOPIC_LOCAL} ochrana údajů {YEAR}"},
-      {"domain": "ihned.cz", "category": "media", "authority": 3, "search_pattern": "site:ihned.cz {TOPIC_LOCAL} {YEAR}"}
+      {"domain": "e15.cz", "category": "media", "authority": 3, "search_pattern": "site:e15.cz {TOPIC_LOCAL} {YEAR}"}
     ],
     "regulatory_bodies": ["EUR-Lex (EU)", "ÚOOÚ", "ČTÚ", "NÚKIB"],
     "currency": "CZK"
@@ -347,7 +347,7 @@
       "geographic_modifiers": ["Slovensko", "slovenský", "slovenská", "Slovakia"]
     },
     "authority_sources": [
-      {"domain": "statistics.sk", "category": "statistics", "authority": 5, "search_pattern": "site:statistics.sk {TOPIC_LOCAL} štatistika {YEAR}"},
+      {"domain": "slovak.statistics.sk", "category": "statistics", "authority": 5, "search_pattern": "site:slovak.statistics.sk {TOPIC_LOCAL} štatistika {YEAR}"},
       {"domain": "sav.sk", "category": "research", "authority": 5, "search_pattern": "site:sav.sk {TOPIC_LOCAL} výskum {YEAR}"},
       {"domain": "teleoff.gov.sk", "category": "government", "authority": 5, "search_pattern": "site:teleoff.gov.sk {TOPIC_LOCAL} telekomunikácie {YEAR}"},
       {"domain": "dataprotection.gov.sk", "category": "government", "authority": 5, "search_pattern": "site:dataprotection.gov.sk {TOPIC_LOCAL} ochrana údajov {YEAR}"},
@@ -368,7 +368,7 @@
     },
     "authority_sources": [
       {"domain": "ksh.hu", "category": "statistics", "authority": 5, "search_pattern": "site:ksh.hu {TOPIC_LOCAL} statisztika {YEAR}"},
-      {"domain": "mta.hu", "category": "research", "authority": 5, "search_pattern": "site:mta.hu {TOPIC_LOCAL} kutatás {YEAR}"},
+      {"domain": "hun-ren.hu", "category": "research", "authority": 5, "search_pattern": "site:hun-ren.hu {TOPIC_LOCAL} kutatás {YEAR}"},
       {"domain": "nmhh.hu", "category": "government", "authority": 5, "search_pattern": "site:nmhh.hu {TOPIC_LOCAL} távközlés szabályozás {YEAR}"},
       {"domain": "naih.hu", "category": "government", "authority": 5, "search_pattern": "site:naih.hu {TOPIC_LOCAL} adatvédelem {YEAR}"},
       {"domain": "portfolio.hu", "category": "media", "authority": 3, "search_pattern": "site:portfolio.hu {TOPIC_LOCAL} {YEAR}"}
@@ -427,7 +427,7 @@
       "geographic_modifiers": ["Ελλάδα", "ελληνικός", "ελληνική", "Greece", "Hellenic"]
     },
     "authority_sources": [
-      {"domain": "statistics.gr", "category": "statistics", "authority": 5, "search_pattern": "site:statistics.gr {TOPIC_LOCAL} στατιστική {YEAR}"},
+      {"domain": "www.statistics.gr", "category": "statistics", "authority": 5, "search_pattern": "site:www.statistics.gr {TOPIC_LOCAL} στατιστική {YEAR}"},
       {"domain": "academyofathens.gr", "category": "research", "authority": 5, "search_pattern": "site:academyofathens.gr {TOPIC_LOCAL} έρευνα {YEAR}"},
       {"domain": "eett.gr", "category": "government", "authority": 5, "search_pattern": "site:eett.gr {TOPIC_LOCAL} τηλεπικοινωνίες {YEAR}"},
       {"domain": "dpa.gr", "category": "government", "authority": 5, "search_pattern": "site:dpa.gr {TOPIC_LOCAL} προστασία δεδομένων {YEAR}"},


### PR DESCRIPTION
Closes #42.

## Summary
- Add 8 new market profiles to `cogni-research/references/market-sources.json` for the single-country markets introduced by PR #40 in cogni-portfolio: `at`, `cz`, `sk`, `hu`, `ro`, `hr`, `gr`, `mk`.
- Each profile mirrors the existing `it`/`pl`/`nl`/`es` shape: `default_output_language`, `local_language`, `region_qualifiers{en,local}`, `local_query_tips{compound_nouns,keep_english,geographic_modifiers}`, `authority_sources[]` (5 per country, typed by category with authority scores and localized `search_pattern` strings), `regulatory_bodies[]`, `currency`.
- Each country gets: national statistics office, national academy/research body, electronic communications regulator, data protection authority, and flagship business daily (issue's 3-source starter table expanded with the DPA and telecom regulator per triage guidance).
- Bump `cogni-research` from `0.7.7` to `0.7.8` in both `cogni-research/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.

## Scope decisions
- **In:** all 8 country profiles in a single PR. Reference data edits are independent per-country and a phased approach would create 8 trivial PRs with no review value.
- **In:** 5 sources per country (the floor stated in the plan). The issue's 3-source starter table is expanded with the national DPA (`uoou.cz`, `dataprotection.gov.sk`, `naih.hu`, `dataprotection.ro`, `azop.hr`, `dpa.gr`, `azlp.mk`) and the telecom/electronic-communications regulator (`rtr.at`, `ctu.cz`, `teleoff.gov.sk`, `nmhh.hu`, `ancom.ro`, `hakom.hr`, `eett.gr`, `aek.mk`).
- **In:** `regulatory_bodies[]` includes `EUR-Lex (EU)` for the 7 EU members; MK gets only national bodies (not in EU).
- **In:** patch version bump in both plugin.json and marketplace.json per repo convention.
- **Out:** no changes to the `eu` composite_markets fan-out list — currently `de/fr/it/pl/nl/es` — because whether the composite should grow with portfolio expansion is a separate product decision (see deferred).
- **Out:** no section-header mappings for the 8 new languages (`references/section-headers-{cs,sk,hu,ro,hr,el,mk}.md`) — only matter if reports are written in those languages, which is uncommon.
- **Out:** issue #41 (fr/it/nl/es portfolio regions) is independent and not touched here.

## Test plan
- [x] `python3 -m json.tool cogni-research/references/market-sources.json` parses.
- [x] All 8 codes (at/cz/sk/hu/ro/hr/gr/mk) present in `d['regions']` with the 7 required fields each.
- [x] Each new profile has `len(authority_sources) >= 5` with `domain`, `category`, `authority`, `search_pattern` on every source.
- [x] Local-script orthography preserved: AT uses `Österreich`/`ß`, CZ uses `Česká`/`č/š`, SK uses `Slovensko`/`á/č/š`, HU uses `Magyarország`/`é/á/ő`, RO uses `România`/`ă/â/ș`, HR uses `Hrvatska`/`č/š`, GR uses Greek script, MK uses Cyrillic.
- [x] `cogni-research/.claude-plugin/plugin.json` version is `0.7.8` and matches `.claude-plugin/marketplace.json`.
- [ ] A cogni-research project with `market: at` (or any of the 8) confirms section-researcher uses the new authority sources rather than falling back to `_default`. (End-to-end run left for reviewer — the new keys are picked up via the same market-lookup path as existing markets.)

## Deferred (not in this PR)
- Add the 8 new countries to the `eu` composite_markets fan-out list (currently de/fr/it/pl/nl/es).
- Expand each new profile from 5 sources to the 10–15 fidelity of the existing `it`/`nl` entries.
- Add section-header mappings (`references/section-headers-{lang}.md`) for cs/sk/hu/ro/hr/el/mk.
