### PR TITLE
Dashboards: fix Safari IntersectionObserver race leaving sections invisible

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -74,7 +74,7 @@
     {
       "name": "cogni-trends",
       "source": "./cogni-trends",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "maturity": "preview",
       "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
       "keywords": [
@@ -90,7 +90,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.7",
+      "version": "0.9.8",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies.",
       "keywords": [

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/skills/portfolio-dashboard/scripts/generate-dashboard.py
+++ b/cogni-portfolio/skills/portfolio-dashboard/scripts/generate-dashboard.py
@@ -3595,6 +3595,10 @@ function fmtCurrency(val, cur) {{
 
   document.querySelectorAll('.reveal').forEach(function(el) {{
     observer.observe(el);
+    if (el.getBoundingClientRect().top < window.innerHeight) {{
+      el.classList.add('visible');
+      observer.unobserve(el);
+    }}
   }});
 
   /* Nav: smooth scroll to sections and active state tracking */

--- a/cogni-trends/.claude-plugin/plugin.json
+++ b/cogni-trends/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-trends",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-trends/skills/trends-dashboard/scripts/generate-dashboard.py
+++ b/cogni-trends/skills/trends-dashboard/scripts/generate-dashboard.py
@@ -2864,7 +2864,13 @@ function initGraph() {
       }
     });
   }, { threshold: 0.08, rootMargin: '0px 0px -40px 0px' });
-  document.querySelectorAll('.reveal').forEach(function(el) { observer.observe(el); });
+  document.querySelectorAll('.reveal').forEach(function(el) {
+    observer.observe(el);
+    if (el.getBoundingClientRect().top < window.innerHeight) {
+      el.classList.add('visible');
+      observer.unobserve(el);
+    }
+  });
 })();
 
 // ============ SCROLL SPY for left panel ============


### PR DESCRIPTION
Closes #52.

## Summary
- Fix Safari (and occasional Chrome tab-restore) race where `.reveal` sections on `portfolio-dashboard` and `trends-dashboard` stay at `opacity: 0` on initial load because the IntersectionObserver does not fire for elements already in the viewport at attach time.
- After attaching the observer, immediately walk the `.reveal` list and force-mark any element whose `getBoundingClientRect().top < window.innerHeight` as `.visible`, unobserving it so the animation still fires normally on scroll for off-screen sections.
- Apply the same 6-line patch in both dashboard generators (`cogni-portfolio/skills/portfolio-dashboard/scripts/generate-dashboard.py` around line 3598 and `cogni-trends/skills/trends-dashboard/scripts/generate-dashboard.py` around line 2867).
- Bump patch versions: cogni-portfolio 0.9.7 → 0.9.8, cogni-trends 0.4.4 → 0.4.5, mirrored in `.claude-plugin/marketplace.json` so Claude Desktop picks up the update.

## Scope decisions
- **In scope:** exactly the two files the triage identified, plus the four version-metadata touch points (2× plugin.json, 2× marketplace.json entries). Per blast-radius check, no other dashboard uses the `.reveal` + IntersectionObserver pattern (cogni-wiki/wiki-dashboard, cogni-visual/render-html-slides, cogni-visual/enrich-report, and cogni-website/website-build are unaffected).
- **Out of scope (deferred):** (a) removing or softening `rootMargin: '0px 0px -40px 0px'` — the immediate-reveal walk makes the negative margin harmless for the initial paint, and removing it would change scroll-in timing for every reviewer's muscle memory; (b) switching to a CSS `@supports`-based no-JS fallback so `.reveal` is visible by default when JS is disabled — worthwhile but a separate concern; (c) adding a regression test harness that actually opens the generated HTML in a headless browser — the dashboards have no such harness today and adding one is a much larger change.
- **Format choices:** cogni-portfolio's script is a Python f-string so the inserted JS must use doubled braces (`{{` / `}}`); cogni-trends's script embeds the JS in a plain string so single braces are used.

## Test plan
- [ ] Regenerate a portfolio dashboard and open `dashboard.html` in Safari — all sections visible on first paint, no scroll required.
- [ ] Regenerate a trends dashboard and confirm the left nav entries and main panels render immediately in Safari.
- [ ] Scroll the regenerated dashboard and confirm off-screen sections still fade in with the original `.reveal.visible` transform — the patch must not disable the animation, only seed the initial viewport.
- [ ] Diff the generated HTML against a pre-patch baseline for a below-the-fold section; only the new immediate-reveal walk should differ.
- [ ] Verify `cogni-portfolio/.claude-plugin/plugin.json` reports `0.9.8`, `cogni-trends/.claude-plugin/plugin.json` reports `0.4.5`, and the corresponding entries in `.claude-plugin/marketplace.json` mirror those numbers.
