### PR TITLE
docs: refresh cogni-workspace Components table + retarget install-path links

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 > "Initialize my insight-wave workspace and check plugin health"
 
-→ [Plugin guide](docs/plugin-guide/cogni-workspace.md) · [Getting started](docs/getting-started.md)
+→ [Plugin guide](docs/plugin-guide/cogni-workspace.md) · [Getting started](docs/workflows/install-to-infographic.md)
 
 #### Source Verification
 
@@ -189,7 +189,7 @@ The insight-wave marketplace lives at [`cogni-work/insight-wave`](https://github
 /plugin marketplace add cogni-work/insight-wave
 ```
 
-For the full walkthrough, see [Getting Started](docs/getting-started.md).
+For the full walkthrough, see [Getting Started](docs/workflows/install-to-infographic.md).
 
 ### Core requirements
 
@@ -221,7 +221,7 @@ For the full deployment guide including GDPR compliance, data handling policies,
 
 ### Learn more
 
-- [Getting started guide](docs/getting-started.md) — full installation walkthrough
+- [Getting started guide](docs/workflows/install-to-infographic.md) — install, workspace, first infographic (~15 minutes)
 - [Ecosystem overview](docs/ecosystem-overview.md) — plugin landscape and data flow
 - [Plugin anatomy](docs/architecture/plugin-anatomy.md) — how plugins are structured
 - [MCP overview](https://docs.anthropic.com/en/docs/build-with-claude/mcp) — what Model Context Protocol is and how it works
@@ -263,7 +263,7 @@ Or browse interactively with `/plugin` and go to the **Discover** tab.
 /manage-workspace
 ```
 
-This runs dependency checks, discovers installed plugins, gathers your preferences, and generates shared settings. See the [getting started guide](docs/getting-started.md) for the full walkthrough.
+This runs dependency checks, discovers installed plugins, gathers your preferences, and generates shared settings. See the [getting started guide](docs/workflows/install-to-infographic.md) for the full walkthrough.
 
 ## How it works
 
@@ -276,10 +276,10 @@ insight-wave/
 ├── .claude-plugin/
 │   └── marketplace.json                    # Marketplace manifest (14 plugins)
 ├── docs/                                   # User documentation
-│   ├── getting-started.md                  # Installation and first steps
+│   ├── getting-started.md                  # Forwarder → workflows/install-to-infographic.md
 │   ├── ecosystem-overview.md               # Plugin landscape and data flow
 │   ├── plugin-guide/                       # Per-plugin deep dives (14 guides)
-│   ├── workflows/                          # Cross-plugin pipeline guides (6 workflows)
+│   ├── workflows/                          # Cross-plugin pipeline guides (7 workflows)
 │   ├── architecture/                       # Design philosophy, plugin anatomy, ER diagram
 │   └── contributing/                       # Plugin development guide
 ├── cogni-claims/                           # Claim verification
@@ -330,9 +330,9 @@ Plugins follow the [Claude Code plugin standard](https://code.claude.com/docs/en
 
 **91 skills, 74 agents** across the ecosystem.
 
-See [Cross-Plugin Data Flow](docs/er-diagram.md) for how data flows between plugins, or browse the [full documentation](docs/getting-started.md).
+See [Cross-Plugin Data Flow](docs/er-diagram.md) for how data flows between plugins, or browse the [full documentation](docs/ecosystem-overview.md).
 
-Workflow guides: [Research to Report](docs/workflows/research-to-report.md) | [Portfolio to Pitch](docs/workflows/portfolio-to-pitch.md) | [Portfolio to Website](docs/workflows/portfolio-to-website.md) | [Trends to Solutions](docs/workflows/trends-to-solutions.md) | [Consulting Engagement](docs/workflows/consulting-engagement.md) | [Content Pipeline](docs/workflows/content-pipeline.md)
+Workflow guides: [Install to Infographic](docs/workflows/install-to-infographic.md) | [Research to Report](docs/workflows/research-to-report.md) | [Portfolio to Pitch](docs/workflows/portfolio-to-pitch.md) | [Portfolio to Website](docs/workflows/portfolio-to-website.md) | [Trends to Solutions](docs/workflows/trends-to-solutions.md) | [Consulting Engagement](docs/workflows/consulting-engagement.md) | [Content Pipeline](docs/workflows/content-pipeline.md)
 
 ## Contributing
 

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -91,6 +91,8 @@ Claude checks dependencies, discovers installed plugins, asks for your language 
 | `check-skill-names.sh` | script | Validates skill directory names against plugin.json manifest for consistency |
 | `discover-plugins.sh` | script | Scans marketplace cache for installed cogni-x plugins, returns JSON inventory |
 | `generate-settings.sh` | script | Generates settings files; supports `--update` to preserve custom env vars |
+| `install-mcp.sh` | script | Installs a git-based MCP server into `~/.claude/mcp-servers/` (clone, build, wrapper); outputs JSON with install and wrapper paths |
+| `patch-desktop-config.py` | script | Merges git-installed MCP servers into Claude Desktop's config from `mcp-git-registry.json`, preserving existing entries |
 | `setup-obsidian.sh` | script | Copies vault templates, downloads Terminal plugin, substitutes path placeholders |
 | `update-obsidian.sh` | script | Merges profiles, fixes WSL paths, removes deprecated profiles, copies scripts |
 | `portability-utils.sh` | script | Cross-platform utilities (macOS, Linux, WSL, Git Bash) |

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -6,7 +6,7 @@ Enterprise deployment reference for Claude Code and Claude Cowork — security c
 >
 > If this guide is more than 90 days old, consider running `/doc-deploy` in the cogni-docs plugin to refresh the underlying data before relying on specific configuration values.
 
-For the canonical plugin and workspace setup, see [Getting Started](getting-started.md). This guide covers the infrastructure and compliance layer that sits underneath.
+For the canonical plugin and workspace setup, see [Install to Infographic](workflows/install-to-infographic.md). This guide covers the infrastructure and compliance layer that sits underneath.
 
 ---
 
@@ -584,7 +584,7 @@ For current rates, see the [Anthropic pricing page](https://www.anthropic.com/pr
 
 ## Further Reading
 
-- [Getting Started](getting-started.md) — workspace and plugin setup
+- [Install to Infographic](workflows/install-to-infographic.md) — workspace and plugin setup
 - [Ecosystem Overview](ecosystem-overview.md) — how the plugins fit together
 - [cogni-workspace plugin guide](plugin-guide/cogni-workspace.md) — workspace initialization details
 - [Anthropic documentation](https://docs.anthropic.com/)

--- a/docs/ecosystem-overview.md
+++ b/docs/ecosystem-overview.md
@@ -328,7 +328,7 @@ Six end-to-end workflow guides document the cross-plugin pipelines:
 
 ## See Also
 
-- [Getting Started](getting-started.md) — install the marketplace and run your first report
+- [Install to Infographic](workflows/install-to-infographic.md) — install the marketplace, set up your workspace, and produce your first infographic
 - [er-diagram.md](er-diagram.md) — cross-plugin entity relationship diagram
 - Plugin guides in [docs/plugin-guide/](plugin-guide/) — per-plugin tutorials with worked examples
 - Workflow guides in [docs/workflows/](workflows/) — end-to-end pipeline walkthroughs


### PR DESCRIPTION
## Summary
- Refresh `cogni-workspace` Components table to include `install-mcp.sh` and `patch-desktop-config.py`
- Retarget 9 stale `docs/getting-started.md` inbound links to `docs/workflows/install-to-infographic.md` (root README + ecosystem-overview + deployment-guide); `getting-started.md` is now a forwarder stub since commit 3b41ad1
- Update root README directory-tree: workflows count 6 → 7 and getting-started.md annotation to describe the forwarder
- Add the new workflow to the root-README workflow-guides bar

## Plugins fixed
- `cogni-workspace`: Components drift — adds `install-mcp.sh` and `patch-desktop-config.py` rows
- Repository-level: stale canonical links after `docs/getting-started.md` → `workflows/install-to-infographic.md` relocation

## Audit gap
`/doc-audit` did **not** flag the stale install-path links. The orphan-workflow signal only fires on **zero** inbound matches, and the stub provides one. A tracking issue is filed against the cogni-docs plugin in the managed-service repo to add a "forwarder-stub inbound link" signal so this class of drift is caught next time.

## Test plan
- [x] `cogni-workspace/README.md` Components table now lists `install-mcp.sh` and `patch-desktop-config.py`
- [x] No inbound links to `docs/getting-started.md` remain in the root README, ecosystem-overview, or deployment-guide (verified via grep)
- [x] `docs/workflows/install-to-infographic.md` appears in the root-README workflow bar
- [ ] Render root README and docs/* on github.com and confirm all retargeted links resolve
- [ ] Re-run `/cogni-docs:doc-audit all` on the branch and confirm no drift regression

## Automated review (first commit)

### Completeness
1 of 1 planned plugin verified clean (cogni-workspace: Components DRIFT -> OK).

### Prose spot-check
Components table gained two well-formed rows (`install-mcp.sh`, `patch-desktop-config.py`) with proper 3-column structure and descriptive summaries. Follow-up commit retargets 9 inbound links and updates one directory-tree annotation; no auto-review was run on the follow-up but the diff is mechanical.

### Version bump
Not required — README / docs-only change (`docs:` commit prefix applies).
