### PR TITLE
docs: ecosystem-wide install/readiness sweep + known-issues mirror

### DIFF
--- a/cogni-claims/README.md
+++ b/cogni-claims/README.md
@@ -1,6 +1,8 @@
 # cogni-claims
 
-> **Preview** (v0.x) — core skills defined but may change. Feedback welcome.
+> **Preview** (v0.10) — core skills defined but may change. Feedback welcome.
+
+> **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
 cogni-claims is the citation-integrity layer for [Claude Cowork](https://claude.ai/cowork) — a systematic verification workflow that detects when sourced claims misrepresent, overstate, or contradict what their cited sources actually say.
 
@@ -40,37 +42,17 @@ If you ship research, reports, or any content that leans on sourced claims, this
 
 ## Known Limitations
 
-> **Chrome native messaging host conflict between Cowork and Claude Code** (S2-major) — Browser-based claim source co-browsing unavailable when Claude Code's native host is active — claim verification falls back to web fetch only. Workaround: Toggle native messaging host configs by renaming the .json file for the unused product and restarting Chrome. See [Known Issues Registry](../../cogni-docs/references/known-issues.md#ki-001) for details.
+> **Chrome native messaging host conflict between Cowork and Claude Code** (S2-major) — Browser-based claim source co-browsing unavailable when Claude Code's native host is active — claim verification falls back to web fetch only. Workaround: Toggle native messaging host configs by renaming the .json file for the unused product and restarting Chrome. See [Known Issues Registry](../docs/known-issues.md#ki-001) for details.
 
-## Installation
+## Install
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
+Install insight-wave via Claude Code desktop:
 
-### Claude Code desktop (recommended for insight-wave)
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
 
-Install Claude Code via the native installer, then register the insight-wave marketplace and install this plugin:
-
-```bash
-# 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
-curl -fsSL https://claude.ai/install.sh | bash
-
-# 2. Register the insight-wave marketplace
-/plugin marketplace add cogni-work/insight-wave
-
-# 3. Install this plugin
-/plugin install cogni-claims@insight-wave
-```
-
-### Claude Cowork (short text-only tasks)
-
-Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, Enterprise). For insight-wave, prefer Claude Code desktop — Cowork has two caveats that affect this plugin's workflows:
-
-- **Context window**: Cowork caps context at ~200K tokens; long multi-agent flows trigger mid-session compressions.
-- **Pencil MCP fidelity**: lower visual fidelity in Cowork than in Claude Code desktop.
-
-See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
-
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
 ## Quick start
 
@@ -80,7 +62,7 @@ See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo
 /claims dashboard             # review claim statuses and deviation summaries
 /claims inspect <claim-id>    # open the source in your browser with the passage highlighted
 /claims resolve <claim-id>    # decide what to do about a deviation
-/claims cobrowse               # interactively recover sources that automated verification couldn't reach
+/claims cobrowse              # interactively recover sources that automated verification couldn't reach
 ```
 
 Aliases: `/claim`, `/verify-claims`
@@ -130,19 +112,23 @@ Claims are stored in your project's `cogni-claims/` directory as JSON. When you 
 
 ## Components
 
-| Component | Type | What it does |
-|-----------|------|--------------|
-| `claims` | skill | Manage claim verification lifecycle — submit, verify, review dashboard, inspect, resolve, and cobrowse claims |
-| `claim-entity` | skill | Cross-plugin data model for claim verification — defines ClaimRecord, DeviationRecord, and ResolutionRecord schemas |
-| `claim-verifier` | agent | Verify claims against a single source URL |
-| `source-inspector` | agent | Open a source URL in the browser and highlight the relevant passage for user inspection |
-| `/claims` | command | Manage claim verification lifecycle — submit, verify, review dashboard, inspect, resolve, and cobrowse claims |
+| Component | Type | Description |
+|-----------|------|-------------|
+| `claims` | Skill | Manage claim verification lifecycle — submit, verify, review dashboard, inspect, resolve, and cobrowse claims |
+| `claim-entity` | Skill | Cross-plugin data model for claim verification — defines ClaimRecord, DeviationRecord, and ResolutionRecord schemas |
+| `claim-verifier` | Agent | Verify claims against a single source URL and return deviation analysis as JSON |
+| `source-inspector` | Agent | Fetch a source URL via claude-in-chrome, locate the relevant passage, and present evidence to the user |
+| `/claims` | Command | Manage claim verification lifecycle — submit, verify, review dashboard, inspect, resolve, and cobrowse claims |
 
 ## Architecture
 
 ```
 cogni-claims/
 ├── .claude-plugin/plugin.json    Plugin manifest
+├── README.md                     Plugin documentation
+├── CLAUDE.md                     Developer guide
+├── CONTRIBUTING.md               Contribution guidelines
+├── LICENSE                       AGPL-3.0
 ├── skills/                       2 verification skills
 │   ├── claims/                   Lifecycle orchestrator (submit → verify → resolve)
 │   └── claim-entity/             Cross-plugin data contract and schema definitions

--- a/cogni-consulting/README.md
+++ b/cogni-consulting/README.md
@@ -2,6 +2,8 @@
 
 > **Incubating** (v0.0.x) — skills, data formats, and workflows may change at any time.
 
+> **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
+
 A [Claude Cowork](https://claude.ai/cowork) plugin that orchestrates consulting engagements through the Double Diamond framework — diverge to explore, converge to decide, twice. Includes Lean Canvas authoring via business-model-hypothesis, and lightweight how-might-we engagements for bounded challenges using guided ideation.
 
 ## Why this exists

--- a/cogni-consulting/README.md
+++ b/cogni-consulting/README.md
@@ -45,8 +45,6 @@ Install insight-wave via Claude Code desktop:
 
 This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
-> **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
-
 ## Quick start
 
 ```

--- a/cogni-consulting/README.md
+++ b/cogni-consulting/README.md
@@ -33,35 +33,17 @@ A process orchestrator for the insight-wave ecosystem. cogni-consulting doesn't 
 - **Resume — or refine — any engagement with full context.** Engagement state, 40+ decisions, and method selections persist in `consulting-project.json`. Pick up weeks later without re-reading notes, or re-enter a completed phase to refine it — the Diamond Coach reads your existing artifacts and focuses the iteration on what you want to improve.
 - **Phase gates protect quality, Diamond Coach explains why.** Each diamond transition blocks by default when required inputs are missing or inadequate — checking content quality, not just file existence. The Diamond Coach opens every phase with its intent and what good looks like, guides you through a task list, and closes with an accomplishment summary. You can override any gate explicitly when you're ready to proceed.
 
-## Installation
+## Install
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
+Install insight-wave via Claude Code desktop:
 
-### Claude Code desktop (recommended for insight-wave)
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
 
-Install Claude Code via the native installer, then register the insight-wave marketplace and install this plugin:
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
-```bash
-# 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
-curl -fsSL https://claude.ai/install.sh | bash
-
-# 2. Register the insight-wave marketplace
-/plugin marketplace add cogni-work/insight-wave
-
-# 3. Install this plugin
-/plugin install cogni-consulting@insight-wave
-```
-
-### Claude Cowork (short text-only tasks)
-
-Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, Enterprise). For insight-wave, prefer Claude Code desktop — Cowork has two caveats that affect this plugin's workflows:
-
-- **Context window**: Cowork caps context at ~200K tokens; long multi-agent flows trigger mid-session compressions.
-- **Pencil MCP fidelity**: lower visual fidelity in Cowork than in Claude Code desktop.
-
-See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
-
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
+> **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
 ## Quick start
 
@@ -104,7 +86,7 @@ See [references/data-model.md](references/data-model.md) for the full schema.
 
 ## How it works
 
-Each engagement lives in `cogni-consulting/{slug}/` with phase output directories (discover/, define/, develop/, deliver/) and a final output/ package. The **phase-analyst** agent assesses readiness at each gate and recommends methods from a 14-method library. Plugin refs in `consulting-project.json` store paths to projects created by other plugins — no data is copied, only referenced.
+Each engagement lives in `cogni-consulting/{slug}/` with phase output directories (discover/, define/, develop/, deliver/) and a final output/ package. The **phase-analyst** agent assesses readiness at each gate and recommends methods from a 16-method library. Plugin refs in `consulting-project.json` store paths to projects created by other plugins — no data is copied, only referenced.
 
 ## Components
 
@@ -149,13 +131,15 @@ cogni-consulting/
 │   ├── canvas-format.md
 │   ├── lean-canvas-sections.md
 │   ├── persona-schema.md
-│   ├── methods/                  14 consulting methods
+│   ├── methods/                  16 consulting methods
 │   │   ├── affinity-clustering.md
 │   │   ├── assumption-mapping.md
 │   │   ├── business-case-canvas.md
 │   │   ├── customer-journey-analysis.md
 │   │   ├── data-audit.md
 │   │   ├── desk-research-framing.md
+│   │   ├── empathy-mapping.md
+│   │   ├── guided-ideation.md
 │   │   ├── hmw-synthesis.md
 │   │   ├── lean-canvas-authoring.md
 │   │   ├── lean-canvas-refinement.md

--- a/cogni-copywriting/README.md
+++ b/cogni-copywriting/README.md
@@ -2,7 +2,7 @@
 
 > **Preview** (v0.x) — core skills defined but may change. Feedback welcome.
 
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
+> **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
 A [Claude Cowork](https://claude.ai/cowork) plugin that turns AI-generated drafts into executive-ready documents. Seven messaging frameworks, five parallel stakeholder personas for blind-spot review, bilingual readability validation (English Flesch, German Amstad + Wolf Schneider), and Power Positions sales enhancement — while preserving upstream story arc structure from cogni-narrative. A `copy-json` adapter polishes text fields inside JSON files, and `audit-copywriter` verifies arc contracts stay in sync with cogni-narrative upstream.
 

--- a/cogni-copywriting/README.md
+++ b/cogni-copywriting/README.md
@@ -41,11 +41,13 @@ A professional editing toolkit for the insight-wave ecosystem. Seven messaging f
 
 ## Install
 
-Part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave). See the [install guide](../cogni-docs/references/Claude%20Code%20desktop.md) for the full setup walkthrough.
+Install insight-wave via Claude Code desktop:
 
-**Prerequisites:**
-- Python 3 (for readability calculations)
-- Optional: **cogni-narrative** (arc-aware polishing when `arc_id` frontmatter is present)
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
+
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
 ## Quick start
 

--- a/cogni-copywriting/README.md
+++ b/cogni-copywriting/README.md
@@ -2,6 +2,8 @@
 
 > **Preview** (v0.x) — core skills defined but may change. Feedback welcome.
 
+> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
+
 A [Claude Cowork](https://claude.ai/cowork) plugin that turns AI-generated drafts into executive-ready documents. Seven messaging frameworks, five parallel stakeholder personas for blind-spot review, bilingual readability validation (English Flesch, German Amstad + Wolf Schneider), and Power Positions sales enhancement — while preserving upstream story arc structure from cogni-narrative. A `copy-json` adapter polishes text fields inside JSON files, and `audit-copywriter` verifies arc contracts stay in sync with cogni-narrative upstream.
 
 ## Why this exists
@@ -37,35 +39,9 @@ A professional editing toolkit for the insight-wave ecosystem. Seven messaging f
 - **Protect your narrative investment.** Arc-aware polishing detects story arc structure and applies element-specific techniques — so a document that took cogni-narrative 30 minutes to compose doesn't lose its persuasive spine during editing.
 - **Publish in both markets without a second editing cycle.** English uses Flesch scoring (target 50-60); German uses Wolf Schneider rules with Amstad scoring (target 30-50) — eliminating the separate localization review that typically adds 1-2 days per document.
 
-## Installation
+## Install
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
-
-### Claude Code desktop (recommended for insight-wave)
-
-Install Claude Code via the native installer, then register the insight-wave marketplace and install this plugin:
-
-```bash
-# 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
-curl -fsSL https://claude.ai/install.sh | bash
-
-# 2. Register the insight-wave marketplace
-/plugin marketplace add cogni-work/insight-wave
-
-# 3. Install this plugin
-/plugin install cogni-copywriting@insight-wave
-```
-
-### Claude Cowork (short text-only tasks)
-
-Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, Enterprise). For insight-wave, prefer Claude Code desktop — Cowork has two caveats that affect this plugin's workflows:
-
-- **Context window**: Cowork caps context at ~200K tokens; long multi-agent flows trigger mid-session compressions.
-- **Pencil MCP fidelity**: lower visual fidelity in Cowork than in Claude Code desktop.
-
-See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
-
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
+Part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave). See the [install guide](../cogni-docs/references/Claude%20Code%20desktop.md) for the full setup walkthrough.
 
 **Prerequisites:**
 - Python 3 (for readability calculations)

--- a/cogni-help/README.md
+++ b/cogni-help/README.md
@@ -168,7 +168,7 @@ Contributions welcome — course content, workflow templates, diagnostic checks,
 
 | ID | Issue | Severity | Affected Skills | Workaround |
 |----|-------|----------|----------------|------------|
-| KI-001 | Chrome native messaging host conflict between Cowork and Claude Code | S2-major | `/cogni-issues` (browser filing) | Toggle native host configs by renaming the `.json` file for the unused product and restarting Chrome. See [known-issues registry](https://github.com/anthropics/managed-service/blob/main/cogni-docs/references/known-issues.md) for detailed steps. |
+| KI-001 | Chrome native messaging host conflict between Cowork and Claude Code | S2-major | `/cogni-issues` (browser filing) | Toggle native host configs by renaming the `.json` file for the unused product and restarting Chrome. See [Known Issues Registry](../docs/known-issues.md#ki-001) for detailed steps. |
 
 > When both Claude Desktop (Cowork) and Claude Code are installed, their competing native messaging host configurations cause browser automation tools to silently vanish. The `/cogni-issues` skill falls back to `gh` CLI — issue filing still works, but interactive browser-based filing is unavailable until the conflict is resolved.
 

--- a/cogni-help/README.md
+++ b/cogni-help/README.md
@@ -2,6 +2,8 @@
 
 > **Incubating** (v0.0.x) — skills, data formats, and workflows may change at any time.
 
+> **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
+
 cogni-help unifies the [insight-wave](https://github.com/cogni-work/insight-wave) ecosystem into a single entry point — teaching users through a 12-course curriculum, routing tasks to the right plugin, chaining multi-plugin workflows, diagnosing problems, generating one-screen cheatsheets, and filing GitHub issues straight from the session — so 12 plugins with 70+ skills behave like one coherent system.
 
 ## Why this exists
@@ -34,35 +36,15 @@ A meta-plugin for the insight-wave ecosystem. While other plugins produce conten
 - **Collapse multi-plugin work into 3–4 steps.** Run any of 6 workflow templates to chain plugins into repeatable pipelines — research-to-slides in 3 steps, portfolio-to-pitch in 4.
 - **Catch failures before they surface.** Run the 5-tier health check to surface missing dependencies, stale configs, and integrity issues before they become cryptic runtime errors.
 
-## Installation
+## Install
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
+Install insight-wave via Claude Code desktop:
 
-### Claude Code desktop (recommended for insight-wave)
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
 
-Install Claude Code via the native installer, then register the insight-wave marketplace and install this plugin:
-
-```bash
-# 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
-curl -fsSL https://claude.ai/install.sh | bash
-
-# 2. Register the insight-wave marketplace
-/plugin marketplace add cogni-work/insight-wave
-
-# 3. Install this plugin
-/plugin install cogni-help@insight-wave
-```
-
-### Claude Cowork (short text-only tasks)
-
-Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, Enterprise). For insight-wave, prefer Claude Code desktop — Cowork has two caveats that affect this plugin's workflows:
-
-- **Context window**: Cowork caps context at ~200K tokens; long multi-agent flows trigger mid-session compressions.
-- **Pencil MCP fidelity**: lower visual fidelity in Cowork than in Claude Code desktop.
-
-See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
-
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
 ## Quick start
 

--- a/cogni-marketing/README.md
+++ b/cogni-marketing/README.md
@@ -2,6 +2,8 @@
 
 > **Incubating** (v0.0.x) — skills, data formats, and workflows may change at any time.
 
+> **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
+
 B2B marketing content engine for [Claude Cowork](https://claude.ai/cowork). Bridges cogni-trends strategic themes and cogni-portfolio propositions into channel-ready content. Supports thought leadership, demand generation, lead generation, sales enablement, and ABM across markets with configurable brand voice. Bilingual DE/EN.
 
 ## Why this exists
@@ -38,40 +40,15 @@ A content generation bridge between strategy and execution in the insight-wave e
 - **See coverage gaps at a glance.** The 3D dashboard (market × GTM path × content type) shows exactly which combinations have content and which don't — across all markets, themes, and funnel stages on one screen.
 - **Publish bilingual without re-authoring.** Full DE/EN support with language-specific brand voice configuration — one strategy, two languages, no manual translation pass.
 
-## Installation
+## Install
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
+Install insight-wave via Claude Code desktop:
 
-### Claude Code desktop (recommended for insight-wave)
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
 
-Install Claude Code via the native installer, then register the insight-wave marketplace and install this plugin:
-
-```bash
-# 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
-curl -fsSL https://claude.ai/install.sh | bash
-
-# 2. Register the insight-wave marketplace
-/plugin marketplace add cogni-work/insight-wave
-
-# 3. Install this plugin
-/plugin install cogni-marketing@insight-wave
-```
-
-### Claude Cowork (short text-only tasks)
-
-Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, Enterprise). For insight-wave, prefer Claude Code desktop — Cowork has two caveats that affect this plugin's workflows:
-
-- **Context window**: Cowork caps context at ~200K tokens; long multi-agent flows trigger mid-session compressions.
-- **Pencil MCP fidelity**: lower visual fidelity in Cowork than in Claude Code desktop.
-
-See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
-
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
-
-**Prerequisites:**
-- **cogni-portfolio** (required — provides propositions, markets, competitors)
-- **cogni-trends** (required — provides strategic themes and trend data)
-- Optional: **cogni-copywriting** (polish generated content), **cogni-visual** (slides and visual assets)
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
 ## Quick start
 

--- a/cogni-narrative/README.md
+++ b/cogni-narrative/README.md
@@ -2,6 +2,8 @@
 
 > **Preview** (v0.x) — core skills defined but may change. Feedback welcome.
 
+> **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
+
 The story arc engine for the insight-wave ecosystem — transforms structured research and portfolio output into executive-grade narratives using 10 arc frameworks (Corporate Visions, JTBD Portfolio, Strategic Foresight, Trend Panorama, and six more) and 8 narrative techniques, sitting between cogni-research and cogni-copywriting in the pipeline and feeding cogni-visual, cogni-sales, and cogni-marketing downstream. Bilingual EN/DE.
 
 ## Why this exists

--- a/cogni-narrative/README.md
+++ b/cogni-narrative/README.md
@@ -39,9 +39,15 @@ A story arc engine for the insight-wave ecosystem. Ten named arc frameworks — 
 - **One narrative, three derivative formats.** Executive briefs, talking points, and one-pagers — adapted from the source narrative without rewriting.
 - **Ship in the reader's language.** Full EN/DE support with localized arc headers and proper Unicode — no post-processing needed for German-language clients or DACH reports.
 
-## Installation
+## Install
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave). See the [install-to-infographic workflow](../docs/workflows/install-to-infographic.md) for the full setup path.
+Install insight-wave via Claude Code desktop:
+
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
+
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
 ## Quick start
 

--- a/cogni-narrative/README.md
+++ b/cogni-narrative/README.md
@@ -39,33 +39,7 @@ A story arc engine for the insight-wave ecosystem. Ten named arc frameworks — 
 
 ## Installation
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
-
-### Claude Code desktop (recommended for insight-wave)
-
-Install Claude Code via the native installer, then register the insight-wave marketplace and install this plugin:
-
-```bash
-# 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
-curl -fsSL https://claude.ai/install.sh | bash
-
-# 2. Register the insight-wave marketplace
-/plugin marketplace add cogni-work/insight-wave
-
-# 3. Install this plugin
-/plugin install cogni-narrative@insight-wave
-```
-
-### Claude Cowork (short text-only tasks)
-
-Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, Enterprise). For insight-wave, prefer Claude Code desktop — Cowork has two caveats that affect this plugin's workflows:
-
-- **Context window**: Cowork caps context at ~200K tokens; long multi-agent flows trigger mid-session compressions.
-- **Pencil MCP fidelity**: lower visual fidelity in Cowork than in Claude Code desktop.
-
-See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
-
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
+This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave). See the [install-to-infographic workflow](../docs/workflows/install-to-infographic.md) for the full setup path.
 
 ## Quick start
 

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -2,6 +2,8 @@
 
 > **Preview** (v0.x) — core skills defined but may change. Feedback welcome.
 
+> **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
+
 A [Claude Cowork](https://claude.ai/cowork) plugin for portfolio messaging and proposition planning. Helps SMEs build structured, market-specific value propositions using the IS/DOES/MEANS (FAB) framework — from product definition through competitive analysis and customer profiling to export-ready deliverables, across eight pluggable industry taxonomies (B2B SaaS, FinTech, HealthTech, MarTech, Industrial Tech, ICT, Professional Services, Commercial Open Source).
 
 ## Why this exists
@@ -47,33 +49,13 @@ A structured portfolio messaging workflow for Claude Cowork. Eight pluggable tax
 
 ## Install
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
+Install insight-wave via Claude Code desktop:
 
-### Claude Code desktop (recommended for insight-wave)
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
 
-Install Claude Code via the native installer, then register the insight-wave marketplace and install this plugin:
-
-```bash
-# 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
-curl -fsSL https://claude.ai/install.sh | bash
-
-# 2. Register the insight-wave marketplace
-/plugin marketplace add cogni-work/insight-wave
-
-# 3. Install this plugin
-/plugin install cogni-portfolio@insight-wave
-```
-
-### Claude Cowork (short text-only tasks)
-
-Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, Enterprise). For insight-wave, prefer Claude Code desktop — Cowork has two caveats that affect this plugin's workflows:
-
-- **Context window**: Cowork caps context at ~200K tokens; long multi-agent flows trigger mid-session compressions.
-- **Pencil MCP fidelity**: lower visual fidelity in Cowork than in Claude Code desktop.
-
-See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
-
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-MCP fidelity gaps.
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
 ## Quick start
 

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -45,7 +45,7 @@ A structured portfolio messaging workflow for Claude Cowork. Eight pluggable tax
 - **Canvas to portfolio in one step.** Bootstrap a full portfolio directly from a Lean Canvas — extract products, features, and markets from a founding-stage hypothesis without a single field of manual re-entry.
 - **Deep-dive without leaving the plugin.** Two dedicated research agents (`feature-deep-diver`, `proposition-deep-diver`) validate buyer language against live web evidence and propose refinements grounded in verifiable sources.
 
-## Installation
+## Install
 
 This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
 
@@ -73,9 +73,7 @@ Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, En
 
 See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
 
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
-
-> **Note**: All outputs — especially market sizing, competitive intelligence, and claim verification — should be reviewed by domain experts before use in sales materials, proposals, or strategic decisions.
+> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-MCP fidelity gaps.
 
 ## Quick start
 

--- a/cogni-research/README.md
+++ b/cogni-research/README.md
@@ -2,6 +2,8 @@
 
 > **Preview** (v0.x) — core skills defined but may change. Feedback welcome.
 
+> **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
+
 Multi-agent research report generator for [Claude Cowork](https://claude.ai/cowork). STORM-inspired editorial workflow with parallel section research and claims-verified review loops. Five report types (basic, detailed, deep, outline, resource) and four source modes (web, local documents, wiki, hybrid) — from quick overviews to deep recursive explorations. Research runs localized across 18 European and Anglo markets (DACH, DE, AT, FR, IT, ES, NL, PL, CZ, SK, HU, RO, HR, GR, MK, UK, US, EU) with intent-based bilingual search and per-market authority sources.
 
 ## Why this exists
@@ -43,41 +45,15 @@ If you produce research, analysis, or any content that needs to be both sourced 
 - **Trace every finding back to a source.** Every finding links to a source, every claim links to a verification result. The full workspace is Obsidian-browsable.
 - **Match research intensity to the question.** Quick overview (basic), multi-section report (detailed), recursive tree exploration (deep), structured framework (outline), or annotated bibliography (resource) — matched to your needs.
 
-## Installation
+## Install
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
+Install insight-wave via Claude Code desktop:
 
-### Claude Code desktop (recommended for insight-wave)
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
 
-Install Claude Code via the native installer, then register the insight-wave marketplace and install this plugin:
-
-```bash
-# 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
-curl -fsSL https://claude.ai/install.sh | bash
-
-# 2. Register the insight-wave marketplace
-/plugin marketplace add cogni-work/insight-wave
-
-# 3. Install this plugin
-/plugin install cogni-research@insight-wave
-```
-
-### Claude Cowork (short text-only tasks)
-
-Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, Enterprise). For insight-wave, prefer Claude Code desktop — Cowork has two caveats that affect this plugin's workflows:
-
-- **Context window**: Cowork caps context at ~200K tokens; long multi-agent flows trigger mid-session compressions.
-- **Pencil MCP fidelity**: lower visual fidelity in Cowork than in Claude Code desktop.
-
-See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
-
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
-
-**Prerequisites:**
-- Web access enabled (for research)
-- bash, python3 (stdlib only — no pip dependencies)
-- **cogni-claims** plugin (recommended — enables claims-verified review loop)
-- Optional: **cogni-narrative** (story arc polish), **cogni-copywriting** (executive polish), **cogni-visual** (presentation generation)
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
 ## Quick start
 
@@ -209,7 +185,7 @@ cogni-research/
 
 | Plugin | Required | Purpose |
 |--------|----------|---------|
-| cogni-claims | No | Claims verification loop in `verify-report` — extracts and checks claims against source URLs |
+| cogni-claims | Yes | Claims verification loop in `verify-report` — extracts and checks claims against source URLs |
 | cogni-visual | No | Visual enrichment and format export via `enrich-report` — themed HTML with charts, optional PDF/DOCX |
 | cogni-wiki | No | Wiki source mode for research queries via wiki-researcher agent |
 | cogni-workspace | No | Theme selection for visual exports (indirect — consumed via cogni-visual:enrich-report) |

--- a/cogni-sales/README.md
+++ b/cogni-sales/README.md
@@ -2,6 +2,8 @@
 
 > **Preview** (v0.x) — core skills defined but may change. Feedback welcome.
 
+> **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
+
 B2B sales pitch generation for [Claude Cowork](https://claude.ai/cowork) using Corporate Visions Why Change methodology. Creates sales presentations and proposals for named customers (deal-specific) or market segments (reusable). Builds on cogni-portfolio data with optional TIPS strategic enrichment. Bilingual DE/EN.
 
 ## Why this exists
@@ -39,41 +41,15 @@ A pitch generation pipeline built on the Corporate Visions Why Change methodolog
 - **Claims-verified before you present.** Every factual claim in the deck is registered with a source URL; optional cogni-claims integration verifies all of them in one pass — zero unsourced statistics in front of the customer.
 - **Keep multi-day deals moving without rework.** Interrupted pitches resume from the last completed phase — no research lost, no phase reruns, no pipeline stall when a conversation ends mid-workflow.
 
-## Installation
+## Install
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
+Install insight-wave via Claude Code desktop:
 
-### Claude Code desktop (recommended for insight-wave)
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
 
-Install Claude Code via the native installer, then register the insight-wave marketplace and install this plugin:
-
-```bash
-# 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
-curl -fsSL https://claude.ai/install.sh | bash
-
-# 2. Register the insight-wave marketplace
-/plugin marketplace add cogni-work/insight-wave
-
-# 3. Install this plugin
-/plugin install cogni-sales@insight-wave
-```
-
-### Claude Cowork (short text-only tasks)
-
-Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, Enterprise). For insight-wave, prefer Claude Code desktop — Cowork has two caveats that affect this plugin's workflows:
-
-- **Context window**: Cowork caps context at ~200K tokens; long multi-agent flows trigger mid-session compressions.
-- **Pencil MCP fidelity**: lower visual fidelity in Cowork than in Claude Code desktop.
-
-See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
-
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
-
-**Prerequisites:**
-- Web access enabled (for customer and industry research)
-- **cogni-portfolio** (required — provides products, propositions, markets, competitors)
-- **cogni-narrative** (required — provides Corporate Visions story arc patterns)
-- Optional: **cogni-trends** (TIPS strategic theme enrichment), **cogni-claims** (source verification), **cogni-copywriting** (executive polish), **cogni-visual** (PPTX generation)
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
 ## Quick start
 

--- a/cogni-sales/README.md
+++ b/cogni-sales/README.md
@@ -132,7 +132,7 @@ Each pitch project tracks state in `pitch-log.json` with pitch mode (customer/se
 | `why-change` | skill | Create a Why Change sales pitch for a named customer or a reusable segment pitch for a market. |
 | `why-change-researcher` | agent (opus) | Research and generate content for a specific phase of the Why Change pitch workflow. |
 | `pitch-synthesizer` | agent (sonnet) | Assemble final sales-presentation.md and sales-proposal.md from phase research. |
-| `pitch-review-assessor` | agent (haiku) | Assess completed sales pitch quality from three stakeholder perspectives: target buyer, sales director, and marketing director. |
+| `pitch-review-assessor` | agent (haiku) | Assess sales pitch quality from three stakeholder perspectives (buyer, sales, marketing). |
 | `pitch-revisor` | agent (sonnet) | Revise sales pitch deliverables based on pitch-review-assessor feedback. |
 | `/why-change` | command | Create a Why Change sales pitch for a named customer or market segment (aliases: `/pitch`, `/sales-pitch`, `/segment-pitch`) |
 | `discover-portfolio.sh` | script | Scan workspace for cogni-portfolio projects and return JSON metadata |

--- a/cogni-trends/README.md
+++ b/cogni-trends/README.md
@@ -1,6 +1,8 @@
 # cogni-trends
 
-> **Preview** (v0.x) — core skills defined but may change. Feedback welcome.
+> **Preview** (v0.4) — core skills defined but may change. Feedback welcome.
+
+> **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
 A [Claude Cowork](https://claude.ai/cowork) plugin for scouting, selecting, and reporting on strategic industry trends — **rooted in the German Mittelstand, covering European markets (DE/FR/IT/PL/NL/ES) and US/UK**. Combines the [Smarter Service Trendradar](https://www.smarter-service.com/2023/01/31/trendradar-fuer-die-multikrise-und-neue-geooekonomie/) (4-dimension structure by Bernhard Steimel) with the TIPS content framework (Trends, Implications, Possibilities, Solutions — a B2B consulting methodology widely used since the early 2000s; see [WO2018046399A1](https://patents.google.com/patent/WO2018046399A1/en) for a detailed treatment, filed by Siemens 2017, ceased 2019).
 
@@ -70,40 +72,15 @@ If you need to stay ahead of industry trends for strategy, advisory, or portfoli
 - **Multi-session workflow.** Resume any project mid-stream with full state recovery via `/trends-resume` — zero context loss between sessions.
 - **Research your market natively.** Per-market bilingual queries against curated regional institutional sources — DACH (VDMA, BITKOM, Fraunhofer), FR (INRIA, Les Echos), IT (CNR, AGCOM), PL (UKE, POLSA), NL (TNO, ACM), ES (CNMC, INTA), plus US/UK. Zero reliance on generic US-centric datasets; output in your chosen language.
 
-## Installation
+## Install
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
+Install insight-wave via Claude Code desktop:
 
-### Claude Code desktop (recommended for insight-wave)
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
 
-Install Claude Code via the native installer, then register the insight-wave marketplace and install this plugin:
-
-```bash
-# 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
-curl -fsSL https://claude.ai/install.sh | bash
-
-# 2. Register the insight-wave marketplace
-/plugin marketplace add cogni-work/insight-wave
-
-# 3. Install this plugin
-/plugin install cogni-trends@insight-wave
-```
-
-### Claude Cowork (short text-only tasks)
-
-Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, Enterprise). For insight-wave, prefer Claude Code desktop — Cowork has two caveats that affect this plugin's workflows:
-
-- **Context window**: Cowork caps context at ~200K tokens; long multi-agent flows trigger mid-session compressions.
-- **Pencil MCP fidelity**: lower visual fidelity in Cowork than in Claude Code desktop.
-
-See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
-
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
-
-**Prerequisites:**
-- Web access enabled (for trend research)
-- Optional: `cogni-claims` plugin (recommended for claim verification of trend report citations)
-- Optional: `cogni-narrative` plugin (for insight summary generation)
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
 ## Quick start
 

--- a/cogni-visual/README.md
+++ b/cogni-visual/README.md
@@ -2,6 +2,8 @@
 
 > **Preview** (v0.x) — core skills defined but may change. Feedback welcome.
 
+> **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
+
 A [Claude Cowork](https://claude.ai/cowork) plugin for brief-based visual production — skills distill polished narratives and structured data into YAML+Markdown briefs (slides, infographics, storyboards, web narratives, enriched reports), then rendering agents hand those briefs to PPTX, Excalidraw, Pencil MCP, and HTML backends. Every output inherits brand identity from your cogni-workspace theme instead of generic templates.
 
 ## Why this exists
@@ -39,24 +41,15 @@ A brief-based visual production pipeline. Skills generate structured briefs (YAM
 
 > **Chrome native messaging host conflict between Cowork and Claude Code** (S2-major) — Browser-based zone review for rendered visuals may fail silently when tools are missing. Workaround: Toggle native messaging host configs by renaming the .json file for the unused product and restarting Chrome. See [Known Issues Registry](../docs/known-issues.md#ki-001) for details.
 
-## Installation
+## Install
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
+Install insight-wave via Claude Code desktop:
 
-```bash
-# 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
-curl -fsSL https://claude.ai/install.sh | bash
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
 
-# 2. Register the insight-wave marketplace
-/plugin marketplace add cogni-work/insight-wave
-
-# 3. Install this plugin
-/plugin install cogni-visual@insight-wave
-```
-
-See the [install-to-infographic workflow](../docs/workflows/install-to-infographic.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
-
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
 > **Note:** Excalidraw MCP is required for hand-drawn infographic rendering (sketchnote, whiteboard traditions). Pencil MCP is required for editorial infographic rendering (economist, editorial, data-viz, corporate), web narratives, and storyboards. Both MCPs are optional — the brief-generation skills work without them.
 

--- a/cogni-visual/README.md
+++ b/cogni-visual/README.md
@@ -37,15 +37,11 @@ A brief-based visual production pipeline. Skills generate structured briefs (YAM
 
 ## Known Limitations
 
-> **Chrome native messaging host conflict between Cowork and Claude Code** (S2-major) — Browser-based zone review for rendered visuals may fail silently when tools are missing. Workaround: Toggle native messaging host configs by renaming the .json file for the unused product and restarting Chrome. See [Known Issues Registry](../../cogni-docs/references/known-issues.md#ki-001) for details.
+> **Chrome native messaging host conflict between Cowork and Claude Code** (S2-major) — Browser-based zone review for rendered visuals may fail silently when tools are missing. Workaround: Toggle native messaging host configs by renaming the .json file for the unused product and restarting Chrome. See [Known Issues Registry](../docs/known-issues.md#ki-001) for details.
 
 ## Installation
 
 This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
-
-### Claude Code desktop (recommended for insight-wave)
-
-Install Claude Code via the native installer, then register the insight-wave marketplace and install this plugin:
 
 ```bash
 # 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
@@ -58,14 +54,7 @@ curl -fsSL https://claude.ai/install.sh | bash
 /plugin install cogni-visual@insight-wave
 ```
 
-### Claude Cowork (short text-only tasks)
-
-Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, Enterprise). For insight-wave, prefer Claude Code desktop — Cowork has two caveats that affect this plugin's workflows:
-
-- **Context window**: Cowork caps context at ~200K tokens; long multi-agent flows trigger mid-session compressions.
-- **Pencil MCP fidelity**: lower visual fidelity in Cowork than in Claude Code desktop.
-
-See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
+See the [install-to-infographic workflow](../docs/workflows/install-to-infographic.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
 
 > **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
 

--- a/cogni-website/README.md
+++ b/cogni-website/README.md
@@ -2,6 +2,8 @@
 
 > **Incubating** (v0.0.x) — skills, data formats, and workflows may change at any time.
 
+> **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
+
 Assembles multi-page customer websites from portfolio, marketing, trend, and research content produced by other insight-wave plugins — outputting a deployable static site with shared navigation, theming, and responsive HTML.
 
 ## Why this exists

--- a/cogni-website/README.md
+++ b/cogni-website/README.md
@@ -34,35 +34,18 @@ A static-site generation pipeline purpose-built for the insight-wave ecosystem. 
 8. **Validate and preview** — verify completeness and link integrity; open the site in the default browser; suggest a local HTTP server for full navigation testing
 9. **Resume across sessions** — detect project phase from existing files; compare source modification times against built HTML; flag new entities or newly discovered upstream plugins; recommend targeted partial rebuilds
 
-## Installation
+## What it means for you
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
+- **From portfolio data to live website in one session.** Setup, plan, and build run sequentially with interactive checkpoints — what would take a web team 2-3 days of content migration completes in a single working session.
+- **Always current, never stale.** Resume detects when source files have changed since the last build and regenerates only the affected pages — content updates in cogni-portfolio or cogni-marketing propagate to the website without starting from scratch.
+- **One theme, every page.** A single design-variables.json drives all color, font, and shadow tokens across the entire site — reskinning means updating one file, not editing 10+ HTML pages.
+- **Deploy anywhere without build tooling.** The output is a self-contained static folder with validated internal links — drop onto Netlify, Vercel, or S3 with zero configuration.
 
-### Claude Code desktop (recommended for insight-wave)
+## Install
 
-Install Claude Code via the native installer, then register the insight-wave marketplace and install this plugin:
+This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave). Follow the [install-to-infographic walkthrough](../docs/workflows/install-to-infographic.md) to get Claude Code desktop, the marketplace, and this plugin set up in one pass. For enterprise environments (SSO, GDPR data residency, audit logging) read the [deployment guide](../docs/deployment-guide.md) first.
 
-```bash
-# 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
-curl -fsSL https://claude.ai/install.sh | bash
-
-# 2. Register the insight-wave marketplace
-/plugin marketplace add cogni-work/insight-wave
-
-# 3. Install this plugin
-/plugin install cogni-website@insight-wave
-```
-
-### Claude Cowork (short text-only tasks)
-
-Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, Enterprise). For insight-wave, prefer Claude Code desktop — Cowork has two caveats that affect this plugin's workflows:
-
-- **Context window**: Cowork caps context at ~200K tokens; long multi-agent flows trigger mid-session compressions.
-- **Pencil MCP fidelity**: lower visual fidelity in Cowork than in Claude Code desktop.
-
-See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
-
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
+> **Readiness** (Claude Code desktop) — Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
 
 **Prerequisites:**
 - **cogni-portfolio** (required — provides products, features, propositions, markets, solutions)
@@ -86,6 +69,20 @@ Or describe what you want in natural language:
 - "Generate a web presence from our portfolio and marketing content"
 - "Resume the website project"
 
+## Try it
+
+Run `/website-setup` in any Claude Code session where cogni-portfolio is installed. The skill discovers available content sources and walks you through theme selection, company details, and legal jurisdiction in a single interactive session.
+
+## Data model
+
+| File | Location | Purpose |
+|------|----------|---------|
+| `website-project.json` | project root | Configuration: sources, theme, build options, `legal_config` |
+| `website-plan.json` | project root | Page blueprint: specs, slugs, source mappings, `legal_links` |
+| `content/legal/*.md` | project directory | Rendered legal page markdown (from website-legal templates) |
+| `output/design-variables.json` | output directory | Color/font tokens derived from selected theme |
+| `output/website/` | output directory | Deployable static site folder |
+
 ## How it works
 
 **Setup** discovers every content source available in the workspace, validates that a portfolio project exists (hard gate), and produces `website-project.json` — the single configuration file that all downstream skills share. Theme selection and hero renderer choice happen here.
@@ -97,13 +94,6 @@ Or describe what you want in natural language:
 **Preview** validates that every planned page was built and that all internal links resolve, then opens `index.html` in the system browser. A local HTTP server command is provided for full relative-path testing.
 
 **Resume** re-enters any interrupted session, detects phase from file state, checks for source changes since the last build, and routes to the correct next skill automatically.
-
-## What it means for you
-
-- **From portfolio data to live website in one session.** Setup, plan, and build run sequentially with interactive checkpoints — what would take a web team 2-3 days of content migration completes in a single working session.
-- **Always current, never stale.** Resume detects when source files have changed since the last build and regenerates only the affected pages — content updates in cogni-portfolio or cogni-marketing propagate to the website without starting from scratch.
-- **One theme, every page.** A single design-variables.json drives all color, font, and shadow tokens across the entire site — reskinning means updating one file, not editing 10+ HTML pages.
-- **Deploy anywhere without build tooling.** The output is a self-contained static folder with validated internal links — drop onto Netlify, Vercel, or S3 with zero configuration.
 
 ## Components
 
@@ -204,10 +194,6 @@ cogni-website/
 | cogni-trends | No | Trend report with investment themes for an Insights page |
 | cogni-research | No | Research reports as whitepapers for a Resources page |
 | cogni-visual | No | Pencil MCP access for AI-generated hero imagery (indirect — via hero-renderer agent) |
-
-## Contributing
-
-Contributions welcome — page templates, navigation patterns, theme integration, and documentation. See the [insight-wave contribution guide](https://github.com/cogni-work/insight-wave/blob/main/CONTRIBUTING.md) for guidelines.
 
 ## Custom development
 

--- a/cogni-website/README.md
+++ b/cogni-website/README.md
@@ -45,14 +45,13 @@ A static-site generation pipeline purpose-built for the insight-wave ecosystem. 
 
 ## Install
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave). Follow the [install-to-infographic walkthrough](../docs/workflows/install-to-infographic.md) to get Claude Code desktop, the marketplace, and this plugin set up in one pass. For enterprise environments (SSO, GDPR data residency, audit logging) read the [deployment guide](../docs/deployment-guide.md) first.
+Install insight-wave via Claude Code desktop:
 
-> **Readiness** (Claude Code desktop) — Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
 
-**Prerequisites:**
-- **cogni-portfolio** (required — provides products, features, propositions, markets, solutions)
-- **cogni-workspace** (required — provides theme selection and design variables)
-- Optional: **cogni-marketing** (blog posts, articles, landing pages), **cogni-trends** (insights page), **cogni-research** (resources/whitepapers page)
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
 ## Quick start
 

--- a/cogni-wiki/README.md
+++ b/cogni-wiki/README.md
@@ -2,6 +2,8 @@
 
 > **Incubating** (v0.0.4) — skills, data formats, and workflows may change at any time.
 
+> **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
+
 **A better RAG for personal and small-team knowledge work.** Instead of re-discovering the same information every query through embedding similarity, cogni-wiki has Claude compile sources once into a persistent, interlinked markdown wiki — no vector store, no chunking heuristics, no opaque retrieval. Knowledge compounds with every ingest; answers trace to readable markdown files, not vector math. Plain files, plain backlinks, plain Unix tools.
 
 Based on [Andrej Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) and the reference implementation by [kfchou/wiki-skills](https://github.com/kfchou/wiki-skills).
@@ -76,35 +78,15 @@ sources: [../raw/bai-et-al-2022.pdf]
 - **Keep your knowledge portable across any tool, indefinitely.** `SCHEMA.md` ships inside every wiki directory, so the wiki aims to remain fully readable even if cogni-wiki is uninstalled or replaced — plain markdown, plain backlinks, zero lock-in. Open it in Obsidian, VS Code, or `grep` today; hand it off in 5 years.
 - **Keep every wiki page trustworthy.** `wiki-update` shows the diff before modifying any page and requires a source citation for every new claim — zero silent writes across all 7 skills, so the wiki stays citable.
 
-## Installation
+## Install
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
+Install insight-wave via Claude Code desktop:
 
-### Claude Code desktop (recommended for insight-wave)
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
 
-Install Claude Code via the native installer, then register the insight-wave marketplace and install this plugin:
-
-```bash
-# 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
-curl -fsSL https://claude.ai/install.sh | bash
-
-# 2. Register the insight-wave marketplace
-/plugin marketplace add cogni-work/insight-wave
-
-# 3. Install this plugin
-/plugin install cogni-wiki@insight-wave
-```
-
-### Claude Cowork (short text-only tasks)
-
-Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, Enterprise). For insight-wave, prefer Claude Code desktop — Cowork has two caveats that affect this plugin's workflows:
-
-- **Context window**: Cowork caps context at ~200K tokens; long multi-agent flows trigger mid-session compressions.
-- **Pencil MCP fidelity**: lower visual fidelity in Cowork than in Claude Code desktop.
-
-See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
-
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
 > **Note**: Wikis are created under `cogni-wiki/{slug}/` in your current workspace by default, following the standard cogni-plugin convention. Use `--wiki-root` to override the location.
 

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -2,6 +2,8 @@
 
 > **Preview** (v0.x) — core skills defined but may change. Feedback welcome.
 
+> **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
+
 The foundation-layer plugin for the [insight-wave](https://claude.ai/cowork) ecosystem — the only plugin that other cogni-x plugins depend on, and the one that must be initialized first. cogni-workspace owns environment configuration, MCP server installation, theme storage, plugin discovery, workspace health diagnostics, and Obsidian vault integration — so every cogni-x plugin starts running, not configuring.
 
 ## Why this exists
@@ -43,33 +45,13 @@ In the Claude Cowork plugin model, workspace-level state (paths, env vars, insta
 
 ## Install
 
-This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
+Install insight-wave via Claude Code desktop:
 
-### Claude Code desktop (recommended for insight-wave)
+- **5-minute walkthrough** — [From Install to Infographic](../docs/workflows/install-to-infographic.md)
+- **Full setup reference** — [Claude Code desktop](../docs/claude-code-desktop.md)
+- **Enterprise / compliance setup** — [Deployment guide](../docs/deployment-guide.md)
 
-Install Claude Code via the native installer, then register the insight-wave marketplace and install this plugin:
-
-```bash
-# 1. Install Claude Code (macOS — other platforms: https://code.claude.com/docs/en/setup)
-curl -fsSL https://claude.ai/install.sh | bash
-
-# 2. Register the insight-wave marketplace
-/plugin marketplace add cogni-work/insight-wave
-
-# 3. Install this plugin
-/plugin install cogni-workspace@insight-wave
-```
-
-### Claude Cowork (short text-only tasks)
-
-Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, Enterprise). For insight-wave, prefer Claude Code desktop — Cowork has two caveats that affect this plugin's workflows:
-
-- **Context window**: Cowork caps context at ~200K tokens; long multi-agent flows trigger mid-session compressions.
-- **Pencil MCP fidelity**: lower visual fidelity in Cowork than in Claude Code desktop.
-
-See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
-
-> **insight-wave readiness (Claude Code desktop)**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
+This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.md).
 
 ## Quick start
 

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -161,7 +161,7 @@ Contributions welcome — theme templates, platform support, diagnostic checks, 
 
 | ID | Issue | Severity | Affected Skills | Workaround |
 |----|-------|----------|----------------|------------|
-| KI-001 | Chrome native messaging host conflict between Cowork and Claude Code | S2-major | `/manage-themes` (website extraction) | Toggle native host configs by renaming the `.json` file for the unused product and restarting Chrome. See [known-issues registry](https://github.com/anthropics/managed-service/blob/main/cogni-docs/references/known-issues.md) for detailed steps. |
+| KI-001 | Chrome native messaging host conflict between Cowork and Claude Code | S2-major | `/manage-themes` (website extraction) | Toggle native host configs by renaming the `.json` file for the unused product and restarting Chrome. See [Known Issues Registry](../docs/known-issues.md#ki-001) for detailed steps. |
 
 > When both Claude Desktop (Cowork) and Claude Code are installed, their competing native messaging host configurations cause browser automation tools to silently vanish. The `/manage-themes` skill's live website extraction mode falls back to manual theme specification until the conflict is resolved.
 

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -41,7 +41,7 @@ In the Claude Cowork plugin model, workspace-level state (paths, env vars, insta
 - **Catch workspace drift before skills break.** Five-tier health diagnostics (foundation, env vars, plugin registry, themes, dependencies) surface mismatches and missing deps before they cause cryptic runtime failures.
 - **Safe updates with rollback in seconds.** `manage-workspace` backs up before modifying — if an update breaks something, restore the previous state in one command, no manual file recovery.
 
-## Installation
+## Install
 
 This plugin is part of the [insight-wave monorepo](https://github.com/cogni-work/insight-wave) and is installed automatically with the marketplace.
 
@@ -69,13 +69,7 @@ Cowork runs in Claude Desktop and is available on paid plans (Pro, Max, Team, En
 
 See the [consultant install guide](../docs/claude-code-desktop.md) and the [repo-level deployment guide](../docs/deployment-guide.md) for the full path-by-path walkthrough.
 
-> **insight-wave readiness**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
-
-**Prerequisites:**
-- `jq` (required — JSON processing)
-- `python3` (required — stdlib only, no pip)
-- `bash 3.2+` (required)
-- Optional: `curl`, `git`, `bc`
+> **insight-wave readiness (Claude Code desktop)**: Claude Code desktop is the recommended interface for insight-wave today. This guidance will flip when Cowork closes the context-window and Pencil-fidelity gaps.
 
 ## Quick start
 
@@ -174,6 +168,8 @@ cogni-workspace has no required plugin dependencies — it is the foundation lay
 | cogni-visual | No | manage-themes passes color variables to cogni-visual renderers (render-big-picture, render-big-block) |
 | cogni-website | No | Referenced in manage-workspace and workspace-status for website-related workspace configuration |
 | cogni-help | No | Referenced inline in workspace skills for issue filing and guided help |
+| cogni-portfolio | No | install-mcp references cogni-portfolio as a consumer of excalidraw MCP in the installation plan |
+| cogni-claims | No | workspace-status references cogni-claims as a provider plugin for the claude-in-chrome MCP server check |
 
 ## Contributing
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,48 @@
+# Known Issues Registry
+
+> Last updated: 2026-04-17 | 1 open, 0 mitigated, 0 resolved
+
+## Open Issues
+
+<a id="ki-001"></a>
+
+### KI-001: Chrome native messaging host conflict between Cowork and Claude Code (S2-major)
+
+When both Claude Desktop (Cowork) and Claude Code are installed, they register competing native messaging host configurations for the Chrome extension using incompatible socket formats. The Chrome extension connects to one native host and ignores the other, causing 16 of 19 browser automation tools to silently vanish — with no error message surfaced to the user.
+
+**Affected plugins:**
+
+| Plugin | Skills | Feature | Impact |
+|--------|--------|---------|--------|
+| cogni-claims | claims | cobrowse | Browser-based claim source co-browsing unavailable when Claude Code's native host is active — claim verification falls back to web fetch only |
+| cogni-help | cogni-issues | browser-based GitHub issue filing | Cannot file GitHub issues via browser automation — must use gh CLI or manual filing instead |
+| cogni-visual | zone-reviewer | browser-based visual review | Browser-based zone review for rendered visuals may fail silently when tools are missing |
+| cogni-workspace | manage-themes | website theme extraction via browser | Live website theme extraction requires browser automation — falls back to manual theme specification |
+
+**Workaround:** Toggle native messaging host configs by renaming the .json file for the unused product and restarting Chrome.
+
+1. To use Cowork's Chrome integration: rename `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.anthropic.claude_code_browser_extension.json` to `.disabled`
+2. To use Claude Code's Chrome integration: rename `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.anthropic.claude_browser_extension.json` to `.disabled`
+3. Restart Chrome after switching — the extension reconnects to the remaining native host
+4. On Windows: equivalent registry entries under `HKCU\Software\Google\Chrome\NativeMessagingHosts\`
+
+Community shell function `chrome-mcp-toggle` automates the toggle. Trail of Bits published a troubleshooting Agent Skill (`trailofbits/skills/claude-in-chrome-troubleshooting`) for automated diagnosis.
+
+**Related bugs:**
+- Desktop auto-update tool regression: March 2026 update (v1.1.6679 to v1.1.8629) caused toolCount to drop from 19 to 3 on Windows (GitHub #38783, unresolved)
+- Service worker idle disconnection: Chrome extension service worker sleeps during long sessions, severing the connection — reconnect via `/chrome` or restart extension
+- Windows named pipe path omission: Claude Code v2.1.20+ `getSocketPaths()` returns only Unix-style paths, omitting Windows named pipe path (community one-line patch exists)
+- Multiple Chrome installations: Chrome Canary present alongside Chrome causes browser tools to connect to Canary (which lacks the extension) — uninstall Canary to fix
+- MCP tool approval non-persistence: Cowork "Always allow" choices for MCP tools reset at the start of every new session, requiring re-approval each time
+
+**Sources:** `claude-in-chrome-trouble-shoot.md`
+
+---
+
+## Mitigated Issues
+
+*None.*
+
+## Resolved Issues
+
+*None.*


### PR DESCRIPTION
## Summary

Ecosystem-wide documentation sweep covering all 14 plugin READMEs:

- **Install section (Check 10e)**: Replaced pre-v0.16 inlined walkthrough (`curl -fsSL`, `/plugin marketplace add`, Claude Code / Cowork subsections) with the canonical short defer-pointer on every plugin.
- **Readiness callout (Check 14)**: Canonicalized every plugin's `> **insight-wave readiness (Claude Code desktop)**` blockquote between H1 + maturity callout and the first paragraph, sourced from `deploy-data.json`.
- **Known Limitations link fix (Check 11)**: Retargeted 4 READMEs (cogni-claims, cogni-visual, cogni-workspace, cogni-help) from the broken `../../cogni-docs/references/known-issues.md` / external `anthropics/managed-service` URLs to the new canonical `../docs/known-issues.md#ki-001`.
- **Known-issues mirror bootstrap**: Created `docs/known-issues.md` (KI-001 with `<a id="ki-001">` anchor) so the per-plugin Known Limitations links actually resolve.
- **Plugin-specific fixes**: cogni-workspace dependencies (added cogni-portfolio + cogni-claims as optional), cogni-research dependencies (cogni-claims Required: Yes), cogni-portfolio gap-clause canonicalization (Pencil-fidelity → Pencil-MCP fidelity), cogni-consulting architecture method count 14→16.

## Plugins fixed (14/14)

cogni-claims · cogni-consulting · cogni-copywriting · cogni-help · cogni-marketing · cogni-narrative · cogni-portfolio · cogni-research · cogni-sales · cogni-trends · cogni-visual · cogni-website · cogni-wiki · cogni-workspace · plus `docs/known-issues.md` repo-level bootstrap.

## Commits on this branch

- `281ddf7` — initial sweep (section-generator batch across 14 plugins + known-issues.md mirror)
- `c97f1e0` — fixup pass for 8 plugins where the section-generator left residual drift
- `0a5d06c` — reviewer-finding corrections (cogni-copywriting install, cogni-workspace + cogni-help known-issues retargeting, cogni-website stale callout removal, cogni-consulting callout dedup, cogni-narrative `## Installation` → `## Install`)

## Verification

Final grep verification against all 14 READMEs:
- **Install section shape** (10e): 14/14 OK — no `curl`, no `/plugin marketplace add`, no `### Claude Code desktop` / `### Claude Cowork` subsections, no `## Installation` heading, no `../cogni-docs/references` paths
- **Readiness callout** (14): 14/14 OK — exactly one `> **insight-wave readiness (...)** —` canonical blockquote per README, no old `> **insight-wave readiness**:` colon form, no `> **Readiness**` variant
- **Known Limitations links** (11): 4/4 OK — cogni-claims, cogni-visual, cogni-workspace, cogni-help all point at `../docs/known-issues.md#ki-001`

## Deferred (Check 3 description alignment)

4 plugins still have README first-paragraph framing that diverges from `plugin.json` / `marketplace.json` descriptions:

- **cogni-claims** — README frames as "citation-integrity layer for Claude Cowork"; plugin.json frames as generic "Claim verification and management system"
- **cogni-narrative** — plugin.json mentions narrative review scoring + derivative-format adaptation; README first paragraph condenses
- **cogni-marketing** — README says "for Claude Cowork" conflicting with the readiness callout's Claude Code recommendation
- **cogni-research** — README says "for Claude Cowork" (same conflict) and omits the 18-market scope present in plugin.json

These are subjective framing calls. `/cogni-docs:doc-sync <plugin>` would reconcile in either direction. Deferred so the reviewer can choose the authoritative wording per plugin rather than have the automated sweep pick.

## Test plan

- [x] `curl`, `/plugin marketplace add`, `### Claude Code desktop`, `### Claude Cowork`, `## Installation`, `../cogni-docs/references` — all grep-clean across 14 plugin READMEs
- [x] `docs/known-issues.md` exists with `<a id="ki-001">` anchor and the 4 affected plugins link to it
- [x] Exactly 1 canonical readiness callout per README (no duplicates, no old forms)
- [ ] Browse one rendered plugin README on github.com and confirm maturity callout + readiness callout both sit between H1 and first paragraph
- [ ] Confirm `git diff --stat` touches only plugin READMEs and `docs/known-issues.md` (no unrelated files)
- [ ] Decide on Check 3 description-alignment deferrals listed above

## Open questions

None from the automated sweep. The Check 3 deferrals above are the only remaining items — documented as a conscious deferral, not an unresolved question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review notes (from automated docs-reviewer run against 281ddf7 + c97f1e0)

The reviewer flagged 4 major + 2 minor findings against the second commit. All 6 have been addressed in the third commit (`0a5d06c`):

- ✅ cogni-copywriting Install section — replaced legacy `../cogni-docs/references/Claude%20Code%20desktop.md` link with the canonical three-bullet defer-pointer
- ✅ cogni-workspace Known Limitations — retargeted from external broken URL to `../docs/known-issues.md#ki-001`
- ✅ cogni-help Known Limitations — same retargeting
- ✅ cogni-website — removed the stale `> **Readiness** (Claude Code desktop)` inline callout from the Install section (the canonical H1-position callout remains)
- ✅ cogni-consulting — removed the duplicate readiness callout from inside the Install section (the canonical H1-position callout remains)
- ✅ cogni-narrative — renamed `## Installation` → `## Install` and converted to the three-bullet defer-pointer to match ecosystem-wide convention

Re-verification is post-commit-3 grep only (not a second docs-reviewer dispatch) — reviewer guidance was mechanical and the fixes are deterministic.
