### PR TITLE
docs: drop Cowork-specific framing from 3 plugin pitches

### DIFF
--- a/cogni-claims/README.md
+++ b/cogni-claims/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-cogni-claims is the citation-integrity layer for [Claude Cowork](https://claude.ai/cowork) — a systematic verification workflow that detects when sourced claims misrepresent, overstate, or contradict what their cited sources actually say.
+cogni-claims is the citation-integrity layer for the insight-wave ecosystem — a systematic verification workflow that detects when sourced claims misrepresent, overstate, or contradict what their cited sources actually say.
 
 ## Why this exists
 

--- a/cogni-marketing/README.md
+++ b/cogni-marketing/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-B2B marketing content engine for [Claude Cowork](https://claude.ai/cowork). Bridges cogni-trends strategic themes and cogni-portfolio propositions into channel-ready content. Supports thought leadership, demand generation, lead generation, sales enablement, and ABM across markets with configurable brand voice. Bilingual DE/EN.
+B2B marketing content engine for the insight-wave ecosystem. Bridges cogni-trends strategic themes and cogni-portfolio propositions into channel-ready content. Supports thought leadership, demand generation, lead generation, sales enablement, and ABM across markets with configurable brand voice. Bilingual DE/EN.
 
 ## Why this exists
 

--- a/cogni-research/README.md
+++ b/cogni-research/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-Multi-agent research report generator for [Claude Cowork](https://claude.ai/cowork). STORM-inspired editorial workflow with parallel section research and claims-verified review loops. Five report types (basic, detailed, deep, outline, resource) and four source modes (web, local documents, wiki, hybrid) — from quick overviews to deep recursive explorations. Research runs localized across 18 European and Anglo markets (DACH, DE, AT, FR, IT, ES, NL, PL, CZ, SK, HU, RO, HR, GR, MK, UK, US, EU) with intent-based bilingual search and per-market authority sources.
+Multi-agent research report generator for the insight-wave ecosystem. STORM-inspired editorial workflow with parallel section research and claims-verified review loops. Five report types (basic, detailed, deep, outline, resource) and four source modes (web, local documents, wiki, hybrid) — from quick overviews to deep recursive explorations. Research runs localized across 18 European and Anglo markets (DACH, DE, AT, FR, IT, ES, NL, PL, CZ, SK, HU, RO, HR, GR, MK, UK, US, EU) with intent-based bilingual search and per-market authority sources.
 
 ## Why this exists
 


### PR DESCRIPTION
## Summary

Resolves the 3 Check 3 description-alignment deferrals from PR #58. Each plugin's first-paragraph pitch was retargeted from "for [Claude Cowork]" to "for the insight-wave ecosystem" so it no longer contradicts the canonical readiness callout sitting three lines above it (which recommends Claude Code desktop, not Cowork).

## Plugins touched

- **cogni-claims** — "citation-integrity layer for Claude Cowork" → "citation-integrity layer for the insight-wave ecosystem"
- **cogni-marketing** — "B2B marketing content engine for Claude Cowork" → "... for the insight-wave ecosystem"
- **cogni-research** — "Multi-agent research report generator for Claude Cowork" → "... for the insight-wave ecosystem"

These plugins are not Cowork-specific — they run in Claude Code desktop just as well, and the canonical readiness callout in their own READMEs explicitly recommends Claude Code desktop.

## Verification

`Cowork-framed=False` on all three first paragraphs after the edit. No other sections touched; diff is 3 lines across 3 files.

## Test plan

- [x] Check 3 framing contradiction resolved (grep verified)
- [ ] Spot-check one rendered README on github.com to confirm the first paragraph still reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
