### PR TITLE
docs: narrow claude-code-desktop + thin root README Install (v0.17.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,50 +156,15 @@ Your pipeline needs more content, but the budget doesn't cover additional headco
 
 For CMS integration and managed content operations: [cogni-work.ai](https://cogni-work.ai)
 
-## Prerequisites
+## Install
 
-### Getting started
+Install insight-wave via Claude Code desktop — about 15 minutes from zero:
 
-Choose the path that fits your role:
+- **Walkthrough** — [From Install to Infographic](docs/workflows/install-to-infographic.md) — adds the marketplace, installs plugins, runs `/install-mcp`, renders your first infographic.
+- **Claude Code desktop install** — [Claude Code desktop guide](docs/claude-code-desktop.md) — macOS, Windows, authentication, troubleshooting.
+- **Enterprise deployment** — [Deployment Guide](docs/deployment-guide.md) — GDPR, SSO, managed settings, MDM / Group Policy.
 
-#### Standard path: Claude Desktop / Cowork
-
-For consultants, sales teams, and marketing teams who want to use plugins through a visual interface:
-
-- [Download Claude Desktop](https://claude.ai/download) (macOS, Windows)
-- [Get started with Cowork](https://support.claude.com/en/articles/13345190-get-started-with-cowork) — collaborative working sessions with local file access
-- [Set up MCP servers in Desktop](https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop) — connect plugins to external tools
-- Course: [Introduction to Claude Cowork](https://anthropic.skilljar.com/introduction-to-claude-cowork)
-
-#### Specialist path: Claude Code
-
-For developers and power users who want CLI access, IDE integration, and full plugin control:
-
-- [Claude Code setup](https://docs.anthropic.com/en/docs/claude-code/setup) (CLI, VS Code, JetBrains)
-- [MCP in Claude Code](https://docs.anthropic.com/en/docs/claude-code/mcp) — configure MCP servers for extended capabilities
-- [Discover and install plugins](https://code.claude.com/docs/en/discover-plugins) — browse and install marketplace plugins
-- Course: [Introduction to Agent Skills](https://anthropic.skilljar.com/introduction-to-agent-skills)
-- Course: [Introduction to Subagents](https://anthropic.skilljar.com/introduction-to-subagents)
-
-### Quick install
-
-The insight-wave marketplace lives at [`cogni-work/insight-wave`](https://github.com/cogni-work/insight-wave):
-
-```
-/plugin marketplace add cogni-work/insight-wave
-```
-
-For the full walkthrough, see [Getting Started](docs/workflows/install-to-infographic.md).
-
-### Core requirements
-
-Both paths require:
-
-- Terminal access (macOS, Linux, or WSL)
-- `bash` 3.2+, `python3` (stdlib only), `jq`
-- Optional: [Obsidian](https://obsidian.md/) for browsable knowledge management
-
-### MCP servers
+### MCP servers at a glance
 
 Some plugins extend their capabilities through external [MCP servers](https://docs.anthropic.com/en/docs/build-with-claude/mcp). Plugins declare their MCP dependencies in `.mcp.json` files — Desktop/Cowork auto-discovers and starts required servers on install.
 
@@ -211,59 +176,11 @@ Some plugins extend their capabilities through external [MCP servers](https://do
 
 Plugins that don't use MCP servers work without them — only install what you need.
 
-### Security & compliance
-
-- **API keys**: Created exclusively through the Claude Console, scoped to Organizations with workspace-level isolation. Rotate regularly and audit via the Admin API.
-- **Data residency**: The direct Anthropic API offers global and US inference geographies. For guaranteed EU data residency, use AWS Bedrock (Frankfurt) or Google Vertex AI (Frankfurt, Zurich).
-- **Enterprise SSO**: Enterprise plan includes SSO with domain capture and SCIM provisioning, one Identity Provider per parent organization.
-
-For the full deployment guide including GDPR compliance, data handling policies, and operations best practices, see [Deployment Guide](docs/deployment-guide.md).
-
 ### Learn more
 
-- [Getting started guide](docs/workflows/install-to-infographic.md) — install, workspace, first infographic (~15 minutes)
-- [Ecosystem overview](docs/ecosystem-overview.md) — plugin landscape and data flow
-- [Plugin anatomy](docs/architecture/plugin-anatomy.md) — how plugins are structured
 - [MCP overview](https://docs.anthropic.com/en/docs/build-with-claude/mcp) — what Model Context Protocol is and how it works
 - [MCP course](https://anthropic.skilljar.com/introduction-to-model-context-protocol) — hands-on introduction to building and using MCP servers
 - [Build an MCP server](https://modelcontextprotocol.io/docs/develop/build-server) — official MCP development docs
-
-## Quick start
-
-### 1. Add the marketplace
-
-```shell
-/plugin marketplace add cogni-work/insight-wave
-```
-
-### 2. Install plugins
-
-```shell
-/plugin install cogni-workspace@insight-wave    # install first — foundation layer
-/plugin install cogni-research@insight-wave
-/plugin install cogni-trends@insight-wave
-/plugin install cogni-portfolio@insight-wave
-/plugin install cogni-narrative@insight-wave
-/plugin install cogni-copywriting@insight-wave
-/plugin install cogni-sales@insight-wave
-/plugin install cogni-marketing@insight-wave
-/plugin install cogni-visual@insight-wave
-/plugin install cogni-claims@insight-wave
-/plugin install cogni-consulting@insight-wave
-/plugin install cogni-website@insight-wave
-/plugin install cogni-wiki@insight-wave
-/plugin install cogni-help@insight-wave
-```
-
-Or browse interactively with `/plugin` and go to the **Discover** tab.
-
-### 3. Initialize your workspace
-
-```
-/manage-workspace
-```
-
-This runs dependency checks, discovers installed plugins, gathers your preferences, and generates shared settings. See the [getting started guide](docs/workflows/install-to-infographic.md) for the full walkthrough.
 
 ## How it works
 

--- a/docs/claude-code-desktop.md
+++ b/docs/claude-code-desktop.md
@@ -1,6 +1,14 @@
+<!--
+Narrowed to platform install + authentication + verification + troubleshooting
+only. Plugin ecosystem lives in docs/workflows/install-to-infographic.md.
+Low-level MCP server setup lives in docs/deployment-guide.md. Do not re-inflate
+without re-consolidation — see Install Surfaces Policy in
+cogni-docs/skills/doc-hub/references/doc-templates.md.
+-->
+
 # Claude Code desktop installation guide for consultants
 
-This guide gets you from zero to a working Claude Code setup — authenticated with your Claude Max subscription, connected to the cogni-work plugin marketplace, and wired to the MCP servers you need for client work. It covers **macOS 13+** and **Windows 10 (1809+) / 11**, uses Anthropic's **native installer** (now the recommended path as of April 2026), and flags the exact places where Mac and Windows steps diverge. Expect about **20–30 minutes** for a first-time setup.
+This guide gets you from zero to a working **Claude Code** setup — authenticated with your Claude Max subscription and ready to install the insight-wave plugin suite. It covers **macOS 13+** and **Windows 10 (1809+) / 11**, uses Anthropic's **native installer** (recommended as of April 2026), and flags the exact places where Mac and Windows steps diverge. Expect about **15 minutes** for a first-time setup; then jump to [From Install to Infographic](workflows/install-to-infographic.md) to add the insight-wave marketplace.
 
 A note on what changed in 2026: Anthropic replaced the old npm-based installer with a one-line native installer that auto-updates in the background. **Windows no longer requires WSL2** — native Windows works fine as long as Git for Windows is installed. If you followed an older guide, the instructions below supersede it.
 
@@ -76,7 +84,7 @@ brew install --cask claude-code
 
 The built-in **Terminal.app** works fine. Most consultants prefer one of:
 
-- **iTeam2** (`brew install --cask iterm2`) — mature, scriptable, great for split panes.
+- **iTerm2** (`brew install --cask iterm2`) — mature, scriptable, great for split panes.
 - **Warp** (`brew install --cask warp`) — modern UI, AI features, block-based command history.
 
 Any of the three works with Claude Code. Pick one and stick with it.
@@ -201,231 +209,39 @@ Anthropic doesn't publish hard message counts — limits are framed as multiplie
 
 ---
 
-## Part 4 — Set up the plugin ecosystem
+## Part 4 — Verify your install
 
-Plugins extend Claude Code with commands, sub-agents, skills, and bundled MCP servers. Anthropic's **official marketplace is pre-registered** — you get it for free. For the cogni-work plugins (your firm's custom toolkit), you need to add that marketplace manually.
-
-### Step 4.1: Understand the two-step model
-
-Claude Code separates **marketplaces** (catalogs that point to plugins) from **plugins** (the actual tools you install). You add a marketplace once, then install specific plugins from it.
-
-### Step 4.2: Add the cogni-work marketplace
-
-Inside Claude Code, run:
-
-```
-/plugin marketplace add <your-cogni-work-repo>
-```
-
-The `<your-cogni-work-repo>` value is whatever your firm distributes — typically a GitHub shorthand like `your-org/cogni-work-plugins`, a full HTTPS URL, or a local path. Examples of valid formats:
-
-```
-/plugin marketplace add your-org/cogni-work-plugins
-/plugin marketplace add https://github.com/your-org/cogni-work-plugins.git
-/plugin marketplace add git@github.com:your-org/cogni-work-plugins.git#v1.2.0
-/plugin marketplace add ./cogni-work-plugins
-```
-
-Your firm's internal setup instructions specify the exact value — use what they provide verbatim.
-
-Verify the add worked:
-
-```
-/plugin marketplace list
-```
-
-You should see `cogni-work` (or whatever name the marketplace declares) alongside the auto-registered `claude-plugins-official`.
-
-### Step 4.3: Install the cogni plugins
-
-Install plugins one at a time with the `name@marketplace` syntax. Assuming the marketplace name is `cogni-work`:
-
-```
-/plugin install cogni-portfolio@cogni-work
-/plugin install cogni-narrative@cogni-work
-/plugin install cogni-sales@cogni-work
-/plugin install cogni-claims@cogni-work
-/plugin install cogni-tips@cogni-work
-/plugin install cogni-diamond@cogni-work
-```
-
-By default these install at **user scope** — available in every project on your machine. If you want a plugin scoped to just one client project (useful for `cogni-claims` on a litigation engagement, for example), `cd` into that project first and run:
-
-```
-/plugin install cogni-claims@cogni-work --scope project
-```
-
-Project scope writes to `.claude/settings.json` in the repo so your team gets the same plugin when they clone it.
-
-### Step 4.4: Verify plugins loaded
-
-Open the plugin panel:
-
-```
-/plugin
-```
-
-You'll see four tabs (**Discover**, **Installed**, **Marketplaces**, **Errors**). Check **Installed** — all six cogni plugins should be listed with green status. If any show in **Errors**, note the message and see [troubleshooting](#plugin-marketplace-or-plugin-errors).
-
-Each plugin's commands are namespaced by plugin name. For example, `cogni-portfolio` might expose `/cogni-portfolio:summarize`, which you can tab-complete at the Claude Code prompt.
-
-### Step 4.5: Managing plugins over time
-
-Common commands you'll use later:
-
-- `/plugin marketplace update cogni-work` — pull the latest catalog from your firm
-- `/plugin update cogni-portfolio@cogni-work` — update one plugin
-- `/plugin disable cogni-claims@cogni-work` — temporarily turn off a plugin
-- `/plugin uninstall cogni-tips@cogni-work` — remove a plugin
-
-Plugin files live in `~/.claude/plugins/cache/`. Persistent per-plugin data (notes, tokens, local state) lives in `~/.claude/plugins/data/<plugin-id>/` and survives updates.
-
----
-
-## Part 5 — Configure MCP servers for consulting work
-
-MCP (Model Context Protocol) servers let Claude Code read and write to external systems — your filesystem, Google Drive, Gmail, Microsoft 365, and drawing tools. Each server is a small adapter process that Claude Code launches when needed.
-
-### Step 5.1: Where MCP config lives
-
-Two places matter:
-
-- **Project-scoped `.mcp.json`** — a JSON file at the root of a client project folder, checked into git so teammates share the same servers. This is the right place for client-specific connections.
-- **User-scoped** (stored in `~/.claude.json` on all platforms) — servers available across every project on your machine. Good for personal tools like your own Google Drive.
-
-You add servers either interactively via the `/mcp` command inside Claude Code, or from the shell via `claude mcp add`.
-
-### Step 5.2: Add the Filesystem server (start here)
-
-The **Filesystem** server is the official Anthropic reference MCP — it lets Claude Code read and edit files in specific directories you authorize. Recommended for every consultant.
-
-**macOS / Linux:**
-
-```bash
-claude mcp add filesystem --scope user -- npx -y @modelcontextprotocol/server-filesystem "$HOME/Documents" "$HOME/Desktop"
-```
-
-**Windows (PowerShell):** use a `cmd /c` wrapper because npx on Windows needs it:
-
-```powershell
-claude mcp add filesystem --scope user -- cmd /c npx -y "@modelcontextprotocol/server-filesystem" "$env:USERPROFILE\Documents" "$env:USERPROFILE\Desktop"
-```
-
-Replace the paths with any directories you want Claude Code to access. **The server will only touch these directories** — everything else on your disk is off-limits.
-
-### Step 5.3: Add Google Drive and Gmail
-
-Google connections require a one-time OAuth setup. In Google Cloud Console ([console.cloud.google.com](https://console.cloud.google.com)):
-
-1. Create a project (or use an existing one).
-2. Enable the **Google Drive API** and **Gmail API** under "APIs & Services."
-3. Under "OAuth consent screen," configure the app (internal if your firm uses Google Workspace).
-4. Under "Credentials," create an **OAuth client ID** of type **Desktop app**, download the JSON as `gcp-oauth.keys.json`.
-
-**Important context:** Anthropic's own Google Drive MCP reference server has been archived — maintained community forks are the current best option. For Gmail, there is no Anthropic-built server; most consultants use the `@gongrzhe/server-gmail-autoauth-mcp` community package. Both require your `gcp-oauth.keys.json`. Follow the installation instructions on the specific repo you choose and register the result with:
-
-```bash
-claude mcp add gmail --scope user -- npx -y @gongrzhe/server-gmail-autoauth-mcp
-```
-
-Tokens are stored in `~/.gmail-mcp/`. **Never commit these files to git.**
-
-### Step 5.4: Add Microsoft 365 (Outlook, OneDrive, Teams)
-
-The most capable community server is **Softeria's MS 365 MCP**, which uses Microsoft Graph to reach Outlook mail/calendar, OneDrive, SharePoint, and Teams. Register an app in **Entra ID → App Registrations** to get a client ID and tenant ID.
-
-**macOS:**
-
-```bash
-claude mcp add ms365 --scope user -- npx -y @softeria/ms-365-mcp-server --org-mode
-```
-
-**Windows:**
-
-```powershell
-claude mcp add ms365 --scope user -- cmd /c npx -y "@softeria/ms-365-mcp-server" --org-mode
-```
-
-First-time login (once only):
-
-```bash
-npx @softeria/ms-365-mcp-server --login
-```
-
-This opens a device-code flow in your browser. If your firm has Microsoft 365 Copilot licensing, ask IT about Microsoft's pre-certified **Work IQ MCP servers** — those are the "official Microsoft" path but require enterprise setup through Microsoft's Agent 365 control plane.
-
-### Step 5.5: Add Excalidraw for diagrams
-
-Excalidraw is useful for whiteboard-style diagrams during strategy work. The community-maintained `yctimlin/mcp_excalidraw` offers a full canvas and works on both platforms via Docker:
-
-```bash
-docker run -d -p 3000:3000 --name mcp-excalidraw-canvas ghcr.io/yctimlin/mcp_excalidraw-canvas:latest
-
-claude mcp add excalidraw --scope user -- docker run -i --rm -e EXPRESS_SERVER_URL=http://host.docker.internal:3000 -e ENABLE_CANVAS_SYNC=true ghcr.io/yctimlin/mcp_excalidraw:latest
-```
-
-If you prefer not to run Docker, the Excalidraw team has blessed `excalidraw/excalidraw-mcp` as an official alternative — check that repo for a simpler stdio-based install.
-
-### Step 5.6: Example project-scoped `.mcp.json`
-
-For a client engagement folder, create a `.mcp.json` at the project root so every teammate who clones the repo gets the same servers. A practical template:
-
-```json
-{
-  "mcpServers": {
-    "client-files": {
-      "command": "npx",
-      "args": [
-        "-y", "@modelcontextprotocol/server-filesystem",
-        "./deliverables", "./research"
-      ]
-    },
-    "drive": {
-      "command": "npx",
-      "args": ["-y", "@gongrzhe/server-gmail-autoauth-mcp"]
-    }
-  }
-}
-```
-
-When Claude Code opens a project with a `.mcp.json`, it prompts you to trust the file before launching any servers — review it first, especially for repos shared across the firm.
-
-### Step 5.7: Verify MCP servers connected
-
-Inside Claude Code:
-
-```
-/mcp
-```
-
-You'll see each server listed with its connection status. Green = connected and tools available. Red = failed to start (check `claude doctor` for diagnostics). For servers that need OAuth (most Google and Microsoft ones), the panel offers an "Authenticate" action that walks you through the browser flow.
-
----
-
-## Part 6 — First-run verification
-
-Run this sequence to confirm every layer works before you start real client work.
-
-**Check the install:**
+Run this short sequence to confirm Claude Code itself is healthy before you layer insight-wave on top.
 
 ```bash
 claude --version
 claude doctor
 ```
 
-`claude doctor` reports your install method, version, ripgrep status, MCP server health, and any config-vs-runtime mismatches. Treat any red flags here before continuing.
+`claude doctor` reports your install method, version, ripgrep status, and any config-vs-runtime mismatches. Treat any red flags here before continuing.
 
-**Check auth:** at the Claude Code prompt, type `/status` and confirm **auth method: subscription** with your correct email.
+Then at the Claude Code prompt, confirm authentication:
 
-**Check plugins:** type `/plugin` and visit the **Installed** tab. All six cogni plugins should be present with no errors.
+```
+/status
+```
 
-**Check MCP servers:** type `/mcp`. Filesystem, Gmail, Drive, MS 365, and Excalidraw should show as connected (after completing each one's OAuth the first time).
+You should see **auth method: subscription** with your correct email. If not, see the [Authentication failures](#authentication-failures) section below.
 
-**Hello world smoke test:** start a fresh Claude Code session in any folder and ask:
+That's it for Claude Code itself. Plugin-level and MCP-level checks live in the insight-wave walkthrough — head there next.
 
-> *List the files in my Documents folder and summarize what types of documents are there.*
+---
 
-If Claude Code uses the filesystem tool to read your directory and returns a sensible summary, **everything is wired up correctly**.
+<a name="plugin-ecosystem"></a>
+<a name="mcp-servers"></a>
+
+## Part 5 — Next: install insight-wave
+
+Your Claude Code is ready. The plugin ecosystem and MCP servers for insight-wave are installed as one walkthrough — don't configure them à la carte.
+
+**Continue here:** [From Install to Infographic](workflows/install-to-infographic.md) — the 15-minute first-run workflow that adds the insight-wave marketplace, installs the plugins you need, runs `/install-mcp` for Pencil + Excalidraw + claude-in-chrome, and renders your first infographic.
+
+Why one walkthrough rather than separate plugin / MCP steps here? insight-wave ships `cogni-workspace` as the foundation layer (it sets up directories, themes, and MCP defaults), and `/install-mcp` handles all three MCP servers at once. Hand-running `claude mcp add` for each server works for generic Claude Code setups but conflicts with the insight-wave pattern. For enterprise-managed MCP configuration (MDM, allow-lists, managed settings), see [Deployment Guide](deployment-guide.md).
 
 ---
 
@@ -448,7 +264,7 @@ After a fresh install, close and reopen your terminal — PATH changes don't app
 
 ### Node version mismatches
 
-You only hit this if you use the deprecated npm install path or run MCP servers that call `node` directly. Check with `node --version` — Claude Code and most MCP servers need **Node 18 or newer**. If you manage Node via `nvm`, MCP subprocesses may not find your Node version because they launch in non-interactive shells. Fix by using absolute paths to `node` in your `.mcp.json`'s `command` field, or install the native Claude Code binary which has zero Node dependency.
+You only hit this if you use the deprecated npm install path or run MCP servers that call `node` directly. Check with `node --version` — Claude Code and most MCP servers need **Node 18 or newer**. Fix by using the native Claude Code binary (zero Node dependency) or by pinning Node via absolute paths in MCP config.
 
 ### Authentication failures
 
@@ -463,12 +279,6 @@ Then `/status` should show subscription auth. If your token genuinely expired, r
 
 On macOS, a locked Keychain can prevent credential storage — `claude doctor` flags this; unlock via Keychain Access.
 
-### Plugin marketplace or plugin errors
-
-- **"Marketplace not found":** verify the repo URL is correct and reachable. For private repos, make sure your git credentials are set up (`git clone` the repo manually first to confirm access).
-- **"Unknown command /plugin":** your Claude Code is too old. Run `claude update` (native install) or reinstall via the one-liner.
-- **Plugin loads but commands don't appear:** run `/reload-plugins`, or restart Claude Code.
-
 ### Windows-specific gotchas
 
 - **Execution policy blocks scripts:** `Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned` (one-time fix).
@@ -482,7 +292,6 @@ On macOS, a locked Keychain can prevent credential storage — `claude doctor` f
   ```
   Reboot after the registry change.
 - **Git line endings mangle scripts:** set `git config --global core.autocrlf true` on Windows and `input` on macOS. Better, commit a `.gitattributes` with `* text=auto eol=lf` so shell scripts stay LF-only.
-- **MCP `npx` servers fail with "Connection closed":** wrap them with `cmd /c`, as shown in the examples above.
 
 ### The universal debug move
 
@@ -492,16 +301,4 @@ When anything is off and you don't know why, run:
 claude doctor
 ```
 
-It reports the install path, version channel, MCP server health, and any environment conflicts. Between `claude doctor` and the `/mcp`, `/plugin`, and `/status` panels, you can self-diagnose the vast majority of setup issues.
-
----
-
-## What's next
-
-You're now running Claude Code with your Max subscription, the full cogni-work plugin suite, and MCP servers reaching into your filesystem, email, drive, and diagrams. Two directions to take from here:
-
-**Go deeper on plugins.** Each cogni plugin has its own command set — run `/plugin` and browse the **Installed** tab to see what each exposes. Tab-completion at the Claude Code prompt reveals commands like `/cogni-portfolio:*` or `/cogni-sales:*`. Your firm's internal docs should cover recommended workflows per plugin.
-
-**Tune MCP per engagement.** For a new client project, create a project-scoped `.mcp.json` at the folder root with only the servers that engagement needs. This keeps context tight and prevents Claude Code from accidentally pulling data from unrelated clients. Commit the file to the project repo so your team shares the same setup.
-
-Bookmark two pages for reference: [code.claude.com/docs](https://code.claude.com/docs/en/setup) for official Claude Code documentation, and your firm's internal cogni-work repo for plugin-specific guidance and marketplace updates.
+It reports the install path, version channel, and any environment conflicts. Between `claude doctor` and the `/status` panel, you can self-diagnose the vast majority of Claude-Code-level setup issues. For plugin or MCP troubleshooting specific to insight-wave, see the troubleshooting table in [From Install to Infographic](workflows/install-to-infographic.md).


### PR DESCRIPTION
## Summary

Regenerates the two root-side install surfaces against the v0.17.0 cogni-docs templates ([managed-service#12](https://github.com/cogni-work/managed-service/pull/12)), completing the "one canonical install path" work that v0.16.0 shipped on the per-plugin side.

Per the Install Surfaces Policy (three canonical docs by role, everything else defers), each surface now has exactly one role:

- **Canonical walkthrough** — `docs/workflows/install-to-infographic.md` (unchanged)
- **Setup deep-dive** — `docs/claude-code-desktop.md` narrowed from 506 → 304 lines
- **Enterprise reference** — `docs/deployment-guide.md` (unchanged)
- **Root `README.md` `## Install`** — narrowed from ~108 lines to ~26 lines

## What changed

### `docs/claude-code-desktop.md` (506 → 304 lines)

Stripped:
- **Part 4 (plugin ecosystem)** — used generic `<your-cogni-work-repo>` placeholders and invented plugins (`cogni-tips`, `cogni-diamond`) that don't exist in the insight-wave marketplace. Plugin install walkthroughs belong in `install-to-infographic.md` only.
- **Part 5 (MCP servers)** — hand-coded `claude mcp add` commands for Filesystem / Gmail / Drive / MS 365 / Excalidraw. These duplicate generic Claude Code docs and conflict with insight-wave's `/install-mcp` flow. Low-level MCP configuration for enterprise deployers lives in `deployment-guide.md`.

Kept:
- Part 1 (macOS install — native installer + Homebrew cask)
- Part 2 (Windows install — native PowerShell + WinGet, WSL2 note, execution-policy fix)
- Part 3 (authentication + Max/Pro comparison)
- Troubleshooting (PATH, Node, auth, Windows gotchas, universal debug)

Added:
- Part 4 (narrower first-run verify — just `claude --version`, `claude doctor`, `/status`)
- Part 5 (handoff block into `install-to-infographic.md`)
- HTML-comment guardrail at the top instructing future `/doc-deploy` overlays not to re-inflate
- Anchor stubs `<a name="plugin-ecosystem"></a>` and `<a name="mcp-servers"></a>` preceding the handoff so pre-v0.17 deep-links continue to resolve

### `README.md` (`## Install` section: ~108 → ~26 lines)

Dropped:
- Two-track Prerequisites (Standard / Specialist paths) — already in `install-to-infographic.md`'s Prerequisites section
- Quick install marketplace-add code block — duplicate
- Core requirements bullets — duplicate
- Security & compliance bullets — already in `deployment-guide.md`
- Full 3-step Quick start walkthrough — Steps 1–3 verbatim from `install-to-infographic.md`

Replaced with:
- Three Install pointer bullets (walkthrough → setup deep-dive → enterprise) per the Install Surfaces Policy
- MCP-at-a-glance table (preserved with real data — the only root-level content not duplicated elsewhere)
- Learn more subsection (MCP-focused)

### Untouched

- All 14 plugin README Install sections — already canonicalized in v0.16.0, defer to the three canonical docs
- `docs/workflows/install-to-infographic.md` — canonical walkthrough, no changes
- `docs/deployment-guide.md` — enterprise reference, no changes
- `docs/getting-started.md` — forwarder stub (7 lines), no changes

## Safety

- **15 inbound links to `claude-code-desktop.md`** checked: all use the file path only, no `#anchor` deep-links. Internal restructure is safe.
- **Anchor stubs preserved** for any external bookmarks that pointed at the stripped Parts 4–5.
- **forwarder-drift.sh clean** — no inbound-link rot on `getting-started.md`.

## Net

-286 lines across 2 files.

## Test plan

- [ ] Visual check: `README.md` Install section (lines 159–184) contains only the 3-bullet pointer + MCP table + Learn more; no `/plugin marketplace add`, no `/plugin install`, no `### Quick start`
- [ ] Visual check: `docs/claude-code-desktop.md` ends at Troubleshooting; no Part 4 plugin ecosystem content; no Part 5 hand-coded `claude mcp add`; handoff block + anchor stubs present
- [ ] Click-through: every bullet in the new Install section resolves to an existing file
- [ ] When cogni-docs v0.17.0 is live in local plugin cache: `/cogni-docs:doc-audit` reports OK on all 14 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)