### PR TITLE
docs: README Install reads as numbered step sequence, walkthrough last

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ For CMS integration and managed content operations: [cogni-work.ai](https://cogn
 
 ## Install
 
-Install insight-wave via Claude Code desktop — about 15 minutes from zero:
+Install insight-wave via Claude Code desktop — about 15 minutes from zero, in this order:
 
-- **Walkthrough** — [From Install to Infographic](docs/workflows/install-to-infographic.md) — adds the marketplace, installs plugins, runs `/install-mcp`, renders your first infographic.
-- **Claude Code desktop install** — [Claude Code desktop guide](docs/claude-code-desktop.md) — macOS, Windows, authentication, troubleshooting.
-- **Enterprise deployment** — [Deployment Guide](docs/deployment-guide.md) — GDPR, SSO, managed settings, MDM / Group Policy.
+1. **Install Claude Code** — [Claude Code desktop guide](docs/claude-code-desktop.md) — macOS, Windows, authentication, troubleshooting. Skip if you already have it.
+2. **Configure for your environment** *(optional, enterprise only)* — [Deployment Guide](docs/deployment-guide.md) — GDPR, SSO, managed settings, MDM / Group Policy. Skip unless your firm mandates managed Claude Code settings before install.
+3. **Install insight-wave and render your first infographic** — [From Install to Infographic](docs/workflows/install-to-infographic.md) — adds the marketplace, installs plugins, runs `/install-mcp`, renders your first infographic. This is the capstone step where you go from installed to producing.
 
 ### MCP servers at a glance
 


### PR DESCRIPTION
## Summary

v0.17.0's Install section was a bullet list in the order walkthrough → deep-dive → enterprise. Reads as a menu, not a sequence, and puts the walkthrough ahead of its Claude Code prerequisite.

Apply the v0.17.1 cogni-docs template (cogni-work/managed-service#TBD) so the README Install section reads as the actual user journey:

1. **Install Claude Code** — prerequisite, skip if already installed
2. **Configure for your environment** *(optional, enterprise only)* — managed settings overlay
3. **Install insight-wave and render your first infographic** — capstone step

## Changes

`README.md` Install section: unordered bullets → numbered list, walkthrough moved to step 3. 4 lines added, 4 lines removed.

## Test plan

- [x] Install section reads top-to-bottom as the actual user journey (Claude Code first, walkthrough last as the "you are now using the product" moment)
- [x] Three links still resolve — no file changes, only ordering and formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)