### PR TITLE
docs: drop 2026 transition note from claude-code-desktop.md

### DIFF
--- a/docs/claude-code-desktop.md
+++ b/docs/claude-code-desktop.md
@@ -8,9 +8,7 @@ cogni-docs/skills/doc-hub/references/doc-templates.md.
 
 # Claude Code desktop installation guide for consultants
 
-This guide gets you from zero to a working **Claude Code** setup — authenticated with your Claude Max subscription and ready to install the insight-wave plugin suite. It covers **macOS 13+** and **Windows 10 (1809+) / 11**, uses Anthropic's **native installer** (recommended as of April 2026), and flags the exact places where Mac and Windows steps diverge. Expect about **15 minutes** for a first-time setup; then jump to [From Install to Infographic](workflows/install-to-infographic.md) to add the insight-wave marketplace.
-
-A note on what changed in 2026: Anthropic replaced the old npm-based installer with a one-line native installer that auto-updates in the background. **Windows no longer requires WSL2** — native Windows works fine as long as Git for Windows is installed. If you followed an older guide, the instructions below supersede it.
+This guide gets you from zero to a working **Claude Code** setup — authenticated with your Claude Max subscription and ready to install the insight-wave plugin suite. It covers **macOS 13+** and **Windows 10 (1809+) / 11**, uses Anthropic's **native installer**, and flags the exact places where Mac and Windows steps diverge. Expect about **15 minutes** for a first-time setup; then jump to [From Install to Infographic](workflows/install-to-infographic.md) to add the insight-wave marketplace.
 
 ---
 


### PR DESCRIPTION
## Summary

Applies cogni-docs v0.17.2 (cogni-work/managed-service#TBD). The "A note on what changed in 2026" callout and "(recommended as of April 2026)" qualifier had no ongoing value for users starting today — the native installer is already covered inline in Step 1.3 / 2.3, and the WSL2 question is handled in Step 2.4.

## Changes

`docs/claude-code-desktop.md` — drop the historical-transition paragraph + age-qualifier in the opening lead. -2 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)