### PR TITLE
cogni-workspace: fix Obsidian Terminal template drift

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -61,7 +61,7 @@
     {
       "name": "cogni-workspace",
       "source": "./cogni-workspace",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "maturity": "preview",
       "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
       "keywords": [

--- a/cogni-workspace/.claude-plugin/plugin.json
+++ b/cogni-workspace/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-workspace",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-workspace/scripts/setup-obsidian.sh
+++ b/cogni-workspace/scripts/setup-obsidian.sh
@@ -216,7 +216,7 @@ install_terminal_plugin() {
 
 update_terminal_profile() {
     local terminal_data_path="${TARGET_OBSIDIAN}/plugins/terminal/data.json"
-    local orchestrator_script="${TARGET_OBSIDIAN}/plugins/terminal/workplace-orchestrator.sh"
+    local orchestrator_script="${TARGET_OBSIDIAN}/plugins/terminal/workspace-orchestrator.sh"
 
     if [[ "$DRY_RUN" == "true" ]]; then
         echo "DRY RUN: Would update paths in terminal profile" >&2

--- a/cogni-workspace/templates/obsidian/plugins/terminal/data.json
+++ b/cogni-workspace/templates/obsidian/plugins/terminal/data.json
@@ -17,7 +17,7 @@
     "workplace": {
       "args": [
         "-c",
-        "export PATH=\"$HOME/bin:$HOME/.local/bin:$HOME/.npm-global/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:$PATH\"; ORCHESTRATOR_SCRIPT=\"{{WORKPLACE_ROOT}}/.obsidian/plugins/terminal/workplace-orchestrator.sh\"; if [ -f \"$ORCHESTRATOR_SCRIPT\" ]; then bash \"$ORCHESTRATOR_SCRIPT\"; else cd {{WORKPLACE_ROOT}} && source .workplace-env.sh 2>/dev/null; exec ${SHELL:-bash}; fi"
+        "export PATH=\"$HOME/bin:$HOME/.local/bin:$HOME/.npm-global/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:$PATH\"; ORCHESTRATOR_SCRIPT=\"{{WORKPLACE_ROOT}}/.obsidian/plugins/terminal/workspace-orchestrator.sh\"; if [ -f \"$ORCHESTRATOR_SCRIPT\" ]; then bash \"$ORCHESTRATOR_SCRIPT\"; else cd {{WORKPLACE_ROOT}} && source .workspace-env.sh 2>/dev/null; exec ${SHELL:-bash}; fi"
       ],
       "executable": "/bin/bash",
       "name": "Workplace (Unix)",
@@ -26,7 +26,7 @@
         "linux": true,
         "win32": false
       },
-      "pythonExecutable": "/usr/bin/python3",
+      "pythonExecutable": "python3",
       "restoreHistory": true,
       "rightClickAction": "copyPaste",
       "successExitCodes": [
@@ -74,7 +74,7 @@
       "args": [
         "bash",
         "-c",
-        "cd '{{WORKPLACE_ROOT_WSL}}' && export PATH=\"$HOME/bin:$HOME/.local/bin:$HOME/.npm-global/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH\" && ORCHESTRATOR_SCRIPT='{{WORKPLACE_ROOT_WSL}}/.obsidian/plugins/terminal/workplace-orchestrator.sh' && if [ -f \"$ORCHESTRATOR_SCRIPT\" ]; then bash \"$ORCHESTRATOR_SCRIPT\"; else source .workplace-env.sh 2>/dev/null; exec bash; fi"
+        "cd '{{WORKPLACE_ROOT_WSL}}' && export PATH=\"$HOME/bin:$HOME/.local/bin:$HOME/.npm-global/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH\" && ORCHESTRATOR_SCRIPT='{{WORKPLACE_ROOT_WSL}}/.obsidian/plugins/terminal/workspace-orchestrator.sh' && if [ -f \"$ORCHESTRATOR_SCRIPT\" ]; then bash \"$ORCHESTRATOR_SCRIPT\"; else source .workspace-env.sh 2>/dev/null; exec bash; fi"
       ],
       "executable": "wsl.exe",
       "name": "Workplace (WSL)",

--- a/cogni-workspace/templates/obsidian/plugins/terminal/workspace-orchestrator.sh
+++ b/cogni-workspace/templates/obsidian/plugins/terminal/workspace-orchestrator.sh
@@ -61,8 +61,8 @@ setup_claude_path() {
 
 select_language() {
     local default_lang="en"
-    if [[ -f "$WORKPLACE_ROOT/.workplace-config.json" ]] && command -v jq &>/dev/null; then
-        default_lang="$(jq -r '.language // "en"' "$WORKPLACE_ROOT/.workplace-config.json" 2>/dev/null || echo "en")"
+    if [[ -f "$WORKPLACE_ROOT/.workspace-config.json" ]] && command -v jq &>/dev/null; then
+        default_lang="$(jq -r '.language // "en"' "$WORKPLACE_ROOT/.workspace-config.json" 2>/dev/null || echo "en")"
     fi
 
     echo -e "${YELLOW}Language:${NC}" >&2
@@ -111,10 +111,10 @@ copy_claude_template() {
 launch_claude() {
     cd "$WORKPLACE_ROOT"
 
-    # Source workplace environment
-    if [[ -f "$WORKPLACE_ROOT/.workplace-env.sh" ]]; then
+    # Source workspace environment
+    if [[ -f "$WORKPLACE_ROOT/.workspace-env.sh" ]]; then
         # shellcheck disable=SC1091
-        source "$WORKPLACE_ROOT/.workplace-env.sh"
+        source "$WORKPLACE_ROOT/.workspace-env.sh"
     fi
 
     echo -e "${GREEN}Launching Claude Code...${NC}"
@@ -129,12 +129,12 @@ launch_claude() {
     echo ""
 
     # Resolve output-style
-    local OUTPUT_STYLE_FILE="$WORKPLACE_ROOT/.claude/output-styles/workplace-${LANGUAGE}.md"
-    local FALLBACK_OUTPUT_STYLE="$WORKPLACE_ROOT/.claude/output-styles/workplace-en.md"
+    local OUTPUT_STYLE_FILE="$WORKPLACE_ROOT/.claude/output-styles/workspace-${LANGUAGE}.md"
+    local FALLBACK_OUTPUT_STYLE="$WORKPLACE_ROOT/.claude/output-styles/workspace-en.md"
 
     if [[ ! -f "$OUTPUT_STYLE_FILE" ]]; then
         if [[ "$LANGUAGE" != "en" ]] && [[ -f "$FALLBACK_OUTPUT_STYLE" ]]; then
-            echo -e "${YELLOW}⚠${NC} workplace-${LANGUAGE}.md not found, using English" >&2
+            echo -e "${YELLOW}⚠${NC} workspace-${LANGUAGE}.md not found, using English" >&2
             LANGUAGE="en"
             OUTPUT_STYLE_FILE="$FALLBACK_OUTPUT_STYLE"
         else
@@ -144,8 +144,8 @@ launch_claude() {
     fi
 
     if [[ -n "$OUTPUT_STYLE_FILE" ]]; then
-        echo -e "${GREEN}Output-style:${NC} workplace-${LANGUAGE}"
-        echo -e "${CYAN}Activate with:${NC} /output-style workplace-${LANGUAGE}"
+        echo -e "${GREEN}Output-style:${NC} workspace-${LANGUAGE}"
+        echo -e "${CYAN}Activate with:${NC} /output-style workspace-${LANGUAGE}"
     fi
     echo ""
 
@@ -171,7 +171,7 @@ main() {
         echo ""
         echo "Starting shell instead..."
         cd "$WORKPLACE_ROOT"
-        [[ -f "$WORKPLACE_ROOT/.workplace-env.sh" ]] && source "$WORKPLACE_ROOT/.workplace-env.sh"
+        [[ -f "$WORKPLACE_ROOT/.workspace-env.sh" ]] && source "$WORKPLACE_ROOT/.workspace-env.sh"
         exec "${SHELL:-bash}"
     fi
 


### PR DESCRIPTION
Closes #64.

## Summary
- Rename `workplace-*` references to `workspace-*` inside the Obsidian Terminal template so it matches what `generate-settings.sh` actually writes (`.workspace-env.sh`, `.workspace-config.json`) and the on-disk output-styles (`workspace-en.md`, `workspace-de.md`).
- Replace the hardcoded `pythonExecutable: /usr/bin/python3` on the darwin profile with PATH-resolved `python3` (Apple Command Line Tools ships Python 3.9.6, which crashes on `from typing import Self`), matching the WSL profile pattern.
- Rename `templates/obsidian/plugins/terminal/workplace-orchestrator.sh` to `workspace-orchestrator.sh` and update the two `data.json` profile references plus `setup-obsidian.sh` line 219 in lockstep so the file lookup keeps working.
- Bump `cogni-workspace` 0.6.5 → 0.6.6 in `plugin.json` and mirror in `marketplace.json` per repo convention.

## Scope decisions
- **In scope:** all three reported symptoms (hardcoded python, prefix drift in orchestrator + data.json, output-style case mismatch which is just a prefix symptom per triage). Filename rename is included so the asset name itself doesn't perpetuate the old `workplace-*` convention.
- **WSL profile python untouched:** `data.json:86` already uses PATH-resolved `python3` and is correct as-is.
- **No SKILL.md / agent / docs changes:** pure template-asset fix, no behavior contract changes for any caller. The orchestrator script's user-visible "Workplace" header/labels are intentionally kept as cosmetic copy — they're not load-bearing identifiers and changing them is a separate UX decision out of scope here.
- **Out of scope:** any wider audit of remaining `workplace-*` strings in shell scripts (e.g., `update-obsidian.sh` usage messages, deprecated profile name lists, profile keys `workplace` / `workplace-wsl`, `WORKPLACE_ROOT` shell variable and `{{WORKPLACE_ROOT}}` template token). Those refer to legacy/deprecated profile concepts or user-visible labels, not the broken file lookups, and a sweep belongs in its own issue if desired.

## Automated review findings (all minor, all resolved or out-of-scope)
- **data.json:29 pythonExecutable wording (resolved)** — PR description reworded above from "drop" to "replace with PATH-resolved \`python3\`" to match the actual diff. Removing the field entirely was considered but not chosen, since Obsidian Terminal's schema tolerates the key and keeping it aligned with the WSL profile pattern (line 86) is the least-surprising fix.
- **data.json:17 profile keys (\`workplace\`, \`workplace-wsl\`, \`defaultProfile\`)** — Deliberately out of scope. Renaming user-visible profile keys would break existing vaults and requires coordinated updates in \`update-obsidian.sh\`'s deprecated-profile cleanup. Candidate for a future 1.0 bump.
- **workspace-orchestrator.sh UI strings and \`WORKPLACE_ROOT\` variable** — Deliberately out of scope. Header comment, \`show_header\` banner, and the \`WORKPLACE_ROOT\` shell variable + \`{{WORKPLACE_ROOT}}\` template tokens (also touched in setup-obsidian.sh:236-237 and update-obsidian.sh:250,277-278) are cosmetic/legacy identifiers, not load-bearing. Belongs in a coordinated rename patch if ever prioritized.

## Test plan
- [ ] Run \`cogni-workspace/scripts/setup-obsidian.sh\` against a clean test directory and confirm \`templates/obsidian/plugins/terminal/data.json\` is copied with correctly substituted paths and that \`workspace-orchestrator.sh\` lands at \`<workspace>/.obsidian/plugins/terminal/\`.
- [ ] Open Obsidian on the test workspace, launch the \`Workplace (Unix)\` terminal profile, and verify it runs through \`setup_claude_path\`, prompts for language, and successfully sources \`.workspace-env.sh\` (no \`.workplace-env.sh\` lookup error) and finds \`workspace-en.md\` / \`workspace-de.md\`.
- [ ] Run on a stock macOS without Homebrew Python and confirm no \`from typing import Self\` crash (i.e. the orchestrator no longer pins to \`/usr/bin/python3\`).
- [ ] \`grep -rn 'workplace-' cogni-workspace/templates cogni-workspace/scripts/setup-obsidian.sh\` returns no functional file/path references (cosmetic "Workplace" UI strings in the orchestrator are acceptable).
- [ ] \`jq . cogni-workspace/.claude-plugin/plugin.json\` and \`jq '.plugins[] | select(.name==\"cogni-workspace\") | .version' .claude-plugin/marketplace.json\` both report \`0.6.6\`.