### PR TITLE
cogni-wiki: re-ingest pilot (2 pages) via real wiki-ingest workflow

### DIFF
--- a/wiki/wiki/index.md
+++ b/wiki/wiki/index.md
@@ -138,7 +138,7 @@ One page per skill across all 14 plugins. Grouped by plugin, alphabetical within
 - [[skill-cogni-portfolio-portfolio-setup]] — Initialize a new cogni-portfolio project with company context and directory structure.
 - [[skill-cogni-portfolio-portfolio-verify]] — Verify web-sourced claims in portfolio entities against their cited sources.
 - [[skill-cogni-portfolio-products]] — Define and manage the top-level product offerings in the portfolio.
-- [[skill-cogni-portfolio-propositions]] — Generate and manage IS/DOES/MEANS (FAB) value propositions per Feature x Market pair.
+- [[skill-cogni-portfolio-propositions]] — IS/DOES/MEANS (FAB) value-messaging engine: turns features into market-specific propositions per Feature × Market pair, with consulting-style critique and four mandatory tests built in.
 - [[skill-cogni-portfolio-solutions]] — Define implementation plans and pricing tiers for propositions to build customer business cases.
 - [[skill-cogni-portfolio-trends-bridge]] — Bidirectional integration between cogni-trends TIPS analysis and cogni-portfolio product portfolio.
 
@@ -206,7 +206,7 @@ One page per agent role across all 14 plugins. Grouped by plugin, alphabetical w
 
 #### cogni-claims
 
-- [[agent-cogni-claims-claim-verifier]] — Verify claims against a single source URL and return deviation analysis as JSON.
+- [[agent-cogni-claims-claim-verifier]] — Single-source verifier: fetch one URL via WebFetch, verify claims against the fetched content, return a strict JSON deviation report.
 - [[agent-cogni-claims-source-inspector]] — Fetch a source URL via claude-in-chrome, locate the relevant passage, and present evidence to the user.
 
 #### cogni-consulting

--- a/wiki/wiki/log.md
+++ b/wiki/wiki/log.md
@@ -56,3 +56,5 @@ Append-only record of every wiki operation. Never rewritten.
 ## [2026-04-17] ingest | phase-5 batch — 76 agent pages generated from agents/*.md frontmatter (one per agent across 13 plugins; cogni-workspace and cogni-wiki have no agents)
 ## [2026-04-17] index | regenerated wiki/index.md from disk — 211 entries grouped by Ecosystem / Architecture / Concepts / Plugins / Workflows / Skills (per plugin) / Agents (per plugin)
 ## [2026-04-17] lint | phase-4+5 sweep — 0 errors, 172 orphan-page warnings (expected for thin entity-leaf pages)
+## [2026-04-18] re-ingest | agent-cogni-claims-claim-verifier — cogni-claims:claim-verifier (agent) [pilot via real wiki-ingest, replaces script-generated stub; 4 backlinks added]
+## [2026-04-18] re-ingest | skill-cogni-portfolio-propositions — cogni-portfolio:propositions (skill) [pilot via real wiki-ingest, replaces script-generated stub; 3 backlinks added across plugin-cogni-portfolio, agent-cogni-portfolio-proposition-generator, agent-cogni-portfolio-proposition-quality-assessor]

--- a/wiki/wiki/pages/agent-cogni-claims-claim-verifier.md
+++ b/wiki/wiki/pages/agent-cogni-claims-claim-verifier.md
@@ -2,18 +2,66 @@
 id: agent-cogni-claims-claim-verifier
 title: "cogni-claims:claim-verifier (agent)"
 type: entity
-tags: [cogni-claims, claims, agent, sonnet]
+tags: [cogni-claims, claims, agent, sonnet, web-fetch]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-18
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/cogni-claims/agents/claim-verifier.md
 status: stable
-related: [plugin-cogni-claims, concept-agent-model-strategy]
+related: [plugin-cogni-claims, concept-agent-model-strategy, concept-claim-lifecycle, concept-claims-propagation, concept-quality-gates, agent-cogni-claims-source-inspector, concept-script-output-format]
 ---
 
-> One of the agents inside [[plugin-cogni-claims]]. Model tier: **sonnet** — see [[concept-agent-model-strategy]].
+> A sonnet-tier verification agent inside [[plugin-cogni-claims]] — see [[concept-agent-model-strategy]] for tier rationale. Pairs with [[agent-cogni-claims-source-inspector]] for the cobrowse-recovery path.
 
-Verify claims against a single source URL and return deviation analysis as JSON.
+The single-source verifier: fetch one URL via WebFetch, verify one or more claims against the fetched content, and return a deviation report as a strict JSON object.
 
-**Source**: agent definition
-([claim-verifier.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/cogni-claims/agents/claim-verifier.md))
+## Key takeaways
+
+- **One URL per dispatch.** Claims are grouped by source URL upstream; each instance of this agent receives one `source_url` and an array of `{id, statement}` claims to check against it. Grouping minimises fetches and is part of why the agent exists separately from the orchestrating skill.
+- **WebFetch is the only automated path.** No browser fallback inside the agent. Any of `403`, timeout, empty body, or paywall-style content (short body with `login`/`subscribe` keywords) routes the claim to status `source_unavailable`. Sources that need browser access are recovered interactively via [[agent-cogni-claims-source-inspector]] / `/claims cobrowse` — see [[plugin-cogni-claims]] for the cobrowse hand-off.
+- **Source content is cached** to `cogni-claims/sources/{url-hash}.json`, where the hash is `shasum -a 256` of the URL truncated to 16 chars. The cached record carries `url`, `fetched_at`, `fetch_method` (`"webfetch"`), `status`, `content`, and `error`.
+- **Five dimensions → five deviation types.** Accuracy → `misquotation`, Inference → `unsupported_conclusion`, Completeness → `selective_omission`, Currency → `data_staleness`, Agreement → `source_contradiction`. Severity is one of `low | medium | high | critical`.
+- **Source silent ≠ source supportive.** A source that does not address the claim's subject matter cannot support a claim about it — this is explicitly recorded as `unsupported_conclusion` at `medium` severity, not silently passed through. This is the load-bearing rule that prevents quiet false-positive verifications.
+- **Conservative bias is the quality stance.** When a comparison is genuinely ambiguous, the agent does not flag — see [[concept-quality-gates]] for the broader "false positives erode trust" principle. Every finding must include a verbatim source excerpt; explanations use hedged language (`appears to`, `suggests`, `may indicate`) rather than definitive assertions.
+- **Strict output contract.** A single JSON object on stdout — no markdown fences, no surrounding prose, no explanation outside the JSON — see [[concept-script-output-format]]. Each result carries `claim_id`, `status`, `source_excerpt`, `deviations[]`, and `verification_notes`.
+
+## Inputs
+
+The agent receives three named parameters in its task prompt:
+
+| Parameter | Purpose |
+|---|---|
+| `working_dir` | Path to the project directory containing `cogni-claims/`; used to locate the sources cache and registry |
+| `source_url` | The single URL to fetch and verify against |
+| `claims` | Array of `{id, statement}` objects to check against this URL |
+
+## Verification process
+
+1. **Fetch source.** WebFetch the URL. On any failure, mark every claim against this source as `source_unavailable` and write the cache file with the failure reason.
+2. **Per claim, locate the relevant passage.** If the source is silent on the claim's subject, record `unsupported_conclusion` (medium) and explain the silence — do not invent supportive context.
+3. **Compare along the five dimensions.** Multiple deviations per claim are recorded, not just the first.
+4. **Assess severity.** `low` (minor imprecision, meaning preserved) → `critical` (complete contradiction or fabrication).
+5. **Extract evidence.** Verbatim 1–3-sentence excerpt from the source for every finding.
+6. **Write explanation.** Hedged, not definitive.
+
+## Status outcomes per claim
+
+- `verified` — comparison found no deviation
+- `deviated` — at least one deviation recorded with evidence
+- `source_unavailable` — fetch failed; recovery via cobrowse is the next step
+
+These flow into [[concept-claim-lifecycle]] as the input to user resolution.
+
+## Pipeline position
+
+This agent is the verifier in the larger [[concept-claims-propagation]] flow: upstream plugins (`cogni-trends`, `cogni-portfolio`, `cogni-research`, `cogni-consulting`) submit claims; the [[plugin-cogni-claims]] orchestrator dispatches one of these agents per unique source URL; deviations surface to the user for resolution; and resolutions cascade back to the originating entities via the entity provenance chain.
+
+## Edge cases the agent handles
+
+- **Very long source** — focus on passages containing claim keywords; do not attempt to read everything.
+- **Different language** — note in `verification_notes`; attempt verification if the language is intelligible.
+- **Vague claim** — set status to `verified` with a note that the claim is too general for precise verification rather than over-flagging.
+
+## Sources
+
+- [`cogni-claims/agents/claim-verifier.md`](https://github.com/cogni-work/insight-wave/blob/main/cogni-claims/agents/claim-verifier.md) — agent definition (frontmatter + system prompt)

--- a/wiki/wiki/pages/agent-cogni-claims-source-inspector.md
+++ b/wiki/wiki/pages/agent-cogni-claims-source-inspector.md
@@ -4,16 +4,16 @@ title: "cogni-claims:source-inspector (agent)"
 type: entity
 tags: [cogni-claims, claims, agent, sonnet]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-18
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/cogni-claims/agents/source-inspector.md
 status: stable
-related: [plugin-cogni-claims, concept-agent-model-strategy]
+related: [plugin-cogni-claims, concept-agent-model-strategy, agent-cogni-claims-claim-verifier]
 ---
 
 > One of the agents inside [[plugin-cogni-claims]]. Model tier: **sonnet** — see [[concept-agent-model-strategy]].
 
-Fetch a source URL via claude-in-chrome, locate the relevant passage, and present evidence to the user.
+Fetch a source URL via claude-in-chrome, locate the relevant passage, and present evidence to the user. Pairs with [[agent-cogni-claims-claim-verifier]] as the cobrowse-recovery path: when WebFetch in claim-verifier fails (paywall, anti-bot, login wall), the claim is parked as `source_unavailable` and this agent picks it up via `/claims cobrowse` so a user can navigate the source interactively.
 
 **Source**: agent definition
 ([source-inspector.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/cogni-claims/agents/source-inspector.md))

--- a/wiki/wiki/pages/agent-cogni-portfolio-proposition-generator.md
+++ b/wiki/wiki/pages/agent-cogni-portfolio-proposition-generator.md
@@ -4,16 +4,16 @@ title: "cogni-portfolio:proposition-generator (agent)"
 type: entity
 tags: [cogni-portfolio, portfolio, agent, inherit]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-18
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/agents/proposition-generator.md
 status: stable
-related: [plugin-cogni-portfolio, concept-agent-model-strategy]
+related: [plugin-cogni-portfolio, concept-agent-model-strategy, skill-cogni-portfolio-propositions]
 ---
 
 > One of the agents inside [[plugin-cogni-portfolio]]. Model tier: **inherit** — see [[concept-agent-model-strategy]].
 
-Generate IS/DOES/MEANS messaging for a single Feature x Market combination.
+Generate IS/DOES/MEANS messaging for a single Feature x Market combination. Dispatched in parallel by [[skill-cogni-portfolio-propositions]] during batch generation — one agent per Feature × Market pair, with the customer profile passed in when `customers/{market-slug}.json` exists for buyer-grounded messaging.
 
 **Source**: agent definition
 ([proposition-generator.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/agents/proposition-generator.md))

--- a/wiki/wiki/pages/agent-cogni-portfolio-proposition-quality-assessor.md
+++ b/wiki/wiki/pages/agent-cogni-portfolio-proposition-quality-assessor.md
@@ -4,16 +4,16 @@ title: "cogni-portfolio:proposition-quality-assessor (agent)"
 type: entity
 tags: [cogni-portfolio, portfolio, agent, haiku]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-18
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/agents/proposition-quality-assessor.md
 status: stable
-related: [plugin-cogni-portfolio, concept-agent-model-strategy]
+related: [plugin-cogni-portfolio, concept-agent-model-strategy, skill-cogni-portfolio-propositions]
 ---
 
 > One of the agents inside [[plugin-cogni-portfolio]]. Model tier: **haiku** — see [[concept-agent-model-strategy]].
 
-Assess DOES/MEANS messaging quality in propositions — works in any language.
+Assess DOES/MEANS messaging quality in propositions — works in any language. Called by [[skill-cogni-portfolio-propositions]]'s post-check across 12 dimensions: 7 for DOES (including the load-bearing **need correctness** that catches provider-lens contamination) and 5 for MEANS (outcome specificity, escalation, quantification, emotional resonance, conciseness). A "fail" verdict blocks downstream flow until the proposition is rewritten.
 
 **Source**: agent definition
 ([proposition-quality-assessor.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/agents/proposition-quality-assessor.md))

--- a/wiki/wiki/pages/concept-claim-lifecycle.md
+++ b/wiki/wiki/pages/concept-claim-lifecycle.md
@@ -4,7 +4,7 @@ title: Claim lifecycle (unverified → verified | deviated → resolved)
 type: concept
 tags: [cogni-claims, claims, lifecycle, verification]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-18
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/docs/architecture/er-diagram.md
 status: stable
@@ -27,7 +27,7 @@ unverified → verified (no deviation found)
 
 ## What happens at each transition
 
-The transitions are owned by `cogni-claims:claims` (verification of unverified) and the resolution dashboard (deviated → resolved). Once resolved, the [[concept-claims-propagation]] cascade fires: the originating entity file is updated, and downstream entities that referenced it get `propagated_at` timestamps so they can be re-checked.
+The unverified → verified/deviated/source_unavailable transition is performed by [[agent-cogni-claims-claim-verifier]] dispatched by `cogni-claims:claims`. Deviated → resolved is a user action through the resolution dashboard. Once resolved, the [[concept-claims-propagation]] cascade fires: the originating entity file is updated, and downstream entities that referenced it get `propagated_at` timestamps so they can be re-checked.
 
 ## Why three states, not two
 

--- a/wiki/wiki/pages/concept-claims-propagation.md
+++ b/wiki/wiki/pages/concept-claims-propagation.md
@@ -4,7 +4,7 @@ title: Claims propagation (auto-log, verify, cascade)
 type: concept
 tags: [cogni-claims, claims, propagation, source-lineage, cogni-research, cogni-portfolio, cogni-trends]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-18
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/CLAUDE.md
   - https://github.com/cogni-work/insight-wave/blob/main/docs/architecture/er-diagram.md
@@ -16,7 +16,7 @@ Claims propagation is the cross-plugin pattern that turns sourced assertions int
 ## The four steps
 
 1. **Auto-log on creation.** Research agents append claim records to `cogni-claims/claims.json` as they generate sourced assertions. Each record carries `entity_ref` provenance (the plugin entity the claim came from), `source_url`, and the asserted text. cogni-portfolio uses `scripts/append-claim.sh` for this; cogni-research's report agents auto-log via the same pattern.
-2. **Verify in cogni-claims.** The `cogni-claims:claims` skill walks unverified claims, fetches the cited source, and detects deviations between the claim text and what the source actually says. Verdicts: verified / deviated / resolved (see [[concept-claim-lifecycle]]).
+2. **Verify in cogni-claims.** The `cogni-claims:claims` skill walks unverified claims, groups them by source URL, and dispatches one [[agent-cogni-claims-claim-verifier]] per URL — that agent does the WebFetch and detects deviations between each claim and what the source actually says. Verdicts: verified / deviated / resolved (see [[concept-claim-lifecycle]]).
 3. **Propagate corrections back.** When a claim is marked deviated and the user resolves it (by accepting a corrected version or removing the assertion), the correction propagates to the originating entity file via the `entity_ref` pointer.
 4. **Cascade staleness downstream.** Entities that depend on the corrected entity get marked stale via `propagated_at` timestamps. Downstream skills (e.g., proposition-generator reading a corrected feature) detect stale dependencies and either refresh or warn.
 

--- a/wiki/wiki/pages/plugin-cogni-claims.md
+++ b/wiki/wiki/pages/plugin-cogni-claims.md
@@ -4,12 +4,12 @@ title: "cogni-claims (plugin)"
 type: entity
 tags: [cogni-claims, plugin, claims, verification, fact-checking]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-18
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/cogni-claims/README.md
   - https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-claims.md
 status: stable
-related: [concept-claims-propagation, concept-claim-lifecycle]
+related: [concept-claims-propagation, concept-claim-lifecycle, agent-cogni-claims-claim-verifier, agent-cogni-claims-source-inspector]
 ---
 
 > **Preview** (v0.10.1) — core skills defined but may change.
@@ -29,7 +29,7 @@ cogni-claims manages the full lifecycle of sourced-claim verification within an 
 
 ## How it works
 
-Implements the [[concept-claim-lifecycle]] (`unverified → verified | deviated → resolved | source_unavailable`). Verification runs one `claim-verifier` agent per unique source URL, fetching pages and checking all claims citing them in one pass. When sources are unreachable, `source-inspector` opens them in the user's browser via `claude-in-chrome` so the user can compare claim to source visually — see [[concept-mcp-server-map]].
+Implements the [[concept-claim-lifecycle]] (`unverified → verified | deviated → resolved | source_unavailable`). Verification runs one [[agent-cogni-claims-claim-verifier]] per unique source URL — WebFetch-only, claims grouped by URL so each fetch covers many claims in one pass. When sources are unreachable, [[agent-cogni-claims-source-inspector]] opens them in the user's browser via `claude-in-chrome` so the user can compare claim to source visually — see [[concept-mcp-server-map]].
 
 ## Integration
 

--- a/wiki/wiki/pages/plugin-cogni-portfolio.md
+++ b/wiki/wiki/pages/plugin-cogni-portfolio.md
@@ -4,12 +4,12 @@ title: "cogni-portfolio (plugin)"
 type: entity
 tags: [cogni-portfolio, plugin, portfolio, propositions, fab, is-does-means, b2b]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-18
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/README.md
   - https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-portfolio.md
 status: stable
-related: [concept-data-model-patterns, concept-quality-gates, concept-trends-portfolio-bridge]
+related: [concept-data-model-patterns, concept-quality-gates, concept-trends-portfolio-bridge, skill-cogni-portfolio-propositions]
 ---
 
 > **Preview** (v0.9.8) — core skills defined but may change.
@@ -22,7 +22,7 @@ cogni-portfolio gives B2B companies a structured way to build market-specific me
 
 ## Core data model
 
-The Feature × Market join is the unit of work — see [[concept-data-model-patterns]]. Propositions, solutions, competitors, and packages all live at this intersection. Slugs follow the double-dash convention (`feature--market`) — see [[concept-slug-based-lookups]].
+The Feature × Market join is the unit of work — see [[concept-data-model-patterns]]. [[skill-cogni-portfolio-propositions|Propositions]], solutions, competitors, and packages all live at this intersection. Slugs follow the double-dash convention (`feature--market`) — see [[concept-slug-based-lookups]].
 
 Eight pluggable industry taxonomies (b2b-ict, b2b-saas, b2b-fintech, b2b-healthtech, b2b-martech, b2b-industrial-tech, b2b-professional-services, b2b-opensource) auto-classify features and markets.
 

--- a/wiki/wiki/pages/skill-cogni-portfolio-propositions.md
+++ b/wiki/wiki/pages/skill-cogni-portfolio-propositions.md
@@ -1,19 +1,87 @@
 ---
 id: skill-cogni-portfolio-propositions
-title: "cogni-portfolio:propositions"
+title: "cogni-portfolio:propositions (skill)"
 type: entity
-tags: [cogni-portfolio, portfolio, fab, skill, propositions]
+tags: [cogni-portfolio, propositions, fab, is-does-means, messaging, b2b, multilingual, skill]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-04-18
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/skills/propositions/SKILL.md
 status: stable
-related: [plugin-cogni-portfolio]
+related: [plugin-cogni-portfolio, concept-quality-gates, concept-multilingual-support, concept-claims-propagation, concept-data-model-patterns, skill-cogni-portfolio-features, skill-cogni-portfolio-markets, skill-cogni-portfolio-customers, skill-cogni-portfolio-solutions, skill-cogni-portfolio-compete, skill-cogni-portfolio-trends-bridge, agent-cogni-portfolio-proposition-generator, agent-cogni-portfolio-proposition-quality-assessor, agent-cogni-portfolio-proposition-review-assessor, agent-cogni-portfolio-proposition-deep-diver, agent-cogni-portfolio-quality-enricher]
 ---
 
-> One of the skills inside [[plugin-cogni-portfolio]].
+> The IS/DOES/MEANS (FAB) value-messaging engine inside [[plugin-cogni-portfolio]] — generates and manages market-specific propositions per Feature × Market pair, with consulting-style critique built in.
 
-Generate and manage IS/DOES/MEANS (FAB) value propositions per Feature x Market pair.
+The skill that turns a portfolio's market-independent features into market-specific value claims that buyers recognize and pay for. It is deliberately **not** a template-filler — the agent takes a position on messaging quality and pushes back on generic copy.
 
-**Source**: `cogni-portfolio:propositions`
-([SKILL.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/skills/propositions/SKILL.md))
+## Key takeaways
+
+- **Consulting stance, not template-fill.** The skill explicitly rejects mechanical generation. It critiques generic DOES statements, calls out market-agnostic claims, demands a position on which 10-15 of the possible 160 Feature × Market pairs actually deserve a proposition, and refuses to generate every pair as noise. "Generating a proposition for every pair creates noise" is a load-bearing rule.
+- **Four entry modes, four response shapes.** explore (conversational, 3-5 questions max, lead with sharp observations) · batch (gated — confirmation required before generating) · single pair (collaborative draft + critique) · review (jump straight to critique, no discovery). The skill warns against collapsing them into the same response.
+- **Pre-generation gate has three checks plus a coverage gate.** Structural validation script → `feature-quality-assessor` (haiku) → `feature-review-assessor` (haiku). Then a customer-profile coverage gate: markets without `customers/{market-slug}.json` produce weaker, inferred-buyer messaging — the user must explicitly opt in to bypass. See [[concept-quality-gates]] for the broader three-layer pattern.
+- **Four mandatory tests per proposition** before it ships:
+  1. **Market-swap** — substituting a different market should break the messaging; if it still works, the DOES is too generic
+  2. **Competitor** — could a direct competitor credibly make this same claim? If yes, the messaging describes the category, not the product
+  3. **"So what?"** — would a CFO approve budget for this MEANS? Aspirational language ("drives transformation") fails this gate
+  4. **Circularity** — IS/DOES/MEANS must each introduce new information, not rephrase the layer above
+- **Strict word-count discipline.** IS 20-35 words, DOES 15-30, MEANS 15-30 — language-agnostic (German compound nouns count as one word). Validated by `scripts/validate-entities.sh`.
+- **JSON schema lives at `propositions/{feature-slug}--{market-slug}.json`** — `feature_slug` + `market_slug` + IS/DOES/MEANS + optional `evidence[]` array. Each evidence item with a `source_url` is auto-logged as a claim via `scripts/append-claim.sh` for downstream verification through [[concept-claims-propagation]].
+- **Three-layer post-check** — `proposition-quality-assessor` (haiku) evaluates 12 dimensions: 7 for DOES (Buyer-centricity, Buyer-perspective correctness, **Need correctness**, Market-specificity, Differentiation, Status-quo contrast, Conciseness) + 5 for MEANS (Outcome specificity, Escalation, Quantification, Emotional resonance, Conciseness); then structural validation; then `proposition-review-assessor` from three perspectives: buyer persona, sales person, product marketer.
+- **Need correctness is the load-bearing dimension** — catches the subtlest failure: propositions that correctly classify the buyer archetype but frame value through the provider's lens (e.g., telling an SME buyer "your consultant delivers better results" when their actual need is "I can do this without a consultant"). Specifically detects provider-lens contamination in consumer-market propositions.
+- **Variants** allow multiple DOES/MEANS angles per proposition (`regulatory-compliance`, `cost-optimization`, etc.). `variants list / add / promote / delete` operations preserve the primary messaging while accumulating angles; TIPS-derived variants flow in via [[skill-cogni-portfolio-trends-bridge]].
+- **Two enrichment paths.** Quick Fix delegates to [[agent-cogni-portfolio-quality-enricher]] for reactive, targeted gap repair (1-2 warn/fail dimensions on overall pass/warn). Deep Dive delegates to [[agent-cogni-portfolio-proposition-deep-diver]] for buyer-language validation, competitive messaging analysis, evidence enrichment, or co-creation — required when `need_correctness` or `buyer_perspective` failed, when 3+ dimensions failed, or when stakeholder-review verdict is "reject".
+- **Multilingual by design.** Both content language (IS/DOES/MEANS text) and communication language (status messages, recommendations, questions) are driven by `portfolio.json`'s `language` field — see [[concept-multilingual-support]]. Word counts apply equally across languages.
+
+## Inputs
+
+The skill reads (silently, before any user-facing question):
+
+| File / Pattern | Purpose |
+|---|---|
+| `portfolio.json` | Company context, language |
+| `features/*.json` | The IS layer source — every feature description becomes a proposition's IS statement |
+| `markets/*.json` | Market segmentation, pain points, regional context |
+| `propositions/*.json` | Existing propositions (coverage and quality state) |
+| `customers/*.json` | Buyer personas with pain points, decision roles, buyer language — the gate for buyer-grounded vs inferred messaging |
+| `competitors/*.json` | Competitive positioning, claims, white-space opportunities |
+| `context/context-index.json` | Strategic intelligence from uploaded documents — `by_relevance["propositions"]` is queried first |
+
+The data-first pattern (read everything, state inferences, ask only about gaps) is enforced — buyer-language questions are not allowed when `customers/{market-slug}.json` exists.
+
+## Outputs
+
+- One `propositions/{feature-slug}--{market-slug}.json` per generated pair (with optional `variants[]` array)
+- Updated `excluded_markets[]` entries on `features/*.json` when the user confirms a skip recommendation (so decisions persist across sessions)
+- Quality-assessor and review-assessor verdicts, presented in summary tables before downstream skills (solutions, compete) can run
+- Auto-logged claims to `cogni-claims/claims.json` for every evidence URL (verifiable via [[concept-claims-propagation]])
+
+## Pipeline position
+
+```
+features ──┐
+markets ───┼──> propositions ──> solutions ──> packages
+customers ─┤        │
+           │        ├──> compete (per proposition)
+           │        ├──> portfolio-verify (claim verification)
+           │        └──> trends-bridge (TIPS variant generation)
+           └──> propositions
+```
+
+Propositions are the messaging foundation for everything downstream — competitor battlecards, customer profiles, pitch decks, proposals — so the gates are conservative on purpose: weak propositions cascade into weak sales materials.
+
+## Related operations
+
+- **Per-pair editing** — read existing JSON, apply user changes, write back; the skill explicitly considers whether an edit reveals a deeper issue across the feature's other propositions
+- **Slug rename** — when a feature or market slug changes, file rename + `scripts/cascade-rename.sh` to update solutions and competitors that reference the old slug
+- **Variant operations** — `list / add / promote / delete` for multi-angle messaging, including TIPS value-chain variants generated via [[skill-cogni-portfolio-trends-bridge]]
+- **Source registry integration** — when an evidence URL is added, it's also registered in `source-registry.json` with `evidence_refs` pointing back to this proposition; staleness warnings surface when the source has changed since last check
+
+## Why the gates matter
+
+The single sharpest line in the SKILL.md captures the philosophy: *"Five minutes of review here saves hours of rework later."* Once propositions ship into solutions and competitors, fixing a weak DOES or a missing evidence gap means cascading the fix through every dependent entity — and through every pitch and proposal already drafted on top.
+
+## Sources
+
+- [`cogni-portfolio/skills/propositions/SKILL.md`](https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/skills/propositions/SKILL.md) — full skill definition (~620 lines)
+- [`cogni-portfolio/skills/propositions/references/quality-dimensions.md`](https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/skills/propositions/references/quality-dimensions.md) — DOES/MEANS quality-dimension definitions used by `proposition-quality-assessor`


### PR DESCRIPTION
Refs #65.

## Summary
- Re-ingests two existing wiki pages via actual `cogni-wiki:wiki-ingest` invocations (not Python script generation): one thin agent page (`agent-cogni-claims-claim-verifier`, ~115-line source) and one multi-mode skill page (`skill-cogni-portfolio-propositions`, ~620-line source).
- Validates the wiki-ingest workflow end-to-end at both content-size boundaries before committing to the full 164-page rebuild.
- Surfaces concrete cogni-wiki UX gaps found during the pilot — see "Findings to file as separate issues" below.

## What ships in this PR
- 2 fully re-ingested pages (real synthesis from sources, hand-crafted takeaways and details, NOT mechanical frontmatter-lift)
- 7 inline backlinks added to 7 existing pages, materially improving the cogni-claims and cogni-portfolio proposition subgraphs
- index.md entries updated with new one-sentence summaries
- log.md appended with two `re-ingest` entries (no rewrites)

| Page | Source size | Backlinks added | Backlink targets |
|---|---|---|---|
| agent-cogni-claims-claim-verifier | ~115 lines | 4 | plugin-cogni-claims, agent-cogni-claims-source-inspector, concept-claims-propagation, concept-claim-lifecycle |
| skill-cogni-portfolio-propositions | ~620 lines | 3 | plugin-cogni-portfolio, agent-cogni-portfolio-proposition-generator, agent-cogni-portfolio-proposition-quality-assessor |

## Scope decisions

**In scope (this PR):**
- Real `wiki-ingest` invocation against the two source files above
- Backlink audits run via `backlink_audit.py`; only high-confidence candidates with natural inline insertion points were applied (not all ~120 raw audit candidates — many were "matched 'agent' or 'sonnet'" noise)
- `wiki/wiki/index.md` and `wiki/wiki/log.md` updated incrementally per ingest

**Deferred to follow-up issue ("Phase 2: complete the wiki-ingest rebuild"):**
- Re-ingesting the remaining ~164 skill+agent pages (89 skills + 75 agents)
- Wiki-lint orphan-count target (<50) — pilot is too small to move the needle (172 → ~165 expected after this PR; the target requires the bulk rebuild)
- Re-bundling `wiki/` → `cogni-workspace/wiki/` via the existing bundle script
- `cogni-wiki` and `cogni-workspace` plugin.json + marketplace.json version bumps
- Spot-check of 5 concept pages for inline `[[skill-X]]` references (acceptance criterion 3)
- `wiki-query` smoke test (acceptance criterion 4)
- Aggregated bug-filing pass: review pilot session notes and file separate issues for any cogni-wiki UX/correctness gaps found beyond the ones below

**Out of scope entirely:**
- Phases 1–3 hand-written pages (45 pages) — those already followed wiki-ingest discipline
- The `ask` skill, bundle script, and bundled distribution copy — kept as-is per reporter
- Any modifications to cogni-wiki plugin source files (no SKILL.md/script changes); bugs surfaced are filed separately, not fixed inline

## Findings to file as separate cogni-wiki issues

The pilot surfaced these concrete UX gaps in the `cogni-wiki:wiki-ingest` skill — each warrants a dedicated issue:

1. **Re-ingest semantics are undefined.** The skill's Step 8 says "Increment `entries_count`", but on a re-ingest of an existing slug the page count does not change. Should the skill detect re-ingest (existing slug) and skip the increment? Should it warn the user? Should there be a separate `wiki-update` path for re-ingests? Currently the user (or orchestrator) has to know to skip the increment manually. **Suggested fix:** skill detects existing slug and either (a) refuses with "use wiki-update" or (b) explicitly handles re-ingest by skipping the increment and using a `re-ingest` log entry type.

2. **The "Never run when source is already summarised" guard is too aggressive for intentional rebuilds.** It forces the orchestrator to delete the existing page first, then invoke the skill, then conceptually replace it. A `--force` or `--rebuild` flag would let the user explicitly opt into overwriting (the equivalent of "I know what I'm doing, this is a re-ingest").

3. **Backlink audit returns too many low-signal candidates.** For the claim-verifier page, 121 candidates were returned; only ~7 were high-value enough to act on. The audit script matches on tags like `agent` and `sonnet` which are too broad. **Suggested fix:** weight tag matches by tag specificity (rare tags score higher than common ones), and/or surface a "top N by confidence" mode that filters before returning.

4. **Index.md update is the orchestrator's responsibility, not the skill's.** Step 5 says "Read `wiki/index.md` ... insert the line" — but the skill has no enforcement that the line was actually inserted, that alphabetization was preserved, or that re-ingests update the existing line rather than duplicating it. **Suggested fix:** skill could provide a `wiki-index-update` helper script that the orchestrator calls deterministically.

5. **`updated:` frontmatter bumps on backlinked pages are easy to forget.** The skill text says backlinked pages should have `updated:` bumped to today, but no tooling enforces it. **Suggested fix:** the backlink-audit script (or a separate post-processor) could read the JSON output, apply backlinks, and bump frontmatter atomically.

## Test plan
- [ ] `head -25 wiki/wiki/pages/agent-cogni-claims-claim-verifier.md` — confirms YAML frontmatter has the new sources, related[] array, and `updated: 2026-04-18`
- [ ] `head -25 wiki/wiki/pages/skill-cogni-portfolio-propositions.md` — same, confirms larger related[] array reflecting more touched concepts
- [ ] `grep -c '\[\[' wiki/wiki/pages/agent-cogni-claims-claim-verifier.md` — should be 10+ inline wikilinks (vs ~3 in the script-generated stub)
- [ ] `grep -c '\[\[' wiki/wiki/pages/skill-cogni-portfolio-propositions.md` — should be 15+ inline wikilinks
- [ ] `grep '\[\[agent-cogni-claims-claim-verifier\]\]' wiki/wiki/pages/concept-claims-propagation.md wiki/wiki/pages/concept-claim-lifecycle.md wiki/wiki/pages/plugin-cogni-claims.md wiki/wiki/pages/agent-cogni-claims-source-inspector.md` — should return 4 hits, one per backlinked page
- [ ] `grep '\[\[skill-cogni-portfolio-propositions' wiki/wiki/pages/plugin-cogni-portfolio.md wiki/wiki/pages/agent-cogni-portfolio-proposition-generator.md wiki/wiki/pages/agent-cogni-portfolio-proposition-quality-assessor.md` — should return 3 hits
- [ ] `tail -2 wiki/wiki/log.md` — should show two `[2026-04-18] re-ingest |` lines, no rewrites of existing log lines
- [ ] `jq '.entries_count' wiki/.cogni-wiki/config.json` — should still be 211 (re-ingests are not new pages)
- [ ] Spot-check the new claim-verifier page renders well in any markdown viewer — particularly the wikilink-heavy "Pipeline position" and "Key takeaways" sections

## Open questions

None blocking — Phase 2 follow-up issue should incorporate the 5 cogni-wiki findings above as either prerequisites (1, 2) or parallel improvements (3, 4, 5) before committing to the bulk 164-page run.
