### PR TITLE
cogni-trends: close region-catalog drift residue + add cross-plugin drift checker

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -61,7 +61,7 @@
     {
       "name": "cogni-workspace",
       "source": "./cogni-workspace",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "maturity": "preview",
       "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -61,7 +61,7 @@
     {
       "name": "cogni-workspace",
       "source": "./cogni-workspace",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "maturity": "preview",
       "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
       "keywords": [
@@ -76,7 +76,7 @@
     {
       "name": "cogni-trends",
       "source": "./cogni-trends",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "maturity": "preview",
       "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
       "keywords": [

--- a/cogni-trends/.claude-plugin/plugin.json
+++ b/cogni-trends/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-trends",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-trends/skills/trend-report/references/region-authority-sources.json
+++ b/cogni-trends/skills/trend-report/references/region-authority-sources.json
@@ -16,7 +16,8 @@
       { "dimension": "digitale-wertetreiber", "query": "site:handelsblatt.com {SUBSECTOR_LOCAL} Trend Digitalisierung {CURRENT_YEAR}" },
       { "dimension": "digitale-wertetreiber", "query": "site:zvei.org {SUBSECTOR_LOCAL} Innovation Industrie {CURRENT_YEAR}" },
       { "dimension": "digitales-fundament", "query": "site:rolandberger.com {SUBSECTOR_EN} trends Germany {CURRENT_YEAR}" },
-      { "dimension": "digitales-fundament", "query": "site:mckinsey.com {SUBSECTOR_EN} Germany digital {CURRENT_YEAR}" }
+      { "dimension": "digitales-fundament", "query": "site:mckinsey.com {SUBSECTOR_EN} Germany digital {CURRENT_YEAR}" },
+      { "dimension": "digitales-fundament", "query": "site:destatis.de {SUBSECTOR_LOCAL} Statistik {CURRENT_YEAR}" }
     ],
     "regulatory_bodies": ["EUR-Lex (EU)", "BaFin", "Bundesnetzagentur", "BSI"],
     "regulatory_search": "\"EU regulation\" \"{SUBSECTOR_EN}\" compliance deadline {CURRENT_YEAR}",
@@ -370,6 +371,29 @@
     "regulatory_search": "\"EU acquis\" \"{SUBSECTOR_EN}\" compliance \"North Macedonia\" {CURRENT_YEAR}",
     "currency": "MKD",
     "org_size_reference": "mid-size organization with 3B MKD revenue"
+  },
+
+  "eu": {
+    "_note": "Composite EU market — pan-European trends from EU institutions and cross-border industry associations. Use when the trend has explicit EU-wide regulatory or strategic dimension; for country-specific work prefer per-country entries (de, fr, it, pl, nl, es). Mirrors the cogni-research and cogni-portfolio eu entries so the three catalogs agree on the EU composite key.",
+    "region_qualifiers": {
+      "en": "Europe European Union",
+      "local": "Europe European Union"
+    },
+    "local_language": "en",
+    "site_searches": [
+      { "dimension": "externe-effekte", "query": "site:eur-lex.europa.eu {SUBSECTOR_EN} regulation {CURRENT_YEAR}" },
+      { "dimension": "externe-effekte", "query": "site:commission.europa.eu {SUBSECTOR_EN} digital strategy {CURRENT_YEAR}" },
+      { "dimension": "neue-horizonte", "query": "site:esa.int {SUBSECTOR_EN} satellite programme {CURRENT_YEAR}" },
+      { "dimension": "neue-horizonte", "query": "site:enisa.europa.eu {SUBSECTOR_EN} cybersecurity threat {CURRENT_YEAR}" },
+      { "dimension": "digitale-wertetreiber", "query": "site:digitaleurope.org {SUBSECTOR_EN} digital industry {CURRENT_YEAR}" },
+      { "dimension": "digitale-wertetreiber", "query": "site:etno.eu {SUBSECTOR_EN} telecom Europe {CURRENT_YEAR}" },
+      { "dimension": "digitales-fundament", "query": "site:eurostat.ec.europa.eu {SUBSECTOR_EN} statistics Europe {CURRENT_YEAR}" },
+      { "dimension": "digitales-fundament", "query": "site:mckinsey.com {SUBSECTOR_EN} Europe digital {CURRENT_YEAR}" }
+    ],
+    "regulatory_bodies": ["EUR-Lex", "European Commission", "BEREC", "ENISA", "EASA", "EIB"],
+    "regulatory_search": "\"EU regulation\" \"{SUBSECTOR_EN}\" compliance deadline {CURRENT_YEAR}",
+    "currency": "EUR",
+    "org_size_reference": "mid-size organization with €500M revenue"
   },
 
   "_default": {

--- a/cogni-workspace/.claude-plugin/plugin.json
+++ b/cogni-workspace/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-workspace",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-workspace/.claude-plugin/plugin.json
+++ b/cogni-workspace/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-workspace",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-workspace/references/curated-region-sources.json
+++ b/cogni-workspace/references/curated-region-sources.json
@@ -1,0 +1,9 @@
+{
+  "_description": "Curated authority domains per market. Single source of truth synced with CLAUDE.md 'Multilingual European Support' section. Consumed by scripts/check-region-catalogs.sh (currently only DACH is enforced; other markets listed for future drift checks as Stage 3/4 lands).",
+  "dach": ["fraunhofer.de", "bitkom.org", "vdma.org", "destatis.de", "handelsblatt.com"],
+  "fr":   ["inria.fr", "cnes.fr", "arcep.fr", "insee.fr", "lesechos.fr"],
+  "it":   ["cnr.it", "asi.it", "agcom.it", "istat.it", "ilsole24ore.com"],
+  "pl":   ["pan.pl", "polsa.gov.pl", "uke.gov.pl", "stat.gov.pl", "rp.pl"],
+  "nl":   ["tno.nl", "spaceoffice.nl", "acm.nl", "cbs.nl", "fd.nl"],
+  "es":   ["csic.es", "inta.es", "cnmc.es", "ine.es", "expansion.com"]
+}

--- a/cogni-workspace/scripts/check-region-catalogs.sh
+++ b/cogni-workspace/scripts/check-region-catalogs.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# check-region-catalogs.sh — Cross-plugin drift checker for the three region catalogs.
+#
+# Verifies that the region/market keys are consistent across:
+#   - cogni-portfolio/skills/portfolio-setup/references/regions.json     (broadest catalog)
+#   - cogni-trends/skills/trend-report/references/region-authority-sources.json
+#   - cogni-research/references/market-sources.json
+#
+# Also verifies that cogni-trends DACH region references all CLAUDE.md-curated
+# DACH authority sources (fraunhofer.de, bitkom.org, vdma.org, destatis.de,
+# handelsblatt.com).
+#
+# Exits non-zero if any drift is detected with a per-class remediation hint.
+# Prints a single-line JSON envelope `{success, data, error}` on the final line
+# so callers (CI, hooks, other scripts) can parse the verdict deterministically.
+#
+# Usage: bash cogni-workspace/scripts/check-region-catalogs.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PORTFOLIO="${REPO_ROOT}/cogni-portfolio/skills/portfolio-setup/references/regions.json"
+TRENDS="${REPO_ROOT}/cogni-trends/skills/trend-report/references/region-authority-sources.json"
+RESEARCH="${REPO_ROOT}/cogni-research/references/market-sources.json"
+
+# Verify all three catalogs exist before doing anything else.
+for f in "$PORTFOLIO" "$TRENDS" "$RESEARCH"; do
+  if [[ ! -f "$f" ]]; then
+    rel="${f#"$REPO_ROOT/"}"
+    echo "ERROR: catalog file not found: $rel" >&2
+    printf '{"success":false,"data":{},"error":"missing catalog: %s"}\n' "$rel"
+    exit 2
+  fi
+done
+
+# All comparison logic lives in python so the set arithmetic and JSON parsing
+# stay readable. The script body is just orchestration.
+python3 - "$PORTFOLIO" "$TRENDS" "$RESEARCH" <<'PY'
+import json
+import sys
+
+portfolio_path, trends_path, research_path = sys.argv[1:4]
+
+# CLAUDE.md DACH authority sources — keep in sync with insight-wave/CLAUDE.md.
+EXPECTED_DACH_SOURCES = {
+    "fraunhofer.de",
+    "bitkom.org",
+    "vdma.org",
+    "destatis.de",
+    "handelsblatt.com",
+}
+
+
+def load(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def real_keys(d):
+    """Top-level keys that aren't metadata (anything starting with _)."""
+    return {k for k in d.keys() if not k.startswith("_")}
+
+
+portfolio_raw = load(portfolio_path)
+trends = load(trends_path)
+research = load(research_path)
+
+# cogni-portfolio nests regions under a "regions" key; the other two don't.
+portfolio_regions = portfolio_raw.get("regions", portfolio_raw)
+portfolio_keys = real_keys(portfolio_regions)
+trends_keys = real_keys(trends)
+research_keys = real_keys(research)
+
+violations = []
+
+# Drift class 1: regions in trends or research that aren't in portfolio.
+# Portfolio is the union-of-markets source of truth (per the issue #46
+# Stage 1 option (b) recommendation), so the other two catalogs should be
+# subsets of portfolio.
+for plugin, keys in (("cogni-trends", trends_keys), ("cogni-research", research_keys)):
+    extra = sorted(keys - portfolio_keys)
+    if extra:
+        violations.append({
+            "class": "extra_keys",
+            "plugin": plugin,
+            "detail": extra,
+            "hint": f"{plugin} has region keys not in cogni-portfolio: {extra}. "
+                    "Either add them to cogni-portfolio/skills/portfolio-setup/"
+                    "references/regions.json or remove from this plugin.",
+        })
+
+# Drift class 2: regions in trends and research must agree on their intersection
+# with portfolio. Any key that's in one and not the other is drift.
+trends_minus_research = sorted(trends_keys - research_keys)
+research_minus_trends = sorted(research_keys - trends_keys)
+if trends_minus_research:
+    violations.append({
+        "class": "trends_only",
+        "detail": trends_minus_research,
+        "hint": f"cogni-trends has region keys missing from cogni-research: "
+                f"{trends_minus_research}. Add stub entries to cogni-research/"
+                "references/market-sources.json so the two web-search catalogs "
+                "stay in sync.",
+    })
+if research_minus_trends:
+    violations.append({
+        "class": "research_only",
+        "detail": research_minus_trends,
+        "hint": f"cogni-research has region keys missing from cogni-trends: "
+                f"{research_minus_trends}. Add stub entries to cogni-trends/"
+                "skills/trend-report/references/region-authority-sources.json "
+                "so the two web-search catalogs stay in sync.",
+    })
+
+# Drift class 3: cogni-trends DACH must reference all CLAUDE.md-curated sources.
+dach_entry = trends.get("dach", {})
+dach_text_blob = json.dumps(dach_entry)
+missing_dach = sorted(s for s in EXPECTED_DACH_SOURCES if s not in dach_text_blob)
+if missing_dach:
+    violations.append({
+        "class": "dach_sources",
+        "detail": missing_dach,
+        "hint": f"cogni-trends DACH entry is missing CLAUDE.md-curated authority "
+                f"sources: {missing_dach}. Add them as site_searches under the "
+                "appropriate dimension in cogni-trends/skills/trend-report/"
+                "references/region-authority-sources.json.",
+    })
+
+# Print human-readable summary first.
+print(f"cogni-portfolio: {len(portfolio_keys)} region keys")
+print(f"cogni-trends:    {len(trends_keys)} region keys")
+print(f"cogni-research:  {len(research_keys)} region keys")
+print()
+
+if not violations:
+    print("OK: all region catalogs agree and cogni-trends DACH references all "
+          "CLAUDE.md-curated sources.")
+    print(json.dumps({"success": True, "data": {
+        "portfolio_keys": sorted(portfolio_keys),
+        "trends_keys": sorted(trends_keys),
+        "research_keys": sorted(research_keys),
+        "violations": [],
+    }, "error": ""}))
+    sys.exit(0)
+
+print(f"FAIL: {len(violations)} drift class(es) detected.")
+print()
+for v in violations:
+    print(f"  [{v['class']}]")
+    print(f"    {v['hint']}")
+    print()
+
+print(json.dumps({"success": False, "data": {
+    "portfolio_keys": sorted(portfolio_keys),
+    "trends_keys": sorted(trends_keys),
+    "research_keys": sorted(research_keys),
+    "violations": violations,
+}, "error": f"{len(violations)} drift class(es) detected"}))
+sys.exit(1)
+PY

--- a/cogni-workspace/scripts/check-region-catalogs.sh
+++ b/cogni-workspace/scripts/check-region-catalogs.sh
@@ -7,8 +7,9 @@
 #   - cogni-research/references/market-sources.json
 #
 # Also verifies that cogni-trends DACH region references all CLAUDE.md-curated
-# DACH authority sources (fraunhofer.de, bitkom.org, vdma.org, destatis.de,
-# handelsblatt.com).
+# DACH authority sources. The curated list is loaded from
+# cogni-workspace/references/curated-region-sources.json — the single source of
+# truth synced with CLAUDE.md's "Multilingual European Support" section.
 #
 # Exits non-zero if any drift is detected with a per-class remediation hint.
 # Prints a single-line JSON envelope `{success, data, error}` on the final line
@@ -22,9 +23,10 @@ REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 PORTFOLIO="${REPO_ROOT}/cogni-portfolio/skills/portfolio-setup/references/regions.json"
 TRENDS="${REPO_ROOT}/cogni-trends/skills/trend-report/references/region-authority-sources.json"
 RESEARCH="${REPO_ROOT}/cogni-research/references/market-sources.json"
+CURATED="${REPO_ROOT}/cogni-workspace/references/curated-region-sources.json"
 
-# Verify all three catalogs exist before doing anything else.
-for f in "$PORTFOLIO" "$TRENDS" "$RESEARCH"; do
+# Verify all catalog files exist before doing anything else.
+for f in "$PORTFOLIO" "$TRENDS" "$RESEARCH" "$CURATED"; do
   if [[ ! -f "$f" ]]; then
     rel="${f#"$REPO_ROOT/"}"
     echo "ERROR: catalog file not found: $rel" >&2
@@ -35,20 +37,11 @@ done
 
 # All comparison logic lives in python so the set arithmetic and JSON parsing
 # stay readable. The script body is just orchestration.
-python3 - "$PORTFOLIO" "$TRENDS" "$RESEARCH" <<'PY'
+python3 - "$PORTFOLIO" "$TRENDS" "$RESEARCH" "$CURATED" <<'PY'
 import json
 import sys
 
-portfolio_path, trends_path, research_path = sys.argv[1:4]
-
-# CLAUDE.md DACH authority sources — keep in sync with insight-wave/CLAUDE.md.
-EXPECTED_DACH_SOURCES = {
-    "fraunhofer.de",
-    "bitkom.org",
-    "vdma.org",
-    "destatis.de",
-    "handelsblatt.com",
-}
+portfolio_path, trends_path, research_path, curated_path = sys.argv[1:5]
 
 
 def load(path):
@@ -64,6 +57,10 @@ def real_keys(d):
 portfolio_raw = load(portfolio_path)
 trends = load(trends_path)
 research = load(research_path)
+
+# CLAUDE.md DACH authority sources — loaded from curated-region-sources.json
+# (single source of truth synced with CLAUDE.md 'Multilingual European Support').
+EXPECTED_DACH_SOURCES = set(load(curated_path)["dach"])
 
 # cogni-portfolio nests regions under a "regions" key; the other two don't.
 portfolio_regions = portfolio_raw.get("regions", portfolio_raw)


### PR DESCRIPTION
Closes #46.

## Summary
- Add `eu` composite-market entry to cogni-trends `region-authority-sources.json` (trends 17 → 18 keys, matching cogni-research's 18). Site searches cover all four trendradar dimensions with EU institutions: EUR-Lex, European Commission, ESA, ENISA, DigitalEurope, ETNO, Eurostat. Mirrors the cogni-research and cogni-portfolio eu entries so the three catalogs finally agree on the EU composite key.
- Add `destatis.de` site_search to the cogni-trends DACH entry under `digitales-fundament`, aligning with CLAUDE.md's curated DACH source list (fraunhofer.de, bitkom.org, vdma.org, destatis.de, handelsblatt.com). The config previously omitted destatis despite the doc listing it as a DACH authority.
- Ship `cogni-workspace/scripts/check-region-catalogs.sh` — stdlib bash + python3 drift checker that compares the three region catalogs pairwise, verifies cogni-trends DACH references all CLAUDE.md-curated authority sources, prints per-class remediation hints, and exits non-zero on drift. Returns the standard `{success, data, error}` JSON envelope on a final line so callers (CI, hooks, other scripts) can parse the verdict deterministically.
- Patch-bump `cogni-trends` 0.4.5 → 0.4.6 and `cogni-workspace` 0.6.5 → 0.6.6 in `plugin.json` + mirror in root `marketplace.json` per the version-management convention.

## Current state after this PR
```
cogni-portfolio: 26 region keys
cogni-trends:    18 region keys (was 17)
cogni-research:  18 region keys
```
trends and research now have identical key sets. portfolio's extra 8 keys (apac, cn, jp, latam, mea, global, nordics, na) are aspirational/broad regions intentionally out of scope per the issue's "Out of scope" section ("Adding cn, jp, apac, latam, mea, global to the authority configs until there's a real user for them").

## Scope decisions

**In scope (this PR — smallest shippable):** the three drift items the triage identified as still pending after intermediate PRs (#54 et al) addressed most of original Stage 1, plus the cross-plugin drift checker that should have prevented all this churn.

**Deferred to follow-up issues** (recorded in the resolution comment on the issue):
- Stage 2 — derive research-setup's supported-market menu from the canonical catalog instead of hard-coding 10 markets in `cogni-research/skills/research-setup/SKILL.md:5,80,145`; decide silent-DACH-fallback vs error-on-unknown
- Stage 3 — cogni-portfolio's 7 WebSearch agents (`market-researcher`, `customer-researcher`, `competitor-researcher`, `feature-deep-diver`, `proposition-deep-diver`, `portfolio-web-researcher`, `quality-enricher`) consume a shared authority config instead of hardcoded firm lists
- Stage 4 — FR/IT/NL/ES `local_query_tips` parity across the three catalogs (currently DE-DE-only in 5 of 7 cogni-portfolio agents)
- Stage 5 — `trend-deep-researcher`, `trend-generator`, `trend-report-revisor`, `trend-signal-curator` accept `MARKET_REGION` and load the region config
- Stage 6 — DACH composite (de/at/ch fan-out) vs the current monolithic DACH entry — separate discussion
- CI / pre-commit hook integration of `check-region-catalogs.sh` so future drift fails the build (the script is the prerequisite; wiring it is its own small PR)

## Test plan
- [x] `bash cogni-workspace/scripts/check-region-catalogs.sh` prints `OK` and exits 0 on this branch (verified at commit time)
- [ ] Same script prints a remediation hint and exits 1 if you temporarily remove the new `eu` entry from cogni-trends:
      `python3 -c "import json; d=json.load(open('cogni-trends/skills/trend-report/references/region-authority-sources.json')); del d['eu']; open('cogni-trends/skills/trend-report/references/region-authority-sources.json','w').write(json.dumps(d, indent=2))" && bash cogni-workspace/scripts/check-region-catalogs.sh; git checkout cogni-trends/skills/trend-report/references/region-authority-sources.json`
- [ ] Same script also exits 1 if `destatis.de` is removed from DACH (verifies the dach_sources drift class)
- [ ] `python3 -m json.tool cogni-trends/skills/trend-report/references/region-authority-sources.json > /dev/null` parses cleanly (the new `eu` block is valid JSON)
- [ ] `jq -r '.version' cogni-trends/.claude-plugin/plugin.json` reports `0.4.6` and `cogni-workspace` reports `0.6.6`
- [ ] `jq '.plugins[] | select(.name=="cogni-trends" or .name=="cogni-workspace") | {name, version}' .claude-plugin/marketplace.json` confirms both bumps mirrored
- [ ] DACH entry in cogni-trends region-authority-sources.json now contains a `destatis.de` site_search under `digitales-fundament`
- [ ] Drift-check handles missing files gracefully (rename one catalog to confirm exit code 2 with `success:false`)

## Open questions
None blocking — the deferred follow-up issues should each be filed separately and prioritized by impact (Stage 2 has the highest user-visible payoff: silent-DACH-fallback is a correctness trap; Stage 3 unblocks per-market authority targeting for cogni-portfolio agents).
