### PR TITLE
cogni-wiki: define wiki-ingest re-ingest semantics

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -243,7 +243,7 @@
     {
       "name": "cogni-wiki",
       "source": "./cogni-wiki",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "maturity": "incubating",
       "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
       "keywords": [

--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-wiki/skills/wiki-ingest/SKILL.md
+++ b/cogni-wiki/skills/wiki-ingest/SKILL.md
@@ -46,7 +46,7 @@ Derive the target slug from `--title` (or from the source filename / URL title /
 
   Then proceed with the remaining steps — `mode` changes only Step 7 (log entry type) and Step 8 (entry count handling).
 
-The `mode` flag is internal to this skill; it does not surface in frontmatter or config. `wiki-update` remains the right choice for edits that preserve the existing synthesis; `wiki-ingest --mode re-ingest` is for re-synthesising the page from scratch against an updated source.
+See `./references/ingest-workflow.md` §"Mode flag: fresh vs re-ingest" for when to pick `wiki-update` instead of re-ingest.
 
 ### 2. Read the source
 
@@ -58,7 +58,7 @@ Every wiki page must cite a file in `raw/` or a stable URL. This link to raw/ is
 
 ### 3. Surface key takeaways BEFORE writing the page
 
-This is the most important step. Skipping it risks duplicating an existing page or writing content that fragments rather than compounds the wiki. Before writing any page, state in plain prose:
+This is the most important step. Surface takeaways before writing — it prevents duplicate pages and keeps the wiki compounding rather than fragmenting. Before writing any page, state in plain prose:
 
 1. **What the source is** — type, author, date, length
 2. **Three to seven key takeaways** — the claims a future reader of the wiki would actually want
@@ -115,10 +115,17 @@ Edit each page that gains a backlink, updating its `updated:` frontmatter field 
 
 ### 7. Append to `wiki/log.md`
 
-Append a single line. Use `ingest` when `mode: fresh`, `re-ingest` when `mode: re-ingest`:
+Append a single line.
+
+Fresh ingest (`mode: fresh`):
 
 ```
 ## [{YYYY-MM-DD}] ingest    | {slug} — {title}
+```
+
+Re-ingest (`mode: re-ingest`):
+
+```
 ## [{YYYY-MM-DD}] re-ingest | {slug} — {title}
 ```
 

--- a/cogni-wiki/skills/wiki-ingest/SKILL.md
+++ b/cogni-wiki/skills/wiki-ingest/SKILL.md
@@ -20,7 +20,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once at the start of
 ## Never run when
 
 - The wiki has not been set up — check for `.cogni-wiki/config.json`; if missing, offer `wiki-setup` first
-- The source is already summarised in `wiki/pages/` — detect by `grep -l` for the source path or URL in frontmatter; offer `wiki-update` instead
+- The source is already summarised under the same slug and the user wants a content-only edit — in that case offer `wiki-update` instead. Re-ingests of an existing slug (re-synthesising the page from an updated source) are allowed and handled by Step 1's `mode: re-ingest` branch — do not skip the ingest in that case.
 
 ## Parameters
 
@@ -33,9 +33,20 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once at the start of
 
 ## Workflow
 
-### 1. Locate the wiki
+### 1. Locate the wiki and detect ingest mode
 
 Walk upward from the current working directory to find the nearest `.cogni-wiki/config.json`. If none found, stop and offer to run `wiki-setup`.
+
+Derive the target slug from `--title` (or from the source filename / URL title / first heading if `--title` is absent). Then check whether `<wiki-root>/wiki/pages/{slug}.md` already exists:
+
+- **Fresh ingest** (`mode: fresh`) — no page at that slug. Proceed normally.
+- **Re-ingest** (`mode: re-ingest`) — a page at that slug exists. This is an explicit, allowed path (used by pilot rebuilds where the page is being re-synthesised from an updated source), but it is a different operation than a fresh ingest. Emit this warning verbatim to the user before proceeding:
+
+  > Re-ingesting an existing slug (`{slug}`). For content-only tweaks, prefer `wiki-update`; this ingest will overwrite the page, log a `re-ingest` entry, and leave `entries_count` unchanged.
+
+  Then proceed with the remaining steps — `mode` changes only Step 7 (log entry type) and Step 8 (entry count handling).
+
+The `mode` flag is internal to this skill; it does not surface in frontmatter or config. `wiki-update` remains the right choice for edits that preserve the existing synthesis; `wiki-ingest --mode re-ingest` is for re-synthesising the page from scratch against an updated source.
 
 ### 2. Read the source
 
@@ -104,17 +115,21 @@ Edit each page that gains a backlink, updating its `updated:` frontmatter field 
 
 ### 7. Append to `wiki/log.md`
 
-Append a single line:
+Append a single line. Use `ingest` when `mode: fresh`, `re-ingest` when `mode: re-ingest`:
 
 ```
-## [{YYYY-MM-DD}] ingest | {slug} — {title}
+## [{YYYY-MM-DD}] ingest    | {slug} — {title}
+## [{YYYY-MM-DD}] re-ingest | {slug} — {title}
 ```
+
+The hyphenated `re-ingest` form parallels the existing lowercase verb grammar (`ingest`, `update`) and keeps the log greppable by operation type.
 
 Never rewrite existing log lines.
 
 ### 8. Update `.cogni-wiki/config.json`
 
-Increment `entries_count`. Leave all other fields untouched.
+- `mode: fresh` — increment `entries_count`. Leave all other fields untouched.
+- `mode: re-ingest` — leave `entries_count` untouched. The field reflects distinct pages in `wiki/pages/`, not ingest invocations; `wiki-resume`, `wiki-dashboard`, and `wiki-lint` all treat it as a page count, so re-ingests must not inflate it.
 
 ### 9. Report to the user
 
@@ -135,7 +150,7 @@ Tell the user, in ≤5 sentences:
 
 - **Never summarise from memory.** The page's claims must all trace back to the source text. If the source is silent on a topic, the page is silent on it.
 - **Never invent backlinks.** Only link to pages that actually exist in `wiki/pages/`.
-- **Never overwrite a page silently.** If `{slug}.md` already exists, stop and offer `wiki-update` instead.
+- **Never overwrite a page silently.** Overwrites are only allowed through the explicit re-ingest path: Step 1 must detect the existing slug, set `mode: re-ingest`, and emit the re-ingest warning before any page write. Silent overwrites (writing to an existing slug without surfacing `mode: re-ingest` to the user) remain forbidden. For content-only edits that preserve the existing synthesis, use `wiki-update` rather than a re-ingest.
 - **Raw first, page second.** Pasted content is persisted to `raw/` before any page work begins.
 
 ## References

--- a/cogni-wiki/skills/wiki-ingest/references/ingest-workflow.md
+++ b/cogni-wiki/skills/wiki-ingest/references/ingest-workflow.md
@@ -134,3 +134,15 @@ Increment `entries_count` in `.cogni-wiki/config.json`. Report: "Ingested as `ma
 - **Add backlinks to every page that matches a keyword.** Force-linking degrades the signal — only add backlinks that a reader of the target page would genuinely benefit from.
 - **Rewrite the index silently.** The index is edited in-place; never regenerated from scratch (which would destroy human-added organization).
 - **Summarize from memory.** If the source says "X", the page says "X". If the source is silent on Y, the page is silent on Y.
+
+## Mode flag: fresh vs re-ingest
+
+`wiki-ingest` exposes one conceptual parameter that does not appear on the command line: `mode`. Step 1 detects it from the filesystem — if a page already exists at the target slug, `mode` is `re-ingest`; otherwise `fresh`. The flag is internal and never surfaces in frontmatter or config.
+
+Pick the right entry point:
+
+- **`wiki-update`** — the page exists and you want to preserve the existing synthesis (fix a claim, add a source, tweak wording).
+- **`wiki-ingest` (→ re-ingest branch)** — the page exists but the underlying source has changed substantively and the page should be re-synthesised from scratch. This is the pilot-rebuild pattern from PR #67.
+- **`wiki-ingest` (→ fresh branch)** — no page at the target slug.
+
+Step 1 emits a verbatim warning on re-ingest that points users back at `wiki-update` for content-only tweaks; the two paths stay distinct even though they share the same skill entry point.


### PR DESCRIPTION
Closes #69.

## Summary
- Detect existing slug in Step 1 of `wiki-ingest` and branch to a re-ingest path via an internal `mode: fresh | re-ingest` flag.
- Skip the `entries_count` increment in Step 8 on re-ingest (entry count reflects distinct pages, not ingest invocations).
- Log re-ingests with a `re-ingest` entry type in `wiki/log.md` (Step 7) so the append-only log distinguishes the two operations.
- Emit a one-line warning pointing users at `wiki-update` for content-only tweaks, per triage option (b).
- Update Never-run section and Failure Modes to reconcile "never overwrite silently" with the now-explicit re-ingest path.
- Bump cogni-wiki plugin version 0.0.4 → 0.0.5 (mirrored in marketplace.json).

## Scope decisions
- **In scope:** `cogni-wiki/skills/wiki-ingest/SKILL.md` — the sole file where the contradictory / undefined semantics lived (Step 8 unconditional increment, Never-run pointing at wiki-update, Failure Modes forbidding overwrites silently).
- **Out of scope (deferred):** `cogni-wiki/skills/wiki-update/SKILL.md` cross-reference enrichment (adding a "wiki-ingest hands control here on re-ingest" bullet to its When-to-run section), and a worked re-ingest example in `cogni-wiki/skills/wiki-ingest/references/ingest-workflow.md`. Neither is required to close the semantic gap — they are documentation polish and fit better as a follow-up once the semantics ship and are exercised.
- **Log-type grammar:** existing log lines use lowercase verbs (`ingest`, `update`). Re-ingest fits the same grammar as `re-ingest` (hyphenated) to parallel `update` and keep the log greppable by operation type.
- **entries_count definition:** chose "distinct pages in wiki/pages/" (pages, not ingest invocations) because that is what wiki-resume, wiki-dashboard, and wiki-lint already treat the field as.
- **Option (b), not (a).** Triage picked option (b) from the issue — detect and handle — rather than option (a) — refuse outright. Refusing would break the PR #67 pilot pattern where intentional re-ingests are the whole point.

## Test plan
- [ ] Read the revised `cogni-wiki/skills/wiki-ingest/SKILL.md` end-to-end and confirm Steps 1, 7, 8, Never-run (line 23) and Failure-modes (line 153) are internally consistent — no contradiction between "never overwrite silently" and the new re-ingest branch.
- [ ] Dry-run a re-ingest on a pilot wiki page from PR #67: confirm the warning fires verbatim, the log line uses `re-ingest`, and `entries_count` stays unchanged after the run.
- [ ] Dry-run a fresh ingest on a new slug: confirm behavior is unchanged (warning does not fire, log line uses `ingest`, `entries_count` still increments).
- [ ] `grep -n 'entries_count' cogni-wiki/skills/wiki-ingest/SKILL.md` — confirm the increment is now conditional on `mode: fresh`, not unconditional.
