### PR TITLE
cogni-wiki: atomic backlink + updated: write via backlink_audit --apply

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -243,7 +243,7 @@
     {
       "name": "cogni-wiki",
       "source": "./cogni-wiki",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "maturity": "incubating",
       "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
       "keywords": [

--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-wiki/skills/wiki-ingest/SKILL.md
+++ b/cogni-wiki/skills/wiki-ingest/SKILL.md
@@ -105,13 +105,29 @@ Read `wiki/index.md`. Decide which category heading the new page belongs under (
 
 Keep the category list alphabetized within its section.
 
-### 6. Run the backlink audit
+### 6. Run the backlink audit, then apply curated backlinks atomically
 
-Invoke `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/backlink_audit.py --wiki-root <wiki-root> --new-page {slug}`. The script returns JSON with candidate backlinks — existing pages that mention the new page's title, tags, or key entities. If the script exits non-zero or returns malformed JSON, report the error to the user and skip the backlink step — the page itself is already written.
+**6a. Audit.** Invoke `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/backlink_audit.py --wiki-root <wiki-root> --new-page {slug}`. The script returns JSON with candidate backlinks — existing pages that mention the new page's title, tags, or key entities. If the script exits non-zero or returns malformed JSON, report the error to the user and skip the backlink step — the page itself is already written.
 
-For each candidate, read the target page, decide whether a `[[{slug}]]` link would help the reader, and if so add it in an appropriate sentence (not as a dangling "See also" unless the page already has a See-also section). Always add backlinks as natural inline references, not as dumps.
+**6b. Curate.** For each candidate, read the target page and decide whether a `[[{slug}]]` link would help the reader. Always add backlinks as natural inline references, not as dumps. For every target you pick, draft (i) a sentence containing `[[{slug}]]` and (ii) the heading line it should go under (or omit the heading to append at the end). This curation step stays human-in-the-loop — the script never auto-selects targets, to preserve the "never invent backlinks" discipline in the Failure modes section.
 
-Edit each page that gains a backlink, updating its `updated:` frontmatter field to today.
+**6c. Apply atomically.** Re-invoke the same script with `--apply-plan -` and pipe the curated plan JSON on stdin:
+
+```json
+{
+  "targets": [
+    {
+      "slug": "<target-slug>",
+      "sentence": "…inline prose containing [[{slug}]]…",
+      "insert_after_heading": "## <exact heading line>"
+    }
+  ]
+}
+```
+
+The `--apply-plan` pass writes the backlink sentence and bumps the target page's `updated:` frontmatter field to today in a **single atomic write per page**. This replaces the older two-step flow where the orchestrator had to remember to edit `updated:` separately — a rule that worked at 7 pages but drifted silently at larger scale (issue #73). The apply pass is idempotent: targets that already contain `[[{slug}]]` are skipped, so re-running the same plan after a fix is safe.
+
+Output extends the audit JSON with `data.applied[]`, `data.skipped_existing_backlink[]`, and `data.failed[]`. Surface these to the user in the Step 9 report so they can see exactly which pages changed.
 
 ### 7. Append to `wiki/log.md`
 

--- a/cogni-wiki/skills/wiki-ingest/references/ingest-workflow.md
+++ b/cogni-wiki/skills/wiki-ingest/references/ingest-workflow.md
@@ -99,9 +99,9 @@ Under the `## Safety` category heading, insert:
 - [[many-shot-jailbreaking]] — Exploiting long context by stuffing fake dialogue turns to prime harmful completions.
 ```
 
-### Step 6: Backlink audit
+### Step 6: Backlink audit + atomic apply
 
-Run `backlink_audit.py --wiki-root cogni-wiki/ai-research --new-page many-shot-jailbreaking`. The script returns:
+**Audit.** Run `backlink_audit.py --wiki-root cogni-wiki/ai-research --new-page many-shot-jailbreaking`. The script returns:
 
 ```json
 {
@@ -115,9 +115,25 @@ Run `backlink_audit.py --wiki-root cogni-wiki/ai-research --new-page many-shot-j
 }
 ```
 
-For `long-context-vulnerabilities`, add an inline `[[many-shot-jailbreaking]]` link in the body text where the page already discusses attack classes — not in a dangling "See also" list. Update that page's `updated:` field.
+**Curate.** For `long-context-vulnerabilities`, decide a `[[many-shot-jailbreaking]]` link belongs in the attack-classes paragraph — not in a dangling "See also" list. For `rlhf-limitations`, skip — the match is shallow and forcing a backlink would be noise. The orchestrator is the curator; the script never auto-selects targets.
 
-For `rlhf-limitations`, skip — the match was shallow and forcing a backlink would be noise.
+**Apply atomically.** Re-invoke the script with a plan piped on stdin. This writes the backlink sentence and bumps the target page's `updated:` field in a single atomic write, so there is no way to forget the timestamp bump:
+
+```sh
+cat <<'PLAN' | backlink_audit.py --wiki-root cogni-wiki/ai-research --new-page many-shot-jailbreaking --apply-plan -
+{
+  "targets": [
+    {
+      "slug": "long-context-vulnerabilities",
+      "sentence": "The canonical instantiation of this class of attack is [[many-shot-jailbreaking]], which exploits the same long-context-window expansion to prime harmful completions via hundreds of fake dialogue turns.",
+      "insert_after_heading": "## Attack classes"
+    }
+  ]
+}
+PLAN
+```
+
+Output extends the audit JSON with `data.applied[]`, `data.skipped_existing_backlink[]`, and `data.failed[]` so you can confirm exactly which pages the apply pass changed before reporting to the user.
 
 ### Step 7–9: Log, config, report
 

--- a/cogni-wiki/skills/wiki-ingest/scripts/backlink_audit.py
+++ b/cogni-wiki/skills/wiki-ingest/scripts/backlink_audit.py
@@ -1,22 +1,49 @@
 #!/usr/bin/env python3
 """
-backlink_audit.py — find candidate backlinks for a newly ingested wiki page.
+backlink_audit.py — find candidate backlinks for a newly ingested wiki page,
+and (optionally) apply a curated plan of backlink writes atomically.
 
-Given a wiki root and a newly created page, scan existing pages for textual
-references that could justify adding a `[[new-page]]` backlink. Returns a
-ranked list of candidates as JSON on stdout so the calling skill can decide
-which links to actually insert.
+Two modes, sharing one script so the audit + write cycle stays a single
+skill-invocation unit:
 
-Usage:
-    backlink_audit.py --wiki-root <path> --new-page <slug>
+    Audit mode (default)
+        backlink_audit.py --wiki-root <path> --new-page <slug>
 
-Output contract:
+        Scans existing pages for textual references that could justify a
+        `[[new-page]]` backlink. Returns a ranked candidate list. No writes.
+
+    Apply mode
+        backlink_audit.py --wiki-root <path> --new-page <slug> \\
+                          --apply-plan <path-or-dash>
+
+        Reads a curated plan JSON and, for each target, inserts the caller's
+        backlink sentence and bumps the target page's `updated:` frontmatter
+        field to today — as a single atomic write per page. The plan is
+        authored by the orchestrator after reviewing the audit's candidates;
+        the script never auto-selects targets, preserving the
+        "never invent backlinks" discipline from SKILL.md.
+
+Output contract (audit mode):
     {
       "success": true,
       "data": {
         "candidates": [...],
         "search_terms": [...],
         "total_pages_scanned": <int>
+      },
+      "error": ""
+    }
+
+Output contract (apply mode) — extends audit output with write-result fields:
+    {
+      "success": true,
+      "data": {
+        "candidates": [...],
+        "search_terms": [...],
+        "total_pages_scanned": <int>,
+        "applied": [ {"slug": "...", "updated": "YYYY-MM-DD"}, ... ],
+        "skipped_existing_backlink": ["slug", ...],
+        "failed": [ {"slug": "...", "error": "..."}, ... ]
       },
       "error": ""
     }
@@ -30,9 +57,28 @@ Candidate object:
       "existing_backlink": true | false
     }
 
+Plan schema (consumed by --apply-plan):
+    {
+      "targets": [
+        {
+          "slug": "target-page-slug",         # required; must exist under wiki/pages/
+          "sentence": "... [[new-page]] ...", # required; MUST contain [[new-slug]]
+          "insert_after_heading": "## Foo"    # optional; exact heading line to insert after
+        },
+        ...
+      ]
+    }
+
+    If `insert_after_heading` is present and matches a heading line in the target
+    page body, the sentence is inserted as the first paragraph under that heading.
+    If absent (or the heading is not found), the sentence is appended at the end
+    of the body. In every case the frontmatter `updated:` field is rewritten to
+    today's ISO date in the same atomic write.
+
 Flags:
-    --top-n <N>           After ranking, keep only the top N candidates.
-    --min-confidence X    Drop candidates below confidence X (low|medium|high).
+    --top-n <N>           Audit mode: keep only the top N candidates.
+    --min-confidence X    Audit mode: drop candidates below X (low|medium|high).
+    --apply-plan <path>   Apply mode: path to plan JSON, or `-` for stdin.
 
 Ranking is stable: candidates are sorted by confidence bucket (high > medium >
 low), then by matched_score descending, then by page slug alphabetically. Terms
@@ -47,14 +93,18 @@ stdlib-only. Python 3.8+.
 from __future__ import annotations
 
 import argparse
+import datetime as _dt
 import json
+import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 WIKILINK_RE = re.compile(r"\[\[([a-z0-9][a-z0-9\-]*)\]\]")
+UPDATED_FIELD_RE = re.compile(r"^(updated:\s*).*$", re.MULTILINE)
 
 
 def fail(msg: str) -> None:
@@ -177,6 +227,174 @@ def score_match(matched_score: float, match_count: int, body_len: int) -> str:
     return "low"
 
 
+def _load_apply_plan(path: str) -> dict:
+    """Load the apply-plan JSON. `-` reads from stdin."""
+    if path == "-":
+        raw = sys.stdin.read()
+    else:
+        plan_path = Path(path).expanduser().resolve()
+        if not plan_path.is_file():
+            fail(f"apply plan not found: {plan_path}")
+        raw = plan_path.read_text(encoding="utf-8")
+    try:
+        plan = json.loads(raw)
+    except json.JSONDecodeError as e:
+        fail(f"apply plan is not valid JSON: {e}")
+        return {}
+    if not isinstance(plan, dict) or not isinstance(plan.get("targets"), list):
+        fail("apply plan must be an object with a 'targets' list")
+    return plan
+
+
+def _validate_target(target: dict, new_slug: str) -> str:
+    """Return an error string on invalid target, empty string on valid."""
+    if not isinstance(target, dict):
+        return "target is not an object"
+    slug = target.get("slug")
+    if not isinstance(slug, str) or not slug.strip():
+        return "target missing 'slug'"
+    sentence = target.get("sentence")
+    if not isinstance(sentence, str) or not sentence.strip():
+        return f"target {slug!r} missing 'sentence'"
+    wikilink = f"[[{new_slug}]]"
+    if wikilink not in sentence:
+        return f"target {slug!r} sentence does not contain {wikilink}"
+    heading = target.get("insert_after_heading")
+    # Absence (None) or empty string is fine — both mean "append at end of body".
+    # Only reject truly non-string values (numbers, lists, objects).
+    if heading is not None and not isinstance(heading, str):
+        return f"target {slug!r} has a non-string 'insert_after_heading'"
+    return ""
+
+
+def _bump_updated_frontmatter(text: str, today: str) -> str:
+    """Rewrite the frontmatter `updated:` field to today's date.
+
+    Only touches the first frontmatter block. Preserves surrounding content
+    byte-for-byte. If no frontmatter or no `updated:` field is present, returns
+    the text unchanged — an atomic write still happens, just without the bump.
+    """
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return text
+    fm_block = m.group(0)
+    # Use a lambda substitution so we don't hit Python's \1 + "2026..." ambiguity
+    # where the leading digit gets parsed into the backreference (\12 would mean
+    # group 12) and corrupts the output.
+    new_fm, count = UPDATED_FIELD_RE.subn(
+        lambda mm: mm.group(1) + today, fm_block, count=1
+    )
+    if count == 0:
+        return text
+    return new_fm + text[len(fm_block):]
+
+
+def _split_frontmatter_body(text: str) -> tuple:
+    """Return (frontmatter_including_trailing_newline, body)."""
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return "", text
+    return m.group(0), text[len(m.group(0)):]
+
+
+def _insert_sentence(body: str, sentence: str, heading: str) -> str:
+    """Insert `sentence` at the right place in `body`.
+
+    If `heading` is truthy and matches a line exactly, insert `sentence` as a
+    new paragraph immediately after that heading (with a blank-line separator).
+    Otherwise append at the end of the body, preceded by a blank line.
+    """
+    stripped_sentence = sentence.strip()
+    if heading:
+        heading_line = heading.rstrip("\n")
+        # Split lines but keep track so we can rebuild faithfully.
+        lines = body.split("\n")
+        for i, line in enumerate(lines):
+            if line.rstrip() == heading_line:
+                # Insert a blank line then the sentence after the heading.
+                # If the next line is already blank, keep it; then drop our
+                # own separator so we don't produce three-blank-lines.
+                rest_start = i + 1
+                insert_lines = ["", stripped_sentence, ""]
+                new_lines = lines[:rest_start] + insert_lines + lines[rest_start:]
+                return "\n".join(new_lines)
+    if not body.endswith("\n"):
+        body = body + "\n"
+    return body + "\n" + stripped_sentence + "\n"
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write `content` to `path` atomically (write to temp file then os.replace)."""
+    parent = path.parent
+    fd, tmp = tempfile.mkstemp(prefix=".backlink-", dir=str(parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def apply_plan(plan: dict, pages_dir: Path, new_slug: str) -> tuple:
+    """Execute an apply-plan over `pages_dir`.
+
+    Returns (applied, skipped_existing, failed) lists for the output JSON.
+    Each list entry is a small dict the caller embeds under data.*.
+
+    Semantics:
+      - If `[[new_slug]]` already appears in the target body, skip the write
+        entirely (no sentence insert, no `updated:` bump). This keeps re-runs
+        idempotent so the orchestrator can safely re-apply a plan after fixing
+        a typo in one target.
+      - Otherwise, perform one atomic write that both inserts the sentence and
+        rewrites `updated:` to today.
+      - Any per-target failure is captured in `failed[]` without aborting the
+        whole run — partial success is better than no success at scale.
+    """
+    today = _dt.date.today().isoformat()
+    applied: list = []
+    skipped: list = []
+    failed: list = []
+    wikilink_marker = f"[[{new_slug}]]"
+
+    for target in plan.get("targets", []):
+        err = _validate_target(target, new_slug)
+        slug = target.get("slug") if isinstance(target, dict) else None
+        if err:
+            failed.append({"slug": slug, "error": err})
+            continue
+        target_path = pages_dir / f"{slug}.md"
+        if not target_path.is_file():
+            failed.append({"slug": slug, "error": f"target page not found: {target_path.name}"})
+            continue
+        try:
+            text = target_path.read_text(encoding="utf-8")
+        except OSError as e:
+            failed.append({"slug": slug, "error": f"could not read target: {e}"})
+            continue
+        if wikilink_marker in text:
+            skipped.append(slug)
+            continue
+        fm, body = _split_frontmatter_body(text)
+        new_body = _insert_sentence(body, target["sentence"], target.get("insert_after_heading", ""))
+        # Bump `updated:` in the frontmatter block only, so we don't touch any
+        # other `updated:` string that might appear in the body.
+        new_fm = _bump_updated_frontmatter(fm, today) if fm else fm
+        new_text = new_fm + new_body
+        try:
+            _atomic_write(target_path, new_text)
+        except OSError as e:
+            failed.append({"slug": slug, "error": f"atomic write failed: {e}"})
+            continue
+        applied.append({"slug": slug, "updated": today})
+
+    return applied, skipped, failed
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Find candidate backlinks for a new wiki page")
     parser.add_argument("--wiki-root", required=True, help="Absolute path to the wiki root")
@@ -186,6 +404,9 @@ def main() -> None:
     parser.add_argument("--min-confidence", choices=["low", "medium", "high"],
                         default="low",
                         help="Drop candidates below this confidence tier")
+    parser.add_argument("--apply-plan", default=None,
+                        help="Path to a plan JSON (or '-' for stdin). When set, apply the "
+                             "plan's backlink writes atomically after running the audit.")
     args = parser.parse_args()
 
     wiki_root = Path(args.wiki_root).expanduser().resolve()
@@ -208,7 +429,14 @@ def main() -> None:
     new_fm = parse_frontmatter(new_text)
     title_terms, tag_terms = extract_terms(new_text, new_fm)
     if not title_terms and not tag_terms:
-        ok({"candidates": [], "note": "new page has no extractable search terms"})
+        out_empty = {"candidates": [], "note": "new page has no extractable search terms"}
+        if args.apply_plan:
+            plan = _load_apply_plan(args.apply_plan)
+            applied, skipped, failed = apply_plan(plan, pages_dir, new_slug)
+            out_empty["applied"] = applied
+            out_empty["skipped_existing_backlink"] = skipped
+            out_empty["failed"] = failed
+        ok(out_empty)
 
     # Always include the slug itself and the title lowercased as title-weighted terms.
     title_terms.add(new_slug)
@@ -269,11 +497,20 @@ def main() -> None:
     if args.top_n > 0:
         candidates = candidates[: args.top_n]
 
-    ok({
+    out = {
         "candidates": candidates,
         "search_terms": sorted(term_weights.keys()),
         "total_pages_scanned": total_pages,
-    })
+    }
+
+    if args.apply_plan:
+        plan = _load_apply_plan(args.apply_plan)
+        applied, skipped, failed = apply_plan(plan, pages_dir, new_slug)
+        out["applied"] = applied
+        out["skipped_existing_backlink"] = skipped
+        out["failed"] = failed
+
+    ok(out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #73.

## Summary

- Add `--apply-plan <path-or-->` mode to `cogni-wiki/skills/wiki-ingest/scripts/backlink_audit.py`. When invoked, the script reads a curated plan JSON of `{slug, sentence, insert_after_heading}` entries and — for each target — inserts the backlink sentence inline and rewrites the target page's `updated:` frontmatter to today in a **single atomic write per page** (tempfile + `os.replace`).
- Rewrite `wiki-ingest/SKILL.md` Step 6 into `6a/6b/6c` (audit → curate → apply atomically). The old prose sentence "Edit each page that gains a backlink, updating its `updated:` frontmatter field to today" is gone; the timestamp bump now happens inside `--apply` instead of relying on orchestrator memory.
- Refresh the `ingest-workflow.md` worked example (Step 6) to show the two-command flow with a concrete plan piped on stdin.
- Preserve curation discipline: the script never auto-selects targets. The orchestrator still decides which candidates are worth linking, drafts the insertion sentence, and hands a plan to `--apply-plan`. The "never invent backlinks" and "natural inline references, not as dumps" rules are unchanged.
- Default (no `--apply-plan`) behaviour is byte-identical to the prior script — purely additive change.
- Bump `cogni-wiki` from `v0.0.5` to `v0.0.6` in both `plugin.json` and `marketplace.json` per CLAUDE.md's version-management rule.

## Scope decisions

- **In scope**: `--apply-plan` mode, SKILL.md Step 6 refresh, worked-example update, version bump.
- **Out of scope (deferred)**: auto-selecting which candidates to link (would regress curation discipline); retrofitting already-ingested pages (separate task); extending the same guarantee to `wiki-update`'s stale-sweep (different skill, different code path).
- **Why this matters at scale**: pilot disclosure (PR #67) flagged this as gap #5 of 6. At 7 pages the prose rule worked; at 164 pages silent drift is inevitable. One transactional write removes the class of bug.

## Apply-mode semantics

- **Idempotent**: if the target page already contains `[[<new-page>]]`, the target is reported under `skipped_existing_backlink[]` and the file is not touched (no re-write, no timestamp bump). Safe to re-run the same plan after fixing a typo in one target.
- **Partial-success**: per-target failures (missing target, unreadable file, write error) are captured under `failed[]` without aborting the whole run.
- **Malformed plan**: exits non-zero with the standard `{success:false, error:"..."}` contract and makes no writes.
- **Atomic write per page**: frontmatter `updated:` bump and sentence insertion happen in one `tempfile + os.replace` pair, so a crash mid-write can never leave a page with a new sentence but stale timestamp (the bug this PR exists to prevent).

## Test plan

- [x] Audit mode byte-identical without `--apply-plan` — verified (existing output contract unchanged).
- [x] Smoke test on a 4-page fixture wiki: target with heading → sentence inserted under heading, `updated:` bumped; target without heading → appended at end of body, `updated:` bumped; target with pre-existing backlink → skipped, file untouched; missing target → `failed[]` entry with clear error message.
- [x] Idempotency: re-running the same plan after first apply reports every target under `skipped_existing_backlink[]` and makes no writes.
- [x] Malformed-plan path (invalid JSON, missing `targets`): non-zero exit with `{success:false, error:"..."}` and no partial writes.
- [x] Python AST parse + `argparse --help` render cleanly.

## Maturity / version

- `cogni-wiki` bumped `v0.0.5` → `v0.0.6` in both `cogni-wiki/.claude-plugin/plugin.json` and the `.claude-plugin/marketplace.json` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
