### PR TITLE
docs: sync cogni-workspace + 3 plugins with code reality, regen root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Install insight-wave via Claude Code desktop — about 15 minutes from zero, in 
 2. **Configure for your environment** *(optional, enterprise only)* — [Deployment Guide](docs/deployment-guide.md) — GDPR, SSO, managed settings, MDM / Group Policy. Skip unless your firm mandates managed Claude Code settings before install.
 3. **Install insight-wave and render your first infographic** — [From Install to Infographic](docs/workflows/install-to-infographic.md) — adds the marketplace, installs plugins, runs `/install-mcp`, renders your first infographic. This is the capstone step where you go from installed to producing.
 
+### Security & compliance
+
+For regulated environments — GDPR, SSO, managed settings, MDM / Group Policy, egress controls, audit logging — the [Deployment Guide](docs/deployment-guide.md) covers the enterprise-grade configuration options and trust-boundary decisions. Individual-install users can skip this; it matters only when your firm mandates managed Claude Code settings before install. The guide is derived from `cogni-docs/references/deploy-data.json` and refreshed whenever the underlying Anthropic / Claude Code posture changes.
+
 ### MCP servers at a glance
 
 Some plugins extend their capabilities through external [MCP servers](https://docs.anthropic.com/en/docs/build-with-claude/mcp). Plugins declare their MCP dependencies in `.mcp.json` files — Desktop/Cowork auto-discovers and starts required servers on install.
@@ -243,9 +247,9 @@ Plugins follow the [Claude Code plugin standard](https://code.claude.com/docs/en
 | [cogni-claims](cogni-claims/README.md) | Quality | 2 | 2 | Source verification — catches misquotations, unsupported conclusions, and stale data in sourced claims |
 | [cogni-help](cogni-help/README.md) | Platform | 7 | 1 | 12-course curriculum, plugin discovery, workflow templates, troubleshooting, and cheatsheets |
 | [cogni-wiki](cogni-wiki/README.md) | Platform | 7 | 0 | Persistent interlinked markdown wiki — compile-time knowledge from sources, wiki-grounded answers, backlink audit, health lint |
-| [cogni-workspace](cogni-workspace/README.md) | Platform | 5 | 0 | Shared foundation — env vars, MCP installation, theme management, plugin discovery, workspace health, Obsidian integration |
+| [cogni-workspace](cogni-workspace/README.md) | Platform | 6 | 0 | Shared foundation — env vars, MCP installation, theme management, plugin discovery, workspace health, Obsidian integration, bundled wiki |
 
-**91 skills, 74 agents** across the ecosystem.
+**92 skills, 74 agents** across the ecosystem.
 
 See [Cross-Plugin Data Flow](docs/er-diagram.md) for how data flows between plugins, or browse the [full documentation](docs/ecosystem-overview.md).
 

--- a/cogni-marketing/README.md
+++ b/cogni-marketing/README.md
@@ -169,8 +169,6 @@ cogni-marketing/
 | cogni-trends | Yes | Strategic themes (Handlungsfelder), trend data, claims |
 | cogni-copywriting | No | Polish generated content with messaging frameworks |
 | cogni-visual | No | Slide decks and visual assets from content briefs |
-| cogni-narrative | No | Arc-driven transformation for long-form thought leadership |
-| cogni-claims | No | Evidence verification for sourced claims in content |
 
 ## Contributing
 

--- a/cogni-marketing/README.md
+++ b/cogni-marketing/README.md
@@ -169,6 +169,8 @@ cogni-marketing/
 | cogni-trends | Yes | Strategic themes (Handlungsfelder), trend data, claims |
 | cogni-copywriting | No | Polish generated content with messaging frameworks |
 | cogni-visual | No | Slide decks and visual assets from content briefs |
+| cogni-narrative | No | Arc-driven transformation for long-form thought leadership |
+| cogni-claims | No | Evidence verification for sourced claims in content |
 
 ## Contributing
 

--- a/cogni-sales/README.md
+++ b/cogni-sales/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-B2B sales pitch generation for [Claude Cowork](https://claude.ai/cowork) using Corporate Visions Why Change methodology. Creates sales presentations and proposals for named customers (deal-specific) or market segments (reusable). Builds on cogni-portfolio data with optional TIPS strategic enrichment. Bilingual DE/EN.
+B2B sales pitch generation using Corporate Visions Why Change methodology. Creates sales presentations and proposals for named customers (deal-specific) or market segments (reusable). Builds on cogni-portfolio data with optional TIPS strategic enrichment. Bilingual DE/EN.
 
 ## Why this exists
 

--- a/cogni-wiki/README.md
+++ b/cogni-wiki/README.md
@@ -1,6 +1,6 @@
 # cogni-wiki
 
-> **Incubating** (v0.0.4) — skills, data formats, and workflows may change at any time.
+> **Incubating** (v0.0.5) — skills, data formats, and workflows may change at any time.
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-The foundation-layer plugin for the [insight-wave](https://claude.ai/cowork) ecosystem — the only plugin that other cogni-x plugins depend on, and the one that must be initialized first. cogni-workspace owns environment configuration, MCP server installation, theme storage, plugin discovery, workspace health diagnostics, and Obsidian vault integration — so every cogni-x plugin starts running, not configuring.
+The foundation-layer plugin for the [insight-wave](https://claude.ai/cowork) ecosystem — the only plugin that other cogni-x plugins depend on, and the one that must be initialized first. cogni-workspace owns environment configuration, MCP server installation, theme storage, plugin discovery, workspace health diagnostics, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the `ask` skill — so every cogni-x plugin starts running, not configuring.
 
 ## Why this exists
 
@@ -91,6 +91,7 @@ Claude checks dependencies, discovers installed plugins, asks for your language 
 | `pick-theme` | skill | Centralized theme picker — discovers themes, presents interactive selection, returns path |
 | `workspace-status` | skill | Five-tier diagnostic: foundation, env vars, plugin registry, themes, dependencies |
 | `install-mcp` | skill | End-to-end MCP server installation — clone and build git-based MCPs, configure native app MCPs, and patch Claude Desktop config |
+| `ask` | skill | Answer questions about the insight-wave ecosystem by reading the bundled wiki — grounded, cited, never from memory |
 | `on-session-start.sh` | hook (SessionStart) | Sources workspace environment and validates plugin availability at session start |
 | `check-dependencies.sh` | script | Returns JSON with availability/version of required and optional dependencies |
 | `check-skill-names.sh` | script | Validates skill directory names against plugin.json manifest for consistency |
@@ -107,12 +108,14 @@ Claude checks dependencies, discovers installed plugins, asks for your language 
 ```
 cogni-workspace/
 ├── .claude-plugin/plugin.json    Plugin manifest
-├── skills/                       5 workspace management skills
+├── skills/                       6 workspace management skills
+│   ├── ask/                      Query the bundled insight-wave wiki for grounded answers
 │   ├── install-mcp/              MCP server installation and Desktop config patching
 │   ├── manage-workspace/         Init or update workspace (includes Obsidian integration)
 │   ├── manage-themes/
 │   ├── pick-theme/
 │   └── workspace-status/
+├── wiki/                         Bundled vendor-curated insight-wave reference wiki (read by ask)
 ├── templates/                    Shared templates
 │   ├── obsidian/                 Obsidian vault config templates
 │   └── mcp-wrappers/             Wrapper scripts for git-based MCP servers
@@ -155,6 +158,7 @@ cogni-workspace has no required plugin dependencies — it is the foundation lay
 | cogni-help | No | Referenced inline in workspace skills for issue filing and guided help |
 | cogni-portfolio | No | install-mcp references cogni-portfolio as a consumer of excalidraw MCP in the installation plan |
 | cogni-claims | No | workspace-status references cogni-claims as a provider plugin for the claude-in-chrome MCP server check |
+| cogni-wiki | No | `ask` wraps `cogni-wiki:wiki-query` to read the bundled insight-wave reference wiki |
 
 ## Contributing
 

--- a/docs/plugin-guide/cogni-workspace.md
+++ b/docs/plugin-guide/cogni-workspace.md
@@ -168,6 +168,32 @@ Prerequisites: Obsidian must be installed. The skill handles Terminal plugin ins
 
 ---
 
+### `install-mcp` — MCP server installation
+
+End-to-end MCP server installation for the ecosystem. Clones and builds git-based MCPs (Excalidraw, Pencil), detects native-app MCPs (browsermcp, claude-in-chrome), and patches Claude Desktop's `claude_desktop_config.json` so rendering plugins find their tools without hand-edited JSON.
+
+```
+/install-mcp
+```
+
+Backs up the desktop config before any write; rolls back in one command if an install breaks something. Usually invoked automatically by `manage-workspace` Step 5, but available standalone when you add a new plugin that declares an MCP dependency.
+
+---
+
+### `ask` — Query the bundled insight-wave wiki
+
+Answers questions about the insight-wave ecosystem — plugins, skills, agents, architecture, cross-cutting conventions — by reading the vendor-curated wiki bundled at `${CLAUDE_PLUGIN_ROOT}/wiki/`, not from model memory. Wraps `cogni-wiki:wiki-query` so answers are grounded and cited with `[[wikilinks]]`; if the wiki has no page on the topic, the skill says so rather than guessing.
+
+```
+/ask how does claims propagation work across plugins?
+/ask which plugin generates IS/DOES/MEANS messaging?
+/ask what's the difference between cogni-narrative and cogni-copywriting?
+```
+
+First lookup before grepping source files — faster and doesn't pull plugin internals into your context.
+
+---
+
 ## Integration Points
 
 ### Upstream — cogni-workspace depends on nothing


### PR DESCRIPTION
## Summary
- Document the new `ask` skill across cogni-workspace README + docs/
- Align cogni-sales description across README and plugin.json (drop the stray "for Claude Cowork" qualifier that contradicted the readiness callout)
- Refresh cogni-wiki maturity callout (v0.0.4 → v0.0.5)
- Regenerate root README (cogni-workspace skill count 5 → 6, aggregate 91 → 92 skills, add `### Security & compliance` subsection)
- Defer 5 plugins with `## Install` heading drift: the generator emits `## Install` by design but the schema's heading-variants table doesn't list it — the fix belongs in managed-service (`readme-section-schema.md`), not here

## Plugins fixed
- **cogni-workspace** — components + architecture + descriptions + dependencies + docs/ staleness. The new `ask` skill (wraps `cogni-wiki:wiki-query` against a bundled vendor-curated insight-wave reference wiki at `wiki/`) is now documented in the Components table, the Architecture tree (which also gained the `wiki/` directory line), the Dependencies table (new `cogni-wiki` row), and the plugin guide at `docs/plugin-guide/cogni-workspace.md` (both `install-mcp` and `ask` sections added under Capabilities).
- **cogni-sales** — descriptions. README first paragraph dropped the "for [Claude Cowork]" qualifier so all three sources (README, plugin.json, marketplace.json) now say the same thing. The qualifier also contradicted the plugin's own readiness callout ("Claude Code desktop is the recommended interface").
- **cogni-wiki** — maturity. Callout refreshed from `(v0.0.4)` to `(v0.0.5)` to match `plugin.json`.
- **Root README** — "Plugins at a glance" row for cogni-workspace updated from `5 | 0` to `6 | 0`, aggregate updated from "91 skills, 74 agents" to "92 skills, 74 agents", and a new `### Security & compliance` subsection added under `## Install` (was a Check 12d gap — deploy-data.json exists but no dedicated subsection called out the GDPR / SSO / MDM options).

## Plugins deferred
- **cogni-claims**, **cogni-trends**, **cogni-portfolio**, **cogni-consulting** — shared Check 10b DRIFT on `## Install` heading. The doc-generate template emits `## Install` by design (matches the root README and signals "short defer-pointer, not a walkthrough"), but `readme-section-schema.md`'s heading-variants table only lists `## Installation` as canonical with no registered variants. Re-running doc-generate would re-emit the same heading and the drift would stay. Not fixable inside insight-wave.

## Open questions
- **Schema fix needed upstream in `managed-service`**: `cogni-docs/skills/doc-audit/references/readme-section-schema.md` heading-variants table does not list `## Install` as a variant of `## Installation` even though `doc-generate`'s template emits it. 5 plugins will keep flagging Check 10b until either the schema is updated or the generator switches to `## Installation`. Consistent audit-agent readings also disagreed on this between the pre- and post-audit pass (some agents accepted `## Install` as a variant, others didn't) — another signal the schema gap is real.
- **cogni-sales "for Claude Cowork" qualifier**: this PR removes it from the README to match plugin.json. If the qualifier is intentional positioning, prefer adding it to plugin.json + marketplace.json upstream instead — human judgment; review the diff before merge.
- **Mid-cycle revert on cogni-marketing**: the pre-audit flagged cogni-narrative + cogni-claims as missing from the Dependencies table based on a broad grep that included CLAUDE.md and `references/data-model.md`. I added the rows, ran the post-audit, and the post-audit (using Check 4's formal SKILL.md + agent .md scope) flagged them as phantom — cogni-marketing does not actually invoke cogni-narrative or cogni-claims from any skill; the CLAUDE.md mentions describe downstream consumers (what happens to cogni-marketing output), not upstream deps. Reverted in a second commit on this branch. The PR's net diff on cogni-marketing is zero — but I wanted the two commits visible for auditability. Please confirm the revert call in review.
- **Meta pre-flight INFO**: `pipeline-registry.json` is missing 2 skills on disk (`ask` @ cogni-workspace, `service-ship` @ cogni-service). Informational; run `/cogni-docs:doc-meta refresh` separately to reconcile — not blocking this PR.
- **Issue #11 context**: this run was dispatched by managed-service#11 to sweep v0.16.0 templates, but Check 10e (Install section shape) and Check 14 (Readiness callout) are **already OK across all 14 plugins** — issue #11's explicit acceptance criteria are already met. This PR ships the unrelated residual drift that the audit surfaced; the resolution of managed-service#11 is to close it as "acceptance criteria met" with a pointer to this PR.

## Test plan
- [ ] Post-audit verified: cogni-workspace components/architecture/descriptions/dependencies/docs OK, cogni-sales descriptions OK, cogni-wiki maturity OK, root README Check 12a (row count) + Check 12d (Security & compliance) OK.
- [ ] Confirm no unrelated plugins were modified (cogni-narrative, cogni-copywriting, cogni-visual, cogni-help, cogni-research, cogni-website all untouched — only the 4 plugin READMEs + root README + 1 plugin guide changed).
- [ ] Spot-check 3 plugin READMEs to confirm the readiness callout still reads correctly (unchanged — this PR doesn't touch them, issue #11's Check 14 acceptance was already met pre-run).
- [ ] Verify cogni-workspace plugin guide `docs/plugin-guide/cogni-workspace.md` Capabilities section now documents both `install-mcp` and `ask` (previously only 4 of 6 skills were covered).

---

## Automated review — PASS

### Completeness
5 of 5 planned targets verified clean in post-audit:
- cogni-workspace: components, architecture, descriptions, dependencies, docs/ all OK (new `ask` skill now documented in Components table, Architecture tree, Dependencies, and plugin guide).
- cogni-sales: descriptions OK ('for Claude Cowork' qualifier dropped to match plugin.json).
- cogni-wiki: maturity callout OK (v0.0.4 → v0.0.5).
- cogni-marketing: net-zero after mid-cycle revert (pre-audit flagged phantom deps based on CLAUDE.md consumer references; post-audit confirmed Check 4's formal SKILL.md-only scope rules those out — correct call to revert).
- Root README: cogni-workspace row count 5→6, aggregate 91→92, `### Security & compliance` subsection added.

### Regressions
None. Every OK cell in pre-audit remains OK in post-audit.

### Deferred plugins
cogni-claims, cogni-trends, cogni-portfolio, cogni-consulting: not touched, as planned. Shared 10b `## Install` schema-nit remains — needs upstream fix in managed-service (schema's heading-variants table doesn't list `## Install`).

### Version bumps
N/A — all 5 changed files are README/docs-only. No SKILL.md, agent, or script edits. Per CLAUDE.md, `docs:` commits don't require plugin.json version bumps.

### Suggested next step
Ship as draft per `ready_hint: false`. Human reviewer should confirm the cogni-marketing revert rationale and decide whether to land the upstream schema fix for `## Install` before or after merge.
