### PR TITLE
cogni-wiki: wiki-ingest --batch-file parameter (single dispatch, N sources)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -243,7 +243,7 @@
     {
       "name": "cogni-wiki",
       "source": "./cogni-wiki",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "maturity": "incubating",
       "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
       "keywords": [

--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-wiki/CLAUDE.md
+++ b/cogni-wiki/CLAUDE.md
@@ -16,6 +16,7 @@ skills/                         7 wiki skills
     references/
       page-frontmatter.md         YAML schema (id, title, tags, type, sources, ...)
       ingest-workflow.md          Step-by-step ingest behavior
+      batch-mode.md               --batch-file input schema, error policy, worked example
   wiki-query/                     Ask questions; answer from wiki, never from memory
     references/
       query-patterns.md           Read-before-answer, citation discipline

--- a/cogni-wiki/skills/wiki-ingest/SKILL.md
+++ b/cogni-wiki/skills/wiki-ingest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wiki-ingest
-description: "Ingest a source document (file, URL, pasted text, transcript, paper, article) into a Karpathy-style wiki — Claude reads the source, surfaces key takeaways, writes a summary page with YAML frontmatter, updates wiki/index.md, appends to wiki/log.md, and runs a backlink audit to weave the new page into existing knowledge. Use this skill whenever the user says 'ingest this', 'add this to my wiki', 'summarise this paper into the wiki', 'file this source', 'wiki ingest', 'wiki add', drops a document and asks Claude to process it, or pastes content with a request to save it as a wiki page. Also trigger when the user moves a new file into raw/ and asks 'what should I do with this?' — offer to ingest it. Also trigger when the user asks to ingest multiple sources at once ('ingest these papers', 'batch ingest raw/', 'ingest everything in raw/')."
+description: "Ingest a source (file, URL, paste, paper, article) into a Karpathy-style wiki — writes a summary page with YAML frontmatter, updates wiki/index.md, appends to wiki/log.md, and runs a backlink audit. Trigger when the user says 'ingest this', 'add this to my wiki', 'summarise this into the wiki', 'wiki ingest', drops a file in raw/ and asks what to do with it, or asks to batch ingest multiple sources ('ingest these papers', 'batch ingest raw/', 'ingest everything in raw/')."
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 
@@ -29,7 +29,7 @@ Exactly one of `--source` or `--batch-file` must be provided.
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `--source` | Yes (single-source mode) | Path to a file in `raw/`, a URL, or the literal string `--stdin` when the user pasted content. Mutually exclusive with `--batch-file` |
-| `--batch-file` | Yes (batch mode) | Path to a JSON file listing multiple sources to ingest in one dispatch. See `./references/batch-mode.md` for schema. Mutually exclusive with `--source` |
+| `--batch-file` | Yes (batch mode) | Path to a JSON file listing multiple sources to ingest in one dispatch. See `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/batch-mode.md` for schema. Mutually exclusive with `--source` |
 | `--title` | No | Override the page title; otherwise derive from the source (first heading, URL title, filename). Single-source mode only — in batch mode, titles are per-entry in the JSON |
 | `--type` | No | Page type: `concept | entity | summary | decision | learning | note`. Defaults to `summary` for full-source ingests, `note` for short pastes. Single-source mode only |
 | `--tags` | No | Comma-separated tags. Single-source mode only |
@@ -40,14 +40,14 @@ Exactly one of `--source` or `--batch-file` must be provided.
 
 If `--batch-file` is present:
 
-- Validate the JSON against the schema in `${CLAUDE_PLUGIN_ROOT}/references/batch-mode.md` and abort before any write on schema, missing-source, or mutual-exclusion violations (see `${CLAUDE_PLUGIN_ROOT}/references/batch-mode.md` §"Input schema" and §"Error policy").
+- Validate the JSON against the schema in `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/batch-mode.md` and abort before any write on schema, missing-source, or mutual-exclusion violations (see `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/batch-mode.md` §"Input schema" and §"Error policy").
 - Otherwise, run Steps 1–8 as a loop over `sources[]`. Each entry flows through Step 1's `mode: fresh | re-ingest` detection independently. Detect mode per entry; do not treat the batch as a mode-wide toggle.
-- Fail-fast policy: if any per-source step errors, halt the loop and report what completed, what failed, and what was skipped in Step 9. The wiki stays consistent because every per-source step already writes atomically; see `${CLAUDE_PLUGIN_ROOT}/references/batch-mode.md` §"Error policy" for the details and resume procedure.
+- Fail-fast policy: if any per-source step errors, halt the loop and report what completed, what failed, and what was skipped in Step 9. The wiki stays consistent because every per-source step already writes atomically; see `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/batch-mode.md` §"Error policy" for the details and resume procedure.
 - In Step 9, emit one aggregated report instead of a per-source report.
 
 If `--batch-file` is absent, run Steps 1–9 on the single `--source` as before. This is the existing path; nothing about it changes.
 
-In both cases, the skill instructions and `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` + `${CLAUDE_PLUGIN_ROOT}/references/page-frontmatter.md` load exactly once per dispatch — one context load, N sources, materially fewer tokens and lower latency than N single-source dispatches.
+In both cases, the skill instructions and shared references load exactly once per dispatch — one context load, N sources, materially fewer tokens and lower latency than N single-source dispatches.
 
 ### 1. Locate the wiki and detect ingest mode
 
@@ -62,7 +62,7 @@ Derive the target slug from `--title` (or from the source filename / URL title /
 
   Then proceed with the remaining steps — `mode` changes only Step 7 (log entry type) and Step 8 (entry count handling).
 
-See `./references/ingest-workflow.md` §"Mode flag: fresh vs re-ingest" for when to pick `wiki-update` instead of re-ingest.
+See `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/ingest-workflow.md` §"Mode flag: fresh vs re-ingest" for when to pick `wiki-update` instead of re-ingest.
 
 ### 2. Read the source
 
@@ -87,7 +87,7 @@ Show this synthesis to the user before proceeding to write. For autonomous runs 
 
 Path: `<wiki-root>/wiki/pages/{slug}.md` where `slug` is derived from the title.
 
-Frontmatter (see `./references/page-frontmatter.md` for the full schema):
+Frontmatter (see `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/page-frontmatter.md` for the full schema):
 
 ```yaml
 ---
@@ -190,7 +190,7 @@ Never rewrite existing log lines.
 - How many existing pages got backlinks
 - What to do next (usually: drop another source or run `wiki-query`)
 
-**Batch mode.** Emit one aggregated block instead of a per-source report. For every entry that reached this step, print the slug, its resolved mode (`fresh` or `re-ingest`), and its backlink count. Report `entries_count` delta (fresh sources only; re-ingests never increment). On a fail-fast halt, also list the source that failed with its error and any sources that were skipped. See `./references/batch-mode.md` §"Step 9 in batch mode" for the exact format.
+**Batch mode.** Emit one aggregated block instead of a per-source report. For every entry that reached this step, print the slug, its resolved mode (`fresh` or `re-ingest`), and its backlink count. Report `entries_count` delta (fresh sources only; re-ingests never increment). On a fail-fast halt, also list the source that failed with its error and any sources that were skipped. See `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/batch-mode.md` §"Step 9 in batch mode" for the exact format.
 
 ## Output
 
@@ -210,8 +210,8 @@ Never rewrite existing log lines.
 ## References
 
 - `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` — the pattern
-- `./references/page-frontmatter.md` — full frontmatter schema
-- `./references/ingest-workflow.md` — worked example
-- `./references/batch-mode.md` — `--batch-file` input schema, per-source mode rules, error policy, and worked example
-- `./scripts/backlink_audit.py` — candidate backlink finder
-- `./scripts/wiki_index_update.py` — deterministic `wiki/index.md` insert/update helper
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/page-frontmatter.md` — full frontmatter schema
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/ingest-workflow.md` — worked example
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/batch-mode.md` — `--batch-file` input schema, per-source mode rules, error policy, and worked example
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/backlink_audit.py` — candidate backlink finder
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/wiki_index_update.py` — deterministic `wiki/index.md` insert/update helper

--- a/cogni-wiki/skills/wiki-ingest/SKILL.md
+++ b/cogni-wiki/skills/wiki-ingest/SKILL.md
@@ -26,12 +26,27 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once at the start of
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--source` | Yes | Path to a file in `raw/`, a URL, or the literal string `--stdin` when the user pasted content |
-| `--title` | No | Override the page title; otherwise derive from the source (first heading, URL title, filename) |
-| `--type` | No | Page type: `concept | entity | summary | decision | learning | note`. Defaults to `summary` for full-source ingests, `note` for short pastes |
-| `--tags` | No | Comma-separated tags |
+| `--source` | Yes (single-source mode) | Path to a file in `raw/`, a URL, or the literal string `--stdin` when the user pasted content. Mutually exclusive with `--batch-file` |
+| `--batch-file` | Yes (batch mode) | Path to a JSON file listing multiple sources to ingest in one dispatch. See `./references/batch-mode.md` for schema. Mutually exclusive with `--source` |
+| `--title` | No | Override the page title; otherwise derive from the source (first heading, URL title, filename). Single-source mode only — in batch mode, titles are per-entry in the JSON |
+| `--type` | No | Page type: `concept | entity | summary | decision | learning | note`. Defaults to `summary` for full-source ingests, `note` for short pastes. Single-source mode only |
+| `--tags` | No | Comma-separated tags. Single-source mode only |
 
 ## Workflow
+
+### 0. Dispatch: single-source vs batch
+
+If `--batch-file` is present:
+
+- Read the JSON and validate it against the schema in `./references/batch-mode.md` (top-level `sources[]`, per-entry `source` required).
+- Abort before any write if the schema is invalid, if any `source` path is missing, or if both `--source` and `--batch-file` were passed.
+- Otherwise, run Steps 1–8 as a loop over `sources[]`. Each entry flows through Step 1's `mode: fresh | re-ingest` detection independently — the batch is never a mode-wide toggle.
+- Fail-fast policy: if any per-source step errors, halt the loop and report what completed, what failed, and what was skipped in Step 9. The wiki stays consistent because every per-source step already writes atomically; see `./references/batch-mode.md` §"Error policy" for the details and resume procedure.
+- Step 9 emits one aggregated report instead of a per-source report.
+
+If `--batch-file` is absent, run Steps 1–9 on the single `--source` as before. This is the existing path; nothing about it changes.
+
+In both cases, the skill instructions and `references/karpathy-pattern.md` + `references/page-frontmatter.md` load exactly once per dispatch — that is the point of batch mode.
 
 ### 1. Locate the wiki and detect ingest mode
 
@@ -169,10 +184,12 @@ Never rewrite existing log lines.
 
 ### 9. Report to the user
 
-Tell the user, in ≤5 sentences:
+**Single-source mode.** Tell the user, in ≤5 sentences:
 - The new page slug and path
 - How many existing pages got backlinks
 - What to do next (usually: drop another source or run `wiki-query`)
+
+**Batch mode.** Emit one aggregated block instead of a per-source report. For every entry that reached this step, print the slug, its resolved mode (`fresh` or `re-ingest`), and its backlink count. Report `entries_count` delta (fresh sources only; re-ingests never increment). On a fail-fast halt, also list the source that failed with its error and any sources that were skipped. See `./references/batch-mode.md` §"Step 9 in batch mode" for the exact format.
 
 ## Output
 
@@ -194,5 +211,6 @@ Tell the user, in ≤5 sentences:
 - `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` — the pattern
 - `./references/page-frontmatter.md` — full frontmatter schema
 - `./references/ingest-workflow.md` — worked example
+- `./references/batch-mode.md` — `--batch-file` input schema, per-source mode rules, error policy, and worked example
 - `./scripts/backlink_audit.py` — candidate backlink finder
 - `./scripts/wiki_index_update.py` — deterministic `wiki/index.md` insert/update helper

--- a/cogni-wiki/skills/wiki-ingest/SKILL.md
+++ b/cogni-wiki/skills/wiki-ingest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wiki-ingest
-description: "Ingest a source document (file, URL, pasted text, transcript, paper, article) into a Karpathy-style wiki — Claude reads the source, surfaces key takeaways, writes a summary page with YAML frontmatter, updates wiki/index.md, appends to wiki/log.md, and runs a backlink audit to weave the new page into existing knowledge. Use this skill whenever the user says 'ingest this', 'add this to my wiki', 'summarise this paper into the wiki', 'file this source', 'wiki ingest', 'wiki add', drops a document and asks Claude to process it, or pastes content with a request to save it as a wiki page. Also trigger when the user moves a new file into raw/ and asks 'what should I do with this?' — offer to ingest it."
+description: "Ingest a source document (file, URL, pasted text, transcript, paper, article) into a Karpathy-style wiki — Claude reads the source, surfaces key takeaways, writes a summary page with YAML frontmatter, updates wiki/index.md, appends to wiki/log.md, and runs a backlink audit to weave the new page into existing knowledge. Use this skill whenever the user says 'ingest this', 'add this to my wiki', 'summarise this paper into the wiki', 'file this source', 'wiki ingest', 'wiki add', drops a document and asks Claude to process it, or pastes content with a request to save it as a wiki page. Also trigger when the user moves a new file into raw/ and asks 'what should I do with this?' — offer to ingest it. Also trigger when the user asks to ingest multiple sources at once ('ingest these papers', 'batch ingest raw/', 'ingest everything in raw/')."
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 
@@ -24,6 +24,8 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once at the start of
 
 ## Parameters
 
+Exactly one of `--source` or `--batch-file` must be provided.
+
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `--source` | Yes (single-source mode) | Path to a file in `raw/`, a URL, or the literal string `--stdin` when the user pasted content. Mutually exclusive with `--batch-file` |
@@ -38,15 +40,14 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once at the start of
 
 If `--batch-file` is present:
 
-- Read the JSON and validate it against the schema in `./references/batch-mode.md` (top-level `sources[]`, per-entry `source` required).
-- Abort before any write if the schema is invalid, if any `source` path is missing, or if both `--source` and `--batch-file` were passed.
-- Otherwise, run Steps 1–8 as a loop over `sources[]`. Each entry flows through Step 1's `mode: fresh | re-ingest` detection independently — the batch is never a mode-wide toggle.
-- Fail-fast policy: if any per-source step errors, halt the loop and report what completed, what failed, and what was skipped in Step 9. The wiki stays consistent because every per-source step already writes atomically; see `./references/batch-mode.md` §"Error policy" for the details and resume procedure.
-- Step 9 emits one aggregated report instead of a per-source report.
+- Validate the JSON against the schema in `${CLAUDE_PLUGIN_ROOT}/references/batch-mode.md` and abort before any write on schema, missing-source, or mutual-exclusion violations (see `${CLAUDE_PLUGIN_ROOT}/references/batch-mode.md` §"Input schema" and §"Error policy").
+- Otherwise, run Steps 1–8 as a loop over `sources[]`. Each entry flows through Step 1's `mode: fresh | re-ingest` detection independently. Detect mode per entry; do not treat the batch as a mode-wide toggle.
+- Fail-fast policy: if any per-source step errors, halt the loop and report what completed, what failed, and what was skipped in Step 9. The wiki stays consistent because every per-source step already writes atomically; see `${CLAUDE_PLUGIN_ROOT}/references/batch-mode.md` §"Error policy" for the details and resume procedure.
+- In Step 9, emit one aggregated report instead of a per-source report.
 
 If `--batch-file` is absent, run Steps 1–9 on the single `--source` as before. This is the existing path; nothing about it changes.
 
-In both cases, the skill instructions and `references/karpathy-pattern.md` + `references/page-frontmatter.md` load exactly once per dispatch — that is the point of batch mode.
+In both cases, the skill instructions and `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` + `${CLAUDE_PLUGIN_ROOT}/references/page-frontmatter.md` load exactly once per dispatch — one context load, N sources, materially fewer tokens and lower latency than N single-source dispatches.
 
 ### 1. Locate the wiki and detect ingest mode
 

--- a/cogni-wiki/skills/wiki-ingest/references/batch-mode.md
+++ b/cogni-wiki/skills/wiki-ingest/references/batch-mode.md
@@ -1,0 +1,123 @@
+# Batch mode: one dispatch, N sources
+
+`wiki-ingest` normally runs the nine-step workflow against a single `--source`. On bulk rebuilds (e.g., Phase 2 of the pilot rebuild, ~164 skill+agent pages), re-dispatching the skill per source reloads `SKILL.md` + `references/karpathy-pattern.md` + `references/page-frontmatter.md` for every page — the cost is not in the per-page work but in the repeated instruction load.
+
+Batch mode eliminates that redundancy. Pass `--batch-file <path>` to a JSON list of per-source entries. The skill loads its instructions and references once, then iterates Steps 1–8 per entry. Step 9 aggregates the results into a single report.
+
+## When to use batch mode
+
+- Bulk rebuilds of script-generated pages (e.g., every skill page, every agent page, every plugin page).
+- Seeding a new wiki from a folder of raw sources in one go.
+- Any operation where re-dispatching `wiki-ingest` per source would burn tokens on repeated skill loads.
+
+Do **not** use batch mode when:
+
+- You have one source to ingest. The single-source path is simpler and its Step 9 report is richer per page.
+- The sources require different user-visible acknowledgments between them (each Step 3 takeaway synthesis still fires per source in batch mode, but a user looking for a decision point per source should run single-source ingests).
+
+## Input schema
+
+`--batch-file` accepts a path to a UTF-8 JSON file. Top-level shape:
+
+```json
+{
+  "sources": [
+    {
+      "source": "raw/bai-et-al-2022.pdf",
+      "title": "Constitutional AI",
+      "type": "summary",
+      "tags": ["llms", "safety"]
+    },
+    {
+      "source": "raw/many-shot-jailbreak.pdf",
+      "tags": ["safety"]
+    },
+    {
+      "source": "https://arxiv.org/abs/2501.12345"
+    }
+  ]
+}
+```
+
+Per-entry fields mirror the single-source CLI parameters exactly:
+
+| Field | Required | Behaviour |
+|-------|----------|-----------|
+| `source` | Yes | Path (relative to the wiki root) or URL; matches today's `--source` parameter |
+| `title` | No | Override; matches `--title` |
+| `type` | No | `concept \| entity \| summary \| decision \| learning \| note`; matches `--type` |
+| `tags` | No | List of strings; matches `--tags` (no comma splitting needed) |
+
+Any unknown field causes the batch to abort before Step 1 of the first entry — malformed input never half-writes the wiki.
+
+## Per-source mode resolution
+
+The `mode: fresh | re-ingest` resolution from Step 1 runs **per entry**, not per batch. A single batch may mix fresh and re-ingest sources freely; each one hits Step 1's slug-existence check independently, emits the verbatim re-ingest warning if applicable, and honours the mode-specific branches in Step 7 (log line) and Step 8 (entry-count handling).
+
+Batch mode does **not** accept a batch-wide mode toggle. Trying to force every source through one mode would be the wrong primitive: the pilot rebuild case explicitly mixes fresh new pages with re-syntheses of existing stubs, and a batch-wide flag would either double-count fresh entries or silently skip re-ingests.
+
+## Error policy: fail-fast for Phase 1
+
+If any per-source step (1–8) fails — script non-zero exit, malformed JSON, missing source file, write error — the batch halts immediately and Step 9 reports:
+
+1. How many sources completed successfully (slugs, modes).
+2. Which source failed and the error.
+3. Which sources were skipped (never attempted).
+
+The wiki is never left half-written because every per-source step already writes atomically (`wiki/pages/{slug}.md` is one write; `wiki_index_update.py` uses `tempfile + os.replace`; `backlink_audit.py --apply-plan` writes each target atomically; `wiki/log.md` append is one append; `.cogni-wiki/config.json` update is one write). A mid-batch crash leaves the wiki consistent for every source that had completed before the failure.
+
+**To resume** after a failure: re-invoke with a new `--batch-file` containing only the failed source plus the ones that were skipped. The completed sources are already in the wiki and will naturally re-route through the `mode: re-ingest` branch if you re-submit them (harmless — they update in place).
+
+Continue-on-error semantics (`--on-error continue`) are a deliberate Phase 2 follow-up: useful for the 164-page pilot rebuild once the fail-fast path proves stable.
+
+## Step 9 in batch mode
+
+Instead of a per-source report, Step 9 emits one aggregated block:
+
+```
+Batch complete: 3/3 sources
+- constitutional-ai           (re-ingest)  — 2 backlinks applied
+- many-shot-jailbreaking      (fresh)      — 1 backlink applied
+- chain-of-thought-prompting  (fresh)      — 0 backlinks applied
+
+entries_count: 42 → 44 (2 fresh, 1 re-ingest unchanged)
+```
+
+On failure:
+
+```
+Batch halted at source 2/3
+- constitutional-ai           (re-ingest)  — 2 backlinks applied   ✓
+- many-shot-jailbreaking                                            ✗  Step 5 (wiki_index_update.py exited non-zero): invalid category
+- chain-of-thought-prompting                                        · skipped
+
+entries_count: 42 → 42 (no fresh source completed)
+```
+
+## Worked example: 3-source batch
+
+Say the user has seeded `raw/` with three new papers and wants them ingested in one shot. They write `batch.json`:
+
+```json
+{
+  "sources": [
+    { "source": "raw/bai-et-al-2022.pdf", "title": "Constitutional AI", "type": "summary", "tags": ["llms", "safety"] },
+    { "source": "raw/bai-et-al-2024.pdf", "title": "Many-Shot Jailbreaking", "type": "summary", "tags": ["safety", "long-context"] },
+    { "source": "raw/wei-et-al-2022.pdf", "title": "Chain-of-Thought Prompting", "type": "concept", "tags": ["reasoning"] }
+  ]
+}
+```
+
+They invoke `wiki-ingest --batch-file batch.json`. Execution:
+
+1. **Step 0** — parse `batch.json`, validate the schema, confirm all three `source` paths exist. Load the skill instructions and references once.
+2. **Per-source loop** — Steps 1–8 run per entry. The first source detects `constitutional-ai` already exists at the target slug and enters `mode: re-ingest` (emitting the verbatim re-ingest warning and leaving `entries_count` untouched for that entry). The other two are fresh.
+3. **Step 9** — aggregate. Report 3/3 sources, the per-entry mode and backlink count, and the `entries_count` delta.
+
+The skill+references loaded once (not three times); each page still went through Step 3's takeaway synthesis, Step 5's atomic index update, and Step 6's backlink audit — identical per-page behaviour to single-source mode.
+
+## Related
+
+- `./ingest-workflow.md` — the single-source worked example this mode layers above.
+- `./page-frontmatter.md` — YAML schema; unchanged by batch mode.
+- `../scripts/wiki_index_update.py` and `../scripts/backlink_audit.py` — already atomic and idempotent, so calling them in a loop is safe.

--- a/cogni-wiki/skills/wiki-ingest/references/batch-mode.md
+++ b/cogni-wiki/skills/wiki-ingest/references/batch-mode.md
@@ -48,7 +48,7 @@ Per-entry fields mirror the single-source CLI parameters exactly:
 | `type` | No | `concept \| entity \| summary \| decision \| learning \| note`; matches `--type` |
 | `tags` | No | List of strings; matches `--tags` (no comma splitting needed) |
 
-Any unknown field causes the batch to abort before Step 1 of the first entry — malformed input never half-writes the wiki.
+Unknown top-level keys (siblings of `sources`) and unknown per-entry fields both cause the batch to abort before Step 1 of the first entry — malformed input never half-writes the wiki.
 
 ## Per-source mode resolution
 

--- a/cogni-wiki/skills/wiki-ingest/references/ingest-workflow.md
+++ b/cogni-wiki/skills/wiki-ingest/references/ingest-workflow.md
@@ -182,3 +182,68 @@ Pick the right entry point:
 - **`wiki-ingest` (→ fresh branch)** — no page at the target slug.
 
 Step 1 emits a verbatim warning on re-ingest that points users back at `wiki-update` for content-only tweaks; the two paths stay distinct even though they share the same skill entry point.
+
+## Batch mode: one dispatch, N sources
+
+`wiki-ingest` also accepts `--batch-file <path>` pointing at a JSON list of per-source entries. In that mode the skill instructions and references load once, Steps 1–8 run per entry, and Step 9 emits one aggregated report. Use it for bulk rebuilds (the canonical case: the 164-page pilot Phase 2) where re-dispatching the skill per source would burn tokens on repeated instruction loads.
+
+### Scenario
+
+The user has three new AI-safety papers staged in `raw/` and wants them all ingested in one go. They write `batch.json`:
+
+```json
+{
+  "sources": [
+    { "source": "raw/bai-et-al-2022.pdf", "title": "Constitutional AI", "type": "summary", "tags": ["llms", "safety"] },
+    { "source": "raw/bai-et-al-2024.pdf", "title": "Many-Shot Jailbreaking", "type": "summary", "tags": ["safety", "long-context"] },
+    { "source": "raw/wei-et-al-2022.pdf", "title": "Chain-of-Thought Prompting", "type": "concept", "tags": ["reasoning"] }
+  ]
+}
+```
+
+Assume the wiki already has a stub at `wiki/pages/constitutional-ai.md`; the other two slugs don't exist yet. They invoke `wiki-ingest --batch-file batch.json`.
+
+### Step 0: dispatch
+
+The skill reads `batch.json`, validates the schema (top-level `sources[]`, per-entry `source` required), confirms all three source paths exist, and enters batch mode. Instructions + `karpathy-pattern.md` + `page-frontmatter.md` load **once**.
+
+### Per-source iteration (Steps 1–8)
+
+**Source 1 — `bai-et-al-2022.pdf`.**
+
+- Step 1 derives slug `constitutional-ai`, detects the existing page, sets `mode: re-ingest`, and emits the verbatim re-ingest warning.
+- Step 3 surfaces takeaways (three-phase critique, scaling behaviour, constitutional principles list).
+- Step 4 overwrites the existing `constitutional-ai.md` with the re-synthesised content.
+- Step 5 calls `wiki_index_update.py`; the script returns `action: "updated"` (not `inserted`) because the index line already exists.
+- Step 6 finds two backlink candidates; orchestrator curates one; `backlink_audit.py --apply-plan` writes the target atomically.
+- Step 7 appends `## [2026-04-19] re-ingest | constitutional-ai — Constitutional AI`.
+- Step 8 leaves `entries_count` unchanged (re-ingest).
+
+**Source 2 — `bai-et-al-2024.pdf`.**
+
+- Step 1 derives slug `many-shot-jailbreaking`, detects no existing page, sets `mode: fresh`.
+- Steps 2–8 proceed as in the single-source example earlier in this document: new page written, index line inserted, one backlink applied to `long-context-vulnerabilities`, log line appended, `entries_count` incremented.
+
+**Source 3 — `wei-et-al-2022.pdf`.**
+
+- Step 1 derives slug `chain-of-thought-prompting`, fresh.
+- Steps 2–8 complete; no backlinks curated this time (the target pages exist but the matches are too shallow to force).
+- `entries_count` incremented.
+
+### Step 9: aggregated report
+
+```
+Batch complete: 3/3 sources
+- constitutional-ai           (re-ingest)  — 1 backlink applied
+- many-shot-jailbreaking      (fresh)      — 1 backlink applied
+- chain-of-thought-prompting  (fresh)      — 0 backlinks applied
+
+entries_count: 42 → 44 (2 fresh, 1 re-ingest unchanged)
+```
+
+### What batch mode does NOT change
+
+- Every per-source step is identical to single-source mode. Step 3's takeaway synthesis still fires; Step 5's `wiki_index_update.py` still runs atomically; Step 6's audit/curate/apply discipline is preserved; Step 8 still distinguishes fresh from re-ingest for `entries_count`.
+- On error, the fail-fast policy halts the loop and reports partial progress. Every completed source is already safely in the wiki because all per-source writes are atomic — see `./batch-mode.md` §"Error policy" for the full resume procedure.
+
+For the full schema, error policy, and the Phase 2 follow-ups deferred from this iteration (continue-on-error, parallel dispatch), read `./batch-mode.md`.


### PR DESCRIPTION
Closes #74. Unblocks #80.

## Summary
- Adds a new Step 0 to `wiki-ingest` that dispatches between single-source mode (today's behaviour, unchanged) and batch mode driven by `--batch-file <path>` pointing at a JSON list of per-source inputs.
- In batch mode the skill instructions + `references/karpathy-pattern.md` + `references/page-frontmatter.md` load **once** per dispatch; the per-source loop runs Steps 1–8 per entry, honouring each entry's own `mode: fresh | re-ingest` exactly as the existing Step 1 does today.
- Step 9 split into labelled single-source and batch-mode report shapes; batch mode aggregates slugs, per-source mode, backlink counts, and the `entries_count` delta (fresh sources only).
- Adds `skills/wiki-ingest/references/batch-mode.md`: input JSON schema, per-source mode resolution rules, fail-fast error policy with the exact resume procedure, a 3-source worked example, and the Phase 2 deferred items.
- Extends `skills/wiki-ingest/references/ingest-workflow.md` with a mixed fresh/re-ingest 3-source walkthrough end-to-end.
- Bumps `cogni-wiki` **0.0.7 → 0.0.8** in `plugin.json` and `marketplace.json` (mirrored).

## Scope decisions
**In scope (Phase 1):**
- `--batch-file <path>` parameter; mutual exclusion with `--source`; JSON schema validated before any write.
- New Step 0 dispatch (single-source vs batch) inserted above today's Step 1.
- Per-source loop semantics: Steps 1–8 run per source, Step 9 aggregates.
- **Fail-fast** error policy inside the loop — first per-source error halts the batch and reports what succeeded so far. The config writes in Steps 5/7/8 are already atomic (`tempfile + os.replace`, append-only log, idempotent `backlink_audit.py --apply-plan`), so the wiki is never left half-written.
- Worked example in `ingest-workflow.md` showing a 3-source batch that mixes fresh + re-ingest.
- Version bump to 0.0.8 (plugin.json + marketplace.json mirror).

**Deferred (follow-up issues — see `batch-mode.md` for the full list):**
- Standalone `wiki-ingest-batch` skill (option (b) from triage) — only worth doing if the parameter path proves awkward under real bulk runs.
- Continue-on-error batch mode (`--on-error continue`) so one bad source doesn't abort a 164-page run. #80 can resume from the last successful slug by re-submitting the failed+skipped entries.
- Parallel per-source dispatch — scripts are already idempotent and atomic, so this is mechanically safe but orthogonal to the skill-load cost this PR targets.
- Batch shapes for `wiki-update` and `wiki-dashboard` if they surface as bottlenecks during Phase 2.

**Why option (a) over (b):** ~95% of the work is shared with single-source ingest; a second skill would duplicate the Step 1–8 recipe and double the maintenance cost. Triage recommended option (a) as Phase 1; that recommendation stood after the PR #75 unblock and still stands.

## Collision resolution (from the parked comment on #74)
- **Version bump.** Main is past PR #75's 0.0.5 bump, and past PR #77/#78's 0.0.6 → 0.0.7 bumps; this PR lands as 0.0.7 → 0.0.8. Triage's "0.0.5 → 0.0.6" number is stale; the semantic decision (patch-bump) is intact.
- **SKILL.md Step 1 overlap with PR #75.** The new Step 0 (batch dispatch) layers cleanly above the existing Step 1 `mode: fresh | re-ingest` branch. Per-source mode resolution still happens inside the loop at Step 1, per source — the batch is never a mode-wide toggle. Explicitly reaffirmed in `batch-mode.md` §"Per-source mode resolution".

## Test plan
- [ ] `wiki-ingest --source raw/foo.md` (no batch) end-to-end on a scratch wiki — Steps 1–9 fire exactly as before, no regression (pilot repro: PR #67's page-1 flow).
- [ ] `wiki-ingest --batch-file batch.json` with a 3-source JSON list (1 fresh, 1 re-ingest, 1 with a new tag) — instructions load once, each source runs Steps 1–8, Step 9 emits the aggregated summary, `entries_count` increments by exactly 1 (only the fresh new source).
- [ ] Inject a bad `--source` path at position 2 of a 3-source batch — skill reports partial progress (source 1 landed, source 2 failed, source 3 skipped); wiki is not half-written (`index.md`, `log.md`, `config.json` consistent for source 1 only).
- [ ] Re-ingest source in a batch emits the verbatim re-ingest warning and does NOT increment `entries_count`.
- [ ] Both `--source` and `--batch-file` passed together → abort before any write (mutual exclusion).
- [ ] Malformed `batch.json` (missing top-level `sources[]`, missing per-entry `source`, unknown field) → abort before Step 1 of the first entry.
- [ ] `plugin.json` and `marketplace.json` both show 0.0.8 for cogni-wiki.
- [ ] `grep -n 'batch-file' cogni-wiki/skills/wiki-ingest/SKILL.md` → parameter documented in Parameters table, referenced in Step 0 and Step 9, and linked from the References list.
