### PR TITLE
cogni-sales: Brazilian Portuguese section headers (Phase 1 of #95)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -192,9 +192,9 @@
     {
       "name": "cogni-sales",
       "source": "./cogni-sales",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "maturity": "preview",
-      "description": "B2B sales pitch generation using Corporate Visions Why Change methodology. Creates sales presentations and proposals for named customers (deal-specific) or market segments (reusable). Builds on cogni-portfolio data with optional TIPS strategic enrichment. Bilingual DE/EN.",
+      "description": "B2B sales pitch generation using Corporate Visions Why Change methodology. Creates sales presentations and proposals for named customers (deal-specific) or market segments (reusable). Builds on cogni-portfolio data with optional TIPS strategic enrichment. Multilingual EN / DE / PT-BR.",
       "keywords": [
         "sales",
         "pitch",

--- a/cogni-sales/.claude-plugin/plugin.json
+++ b/cogni-sales/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cogni-sales",
-  "version": "0.4.1",
-  "description": "B2B sales pitch generation using Corporate Visions Why Change methodology. Creates sales presentations and proposals for named customers (deal-specific) or market segments (reusable). Builds on cogni-portfolio data with optional TIPS strategic enrichment. Bilingual DE/EN.",
+  "version": "0.4.2",
+  "description": "B2B sales pitch generation using Corporate Visions Why Change methodology. Creates sales presentations and proposals for named customers (deal-specific) or market segments (reusable). Builds on cogni-portfolio data with optional TIPS strategic enrichment. Multilingual EN / DE / PT-BR.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"

--- a/cogni-sales/CLAUDE.md
+++ b/cogni-sales/CLAUDE.md
@@ -1,6 +1,6 @@
 # cogni-sales
 
-B2B sales pitch generation using Corporate Visions Why Change methodology — creates deal-specific or reusable segment pitches from cogni-portfolio data with web research evidence. Bilingual DE/EN.
+B2B sales pitch generation using Corporate Visions Why Change methodology — creates deal-specific or reusable segment pitches from cogni-portfolio data with web research evidence. Multilingual EN / DE / PT-BR.
 
 ## Plugin Architecture
 

--- a/cogni-sales/README.md
+++ b/cogni-sales/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-B2B sales pitch generation using Corporate Visions Why Change methodology. Creates sales presentations and proposals for named customers (deal-specific) or market segments (reusable). Builds on cogni-portfolio data with optional TIPS strategic enrichment. Bilingual DE/EN.
+B2B sales pitch generation using Corporate Visions Why Change methodology. Creates sales presentations and proposals for named customers (deal-specific) or market segments (reusable). Builds on cogni-portfolio data with optional TIPS strategic enrichment. Multilingual EN / DE / PT-BR.
 
 ## Why this exists
 

--- a/cogni-sales/README.md
+++ b/cogni-sales/README.md
@@ -119,7 +119,7 @@ Each pitch project tracks state in `pitch-log.json` with pitch mode (customer/se
 
 ```
 cogni-sales/
-├── .claude-plugin/               Plugin manifest (v0.4.1)
+├── .claude-plugin/               Plugin manifest (v0.4.2)
 ├── skills/                       1 pitch skill
 │   └── why-change/
 │       ├── SKILL.md

--- a/cogni-sales/references/section-headers-pt.md
+++ b/cogni-sales/references/section-headers-pt.md
@@ -1,0 +1,23 @@
+# Brazilian Portuguese Section Headers
+
+When `language` is `pt`, use these Brazilian Portuguese headers instead of the English template defaults.
+
+| English Template Header | Brazilian Portuguese Header |
+|------------------------|------------------------------|
+| Why Change: The Hidden Cost of the Status Quo | Por Que Mudar: O Custo Oculto do Status Quo |
+| The Current Reality | A Realidade Atual |
+| Unconsidered Needs | Necessidades Não Consideradas |
+| Why This Matters | Por Que Isso Importa |
+| Why Now: The Cost of Waiting | Por Que Agora: O Custo de Esperar |
+| Timing Triggers | Gatilhos de Oportunidade |
+| Cost of Inaction | Custo da Inação |
+| Why You: Our Unique Position | Por Que Nós: Nossa Posição Única |
+| Key Differentiators | Principais Diferenciais |
+| Competitive Differentiation | Diferenciação Competitiva |
+| Why Pay: The Business Case | Por Que Investir: O Business Case |
+| Investment Overview | Visão Geral do Investimento |
+| ROI Analysis | Análise do ROI |
+| Next Steps | Próximos Passos |
+| Sources & Claims | Fontes e Evidências |
+| Our References | Nossas Referências |
+| Proven Results | Resultados Comprovados |


### PR DESCRIPTION
Refs #95.

## Summary
- Adds `cogni-sales/references/section-headers-pt.md` mirroring the 17-row DE→EN header table with Brazilian Portuguese equivalents, so `output_language=pt` pitches stop silently falling back to English section labels.
- Updates `cogni-sales/README.md` to document PT-BR as a supported language alongside DE/EN.

## Scope decisions
**In scope (Phase 1):** cogni-sales only. It is the only one of the four downstream plugins that already has a `references/section-headers-{lang}.md` precedent (DE). Mirroring that file for PT is a no-assumption, no-risk change that passes the existing pattern-fidelity bar in the issue's Acceptance section.

**Deferred to follow-up issues:** cogni-narrative, cogni-copywriting, and cogni-marketing PT support. None of them has a plugin-root `references/` per-language file today, so adding PT there requires a scaffolding decision — new `references/*-pt.md` files vs. inline locale branches in existing prompts — that the reporter must weigh in on. See Open questions below. End-to-end `output_language=pt` validation across all four plugins (issue Acceptance #1) lands once those follow-ups ship.

**Out of scope (per issue):** additional PT-speaking markets (Portugal, Angola, Mozambique).

## Test plan
- [ ] `cogni-sales/references/section-headers-pt.md` exists and has the same 17 English template rows as `section-headers-de.md` with Brazilian Portuguese translations.
- [ ] File header prose mirrors the DE file's structure (title + one-sentence usage note referencing `language` is `pt`).
- [ ] Portuguese uses correct characters (á/é/ê/í/ó/ô/ú/ç/ã/õ) — never ASCII substitutes, per repo multilingual convention.
- [ ] `cogni-sales/README.md` mentions PT in the language-support sentence.
- [ ] `grep -r 'section-headers-de' cogni-sales/` shows every consumer that references DE — reviewer spot-checks whether any of those call sites need a parallel PT branch before merge (if not, that's a follow-up issue, not a blocker for this PR).

## Open questions
These questions govern the scope of the three deferred plugins. Please answer on this PR or on #95; follow-up issues will be filed accordingly.

1. **ES before / alongside PT?** The issue presumes a `-es.md` precedent, but no ES per-language reference file exists anywhere in cogni-narrative / cogni-copywriting / cogni-marketing / cogni-sales. Should the follow-up work also add the missing ES downstream paths, or is BR/PT the only target?
2. **Scaffolding shape for the other three plugins.** cogni-narrative and cogni-copywriting have no plugin-root `references/` directory and no per-language reference files at all. For PT support there, do you want (a) brand-new `references/section-headers-pt.md` (and peers) created fresh on the cogni-sales pattern, or (b) inline locale branches in the existing SKILL.md / agent prompts mirroring the current DE inline treatment?
3. **Acceptance test.** Do you want a smoke-test harness that actually walks an `output_language=pt market=br` project through all four plugins end-to-end (significant new effort), or is per-plugin documentation of PT support sufficient and end-to-end verification deferred to the user?
4. **Bundling.** For the deferred three plugins: (a) one unified PR covering all three, or (b) three sibling PRs, one per plugin?
