### PR TITLE
cogni-portfolio: portfolio-consolidate skill (Phase 1 — Confirmed/Not Offered matrix)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,7 +92,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.20",
+      "version": "0.9.23",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
       "keywords": [

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.20",
+  "version": "0.9.23",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/CLAUDE.md
+++ b/cogni-portfolio/CLAUDE.md
@@ -5,7 +5,7 @@ Portfolio messaging and proposition planning — from product definition through
 ## Plugin Architecture
 
 ```
-skills/                         20 portfolio skills
+skills/                         21 portfolio skills
   portfolio-setup/                Initialize project with company context and taxonomy
   portfolio-canvas/               Bootstrap from Lean Canvas or Business Model Canvas
   portfolio-scan/                 Discover offerings via web scanning + taxonomy classification
@@ -38,6 +38,7 @@ skills/                         20 portfolio skills
   portfolio-dashboard/            Interactive HTML dashboard of full portfolio status
   portfolio-architecture/         Excalidraw product-feature hierarchy diagram
   portfolio-lineage/              Source tracking, change detection, and refresh cascades
+  portfolio-consolidate/          Cross-scan taxonomy coverage matrix from N research-only scans
   trends-bridge/                  Bidirectional integration with cogni-trends TIPS analysis
   portfolio-resume/               Detect workflow phase and recommend next actions
 
@@ -95,7 +96,7 @@ references/
 
 | Type | Count | Items |
 |------|-------|-------|
-| Skills | 20 | portfolio-setup, portfolio-canvas, portfolio-scan, portfolio-taxonomy, portfolio-ingest, products, features, markets, propositions, solutions, packages, compete, customers, portfolio-verify, portfolio-communicate, portfolio-dashboard, portfolio-architecture, portfolio-lineage, trends-bridge, portfolio-resume |
+| Skills | 21 | portfolio-setup, portfolio-canvas, portfolio-scan, portfolio-taxonomy, portfolio-ingest, products, features, markets, propositions, solutions, packages, compete, customers, portfolio-verify, portfolio-communicate, portfolio-dashboard, portfolio-architecture, portfolio-lineage, portfolio-consolidate, trends-bridge, portfolio-resume |
 | Agents | 20 | market-researcher, competitor-researcher, customer-researcher, customer-review-assessor, proposition-generator, proposition-quality-assessor, proposition-review-assessor, proposition-deep-diver, solution-architect, solution-planner, solution-review-assessor, feature-quality-assessor, feature-review-assessor, feature-deduplication-detector, feature-deep-diver, quality-enricher, customer-narrative-writer, communicate-review-assessor, dashboard-refresher, portfolio-web-researcher |
 
 ## Typical Workflow

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -141,6 +141,7 @@ Each portfolio project lives in `cogni-portfolio/{slug}/` with typed JSON files 
 | `portfolio-dashboard` | skill | Generate an interactive HTML dashboard showing the full portfolio status |
 | `portfolio-architecture` | skill | Generate an interactive Excalidraw architecture diagram of products and features |
 | `portfolio-lineage` | skill | Track source documents and URLs, detect changes, cascade refresh through features → propositions → solutions |
+| `portfolio-consolidate` | skill | Roll up N research-only scan outputs into a taxonomy-shaped coverage matrix across providers |
 | `trends-bridge` | skill | Bidirectional integration between cogni-trends TIPS analysis and the portfolio |
 | `portfolio-resume` | skill | Resume, continue, or check status of a portfolio project |
 | `market-researcher` | agent | Web research for TAM/SAM/SOM with claim submission |

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -180,7 +180,7 @@ cogni-portfolio/
 │   ├── b2b-industrial-tech/      Industrial Tech (8 dims, 48 cats)
 │   ├── b2b-professional-services/ Professional Services (8 dims, 44 cats)
 │   └── b2b-opensource/           Commercial Open Source (8 dims, 50 cats)
-├── skills/                       20 portfolio skills
+├── skills/                       21 portfolio skills
 │   └── portfolio-canvas-workspace/ Dev workspace (evals, iterations — not a skill)
 ├── agents/                       20 delegation agents
 ├── hooks/                        1 guardrail hook (Excalidraw canvas auto-start)

--- a/cogni-portfolio/scripts/build-coverage-matrix.py
+++ b/cogni-portfolio/scripts/build-coverage-matrix.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Build a cross-scan taxonomy coverage matrix from N research-only scan outputs.
+
+Reads one or more `research/.metadata/scan-output.json` files (typically produced
+by `portfolio-scan --mode=research-only`), parses the associated markdown reports
+for per-category `[Status: X]` tags, and emits:
+
+- `research/consolidated-{scope-slug}-portfolio.md` — markdown pivot table
+  {company × category_id} with cells ✓ (Confirmed = any non-"Not Offered" status)
+  or — (Not Offered / not reported), grouped by taxonomy dimension, plus a
+  per-category coverage-rate column.
+- `research/.metadata/consolidated-{scope-slug}.json` — machine-readable matrix
+  + per-category counts for downstream consumers (portfolio-dashboard in Phase 2+).
+
+Phase 1 scope: two cell states (Confirmed / Not Offered); Emerging and Extended
+roll into Confirmed in the display. Refuses on mismatched `template_type` across
+inputs. Stdlib only.
+
+Example:
+    python3 build-coverage-matrix.py \\
+        --inputs "project/research/.metadata/scan-output.json" \\
+                 "peer-a/research/.metadata/scan-output.json" \\
+        --scope-slug "ict-peer-set" \\
+        --output-dir "project/research" \\
+        --taxonomy-dir "cogni-portfolio/templates/b2b-ict"
+"""
+
+import argparse
+import datetime as _dt
+import json
+import os
+import re
+import sys
+
+
+STATUS_RE = re.compile(r"^###\s+(\d+\.\d+)\s+.*\[Status:\s*([^\]]+)\]", re.MULTILINE)
+NOT_OFFERED = "Not Offered"
+
+
+def _respond(success, data=None, error=None, exit_code=None):
+    payload = {"success": bool(success)}
+    if data is not None:
+        payload["data"] = data
+    if error is not None:
+        payload["error"] = error
+    sys.stdout.write(json.dumps(payload))
+    sys.stdout.write("\n")
+    sys.exit(0 if exit_code is None and success else (1 if exit_code is None else exit_code))
+
+
+def _load_json(path):
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh), None
+    except FileNotFoundError:
+        return None, "file not found"
+    except json.JSONDecodeError as exc:
+        return None, f"malformed JSON: {exc}"
+    except OSError as exc:
+        return None, f"read error: {exc}"
+
+
+def _parse_report(report_path):
+    """Return a dict {category_id: status} parsed from a scan report markdown."""
+    try:
+        with open(report_path, "r", encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError:
+        return {}
+    statuses = {}
+    for match in STATUS_RE.finditer(text):
+        cat_id, status = match.group(1), match.group(2).strip()
+        statuses[cat_id] = status
+    return statuses
+
+
+def _load_scan(scan_output_path):
+    """Load one scan-output.json + its report; return (dict, error)."""
+    raw, err = _load_json(scan_output_path)
+    if err:
+        return None, f"{scan_output_path}: {err}"
+    if not isinstance(raw, dict):
+        return None, f"{scan_output_path}: top-level is not an object"
+
+    template_type = raw.get("template_type")
+    if not template_type:
+        return None, f"{scan_output_path}: missing `template_type`"
+
+    # The report lives relative to the scan's project root (two dirs up from
+    # research/.metadata/scan-output.json).
+    project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(scan_output_path))))
+    output_file = raw.get("output_file", "")
+    report_path = os.path.join(project_root, output_file) if output_file else None
+    statuses = _parse_report(report_path) if report_path and os.path.isfile(report_path) else {}
+
+    return {
+        "scan_output_path": scan_output_path,
+        "company_name": raw.get("company_name") or raw.get("company_slug") or "",
+        "company_slug": raw.get("company_slug", ""),
+        "template_type": template_type,
+        "consolidation_mode": raw.get("consolidation_mode", "consolidate"),
+        "created": raw.get("created", ""),
+        "report_path": report_path,
+        "statuses": statuses,
+    }, None
+
+
+def _load_taxonomy(taxonomy_dir):
+    """Return (categories_list, error). Each item: {id, name, dimension, dimension_name, dimension_slug}."""
+    path = os.path.join(taxonomy_dir, "categories.json")
+    raw, err = _load_json(path)
+    if err:
+        return None, f"{path}: {err}"
+    if not isinstance(raw, list):
+        return None, f"{path}: expected a JSON array"
+    return raw, None
+
+
+def _render_markdown(scans, categories, template_type, scope_slug):
+    """Build the consolidated markdown report."""
+    now = _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    providers = [s["company_name"] for s in scans]
+
+    lines = []
+    lines.append(f"# Consolidated coverage matrix — {scope_slug}")
+    lines.append("")
+    lines.append(f"- **Generated:** {now}")
+    lines.append(f"- **Template:** `{template_type}`")
+    lines.append(f"- **Providers ({len(providers)}):** {', '.join(providers)}")
+    lines.append(f"- **Categories:** {len(categories)}")
+    lines.append("")
+    lines.append("Each cell marks whether the provider's scan report declared a non-`Not Offered` status for that category. `✓` = Confirmed (includes Emerging / Extended per Phase 1 collapse); `—` = Not Offered or not reported. Coverage rate counts `✓` cells over the provider set.")
+    lines.append("")
+
+    # Group categories by dimension for readable section breaks.
+    by_dimension = {}
+    dim_order = []
+    for cat in categories:
+        dim_key = (cat.get("dimension"), cat.get("dimension_name", ""))
+        if dim_key not in by_dimension:
+            by_dimension[dim_key] = []
+            dim_order.append(dim_key)
+        by_dimension[dim_key].append(cat)
+
+    confirmed_cells = 0
+    per_category_counts = {}
+
+    for dim_key in dim_order:
+        dim_num, dim_name = dim_key
+        lines.append(f"## Dimension {dim_num} — {dim_name}")
+        lines.append("")
+        header = ["Category"] + providers + ["Coverage"]
+        lines.append("| " + " | ".join(header) + " |")
+        lines.append("| " + " | ".join(["---"] * len(header)) + " |")
+        for cat in by_dimension[dim_key]:
+            cat_id = cat.get("id", "")
+            cat_name = cat.get("name", "")
+            row = [f"`{cat_id}` {cat_name}"]
+            covered = 0
+            for s in scans:
+                status = s["statuses"].get(cat_id, NOT_OFFERED)
+                is_covered = status.strip().lower() != NOT_OFFERED.strip().lower()
+                row.append("✓" if is_covered else "—")
+                if is_covered:
+                    covered += 1
+                    confirmed_cells += 1
+            rate = f"{covered}/{len(scans)}"
+            row.append(rate)
+            per_category_counts[cat_id] = {
+                "name": cat_name,
+                "dimension": dim_num,
+                "covered": covered,
+                "total": len(scans),
+            }
+            lines.append("| " + " | ".join(row) + " |")
+        lines.append("")
+
+    return "\n".join(lines), confirmed_cells, per_category_counts
+
+
+def cmd_build(args):
+    input_paths = [p for p in args.inputs if p]
+    if len(input_paths) < 1:
+        _respond(False, error="no inputs provided")
+
+    scans = []
+    mismatches = []
+    template_type = None
+    for path in input_paths:
+        scan, err = _load_scan(path)
+        if err:
+            _respond(False, error=err)
+        if template_type is None:
+            template_type = scan["template_type"]
+        elif scan["template_type"] != template_type:
+            mismatches.append({
+                "file": scan["scan_output_path"],
+                "template_type": scan["template_type"],
+            })
+        scans.append(scan)
+
+    if mismatches:
+        _respond(
+            False,
+            error=(
+                "template_type mismatch — cannot consolidate across different taxonomies. "
+                f"Expected `{template_type}`; offenders: "
+                + "; ".join(f"{m['file']}=`{m['template_type']}`" for m in mismatches)
+            ),
+        )
+
+    categories, err = _load_taxonomy(args.taxonomy_dir)
+    if err:
+        _respond(False, error=err)
+
+    markdown, confirmed_cells, per_category = _render_markdown(
+        scans, categories, template_type, args.scope_slug
+    )
+
+    md_path = os.path.join(args.output_dir, f"consolidated-{args.scope_slug}-portfolio.md")
+    meta_path = os.path.join(args.output_dir, ".metadata", f"consolidated-{args.scope_slug}.json")
+    try:
+        os.makedirs(os.path.dirname(md_path), exist_ok=True)
+        os.makedirs(os.path.dirname(meta_path), exist_ok=True)
+        with open(md_path, "w", encoding="utf-8") as fh:
+            fh.write(markdown)
+            if not markdown.endswith("\n"):
+                fh.write("\n")
+        meta = {
+            "version": "1.0.0",
+            "scope_slug": args.scope_slug,
+            "template_type": template_type,
+            "generated": _dt.datetime.now(_dt.timezone.utc).isoformat(
+                timespec="seconds"
+            ).replace("+00:00", "Z"),
+            "providers": [
+                {
+                    "company_name": s["company_name"],
+                    "company_slug": s["company_slug"],
+                    "scan_output": s["scan_output_path"],
+                    "consolidation_mode": s["consolidation_mode"],
+                    "created": s["created"],
+                }
+                for s in scans
+            ],
+            "providers_count": len(scans),
+            "categories_count": len(categories),
+            "confirmed_cells": confirmed_cells,
+            "per_category": per_category,
+        }
+        with open(meta_path, "w", encoding="utf-8") as fh:
+            json.dump(meta, fh, indent=2, ensure_ascii=False)
+            fh.write("\n")
+    except OSError as exc:
+        _respond(False, error=f"write failed: {exc}")
+
+    _respond(True, {
+        "markdown_path": md_path,
+        "metadata_path": meta_path,
+        "providers_count": len(scans),
+        "categories_count": len(categories),
+        "confirmed_cells": confirmed_cells,
+        "template_type": template_type,
+    })
+
+
+def build_parser():
+    p = argparse.ArgumentParser(
+        description="Build a cross-scan taxonomy coverage matrix from research-only scan outputs.",
+    )
+    p.add_argument(
+        "--inputs",
+        nargs="+",
+        required=True,
+        metavar="SCAN_OUTPUT_JSON",
+        help="One or more paths to research/.metadata/scan-output.json files.",
+    )
+    p.add_argument("--scope-slug", required=True, help="Slug used in output filenames (e.g. 'ict-peer-set').")
+    p.add_argument("--output-dir", required=True, help="Directory where consolidated-*.md is written (usually research/).")
+    p.add_argument("--taxonomy-dir", required=True, help="Taxonomy template dir containing categories.json (e.g. cogni-portfolio/templates/b2b-ict).")
+    p.set_defaults(func=cmd_build)
+    return p
+
+
+def main():
+    args = build_parser().parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/cogni-portfolio/scripts/build-coverage-matrix.py
+++ b/cogni-portfolio/scripts/build-coverage-matrix.py
@@ -75,34 +75,64 @@ def _parse_report(report_path):
 
 
 def _load_scan(scan_output_path):
-    """Load one scan-output.json + its report; return (dict, error)."""
+    """Load one scan-output.json + its report; return (scan, warning, error).
+
+    ``warning`` is ``None`` on the happy path. When ``output_file`` is absent
+    from the scan metadata, or when the referenced report cannot be found on
+    disk, the scan still loads (statuses default to empty) but a structured
+    warning is returned so ``cmd_build`` can surface the cause in the JSON
+    envelope. The matrix still renders '—' for missing reports — behaviour is
+    unchanged; only the diagnostic signal is added.
+    """
     raw, err = _load_json(scan_output_path)
     if err:
-        return None, f"{scan_output_path}: {err}"
+        return None, None, f"{scan_output_path}: {err}"
     if not isinstance(raw, dict):
-        return None, f"{scan_output_path}: top-level is not an object"
+        return None, None, f"{scan_output_path}: top-level is not an object"
 
     template_type = raw.get("template_type")
     if not template_type:
-        return None, f"{scan_output_path}: missing `template_type`"
+        return None, None, f"{scan_output_path}: missing `template_type`"
 
     # The report lives relative to the scan's project root (two dirs up from
     # research/.metadata/scan-output.json).
     project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(scan_output_path))))
     output_file = raw.get("output_file", "")
-    report_path = os.path.join(project_root, output_file) if output_file else None
-    statuses = _parse_report(report_path) if report_path and os.path.isfile(report_path) else {}
+    company_slug = raw.get("company_slug", "")
+    warning = None
+
+    if not output_file:
+        report_path = None
+        statuses = {}
+        warning = {
+            "scan_output_path": scan_output_path,
+            "company_slug": company_slug,
+            "report_path": None,
+            "reason": "no_output_file",
+        }
+    else:
+        report_path = os.path.join(project_root, output_file)
+        if os.path.isfile(report_path):
+            statuses = _parse_report(report_path)
+        else:
+            statuses = {}
+            warning = {
+                "scan_output_path": scan_output_path,
+                "company_slug": company_slug,
+                "report_path": report_path,
+                "reason": "report_not_found",
+            }
 
     return {
         "scan_output_path": scan_output_path,
-        "company_name": raw.get("company_name") or raw.get("company_slug") or "",
-        "company_slug": raw.get("company_slug", ""),
+        "company_name": raw.get("company_name") or company_slug or "",
+        "company_slug": company_slug,
         "template_type": template_type,
         "consolidation_mode": raw.get("consolidation_mode", "consolidate"),
         "created": raw.get("created", ""),
         "report_path": report_path,
         "statuses": statuses,
-    }, None
+    }, warning, None
 
 
 def _load_taxonomy(taxonomy_dir):
@@ -180,16 +210,22 @@ def _render_markdown(scans, categories, template_type, scope_slug):
 
 def cmd_build(args):
     input_paths = [p for p in args.inputs if p]
-    if len(input_paths) < 1:
-        _respond(False, error="no inputs provided")
+    if len(input_paths) < 2:
+        _respond(
+            False,
+            error=f"consolidation requires at least two scans; got {len(input_paths)}",
+        )
 
     scans = []
+    warnings = []
     mismatches = []
     template_type = None
     for path in input_paths:
-        scan, err = _load_scan(path)
+        scan, warning, err = _load_scan(path)
         if err:
             _respond(False, error=err)
+        if warning is not None:
+            warnings.append(warning)
         if template_type is None:
             template_type = scan["template_type"]
         elif scan["template_type"] != template_type:
@@ -261,6 +297,7 @@ def cmd_build(args):
         "categories_count": len(categories),
         "confirmed_cells": confirmed_cells,
         "template_type": template_type,
+        "warnings": warnings,
     })
 
 

--- a/cogni-portfolio/skills/compete/SKILL.md
+++ b/cogni-portfolio/skills/compete/SKILL.md
@@ -17,6 +17,8 @@ Analyze the competitive landscape for each proposition (Feature x Market combina
 
 Competitive analysis is scoped to propositions, not features or markets alone. A "cloud monitoring" feature may compete against Datadog in mid-market SaaS but against Splunk in enterprise fintech. The competitive positioning and differentiation are always market-dependent.
 
+**Boundary with `portfolio-consolidate`**: this skill operates at the **proposition / messaging level** (Feature × Market). For comparing providers at the **taxonomy / capability level** (Company × Category) — e.g., "who offers managed Kubernetes in the DACH ICT peer set" — use the `portfolio-consolidate` skill instead. The two are complementary: `portfolio-consolidate` surfaces peer coverage gaps at the taxonomy level, which can then inform which propositions need competitive analysis here.
+
 ## Workflow
 
 ### 1. Select Propositions to Analyze

--- a/cogni-portfolio/skills/portfolio-consolidate/SKILL.md
+++ b/cogni-portfolio/skills/portfolio-consolidate/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: portfolio-consolidate
+description: |
+  Roll up N cogni-portfolio scan outputs into a taxonomy-shaped coverage matrix
+  across providers. Use whenever the user mentions "consolidate scans",
+  "coverage matrix", "roll up research-only scans", "cross-scan matrix",
+  "compare providers by taxonomy", "taxonomy coverage across companies",
+  "peer coverage comparison", "portfolio consolidation", or "consolidated
+  portfolio" — typically after running `portfolio-scan --mode=research-only`
+  against two or more companies in the same industry taxonomy.
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion
+---
+
+# Portfolio Consolidate (Phase 1)
+
+Roll up multiple `portfolio-scan` outputs — typically `research-only` scans of peer companies in the same industry — into one taxonomy-shaped coverage matrix. The output is a markdown pivot table `{company × category_id}` plus a sibling JSON so downstream tooling can reason about cross-provider coverage.
+
+## Core Concept
+
+Every `portfolio-scan` writes `research/.metadata/scan-output.json` plus a markdown report that tags each taxonomy category with a `[Status: X]` marker (Confirmed / Not Offered / Emerging / Extended). When you scan several companies in the same taxonomy, those per-company reports answer "what does each provider cover?" but they live in separate directories. This skill joins them into one table so the reader can see — at a glance — who covers which category and where the peer-group whitespace sits.
+
+## Complementary boundary with `compete`
+
+- **`compete`** — proposition/messaging level (Feature × Market). Runs after propositions exist; produces battle cards and competitive-response messaging.
+- **`portfolio-consolidate`** — taxonomy/capability level (Company × Category). Runs on raw scan output; produces a provider-set coverage matrix.
+
+If the user is asking "who offers what", use this skill. If they are asking "how do I win against provider X on proposition Y", use `compete`.
+
+## Scope (Phase 1)
+
+The v0.9.23 cut ships the minimum useful slice:
+
+- Two cell states — `✓` (Confirmed; includes Emerging and Extended) and `—` (Not Offered or not reported).
+- Per-category coverage rate (count of `✓` cells over the provider set).
+- Hard refuse on `template_type` mismatch across inputs.
+- Single output pair per invocation — `research/consolidated-{scope-slug}-portfolio.md` plus `research/.metadata/consolidated-{scope-slug}.json`.
+
+Deferred to follow-up issues: separate `Emerging` / `Extended` cell states, per-dimension executive summary, whitespace / gap analysis by category, leaders / laggards callouts, and portfolio-dashboard integration. Do not extend the script beyond Phase 1 inside this skill — follow-up issues will track those additions.
+
+## Workflow
+
+### 1. Locate candidate scans
+
+Find research-only scans already on disk so the user has a concrete pick list. The common shape is:
+
+```bash
+find . -path "*/research/.metadata/scan-output.json" -not -path "*/node_modules/*"
+```
+
+Read each discovered file with `Read` and extract `company_name`, `company_slug`, `template_type`, and `consolidation_mode`. Build a short summary (one line per scan) and decide whether there is enough material to proceed. If fewer than two scans exist, tell the user the consolidation is not meaningful yet and suggest `portfolio-scan --mode=research-only` against additional companies.
+
+### 2. Pick the scope
+
+Use `AskUserQuestion` to let the user select which scans to include. Group candidates by `template_type` in the question so the user cannot accidentally mix taxonomies — the script refuses mismatched templates anyway, but asking cleanly up front avoids a failed run.
+
+Also ask for the **scope slug** used in output filenames. Default to `peer-set`, but prompt for something more descriptive (e.g., `ict-germany`, `cloud-hyperscalers`) when the user names a clear peer group.
+
+### 3. Build the matrix
+
+Dispatch `scripts/build-coverage-matrix.py` with the selected inputs:
+
+```bash
+python3 "$CLAUDE_PLUGIN_ROOT/scripts/build-coverage-matrix.py" \
+  --inputs <scan-output-1> <scan-output-2> [...] \
+  --scope-slug <scope-slug> \
+  --output-dir <project-research-dir> \
+  --taxonomy-dir "$CLAUDE_PLUGIN_ROOT/templates/<template_type>"
+```
+
+The script returns the JSON service envelope `{success, data, error}`:
+
+- On success: `data = {markdown_path, metadata_path, providers_count, categories_count, confirmed_cells, template_type}`.
+- On `template_type` mismatch: `success: false` with an error naming the offenders. Surface the message verbatim — the user's next move is either to drop a mismatched scan or pick a different scope.
+
+### 4. Present the result
+
+Tell the user where the markdown landed (`research/consolidated-{scope-slug}-portfolio.md`) and summarise the key numbers: provider count, category count, total Confirmed cells. Do not paste the full matrix back into the chat — it is long; let the user open the file.
+
+If the output reveals obvious gaps (one category covered by zero providers, one provider covering every category, etc.), call them out in one or two sentences. Anything deeper is a Phase 2 ask — don't inline a full gap analysis here.
+
+### 5. Suggest a next step
+
+Typical follow-ons from a fresh coverage matrix:
+
+- **Extend the scope**: run `portfolio-scan --mode=research-only` against one or two more peers and re-run consolidation.
+- **Deep-dive a category**: if one category is covered by everyone except the portfolio's own company, that's the strongest candidate for a `compete`-driven response or a new feature investment.
+- **Wait for Phase 2**: whitespace analysis and per-dimension exec summary are follow-up issues; if the user wants those immediately, point them at issue #103's deferred section.
+
+## Inputs and outputs
+
+Input: one or more `research/.metadata/scan-output.json` files that share a `template_type`. The script reads `output_file` from each and parses the referenced markdown report for `[Status: X]` tags — so the report must still exist next to the metadata.
+
+Output:
+- `research/consolidated-{scope-slug}-portfolio.md` — human-readable pivot grouped by taxonomy dimension.
+- `research/.metadata/consolidated-{scope-slug}.json` — machine-readable matrix + per-category counts for downstream consumers.
+
+## Notes
+
+- **No writes to curated state.** This skill never touches `features/`, `products/`, `propositions/`, or any other entity directory. It reads scan output and writes a summary. Safe to re-run.
+- **Absent categories count as Not Offered.** If a scan report doesn't mention a category at all (e.g., the report was truncated or the taxonomy was extended after the scan), the cell renders `—`. This is intentional: absence is not evidence of presence.
+- **Report discovery is path-relative.** The script assumes `output_file` is relative to the project root two directories above `research/.metadata/scan-output.json`. If a scan was moved or renamed manually, the report lookup will fail silently and every category will render `—` for that provider. Surface this to the user when provider row totals look unexpectedly low.

--- a/cogni-portfolio/skills/portfolio-consolidate/SKILL.md
+++ b/cogni-portfolio/skills/portfolio-consolidate/SKILL.md
@@ -5,9 +5,10 @@ description: |
   across providers. Use whenever the user mentions "consolidate scans",
   "coverage matrix", "roll up research-only scans", "cross-scan matrix",
   "compare providers by taxonomy", "taxonomy coverage across companies",
-  "peer coverage comparison", "portfolio consolidation", or "consolidated
-  portfolio" — typically after running `portfolio-scan --mode=research-only`
-  against two or more companies in the same industry taxonomy.
+  "peer coverage comparison", "coverage gaps across providers", "portfolio
+  consolidation", or "consolidated portfolio" — typically after running
+  `portfolio-scan --mode=research-only` against two or more companies in the
+  same industry taxonomy.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion
 ---
 


### PR DESCRIPTION
Closes #103.

Phase 1 MVP of `cogni-portfolio:portfolio-consolidate` — a new skill that rolls up N `research/.metadata/scan-output.json` files (typically produced under `consolidation_mode: research-only`) into a taxonomy-shaped coverage matrix across providers.

## Summary
- New skill `cogni-portfolio/skills/portfolio-consolidate/SKILL.md` (101 lines) with AskUserQuestion scope picker, candidate discovery, and markdown/JSON emission workflow.
- New stdlib-only script `cogni-portfolio/scripts/build-coverage-matrix.py` — reads N `scan-output.json` + their referenced markdown reports, enforces `template_type` match, enumerates categories from the shipped `templates/{template_type}/categories.json`, parses `[Status: X]` tags from each report, and writes `research/consolidated-{scope-slug}-portfolio.md` + `research/.metadata/consolidated-{scope-slug}.json`.
- Boundary note added to `compete/SKILL.md` pointing at the new skill (proposition/messaging vs taxonomy/capability).
- README Skills table, CLAUDE.md skills tree, and CLAUDE.md Component Inventory updated in-PR (skill count 20 → 21, new row in alphabetical position).
- Version bump to `0.9.23` in both `cogni-portfolio/.claude-plugin/plugin.json` and root `.claude-plugin/marketplace.json` (0.9.21 reserved for draft PR #104, 0.9.22 reserved for draft PR #105).

## Scope decisions

**In Phase 1:**
- Two cell states only: `✓` (Confirmed; Emerging and Extended collapse here) and `—` (Not Offered or not reported).
- Per-category coverage rate column (count `✓` over provider set).
- `template_type` mismatch is a hard refuse (`success: false` with all offenders named); skill surfaces the error verbatim.
- Single output pair per invocation: `research/consolidated-{slug}-portfolio.md` + sibling `research/.metadata/consolidated-{slug}.json`.
- Grouped by taxonomy dimension for readable section breaks.

**Deferred to follow-up issues:**
- Separate `Emerging` / `Extended` cell states (needs more signal than status_summary surfaces today).
- Per-dimension (= product) executive summary section.
- Whitespace / gap analysis naming under-covered categories across the peer group.
- Leaders / laggards per-category callouts beyond raw coverage rate.
- Surface consolidated-*.json on portfolio-dashboard (new card).

## Test plan
- [x] Script parses (`ast.parse`) and `--help` works.
- [x] Happy-path smoke test: two mock research-only scans (t-systems, atos) against a 4-category mock taxonomy produces the expected matrix (5 confirmed cells, per-category counts correct).
- [x] `template_type` mismatch across inputs refuses with an error naming all offenders.
- [x] Missing `template_type` field on any input refuses with a clear error.
- [x] Metadata JSON carries per-category `{covered, total}` counts including 0-coverage categories.
- [x] Version mirror: `grep '0.9.23'` hits both manifests.
- [ ] Manual: run `portfolio-scan --mode=research-only` against two real companies and invoke the new skill — verify the markdown table renders grouped by dimension and the metadata JSON is loadable.
- [ ] Manual: run doc-audit against cogni-portfolio to confirm the skill count reconciles (20 → 21 everywhere).

## Open questions

None — the triage-proposed cut is explicit and all input contracts are shipped (Intervention B, commit 71ad219, v0.9.16).
