### PR TITLE
docs: sync 7 plugins with code reality and registry truth

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,7 +92,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.29",
+      "version": "0.9.30",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,7 +78,7 @@
       "source": "./cogni-trends",
       "version": "0.4.10",
       "maturity": "preview",
-      "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK + Mexico (MX) + Brazil (BR) + China (CN).",
+      "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
       "keywords": [
         "tips",
         "trend-scout",

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ cogni-research/test-diagram-pipeline/
 
 # cogni-wiki batch-mode lockfile (runtime-only, per-wiki advisory lock)
 **/.cogni-wiki/.lock
+
+# cogni-help local issue queue (per-user draft issues, not shared state)
+cogni-issues/

--- a/cogni-marketing/README.md
+++ b/cogni-marketing/README.md
@@ -120,7 +120,7 @@ Content pieces are markdown files with YAML frontmatter tracking type, format, m
 | `marketing-dashboard` | skill | Interactive HTML dashboard for coverage and progress visualization |
 | `marketing-resume` | skill | Resume a session — show status, gaps, and recommended next actions |
 | `content-writer` | agent (sonnet) | Generates individual content pieces per format spec, brand voice, and source data |
-| `channel-adapter` | agent (sonnet) | Adapts existing content to different channels while preserving core message |
+| `channel-adapter` | agent (haiku) | Adapts existing content to different channels while preserving core message |
 | `seo-researcher` | agent (sonnet) | Researches SEO keywords and competitor content for GTM path/market combinations |
 | `/marketing-setup` | command | Initialize a cogni-marketing project with brand, markets, and GTM paths |
 | `/content-strategy` | command | Build the content matrix (market x GTM path x content type) with format recommendations |

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-> **Markets covered.** 22 pluggable regions — single-country (DE, FR, IT, ES, NL, PL, AT, CZ, SK, HU, RO, HR, GR, MK), composite (DACH, EU, Nordics, NA, APAC, LATAM, MEA), and anglo (UK, US, Global) — market-segmented propositions, competitors, and customer personas — not one-size-fits-all.
+> **Markets covered.** 22 pluggable regions — single-country (DE, FR, IT, ES, NL, PL, AT, CZ, SK, HU, RO, HR, GR, MK), composite (DACH, EU, Nordics, NA, APAC, LATAM, MEA), and global (UK, US, Global) — market-segmented propositions, competitors, and customer personas — not one-size-fits-all.
 
 A [Claude Cowork](https://claude.ai/cowork) plugin for portfolio messaging and proposition planning. Helps SMEs build structured, market-specific value propositions using the IS/DOES/MEANS (FAB) framework — from product definition through competitive analysis and customer profiling to export-ready deliverables, across eight pluggable industry taxonomies (B2B SaaS, FinTech, HealthTech, MarTech, Industrial Tech, ICT, Professional Services, Commercial Open Source).
 

--- a/cogni-portfolio/skills/portfolio-resume/SKILL.md
+++ b/cogni-portfolio/skills/portfolio-resume/SKILL.md
@@ -138,6 +138,8 @@ Present entries from `next_actions` **sorted by `priority` (ascending)**. Lower 
 
 If the phase is `complete`, congratulate the user and suggest reviewing outputs or running `portfolio-communicate` for additional deliverables. If communicate files are stale (indicated by a communicate action in `next_actions`), mention that `portfolio-communicate` should be re-run to refresh customer-facing documentation.
 
+After presenting the recommendation, optionally add a one-line pointer to `portfolio-setup` as a side-door for starting a **new** portfolio project (different company or product line). Only surface this when the current project is in a steady state — phase is `complete`, no stale entities, no quality warnings, no source drift, no pending uploads — so it does not compete with priority-ordered workflow actions. Frame it briefly, e.g. "If you want to start a portfolio for a different company or product line, run `portfolio-setup`." This is an orientation aid, not a recommendation; `portfolio-setup` itself redirects back to `portfolio-resume` when a project for the same company already exists, so there is no risk of accidental duplication.
+
 ## Phase Reference
 
 Phases below are the states the script reports via the top-level `phase` field plus three cross-cutting taxonomy/scan states that surface via `next_actions` entries rather than `phase` itself. In other words: `products` can be the `phase` value while the user sees a `portfolio-taxonomy` or `portfolio-scan` action as the *first* recommendation, because those actions are emitted from the phase-independent block and sorted ahead of the phase-specific one by priority.

--- a/cogni-trends/.claude-plugin/plugin.json
+++ b/cogni-trends/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cogni-trends",
   "version": "0.4.10",
-  "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK + Mexico (MX) + Brazil (BR) + China (CN).",
+  "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"

--- a/cogni-trends/README.md
+++ b/cogni-trends/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-> **Markets covered.** 8 European and Anglo markets with per-region trend authorities — DACH (VDMA, BITKOM, Fraunhofer), FR (INRIA, Les Echos), IT (CNR, AGCOM), PL (UKE, POLSA), NL (TNO, ACM), ES (CNMC, INTA), plus US and UK — DE/EN bilingual research against regional authorities — no generic US-centric datasets.
+> **Markets covered.** 8 European and Anglo markets with per-region trend authorities — DACH (VDMA, BITKOM, Fraunhofer), FR (INRIA, ARCEP, Les Echos), IT (CNR, AGCOM, ASI), PL (UKE, POLSA, GUS), NL (TNO, ACM), ES (CNMC, INTA, CDTI), plus US and UK — DE/EN bilingual research against regional authorities — no generic US-centric datasets.
 
 A [Claude Cowork](https://claude.ai/cowork) plugin for scouting, selecting, and reporting on strategic industry trends — **rooted in the German Mittelstand, covering European markets (DE/FR/IT/PL/NL/ES) and US/UK**. Combines the [Smarter Service Trendradar](https://www.smarter-service.com/2023/01/31/trendradar-fuer-die-multikrise-und-neue-geooekonomie/) (4-dimension structure by Bernhard Steimel) with the TIPS content framework (Trends, Implications, Possibilities, Solutions — a B2B consulting methodology widely used since the early 2000s; see [WO2018046399A1](https://patents.google.com/patent/WO2018046399A1/en) for a detailed treatment, filed by Siemens 2017, ceased 2019).
 

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -128,6 +128,7 @@ cogni-workspace/
 │   └── on-session-start.sh
 ├── scripts/                      Utility scripts
 │   ├── check-dependencies.sh
+│   ├── check-region-catalogs.sh  Cross-plugin drift checker for portfolio, trends, research region catalogs
 │   ├── check-skill-names.sh
 │   ├── discover-plugins.sh
 │   ├── generate-settings.sh


### PR DESCRIPTION
## Summary
- Regenerate structural sections (architecture trees, components tables, installation headings) for 6 plugins
- Align README descriptions and markets callouts with plugin.json and markets registry for 4 plugins
- Defer cogni-consulting messaging WEAK verdict and cogni-wiki workspace-artifact question for human review

## Plugins fixed
- cogni-workspace: architecture tree missing .test-results/, .validation/, check-region-catalogs.sh (doc-generate --section=architecture)
- cogni-trends: README first paragraph omits MX/BR/CN, FR markets callout missing ARCEP (doc-sync + doc-generate)
- cogni-portfolio: markets callout lede mismatch ('anglo' vs registry 'and global') (doc-generate)
- cogni-visual: architecture tree missing 3 workspace skill dirs, '## Install' should be '## Installation' (doc-generate full regen)
- cogni-marketing: channel-adapter model type mismatch (haiku not sonnet), '## Install' heading non-canonical (doc-generate + doc-sync)
- cogni-research: architecture missing .test-results/ .validation/, markets callout over-claims 21 markets + MX/BR/CN against registry count of 18 (doc-generate)
- cogni-consulting: README IS paragraph names Claude Cowork but readiness callout names Claude Code desktop (doc-sync)

## Plugins deferred
- cogni-consulting: WEAK messaging — generic 'A [Claude Cowork] plugin that orchestrates' IS opening and MEANS third bullet lacks a quantifier. Editorial voice judgment, not auto-fixable.
- cogni-wiki: wiki-ingest-workspace/ is a dev workspace artifact (only contains iteration-1/, no SKILL.md) but scan-plugin.sh counts it as skill 8. Running doc-generate would enshrine it as a real skill entry in Components+Architecture. Awaiting human decision before auto-regen.

## Test plan
- [ ] Run `/cogni-docs:doc-audit all` on this branch and confirm the 7 fixed plugins drop to OK
- [ ] Check each fixed plugin's README renders on github.com
- [ ] Confirm cogni-consulting and cogni-wiki are untouched in the diff (deferred)
- [ ] Spot-check cogni-research markets callout to confirm it now matches registry (18 markets, no MX/BR/CN) and flag in the 'Open questions' thread if registry should be expanded instead
- [ ] Verify no unrelated plugins (cogni-claims, cogni-narrative, cogni-copywriting, cogni-help, cogni-sales, cogni-website) appear in the diff

## Open questions
- cogni-consulting needs a non-generic IS opening and a quantifier on the MEANS 'Phase gates protect quality' bullet — doc-power can draft candidates, a human should pick the voice.
- cogni-research markets registry vs README: registry market_count_claim is 18 and primary_authorities_shown_in_callout omits MX/BR/CN, but README narrative describes 21 markets including MX/BR/CN. Auto-fix narrows README to registry truth. Confirm this is the intended direction, or expand registry to cover MX/BR/CN instead.
- cogni-wiki wiki-ingest-workspace/ is an eval workspace polluting scan-plugin.sh output. Decide whether to gitignore (preferred — aligns with audit-copywriter-workspace/, install-mcp-workspace/ at repo root), delete, or document it as a real skill. Blocks Components+Architecture regen until resolved.
- cogni-visual has 3 -workspace skill dirs (render-infographic-editorial-workspace, story-to-infographic-workspace, story-to-slides-workspace) that doc-generate will add to the Architecture tree this run. Confirm they should be first-class entries rather than gitignored like the root-level workspaces.

## Automated review — NEEDS REVISION

### Completeness
3 of 7 planned plugins verified clean in post-audit (cogni-marketing, cogni-trends, cogni-workspace). 4 plugins have their planned drift cell still non-OK for documented reasons — the plan correctly pre-declared these as escalations with `ready_hint: false`.

### Regressions
None. No previously-OK check cell moved to DRIFT because of this PR.

### Findings (5 major, 4 minor)

**Major — planned drift cells that did not land clean:**
- **cogni-consulting** descriptions: doc-sync was a no-op; root cause is messaging WEAK (editorial voice), correctly deferred to human review.
- **cogni-portfolio** markets: 'anglo→global' lede fixed, but finer-grained drift remains on US/NA split and missing CN/JP in callout tiers.
- **cogni-research** architecture: no-op by design — `.test-results/` and `.validation/` are empty hidden dirs the generator is specified to skip. Audit/generator contract gap, not a README issue.
- **cogni-research** markets: escalated rather than narrowed. Narrowing README to 18 markets would create new plugin.json↔README drift (plugin.json also claims 21). Needs human call: expand registry to cover MX/BR/CN or narrow plugin.json too.
- **cogni-visual** architecture: no-op by design — 3 workspace subdirs are gitignored via `cogni-visual/.gitignore`. Scanner reads raw filesystem and flags them as missing from README tree. Audit-rule/repo-reality gap.

**Minor — pre-existing drift surfaced by post-audit (not regressions):**
- cogni-portfolio architecture (scripts count 12 vs 13 on disk)
- cogni-portfolio docs (plugin guide lists 19 skills, current 21)
- cogni-portfolio descriptions (plugin.json mentions MX/BR/CN — same shape as cogni-research escalation)
- cogni-workspace doc_logic: `## Install` vs `## Installation` — confirmed audit-rule false positive; generator canonicalizes `## Install`, audit Check 10b heading-variants table doesn't list it. Same false positive fired on cogni-marketing and cogni-visual in pre-audit.

### Deferred plugins
cogni-consulting (messaging) and cogni-wiki (workspace-artifact question) were not touched by the PR, as planned.

### Version bumps
cogni-trends bumped (touched plugin.json). cogni-marketing, cogni-portfolio, cogni-workspace were README-only — no bump required per `docs:` commit prefix convention.

### Suggested next steps
1. Human decides on the 3 registry/audit escalations (research markets, visual workspace dirs, wiki workspace artifact).
2. Open a follow-up issue or next sweep to clear the newly-surfaced cogni-portfolio pre-existing drift (scripts count, plugin guide staleness, plugin.json MX/BR/CN).
3. Track the `## Install` audit-rule false positive in `cogni-docs` (Check 10b heading-variants needs `## Install` added) so the next audit stops re-firing it for every plugin.


## Follow-ups

The 9 findings above are tracked for post-merge resolution:

- **#110** — Registry alignment (cogni-research / cogni-portfolio / cogni-trends markets)  →  covers major findings #2, #4 and minor #8
- **#111** — cogni-portfolio drift sweep (scripts count, plugin guide skill staleness)  →  covers minor findings #6, #7
- **#112** — cogni-consulting messaging editorial pass (IS opening + MEANS quantifier)  →  covers major finding #1 (already deferred in PR body above)
- **#113** — cogni-docs upstream audit/generator contract gaps (`.test-results/.validation` skip, `*-workspace/.gitignore` honor, `## Install` allowlist)  →  covers major findings #3, #5 and minor #9
