### PR TITLE
docs(workflows): portfolio-to-pitch — name /portfolio-resume as the entry gate

### DIFF
--- a/docs/workflows/portfolio-to-pitch.md
+++ b/docs/workflows/portfolio-to-pitch.md
@@ -47,6 +47,15 @@ Pick before Step 2 — the rest of the flow reconverges:
 
 If both apply (e.g., an existing firm launching a new line), start with Path B for the established offering, then re-enter Path A for the new line inside the same project.
 
+## Start or resume with `/portfolio-resume`
+
+`/portfolio-resume` is the standard entry gate for cogni-portfolio — run it first at the top of every session, whether you are starting a new portfolio or coming back to one you already have:
+
+- **New session, no project yet** — `/portfolio-resume` detects that nothing exists and points you straight at `/portfolio-setup` (Step 1 below).
+- **Returning to existing work** — it reports current progress against the stages in this workflow, flags stale entities, and recommends the next skill to run, so you pick up exactly where you left off instead of guessing.
+
+The rest of this workflow still applies as written. Think of `/portfolio-resume` as the dashboard you check first; the numbered steps below are what it dispatches you into.
+
 ## Step-by-Step
 
 ### Step 1 — Initialize the project (shared)


### PR DESCRIPTION
## Summary

- Adds a short section between "Choose Your Starting Path" and "Step-by-Step" that names `/portfolio-resume` as the standard entry gate for cogni-portfolio.
- Covers both fresh-start and returning-session cases:
  - New session, no project yet → `/portfolio-resume` hands off to `/portfolio-setup` (Step 1)
  - Returning to existing work → `/portfolio-resume` reports progress, flags stale entities, and recommends the next skill
- The numbered steps still apply as written; `/portfolio-resume` is framed as the dashboard you check first, not a replacement for the step sequence.

## Why

Readers landing on this workflow had no single "start here" instruction — especially on a return visit, they were left to guess which step they had already completed. Naming `/portfolio-resume` as the first thing to run closes that gap without changing the shape of the workflow.

## Test plan

- [ ] Render `docs/workflows/portfolio-to-pitch.md` on GitHub; confirm the new section reads cleanly between "Choose Your Starting Path" and "Step-by-Step"
- [ ] Confirm `/portfolio-resume` exists under `cogni-portfolio/skills/portfolio-resume/` (it does)

🤖 Generated with [Claude Code](https://claude.com/claude-code)