### PR TITLE
docs: link portfolio-to-pitch workflow from Portfolio Messaging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 > "Set up a portfolio for our cloud monitoring product targeting mid-market SaaS companies in DACH"
 
-→ [Plugin guide](docs/plugin-guide/cogni-portfolio.md)
+→ [Plugin guide](docs/plugin-guide/cogni-portfolio.md) · [Portfolio to Pitch workflow](docs/workflows/portfolio-to-pitch.md)
 
 ### Content Production
 


### PR DESCRIPTION
## Summary

- Adds `· [Portfolio to Pitch workflow](docs/workflows/portfolio-to-pitch.md)` to the end of the `### Portfolio Messaging` section in `README.md`.
- Matches the existing dual-link pattern already used on Research to Report, Trends to Solutions, Content Pipeline, Sales Pitches, Consulting Engagement, Portfolio to Website, and Getting Started.

## Why

The workflow **starts** in Portfolio Messaging (features, markets, propositions) and only lands in a pitch at the end. Previously the link was attached only to Sales Pitches — a reader arriving through Portfolio Messaging had no pointer into the end-to-end pipeline that makes the messaging useful.

Paired with managed-service PR (generator rule update so regeneration preserves the dual link): https://github.com/cogni-work/managed-service/pull/new/docs/portfolio-messaging-cross-link.

## Test plan

- [ ] `grep -n "portfolio-to-pitch" README.md` shows hits on lines 36 (new), 52 (Sales Pitches, existing), 120 (Consulting Firms persona, existing), 256 (footer, existing).
- [ ] Target file `docs/workflows/portfolio-to-pitch.md` exists (it does).
- [ ] Regenerating the root README via the updated cogni-docs rule reproduces the same dual link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)