### PR TITLE
feat(trends+bridge): practical examples — vendor-portfolio mode vs industry case studies

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,7 +92,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.33",
+      "version": "0.9.34",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,7 +92,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.32",
+      "version": "0.9.33",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -76,7 +76,7 @@
     {
       "name": "cogni-trends",
       "source": "./cogni-trends",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "maturity": "preview",
       "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
       "keywords": [
@@ -92,7 +92,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.30",
+      "version": "0.9.31",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -76,7 +76,7 @@
     {
       "name": "cogni-trends",
       "source": "./cogni-trends",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "maturity": "preview",
       "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
       "keywords": [
@@ -92,7 +92,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.31",
+      "version": "0.9.32",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,7 +92,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.34",
+      "version": "0.9.35",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
       "keywords": [

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.30",
+  "version": "0.9.31",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.33",
+  "version": "0.9.34",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.34",
+  "version": "0.9.35",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/.gitignore
+++ b/cogni-portfolio/.gitignore
@@ -8,4 +8,11 @@ __pycache__/
 
 # Local workspace data (skill eval artifacts)
 *-workspace/
-skills/*/evals/
+
+# Skill-creator iteration / run artifacts inside evals/ — but NOT eval definitions
+# or fixture inputs. evals.json and evals/fixtures/ are tracked smoke-test harnesses.
+skills/*/evals/iteration-*/
+skills/*/evals/workspace/
+skills/*/evals/outputs/
+skills/*/evals/benchmark.json
+skills/*/evals/feedback.json

--- a/cogni-portfolio/skills/trends-bridge/SKILL.md
+++ b/cogni-portfolio/skills/trends-bridge/SKILL.md
@@ -168,7 +168,7 @@ TIPS: {pursuit-slug}
   Value Model:        {exists/missing}  ✓/✗
   Solution Templates: {N}               ✓/✗
   Ranked STs:         {N} / {total}     ✓/✗
-  Portfolio Context:  {v2.0 from DATE / v1.0 / missing}
+  Portfolio Context:  {v3.2 from DATE / v3.1 / v3.0 / v2.0 / v1.0 / missing}
 ```
 
 **Step 4: Industry Alignment**
@@ -723,6 +723,38 @@ Write 3-6 entries to `differentiators[]`. Only include entries where
 compatible and the trend-report portfolio close falls back to scanning
 product descriptions when differentiators are empty or absent.
 
+**Step 2.8: Extract Named Customer References**
+
+Scan each market's customers file for concrete named customers to surface as
+vendor-mode grounding for `cogni-trends` value-modeler Step 2.6 Example
+Enrichment. This step is the v3.2 counterpart to Steps 2.5 and 2.7 — it reads
+portfolio-local data only and never invents web-origin prose.
+
+Source: `cogni-portfolio/{portfolio_ref}/customers/{market-slug}.json → named_customers[]`.
+
+For each entry with a non-empty `company_name`, emit one
+`named_customer_references[]` record:
+
+- `market_slug` (required) — the market whose customers file this entry came from
+- `customer_name` (required) — copy from `company_name` verbatim
+- `domain` (optional) — copy from the customer's website root domain if present
+- `outcome_summary` (required) — 1–2 sentences summarizing the engagement
+  outcome. Derive from `named_customers[].key_pain_points` + `fit_score`
+  rationale when no explicit outcome text exists. **Must be portfolio-sourced
+  — do not invent web-origin prose.**
+- `fit_score` (optional) — copy `named_customers[].fit_score` as-is (0.0–1.0)
+- `feature_slugs` (optional) — collect feature slugs from any proposition or
+  solution in this market that references this customer. Fall back to an empty
+  array when no linkage exists in `propositions/` or `solutions/`. Allows
+  Step 2.6 to match references to each Solution Template's
+  `portfolio_grounding[feature_slug, market_slug]` mapping.
+
+Skip `named_customers[]` entries with an empty or missing `company_name`.
+
+If no markets have `named_customers[]` populated, write `named_customer_references[]: []`
+— the field is additive and v3.1 (and earlier) consumers ignore it, so an empty
+array is the backward-compatible signal that no references are available.
+
 **Step 3: Build Context File**
 
 Assemble `portfolio-context.json` v3.2:
@@ -837,11 +869,11 @@ For each `named_customers[]` entry with a non-empty `company_name`, emit one ref
   the portfolio (via propositions or solutions). Allows Step 2.6 to match references to each
   ST's `portfolio_grounding[feature_slug, market_slug]` mapping.
 
-Consumers below v3.2 ignore this field; it's additive.
+The field is additive — see the version notes below for the backward-compatibility contract across v3.1 and earlier consumers.
 
 **Schema version notes:**
 - v3.2 adds `named_customer_references[]` — enables vendor-mode example enrichment in cogni-trends value-modeler Step 2.6
-- v3.1 adds `differentiators[]` per proposition — v3.1 consumers ignore `named_customer_references[]`, preserving backward compatibility with v3.2 producers
+- v3.1 adds top-level `differentiators[]`; v3.1 (and all pre-v3.2) consumers ignore `named_customer_references[]`, preserving backward compatibility with v3.2 producers
 - v3.0 adds `variant_count` and `quality_assessment` per proposition (v2.0 consumers ignore these)
 - v2.0 had propositions without quality or variant data
 - v1.0 (no `schema_version` field) had no embedded propositions at all

--- a/cogni-portfolio/skills/trends-bridge/SKILL.md
+++ b/cogni-portfolio/skills/trends-bridge/SKILL.md
@@ -1,133 +1,51 @@
 ---
 name: trends-bridge
 description: >
-  Bidirectional integration between cogni-trends TIPS analysis and cogni-portfolio product portfolio.
-  Use whenever the user mentions "bridge", "connect tips to portfolio", "import from tips",
-  "tips to portfolio", "portfolio to tips", "sync portfolio with tips", "convert solutions to features",
-  "map trends to products", "enrich propositions from trends", "what did tips find for my portfolio",
-  or wants to flow data between a TIPS value model and a portfolio project. Also trigger when the
-  user has completed value-modeler ranking and asks "how does this connect to my portfolio" or
-  "what features should I add based on the trends". Trigger on "bridge status", "is my portfolio
-  ready for tips", "check bridge readiness", or "can I bridge yet" for the pre-flight check.
-  Also trigger on "push customer references to tips", "vendor-mode examples",
-  "ground solution templates in my customers", "customer examples in trends", or
-  "named customer references" — the v3.2 `named_customer_references[]` field powers
-  vendor-mode example enrichment in value-modeler Step 2.6.
+  Bidirectional integration between cogni-trends TIPS analysis and cogni-portfolio
+  product portfolio. Trigger on "bridge", "tips to portfolio", "portfolio to tips",
+  "sync portfolio with tips", "import from tips", "convert solutions to features",
+  "map trends to products", "enrich propositions from trends", or "what did tips
+  find for my portfolio". Trigger pre-flight on "bridge status", "is my portfolio
+  ready for tips", "check bridge readiness". Trigger v3.2 vendor-reference flow
+  on "push customer references to tips", "vendor-mode examples", "ground solution
+  templates in my customers", "customer examples in trends", or "named customer
+  references".
 allowed-tools: Read, Write, Edit, Glob, Grep, Agent
 ---
 
 # TIPS-Portfolio Bridge
 
-Bidirectional flow between cogni-trends trend analysis and cogni-portfolio product messaging.
-This is the operational link between the "Value/Sales" side (TIPS) and the "Services/Best Practices"
-side (Portfolio) — connecting trend-driven insights to concrete product positioning and go-to-market.
+Bidirectional flow between cogni-trends trend analysis and cogni-portfolio product
+messaging. This is the operational link between the "Value/Sales" side (TIPS) and
+the "Services/Best Practices" side (Portfolio) — connecting trend-driven insights
+to concrete product positioning and go-to-market.
 
 ## Why This Matters
 
 Without the bridge, TIPS and Portfolio are two separate worlds:
-- TIPS identifies what matters (trends, implications, ranked solutions) but doesn't touch products
-- Portfolio structures what you sell (features, propositions, pricing) but doesn't know why it matters
 
-The bridge connects them: trends inform which features to prioritize, ranked solutions become
-new features or enrich existing ones, and portfolio constraints guide solution generation.
+- TIPS identifies what matters (trends, implications, ranked solutions) but
+  doesn't touch products.
+- Portfolio structures what you sell (features, propositions, pricing) but
+  doesn't know why it matters.
+
+The bridge connects them: trends inform which features to prioritize, ranked
+solutions become new features or enrich existing ones, and portfolio constraints
+guide solution generation.
 
 ## Prerequisites & Validation
 
-Every bridge operation runs a pre-flight check before doing any work. This catches
-data gaps and industry mismatches early — before wasting time on exports or imports
-that will produce poor results.
+Every bridge operation runs a pre-flight check before doing any work. The goal is
+to catch data gaps and industry mismatches early — before wasting time on an
+export or import that will produce poor results.
 
-### Shared Pre-flight (all operations)
+The pre-flight has two parts: a shared check (project discovery + industry
+alignment) that runs for every operation, and operation-specific validation
+gates (hard gates block, soft warnings continue). Industry alignment uses a
+4-tier heuristic (exact / vertical / broad / none) so cross-industry intent
+can still be confirmed explicitly when needed.
 
-1. **Discover projects** — Find the TIPS project (`*/tips-project.json`) and the
-   portfolio project (`*/portfolio.json`). If either is missing, stop and report
-   which one with a fix suggestion.
-2. **Industry alignment** — Compare TIPS and portfolio industries (see below).
-   The result is stored for use during market-relevance matching and reported
-   in the summary.
-
-### Industry Alignment
-
-The TIPS project targets a specific industry (e.g., manufacturing/automotive) while
-the portfolio describes what you sell. Bridging across unrelated industries is unusual
-and likely a mistake — but sometimes intentional (e.g., cross-selling into a new vertical).
-
-**How it works:**
-
-1. Read TIPS `industry.primary` and `industry.subsector` from `tips-project.json`
-2. Read portfolio `company.industry` from `portfolio.json` (free text)
-3. Collect all `segmentation.vertical_codes` from `portfolio/markets/*.json`
-4. Slugify `company.industry` (lowercase, replace non-alphanumeric with hyphens)
-
-Match using a 4-tier heuristic:
-
-- **exact** — Slugified `company.industry` matches `industry.primary` or
-  `industry.subsector`. Example: company.industry "Automotive OEM" → slug
-  "automotive-oem" contains "automotive" matching subsector. Proceed silently.
-- **vertical** — Any market `vertical_code` matches `industry.subsector`.
-  Example: market has `vertical_codes: ["automotive"]`, TIPS subsector is
-  "automotive". Proceed silently.
-- **broad** — Any market `vertical_code` is a known subsector of `industry.primary`
-  (use the same parent-child logic as market-relevance matching). Example: market
-  has `vertical_codes: ["autonomous-vehicles"]`, TIPS primary is "manufacturing".
-  Proceed with note: "Portfolio markets have related verticals ({codes}) but no
-  direct match to TIPS subsector '{subsector}'. Bridge results may need manual review."
-- **none** — No match found. Warn and require explicit user confirmation:
-  "Industry mismatch: TIPS analyzes {primary_en}/{subsector_en} but portfolio
-  company.industry is '{company.industry}' with market verticals [{codes}].
-  Cross-industry bridging is unusual — continue anyway?"
-
-### portfolio-to-tips Validation Gates
-
-Run these after shared pre-flight when executing `portfolio-to-tips` or `sync`.
-
-**Hard gates (block execution):**
-- `portfolio.json` must exist and be valid JSON
-- At least 1 product in `portfolio/products/`
-- At least 1 feature in `portfolio/features/` with a valid `product_slug` reference
-
-If any hard gate fails, stop and report the fix:
-- "No products found. Create at least one product first: `/portfolio-setup`"
-- "No features found. Add features to your products: `/features create`"
-
-**Soft warnings (report and continue):**
-- No propositions: "No propositions found. The exported context will lack
-  IS/DOES/MEANS messaging — value-modeler Phase 2 will generate STs without
-  portfolio grounding. Consider running `/propositions create` first."
-- No markets: "No markets defined. The context file will have no market-relevance
-  tagging. Define markets with `/portfolio-setup`."
-- Features with descriptions under 15 words: "{N} features have thin descriptions
-  (under 15 words). Richer descriptions improve ST-to-feature matching accuracy.
-  Consider running `/features enrich` first."
-- No solutions: "No solutions found. The exported context will lack pricing and
-  delivery data."
-
-### tips-to-portfolio Validation Gates
-
-Run these after shared pre-flight when executing `tips-to-portfolio` or `sync`.
-
-**Hard gates (block execution):**
-- `tips-value-model.json` must exist in the TIPS project directory
-- `solution_templates` array must be non-empty
-- At least 1 ST must have `ranking_value` populated (not null) — confirms that
-  value-modeler Phase 4 (ranking) has completed
-
-If any hard gate fails, stop and report the fix:
-- "Value model not found. Run the value modeler first: `/value-model`"
-- "No solution templates in value model. Complete value-modeler Phase 2:
-  `/value-model solutions`"
-- "Solution templates have no ranking values. Complete Phase 4 to calculate
-  rankings: `/value-model rank`"
-
-**Soft warnings (report and continue):**
-- No features in portfolio: "Portfolio has no features. All Solution Templates
-  will produce 'Create' actions (no enrichment possible). Consider adding features
-  first with `/features create`."
-- No propositions: "Portfolio has features but no propositions. Enrichment will
-  create new propositions rather than refining existing ones."
-- All STs have `business_relevance` = null: "No user-scored business relevance
-  found. Rankings use formula-only scores. Consider running `/value-model score`
-  for customer-specific prioritization."
+See `references/validation-gates.md` for the full heuristic and gate lists.
 
 ## Operations
 
@@ -168,8 +86,13 @@ TIPS: {pursuit-slug}
   Value Model:        {exists/missing}  ✓/✗
   Solution Templates: {N}               ✓/✗
   Ranked STs:         {N} / {total}     ✓/✗
-  Portfolio Context:  {v3.2 from DATE / v3.1 / v3.0 / v2.0 / v1.0 / missing}
+  Portfolio Context:  {v3.2 from DATE / v3.1 / v3.0 / missing}
 ```
+
+The Portfolio Context line reports the most recent `schema_version` written by
+`portfolio-to-tips`. Older v1.0/v2.0 exports are effectively equivalent to
+`missing` for Phase 2 consumers — they're listed as `missing` rather than
+cluttering the line.
 
 **Step 4: Industry Alignment**
 
@@ -190,6 +113,7 @@ Bridge Readiness:
 ```
 
 If NOT READY, list fix actions:
+
 - "Add at least 1 feature to a product: `/features create`"
 - "Complete value-modeler ranking: `/value-model rank`"
 - "Resolve industry mismatch: update portfolio.json company.industry or confirm
@@ -201,7 +125,8 @@ If NOT READY, list fix actions:
 /bridge tips-to-portfolio
 ```
 
-Takes ranked Solution Templates from the value model and creates or enriches portfolio entities.
+Takes ranked Solution Templates from the value model and creates or enriches
+portfolio entities.
 
 **Step 1: Discover Projects**
 
@@ -212,10 +137,11 @@ Takes ranked Solution Templates from the value model and creates or enriches por
 
 **Step 1b: Validate Readiness**
 
-Run the shared pre-flight (industry alignment) and tips-to-portfolio validation
-gates. If any hard gate fails — missing value model, empty solution templates,
-or no ranked STs — stop and report the fix suggestion. If soft warnings exist
-(no features, no propositions, no BR scores), report them and continue.
+Run the shared pre-flight (industry alignment) and the `tips-to-portfolio` gate
+set (see `references/validation-gates.md`). If any hard gate fails — missing
+value model, empty solution templates, or no ranked STs — stop and report the
+fix suggestion. If soft warnings exist (no features, no propositions, no BR
+scores), report them and continue.
 
 **Step 2: Match Solution Templates to Features**
 
@@ -344,7 +270,7 @@ evidence's origin without needing to open the TIPS project.
 These become candidate evidence entries on the relevant proposition. Mark them as
 unverified — the user can later run `/portfolio-verify` to check sourced claims.
 
-**Step 5.3: Generate Path Narrative Evidence**
+**Step 5.1: Generate Path Narrative Evidence**
 
 For each matched ST, construct evidence entries from its value chain narratives. These
 transform the abstract T→I→P causal story into concrete, sales-ready content that tells
@@ -413,7 +339,7 @@ the buyer *why this matters now* and *how the pieces connect*.
 5. **Deduplication**: If the same value chain feeds multiple STs matched to the same
    proposition, generate the narrative evidence only once (keyed by chain_id).
 
-**Step 5.5: Propose Solution Stubs**
+**Step 5.2: Propose Solution Stubs**
 
 When an ST maps to a feature that has a proposition but **no solution** for the target
 market, propose creating a solution stub:
@@ -437,7 +363,7 @@ market, propose creating a solution stub:
 
 Only create solution stubs after explicit user approval for each row.
 
-**Step 5.7: Add Provenance Tracking**
+**Step 5.3: Add Provenance Tracking**
 
 For all propositions enriched in Step 4 and evidence added in Step 5, attach
 `tips_enrichment` metadata:
@@ -457,122 +383,35 @@ Valid `enrichment_type` values:
 - `does_refined` — DOES statement was enriched with trend-driven advantage framing
 - `means_refined` — MEANS statement was enriched with business outcome context
 - `evidence_added` — New evidence entries were suggested from TIPS metrics
-- `narrative_evidence_added` — Path narrative evidence (why_now, sales_guide, proposal_justification) was generated from value chains (Step 5.3)
-- `variant_created` — One or more proposition variants were created from TIPS value chains (Step 4)
-- `solution_proposed` — A solution stub was proposed (from Step 5.5)
+- `narrative_evidence_added` — Path narrative evidence (why_now, sales_guide,
+  proposal_justification) was generated from value chains (Step 5.1)
+- `variant_created` — One or more proposition variants were created from TIPS
+  value chains (Step 4)
+- `solution_proposed` — A solution stub was proposed (from Step 5.2)
 
 This metadata is appended to the proposition JSON. Portfolio skills that don't understand
 it will ignore it. It enables future auditing of which TIPS pursuit influenced which
 portfolio positioning.
 
-**Step 5.8: Generate Blueprint-Aware Opportunity Pipeline**
+**Step 5.4: Generate Blueprint-Aware Opportunity Pipeline**
 
-With solution blueprints, the opportunity pipeline becomes more granular and actionable.
-Instead of generating one opportunity per unmatched ST, analyze individual building blocks
-across all STs to surface taxonomy-level gaps. This answers the strategic question: "Which
-portfolio dimensions do we need to invest in to deliver our solution portfolio?"
+For each Solution Template with no strong portfolio match (`match_confidence: "none"`
+or `"low"`), generate a structured opportunity assessment. Aggregate building blocks
+across all STs to produce a taxonomy-level gap report — this answers the strategic
+question "which portfolio dimensions do we need to invest in to deliver our solution
+portfolio?" The taxonomy gap report is typically the most strategically valuable
+output of the bridge.
 
-See `references/opportunity-schema.md` for the full schema definition.
-
-**Two levels of opportunity generation:**
-
-#### Level 1: Per-ST Opportunities (existing behavior, enhanced)
-
-For each Solution Template with `match_confidence: "none"` or `"low"`, generate a
-structured opportunity assessment:
-
-1. **Calculate opportunity score** (0-10):
-   ```
-   opportunity_score = (
-       (ranking_value / 5) × 0.4 +
-       tam_alignment × 0.3 +
-       competitive_whitespace × 0.3
-   ) × 10
-   ```
-   - `ranking_value`: The ST's ranking_value from the TIPS value model (0-5)
-   - `tam_alignment`: Fraction of portfolio markets with `market_relevance` = `"direct"`
-     or `"industry"` for this pursuit (0-1). Read from the market entries in
-     `portfolio-context.json`.
-   - `competitive_whitespace`: If competitive analysis exists for related propositions,
-     estimate whitespace from competitor coverage gaps. Otherwise default to 0.7
-     (moderate whitespace assumption).
-
-2. **Classify the opportunity**:
-   - **build**: The company has adjacent expertise (existing features in the same taxonomy
-     dimension), the opportunity is core to differentiation, and no adequate turnkey
-     solution exists. Requires development investment.
-   - **buy**: A commercial solution exists that covers 80%+ of the need. Faster
-     time-to-market through acquisition or licensing.
-   - **partner**: Requires specialized domain expertise the company lacks. Best addressed
-     through co-development, white-label, or referral partnership.
-
-   Use the ST's `category`, its **blueprint building blocks** (taxonomy dimensions),
-   and the portfolio's existing feature landscape to guide classification. A gap in
-   a consulting dimension (7.x) naturally suggests "partner"; a gap in a core technical
-   dimension (4.x, 6.x) may suggest "build" or "buy".
-
-3. **Estimate revenue** from market TAM data:
-   - Read portfolio markets and filter to those with `market_relevance` = `"direct"`
-   - Use TAM values with conservative penetration assumptions (0.05-0.2%)
-   - Set confidence: `"high"` (validated TAM + comparable pricing), `"medium"` (TAM
-     with assumptions), `"low"` (rough estimate)
-
-4. **Generate feature spec** (roadmap-ready):
-   - `proposed_slug`: Derived from ST name (kebab-case)
-   - `name` and `description`: Adapted from ST for feature language
-   - `category`: Derived from ST category
-   - `readiness`: Always `"planned"`
-   - `unmet_needs`: From blueprint building blocks with `coverage: "gap"` — each gap
-     block's `gaps` array provides specific unmet capabilities. Falls back to
-     `portfolio_anchor.theme_needs_undelivered` or ST description extraction.
-   - `taxonomy_refs`: Array of taxonomy categories from the ST's blueprint gap blocks
-     (e.g., `["1.4", "7.2"]`) — shows which portfolio dimensions this opportunity spans
-   - `source_themes` and `source_sts`: Traceability to TIPS value model
-
-5. **Assign priority**: `"high"` (score ≥ 7.0 AND ranking_value ≥ 4.0), `"medium"`
-   (score ≥ 4.0 OR ranking_value ≥ 3.0), `"low"` (everything else)
-
-#### Level 2: Taxonomy Gap Analysis (new)
-
-After generating per-ST opportunities, aggregate all blueprint building blocks across
-ALL Solution Templates (not just unmatched ones) to produce a taxonomy-level gap report:
-
-1. **Collect all building blocks** from all STs' `solution_blueprint.building_blocks`
-2. **Group by taxonomy dimension** (0-7) and then by category (e.g., "6.6")
-3. **Count coverage status** per category:
-   - How many STs need this category?
-   - How many have it covered vs. partial vs. gap?
-
-4. **Generate Taxonomy Gap Report**:
-
-```
-Taxonomy Gap Analysis — Portfolio Investment Priorities
-
-| Dim | Taxonomy Category | STs Needing | Covered | Partial | Gap | Priority |
-|-----|-------------------|-------------|---------|---------|-----|----------|
-| 7   | Digital Transformation (7.2) | 5 | 0 | 1 | 4 | HIGH |
-| 1   | 5G & IoT Connectivity (1.4) | 4 | 1 | 2 | 1 | MEDIUM |
-| 2   | Cloud Security (2.4) | 3 | 0 | 0 | 3 | HIGH |
-| 7   | Program Management (7.4) | 2 | 0 | 0 | 2 | MEDIUM |
-
-Strategic Insight:
-- Consulting (Dim 7) is the #1 portfolio gap: 7 building blocks across 5 STs need
-  consulting capabilities that don't exist in the portfolio. Consider a consulting
-  partnership or practice build.
-- Security (Dim 2) gaps affect 3 high-ranked STs. Investing here would improve
-  readiness scores across the solution portfolio.
-```
-
-Priority for taxonomy gaps: `HIGH` = ≥3 STs affected AND majority are gap (not partial),
-`MEDIUM` = 2+ STs affected, `LOW` = 1 ST affected.
-
-This taxonomy gap report is the most strategically valuable output of the bridge — it
-transforms individual solution gaps into portfolio-level investment priorities.
+See `references/opportunity-pipeline.md` for the scoring formula, classification
+rules (build/buy/partner), revenue estimation, and taxonomy aggregation algorithm.
+The output file schema lives in `references/opportunity-schema.md`.
 
 **Write** `portfolio-opportunities.json` to the TIPS project directory (alongside
-`tips-value-model.json`). Include both per-ST opportunities and the taxonomy gap summary.
+`tips-value-model.json`). Include both per-ST opportunities and the taxonomy gap
+summary.
 
-**Present** the opportunities table sorted by score, followed by the taxonomy gap report:
+**Present** the opportunities table sorted by score, followed by the taxonomy gap
+report:
 
 ```
 Innovation Pipeline ({N} opportunities)
@@ -616,11 +455,12 @@ Loads the portfolio's products, features, propositions, and solutions into the T
 model context so that Phase 2 (Solution Template generation) is grounded in what you
 actually sell and how you position it per market.
 
-**This operation is informational** — it writes a `portfolio-context.json` (v3.2) file into
-the TIPS project directory that value-modeler Phase 2 can read. The enriched context gives
-Phase 2 access to proposition language (IS/DOES/MEANS), quality assessments, variant counts,
-and solution summaries so that Solution Templates are grounded in real portfolio capabilities
-with quality awareness.
+**This operation is informational** — it writes a `portfolio-context.json` (v3.2) file
+into the TIPS project directory that value-modeler Phase 2 can read. The enriched
+context gives Phase 2 access to proposition language (IS/DOES/MEANS), quality
+assessments, variant counts, solution summaries, provider differentiators, and named
+customer references so that Solution Templates are grounded in real portfolio
+capabilities with quality awareness.
 
 **Step 1: Discover Projects**
 
@@ -628,10 +468,10 @@ Same discovery as `tips-to-portfolio`.
 
 **Step 1b: Validate Readiness**
 
-Run the shared pre-flight (industry alignment) and portfolio-to-tips validation
-gates. If any hard gate fails — no products or no features — stop and report
-the fix suggestion. If soft warnings exist (no propositions, no markets, thin
-descriptions, no solutions), report them and continue.
+Run the shared pre-flight (industry alignment) and the `portfolio-to-tips` gate set
+(see `references/validation-gates.md`). If any hard gate fails — no products or no
+features — stop and report the fix suggestion. If soft warnings exist (no
+propositions, no markets, thin descriptions, no solutions), report them and continue.
 
 **Step 2: Extract Products & Features**
 
@@ -651,29 +491,8 @@ For each feature, check for matching proposition and solution files:
    and `price_range` (min, max, currency)
 5. **Assess proposition quality**: For each proposition, run the `proposition-quality-assessor`
    agent (or read cached assessment if `updated` date hasn't changed since last assessment).
-   Compact the result into a `quality_assessment` object:
-   ```json
-   {
-     "quality_assessment": {
-       "overall": "pass|warn|fail",
-       "does_score": {
-         "buyer_centricity": "pass|warn|fail",
-         "market_specificity": "pass|warn|fail",
-         "differentiation": "pass|warn|fail",
-         "status_quo_contrast": "pass|warn|fail",
-         "conciseness": "pass|warn|fail"
-       },
-       "means_score": {
-         "outcome_specificity": "pass|warn|fail",
-         "escalation": "pass|warn|fail",
-         "quantification": "pass|warn|fail",
-         "emotional_resonance": "pass|warn|fail",
-         "conciseness": "pass|warn|fail"
-       },
-       "assessed_at": "2026-03-13"
-     }
-   }
-   ```
+   Compact the result into a `quality_assessment` object (see
+   `references/portfolio-context-schema.md` for the field shape).
    Quality assessment is cached — only re-run if the proposition's `updated` date is newer
    than `assessed_at`. If no prior assessment exists, run the assessor. If running assessments
    would slow down the export significantly (>10 propositions), warn the user and offer to
@@ -708,18 +527,14 @@ Sources to scan:
    base size, data center locations)
 4. **Market-level segmentation** — geographic presence, industry depth
 
-For each differentiator found, classify by domain:
-- `sovereign-infrastructure`: Data residency, cloud sovereignty, regulatory certifications
-- `network`: Telco/ISP network footprint, edge computing, IoT connectivity
-- `security`: Security certifications, SOC operations, KRITIS expertise
-- `scale`: Revenue, employee count, geographic presence
-- `industry-expertise`: Vertical-specific reference customers, domain knowledge
-- `platform`: Named proprietary platforms, unique technology
-- `regulatory`: Compliance certifications, audit attestations
+Classify each differentiator by `domain` using the enum in
+`references/portfolio-context-schema.md § differentiators[]`
+(`sovereign-infrastructure`, `network`, `security`, `scale`, `industry-expertise`,
+`platform`, `regulatory`).
 
-Write 3-6 entries to `differentiators[]`. Only include entries where
+Write 3–6 entries to `differentiators[]`. Only include entries where
 `swap_test_fails` is true. If the portfolio has no provably unique assets
-(e.g., a generic reseller), write an empty array — v3.1 is backward
+(e.g., a generic reseller), write an empty array — the schema is backward
 compatible and the trend-report portfolio close falls back to scanning
 product descriptions when differentiators are empty or absent.
 
@@ -730,156 +545,45 @@ vendor-mode grounding for `cogni-trends` value-modeler Step 2.6 Example
 Enrichment. This step is the v3.2 counterpart to Steps 2.5 and 2.7 — it reads
 portfolio-local data only and never invents web-origin prose.
 
-Source: `portfolio/customers/{market-slug}.json → named_customers[]`.
+**Source:** `portfolio/customers/{market-slug}.json → named_customers[]` (canonical
+schema in `cogni-portfolio/references/data-model.md § customers/{market-slug}.json`).
 
-For each entry with a non-empty `name`, emit one `named_customer_references[]`
-record. Map `customer_name` from `named_customers[].name` and `domain` from
-`named_customers[].domain`. Derive `outcome_summary` from
-`named_customers[].pain_points` combined with `named_customers[].fit_rationale`
-when no explicit outcome text exists — **must be portfolio-sourced; do not
-invent web-origin prose.** Copy `fit_score` as-is. Emit `feature_slugs` as `[]`
-(v3.2 reserved — see Step 3 for the forward-compatibility rationale).
+**Procedure:**
 
-See Step 3 below for the full `named_customer_references[]` field contract
-(types, required/optional flags, canonical enums).
+1. For each market, attempt to read `portfolio/customers/{market-slug}.json`.
+2. If the file is missing entirely, emit `[]` for that market and continue — the
+   field is additive and an empty array is the backward-compatible "no references"
+   signal.
+3. If the file exists, iterate `named_customers[]` and emit one
+   `named_customer_references[]` record per entry with a **non-empty `name`**.
+   Skip entries with empty or missing `name`.
+4. Apply the field mapping from
+   `references/portfolio-context-schema.md § named_customer_references[]`:
+   - `customer_name` ← `named_customers[].name`
+   - `domain` ← copy `named_customers[].domain` as-is (optional)
+   - `outcome_summary` ← derive from `named_customers[].pain_points` combined
+     with `named_customers[].fit_rationale` when no explicit outcome text
+     exists. **Must be portfolio-sourced — do not invent web-origin prose.**
+   - `fit_score` ← copy `named_customers[].fit_score` (canonical enum
+     `high | medium | low`; never a float, never a percentage)
+   - `feature_slugs` ← always `[]` (v3.2 reserved; no proposition or solution
+     schema currently stores customer linkages, so there is no source to derive
+     slugs from. Kept on the contract so a future v3.3 that adds
+     `named_customer_refs[]` to propositions/solutions can populate it without
+     a schema-version bump)
 
-Skip `named_customers[]` entries with an empty or missing `name`.
-
-If no markets have `named_customers[]` populated, write `named_customer_references[]: []`
-— the field is additive and v3.1 (and earlier) consumers ignore it, so an empty
-array is the backward-compatible signal that no references are available.
+If no markets have `named_customers[]` populated, write
+`named_customer_references[]: []` at the top level and move on. Pre-v3.2
+consumers ignore this field.
 
 **Step 3: Build Context File**
 
-Assemble `portfolio-context.json` v3.2:
-
-```json
-{
-  "schema_version": "3.2",
-  "source": "cogni-portfolio",
-  "portfolio_slug": "{portfolio-slug}",
-  "extracted_at": "{ISO-8601 timestamp}",
-  "differentiators": [
-    {
-      "domain": "sovereign-infrastructure",
-      "claim": "European sovereign cloud with BSI-C5 attestation and German-only data residency",
-      "evidence": "BSI-C5 attestation certificate, data center locations",
-      "swap_test_fails": true
-    }
-  ],
-  "products": [
-    {
-      "slug": "cloud-platform",
-      "name": "Cloud Platform",
-      "revenue_model": "subscription",
-      "maturity": "growth",
-      "features": [
-        {
-          "slug": "cloud-monitoring",
-          "name": "Cloud Infrastructure Monitoring",
-          "description": "Real-time monitoring...",
-          "category": "observability",
-          "readiness": "ga",
-          "propositions": [
-            {
-              "market_slug": "mid-market-saas-dach",
-              "is_statement": "Cloud monitoring for SaaS operations teams",
-              "does_statement": "Reduces MTTR by 60% through AI-correlated alerting",
-              "means_statement": "Protects SaaS uptime SLAs in a market where churn from downtime costs 5-8% ARR",
-              "evidence_count": 3,
-              "variant_count": 2,
-              "quality_assessment": {
-                "overall": "pass",
-                "does_score": {
-                  "buyer_centricity": "pass",
-                  "market_specificity": "pass",
-                  "differentiation": "pass",
-                  "status_quo_contrast": "warn",
-                  "conciseness": "pass"
-                },
-                "means_score": {
-                  "outcome_specificity": "pass",
-                  "escalation": "pass",
-                  "quantification": "pass",
-                  "emotional_resonance": "warn",
-                  "conciseness": "pass"
-                },
-                "assessed_at": "2026-03-12"
-              },
-              "solution_summary": {
-                "solution_type": "project",
-                "pricing_tiers": ["proof_of_value", "small", "medium", "large"],
-                "price_range": { "min": 15000, "max": 250000, "currency": "EUR" }
-              }
-            }
-          ]
-        }
-      ]
-    }
-  ],
-  "markets": [
-    {
-      "slug": "mid-market-saas-dach",
-      "name": "Mid-Market SaaS (DACH)",
-      "region": "dach",
-      "priority": "beachhead",
-      "segmentation_summary": "SaaS companies, 50-500 employees",
-      "vertical_codes": ["saas"],
-      "tam_value": 5000000000,
-      "currency": "EUR",
-      "market_relevance": "direct",
-      "match_reason": "vertical_codes includes 'saas' matching TIPS subsector"
-    }
-  ],
-  "named_customer_references": [
-    {
-      "market_slug": "mid-market-saas-dach",
-      "customer_name": "Acme SaaS GmbH",
-      "domain": "acme-saas.example.com",
-      "outcome_summary": "Reduced incident MTTR from 45 min to 12 min within 90 days of rollout",
-      "fit_score": "high",
-      "feature_slugs": []
-    }
-  ]
-}
-```
-
-Write to `{tips-project-dir}/portfolio-context.json`.
-
-**`named_customer_references[]`** (added in v3.2, optional): Structured customer references
-sourced from each market's `customers/{market-slug}.json → named_customers[]`. Enables
-`cogni-trends` value-modeler Step 2.6 Example Enrichment (vendor mode) to ground Solution
-Templates in concrete portfolio customers without re-reading the portfolio project directly.
-For each `named_customers[]` entry with a non-empty `name`, emit one reference:
-
-- `market_slug` (string, required): Market this customer belongs to.
-- `customer_name` (string, required): Copy of `named_customers[].name`.
-- `domain` (string, optional): Copy of `named_customers[].domain` if present.
-- `outcome_summary` (string, required): 1–2 sentences summarizing the engagement outcome.
-  Derive from `named_customers[].pain_points` combined with `named_customers[].fit_rationale`
-  when no explicit outcome text exists. Must be portfolio-sourced — do not invent web-origin prose.
-- `fit_score` (string, optional): Copy of `named_customers[].fit_score` — canonical enum
-  `high` | `medium` | `low` (per `cogni-portfolio/references/data-model.md` §
-  `customers/{market-slug}.json`).
-- `feature_slugs` (string array, optional): **v3.2 reserved; always `[]`.** No proposition
-  or solution schema currently stores named-customer linkages, so there is no source to
-  derive feature slugs from. Field is kept on the contract so future schemas that add
-  `named_customer_refs[]` to propositions/solutions can populate it without a v3.3 bump.
-
-See the Schema version notes below for the backward-compatibility contract.
-
-**Schema version notes:**
-- v3.2 adds `named_customer_references[]` — enables vendor-mode example enrichment in cogni-trends value-modeler Step 2.6
-- v3.1 adds top-level `differentiators[]`; v3.1 (and all pre-v3.2) consumers ignore `named_customer_references[]`, preserving backward compatibility with v3.2 producers
-- v3.0 adds `variant_count` and `quality_assessment` per proposition (v2.0 consumers ignore these)
-- v2.0 had propositions without quality or variant data
-- v1.0 (no `schema_version` field) had no embedded propositions at all
-
-**Backward compatibility:** The `schema_version` field distinguishes versions. Phase 2
-checks this field: v3.2 enables vendor-reference surfacing, v3.1 enables differentiator
-surfacing, v3.0 enables quality-aware generation and variant tracking, v2.0 enables
-proposition-grounded generation, v1.0 (no field) falls back to basic feature matching.
-Each version is a superset of the previous — new fields are additive.
+Assemble `portfolio-context.json` v3.2 and write it to
+`{tips-project-dir}/portfolio-context.json`. The full JSON example, per-field
+contract, schema version ladder, and backward-compatibility rules all live in
+`references/portfolio-context-schema.md` — that file is the **single source of
+truth** for the export contract. If the upstream `named_customers[]` schema in
+`data-model.md` changes, update the bridge reference in the same commit.
 
 **Step 4: Advise Value Modeler**
 
@@ -887,6 +591,7 @@ Report a summary to the user:
 - N products, M features, P propositions across K markets (R with direct/industry relevance)
 - Any features without propositions (messaging gaps)
 - Any markets with no TIPS relevance (may not contribute to ST generation)
+- N provider differentiators exported (or 0 if none)
 - N named customer references exported across M markets (or 0 if none)
 
 **Industry alignment summary** — aggregate the per-market relevance tags:
@@ -899,8 +604,9 @@ Report a summary to the user:
   Phase 2 grounding."
 
 Tell the user: "Portfolio context (v3.2) saved. When you run value-modeler Phase 2, it
-will use proposition language, quality assessments, solution data, and named customer
-references to ground Solution Templates in your portfolio's actual capabilities and pricing."
+will use proposition language, quality assessments, solution data, provider
+differentiators, and named customer references to ground Solution Templates in your
+portfolio's actual capabilities and pricing."
 
 ### sync — Reconcile Both Directions
 
@@ -921,7 +627,7 @@ prevents running portfolio-to-tips successfully only to fail on tips-to-portfoli
 
 **Step 1: Run portfolio-to-tips**
 
-Execute the full `portfolio-to-tips` operation (enriched v3.2 context export).
+Execute the full `portfolio-to-tips` operation (v3.2 context export).
 
 **Step 2: Run tips-to-portfolio**
 
@@ -945,14 +651,14 @@ Present a unified reconciliation table that shows the full picture across both d
 **Status values:**
 - **Aligned** — Feature has proposition, solution, and matching ST(s). Full bidirectional coverage.
 - **Aligned (quality review)** — Aligned, but the proposition has quality assessment failures. The matched ST has `ranking_value` ≥ 4.0, making quality investment worthwhile.
-- **Needs solution** — Proposition exists but no solution for this market. Step 5.5 should have proposed a stub.
+- **Needs solution** — Proposition exists but no solution for this market. Step 5.2 should have proposed a stub.
 - **Needs enrichment** — Feature matches an ST but lacks a proposition for this market.
 - **Portfolio gap** — ST has no matching feature at all. Innovation opportunity — see Innovation Pipeline below.
 - **TIPS gap** — Feature with proposition/solution has no TIPS relevance signal. Validate market need independently.
 
 **Innovation Pipeline** (from `portfolio-opportunities.json`):
 
-If the `tips-to-portfolio` step generated opportunities (Step 5.8), embed the
+If the `tips-to-portfolio` step generated opportunities (Step 5.4), embed the
 innovation pipeline summary in the reconciliation:
 
 ```
@@ -999,3 +705,15 @@ No shared database, no tight coupling — just slug-based references resolved at
 Use the portfolio project's language for all generated content (features, propositions,
 evidence). Use the TIPS project's language when reading TIPS data. If they differ,
 translate ST descriptions to the portfolio language when creating features.
+
+## References
+
+- `references/portfolio-context-schema.md` — canonical v3.2 schema for the
+  `portfolio-context.json` export (single source of truth for field names,
+  types, enums, and the version ladder).
+- `references/opportunity-pipeline.md` — Step 5.4 deep dive: per-ST scoring,
+  classification rules (build/buy/partner), and taxonomy gap aggregation.
+- `references/opportunity-schema.md` — output schema for
+  `portfolio-opportunities.json`.
+- `references/validation-gates.md` — shared pre-flight, industry alignment
+  4-tier heuristic, and hard/soft gate lists per operation.

--- a/cogni-portfolio/skills/trends-bridge/SKILL.md
+++ b/cogni-portfolio/skills/trends-bridge/SKILL.md
@@ -730,26 +730,30 @@ vendor-mode grounding for `cogni-trends` value-modeler Step 2.6 Example
 Enrichment. This step is the v3.2 counterpart to Steps 2.5 and 2.7 — it reads
 portfolio-local data only and never invents web-origin prose.
 
-Source: `cogni-portfolio/{portfolio_ref}/customers/{market-slug}.json → named_customers[]`.
+Source: `portfolio/customers/{market-slug}.json → named_customers[]`.
 
-For each entry with a non-empty `company_name`, emit one
+For each entry with a non-empty `name`, emit one
 `named_customer_references[]` record:
 
 - `market_slug` (required) — the market whose customers file this entry came from
-- `customer_name` (required) — copy from `company_name` verbatim
-- `domain` (optional) — copy from the customer's website root domain if present
+- `customer_name` (required) — copy from `named_customers[].name` verbatim
+- `domain` (optional) — copy `named_customers[].domain` as-is
 - `outcome_summary` (required) — 1–2 sentences summarizing the engagement
-  outcome. Derive from `named_customers[].key_pain_points` + `fit_score`
-  rationale when no explicit outcome text exists. **Must be portfolio-sourced
-  — do not invent web-origin prose.**
-- `fit_score` (optional) — copy `named_customers[].fit_score` as-is (0.0–1.0)
-- `feature_slugs` (optional) — collect feature slugs from any proposition or
-  solution in this market that references this customer. Fall back to an empty
-  array when no linkage exists in `propositions/` or `solutions/`. Allows
-  Step 2.6 to match references to each Solution Template's
-  `portfolio_grounding[feature_slug, market_slug]` mapping.
+  outcome. Derive from `named_customers[].pain_points` combined with
+  `named_customers[].fit_rationale` when no explicit outcome text exists.
+  **Must be portfolio-sourced — do not invent web-origin prose.**
+- `fit_score` (optional) — copy `named_customers[].fit_score` as-is
+  (canonical enum: `high` | `medium` | `low`, per
+  `cogni-portfolio/references/data-model.md:706`)
+- `feature_slugs` (optional) — **v3.2 reserved; always emit as `[]`.** No
+  proposition or solution schema currently stores named-customer linkages,
+  so there is no source to derive feature slugs from. The field is kept on
+  the contract so future schemas that add `named_customer_refs[]` to
+  propositions/solutions can populate it without a v3.3 bump; Step 2.6's
+  `portfolio_grounding[feature_slug, market_slug]` matcher treats an empty
+  array as "no customer-level feature linkage available".
 
-Skip `named_customers[]` entries with an empty or missing `company_name`.
+Skip `named_customers[]` entries with an empty or missing `name`.
 
 If no markets have `named_customers[]` populated, write `named_customer_references[]: []`
 — the field is additive and v3.1 (and earlier) consumers ignore it, so an empty
@@ -843,8 +847,8 @@ Assemble `portfolio-context.json` v3.2:
       "customer_name": "Acme SaaS GmbH",
       "domain": "acme-saas.example.com",
       "outcome_summary": "Reduced incident MTTR from 45 min to 12 min within 90 days of rollout",
-      "fit_score": 0.88,
-      "feature_slugs": ["cloud-monitoring"]
+      "fit_score": "high",
+      "feature_slugs": []
     }
   ]
 }
@@ -856,20 +860,22 @@ Write to `{tips-project-dir}/portfolio-context.json`.
 sourced from each market's `customers/{market-slug}.json → named_customers[]`. Enables
 `cogni-trends` value-modeler Step 2.6 Example Enrichment (vendor mode) to ground Solution
 Templates in concrete portfolio customers without re-reading the portfolio project directly.
-For each `named_customers[]` entry with a non-empty `company_name`, emit one reference:
+For each `named_customers[]` entry with a non-empty `name`, emit one reference:
 
 - `market_slug` (string, required): Market this customer belongs to.
-- `customer_name` (string, required): Company name.
-- `domain` (string, optional): Customer website root domain (if known).
+- `customer_name` (string, required): Copy of `named_customers[].name`.
+- `domain` (string, optional): Copy of `named_customers[].domain` if present.
 - `outcome_summary` (string, required): 1–2 sentences summarizing the engagement outcome.
-  Derive from `named_customers[].key_pain_points` + `fit_score` rationale when no explicit
-  outcome text exists. Must be portfolio-sourced — do not invent web-origin prose.
-- `fit_score` (float, optional): Copy of the named_customer fit_score (0.0–1.0).
-- `feature_slugs` (string array, optional): Features the customer is associated with inside
-  the portfolio (via propositions or solutions). Allows Step 2.6 to match references to each
-  ST's `portfolio_grounding[feature_slug, market_slug]` mapping.
+  Derive from `named_customers[].pain_points` combined with `named_customers[].fit_rationale`
+  when no explicit outcome text exists. Must be portfolio-sourced — do not invent web-origin prose.
+- `fit_score` (string, optional): Copy of `named_customers[].fit_score` — canonical enum
+  `high` | `medium` | `low` (per `cogni-portfolio/references/data-model.md:706`).
+- `feature_slugs` (string array, optional): **v3.2 reserved; always `[]`.** No proposition
+  or solution schema currently stores named-customer linkages, so there is no source to
+  derive feature slugs from. Field is kept on the contract so future schemas that add
+  `named_customer_refs[]` to propositions/solutions can populate it without a v3.3 bump.
 
-The field is additive — see the version notes below for the backward-compatibility contract across v3.1 and earlier consumers.
+See the Schema version notes below for the backward-compatibility contract.
 
 **Schema version notes:**
 - v3.2 adds `named_customer_references[]` — enables vendor-mode example enrichment in cogni-trends value-modeler Step 2.6

--- a/cogni-portfolio/skills/trends-bridge/SKILL.md
+++ b/cogni-portfolio/skills/trends-bridge/SKILL.md
@@ -721,11 +721,11 @@ product descriptions when differentiators are empty or absent.
 
 **Step 3: Build Context File**
 
-Assemble `portfolio-context.json` v3.1:
+Assemble `portfolio-context.json` v3.2:
 
 ```json
 {
-  "schema_version": "3.1",
+  "schema_version": "3.2",
   "source": "cogni-portfolio",
   "portfolio_slug": "{portfolio-slug}",
   "extracted_at": "{ISO-8601 timestamp}",
@@ -800,21 +800,52 @@ Assemble `portfolio-context.json` v3.1:
       "market_relevance": "direct",
       "match_reason": "vertical_codes includes 'saas' matching TIPS subsector"
     }
+  ],
+  "named_customer_references": [
+    {
+      "market_slug": "mid-market-saas-dach",
+      "customer_name": "Acme SaaS GmbH",
+      "domain": "acme-saas.example.com",
+      "outcome_summary": "Reduced incident MTTR from 45 min to 12 min within 90 days of rollout",
+      "fit_score": 0.88,
+      "feature_slugs": ["cloud-monitoring"]
+    }
   ]
 }
 ```
 
 Write to `{tips-project-dir}/portfolio-context.json`.
 
+**`named_customer_references[]`** (added in v3.2, optional): Structured customer references
+sourced from each market's `customers/{market-slug}.json → named_customers[]`. Enables
+`cogni-trends` value-modeler Step 2.6 Example Enrichment (vendor mode) to ground Solution
+Templates in concrete portfolio customers without re-reading the portfolio project directly.
+For each `named_customers[]` entry with a non-empty `company_name`, emit one reference:
+
+- `market_slug` (string, required): Market this customer belongs to.
+- `customer_name` (string, required): Company name.
+- `domain` (string, optional): Customer website root domain (if known).
+- `outcome_summary` (string, required): 1–2 sentences summarizing the engagement outcome.
+  Derive from `named_customers[].key_pain_points` + `fit_score` rationale when no explicit
+  outcome text exists. Must be portfolio-sourced — do not invent web-origin prose.
+- `fit_score` (float, optional): Copy of the named_customer fit_score (0.0–1.0).
+- `feature_slugs` (string array, optional): Features the customer is associated with inside
+  the portfolio (via propositions or solutions). Allows Step 2.6 to match references to each
+  ST's `portfolio_grounding[feature_slug, market_slug]` mapping.
+
+Consumers below v3.2 ignore this field; it's additive.
+
 **Schema version notes:**
+- v3.2 adds `named_customer_references[]` — enables vendor-mode example enrichment in cogni-trends value-modeler Step 2.6
 - v3.0 adds `variant_count` and `quality_assessment` per proposition (v2.0 consumers ignore these)
 - v2.0 had propositions without quality or variant data
 - v1.0 (no `schema_version` field) had no embedded propositions at all
 
 **Backward compatibility:** The `schema_version` field distinguishes versions. Phase 2
-checks this field: v3.0 enables quality-aware generation and variant tracking, v2.0
-enables proposition-grounded generation, v1.0 (no field) falls back to basic feature
-matching. Each version is a superset of the previous — new fields are additive.
+checks this field: v3.2 enables vendor-reference surfacing, v3.0 enables quality-aware
+generation and variant tracking, v2.0 enables proposition-grounded generation, v1.0 (no
+field) falls back to basic feature matching. Each version is a superset of the previous —
+new fields are additive.
 
 **Step 4: Advise Value Modeler**
 

--- a/cogni-portfolio/skills/trends-bridge/SKILL.md
+++ b/cogni-portfolio/skills/trends-bridge/SKILL.md
@@ -9,6 +9,10 @@ description: >
   user has completed value-modeler ranking and asks "how does this connect to my portfolio" or
   "what features should I add based on the trends". Trigger on "bridge status", "is my portfolio
   ready for tips", "check bridge readiness", or "can I bridge yet" for the pre-flight check.
+  Also trigger on "push customer references to tips", "vendor-mode examples",
+  "ground solution templates in my customers", "customer examples in trends", or
+  "named customer references" — the v3.2 `named_customer_references[]` field powers
+  vendor-mode example enrichment in value-modeler Step 2.6.
 allowed-tools: Read, Write, Edit, Glob, Grep, Agent
 ---
 
@@ -612,7 +616,7 @@ Loads the portfolio's products, features, propositions, and solutions into the T
 model context so that Phase 2 (Solution Template generation) is grounded in what you
 actually sell and how you position it per market.
 
-**This operation is informational** — it writes a `portfolio-context.json` (v3.0) file into
+**This operation is informational** — it writes a `portfolio-context.json` (v3.2) file into
 the TIPS project directory that value-modeler Phase 2 can read. The enriched context gives
 Phase 2 access to proposition language (IS/DOES/MEANS), quality assessments, variant counts,
 and solution summaries so that Solution Templates are grounded in real portfolio capabilities
@@ -837,15 +841,16 @@ Consumers below v3.2 ignore this field; it's additive.
 
 **Schema version notes:**
 - v3.2 adds `named_customer_references[]` — enables vendor-mode example enrichment in cogni-trends value-modeler Step 2.6
+- v3.1 adds `differentiators[]` per proposition — v3.1 consumers ignore `named_customer_references[]`, preserving backward compatibility with v3.2 producers
 - v3.0 adds `variant_count` and `quality_assessment` per proposition (v2.0 consumers ignore these)
 - v2.0 had propositions without quality or variant data
 - v1.0 (no `schema_version` field) had no embedded propositions at all
 
 **Backward compatibility:** The `schema_version` field distinguishes versions. Phase 2
-checks this field: v3.2 enables vendor-reference surfacing, v3.0 enables quality-aware
-generation and variant tracking, v2.0 enables proposition-grounded generation, v1.0 (no
-field) falls back to basic feature matching. Each version is a superset of the previous —
-new fields are additive.
+checks this field: v3.2 enables vendor-reference surfacing, v3.1 enables differentiator
+surfacing, v3.0 enables quality-aware generation and variant tracking, v2.0 enables
+proposition-grounded generation, v1.0 (no field) falls back to basic feature matching.
+Each version is a superset of the previous — new fields are additive.
 
 **Step 4: Advise Value Modeler**
 
@@ -863,9 +868,9 @@ Report a summary to the user:
   the TIPS industry context. The exported context will have limited utility for
   Phase 2 grounding."
 
-Tell the user: "Portfolio context (v3.0) saved. When you run value-modeler Phase 2, it
-will use proposition language, quality assessments, and solution data to ground Solution
-Templates in your portfolio's actual capabilities and pricing."
+Tell the user: "Portfolio context (v3.2) saved. When you run value-modeler Phase 2, it
+will use proposition language, quality assessments, solution data, and named customer
+references to ground Solution Templates in your portfolio's actual capabilities and pricing."
 
 ### sync — Reconcile Both Directions
 
@@ -886,7 +891,7 @@ prevents running portfolio-to-tips successfully only to fail on tips-to-portfoli
 
 **Step 1: Run portfolio-to-tips**
 
-Execute the full `portfolio-to-tips` operation (enriched v2.0 context export).
+Execute the full `portfolio-to-tips` operation (enriched v3.2 context export).
 
 **Step 2: Run tips-to-portfolio**
 

--- a/cogni-portfolio/skills/trends-bridge/SKILL.md
+++ b/cogni-portfolio/skills/trends-bridge/SKILL.md
@@ -732,26 +732,16 @@ portfolio-local data only and never invents web-origin prose.
 
 Source: `portfolio/customers/{market-slug}.json → named_customers[]`.
 
-For each entry with a non-empty `name`, emit one
-`named_customer_references[]` record:
+For each entry with a non-empty `name`, emit one `named_customer_references[]`
+record. Map `customer_name` from `named_customers[].name` and `domain` from
+`named_customers[].domain`. Derive `outcome_summary` from
+`named_customers[].pain_points` combined with `named_customers[].fit_rationale`
+when no explicit outcome text exists — **must be portfolio-sourced; do not
+invent web-origin prose.** Copy `fit_score` as-is. Emit `feature_slugs` as `[]`
+(v3.2 reserved — see Step 3 for the forward-compatibility rationale).
 
-- `market_slug` (required) — the market whose customers file this entry came from
-- `customer_name` (required) — copy from `named_customers[].name` verbatim
-- `domain` (optional) — copy `named_customers[].domain` as-is
-- `outcome_summary` (required) — 1–2 sentences summarizing the engagement
-  outcome. Derive from `named_customers[].pain_points` combined with
-  `named_customers[].fit_rationale` when no explicit outcome text exists.
-  **Must be portfolio-sourced — do not invent web-origin prose.**
-- `fit_score` (optional) — copy `named_customers[].fit_score` as-is
-  (canonical enum: `high` | `medium` | `low`, per
-  `cogni-portfolio/references/data-model.md:706`)
-- `feature_slugs` (optional) — **v3.2 reserved; always emit as `[]`.** No
-  proposition or solution schema currently stores named-customer linkages,
-  so there is no source to derive feature slugs from. The field is kept on
-  the contract so future schemas that add `named_customer_refs[]` to
-  propositions/solutions can populate it without a v3.3 bump; Step 2.6's
-  `portfolio_grounding[feature_slug, market_slug]` matcher treats an empty
-  array as "no customer-level feature linkage available".
+See Step 3 below for the full `named_customer_references[]` field contract
+(types, required/optional flags, canonical enums).
 
 Skip `named_customers[]` entries with an empty or missing `name`.
 
@@ -869,7 +859,8 @@ For each `named_customers[]` entry with a non-empty `name`, emit one reference:
   Derive from `named_customers[].pain_points` combined with `named_customers[].fit_rationale`
   when no explicit outcome text exists. Must be portfolio-sourced — do not invent web-origin prose.
 - `fit_score` (string, optional): Copy of `named_customers[].fit_score` — canonical enum
-  `high` | `medium` | `low` (per `cogni-portfolio/references/data-model.md:706`).
+  `high` | `medium` | `low` (per `cogni-portfolio/references/data-model.md` §
+  `customers/{market-slug}.json`).
 - `feature_slugs` (string array, optional): **v3.2 reserved; always `[]`.** No proposition
   or solution schema currently stores named-customer linkages, so there is no source to
   derive feature slugs from. Field is kept on the contract so future schemas that add
@@ -896,6 +887,7 @@ Report a summary to the user:
 - N products, M features, P propositions across K markets (R with direct/industry relevance)
 - Any features without propositions (messaging gaps)
 - Any markets with no TIPS relevance (may not contribute to ST generation)
+- N named customer references exported across M markets (or 0 if none)
 
 **Industry alignment summary** — aggregate the per-market relevance tags:
 - If any market is `direct`: "Industry alignment: strong ({N} markets with direct

--- a/cogni-portfolio/skills/trends-bridge/evals/evals.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/evals.json
@@ -1,0 +1,88 @@
+{
+  "skill_name": "trends-bridge",
+  "evals": [
+    {
+      "id": 1,
+      "name": "status-happy-path",
+      "prompt": "Check bridge readiness for this project.",
+      "expected_output": "Status report with Portfolio Readiness, TIPS Readiness, Industry Alignment, and Bridge Readiness sections. Portfolio Context line shows v3.2 from the exported context file.",
+      "files": ["fixtures/status-ready/"],
+      "assertions": [
+        {
+          "name": "reports-v3.2-context",
+          "text": "Output's Portfolio Context line reports 'v3.2' (not v3.1, not missing)."
+        },
+        {
+          "name": "readiness-ladder-pruned",
+          "text": "Output does NOT enumerate v1.0 or v2.0 in the Portfolio Context readiness line (pruned to v3.2/v3.1/v3.0/missing)."
+        },
+        {
+          "name": "industry-alignment-reported",
+          "text": "Output includes an Industry Alignment section with one of EXACT/VERTICAL/BROAD/NONE."
+        },
+        {
+          "name": "both-directions-ready",
+          "text": "Bridge Readiness reports both portfolio-to-tips AND tips-to-portfolio as READY given the fixture has products, features, propositions, value model with ranked STs."
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "portfolio-to-tips-with-named-customers",
+      "prompt": "Push my portfolio to TIPS.",
+      "expected_output": "portfolio-context.json written into the TIPS project directory with schema_version 3.2 and a non-empty named_customer_references[] populated from named_customers[].",
+      "files": ["fixtures/with-customers/"],
+      "assertions": [
+        {
+          "name": "schema-version-3.2",
+          "text": "Written portfolio-context.json has \"schema_version\": \"3.2\"."
+        },
+        {
+          "name": "named-customer-refs-non-empty",
+          "text": "named_customer_references[] array has at least one entry."
+        },
+        {
+          "name": "fit-score-canonical-enum",
+          "text": "Every named_customer_references[].fit_score is a string from the set {\"high\", \"medium\", \"low\"} — never a float, never a percentage."
+        },
+        {
+          "name": "feature-slugs-empty",
+          "text": "Every named_customer_references[].feature_slugs is an empty array [] (v3.2 reserved)."
+        },
+        {
+          "name": "customer-name-from-name-field",
+          "text": "Every named_customer_references[].customer_name matches the canonical named_customers[].name field (not company_name, not key_pain_points-derived)."
+        },
+        {
+          "name": "no-web-origin-prose",
+          "text": "Every outcome_summary is traceable to pain_points or fit_rationale in the fixture named_customers[] — no invented company history, no web-sourced claims."
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "name": "portfolio-to-tips-missing-customers",
+      "prompt": "Push my portfolio to TIPS.",
+      "expected_output": "Bridge runs successfully despite the fixture having no customers/ directory at all. portfolio-context.json v3.2 is written with named_customer_references: [] and Step 4 summary reports 0 references.",
+      "files": ["fixtures/without-customers/"],
+      "assertions": [
+        {
+          "name": "no-crash",
+          "text": "Bridge completes without raising an error, returning a written portfolio-context.json."
+        },
+        {
+          "name": "named-customer-refs-empty-array",
+          "text": "Written portfolio-context.json has \"named_customer_references\": [] at the top level (empty array, not missing, not null)."
+        },
+        {
+          "name": "schema-still-v3.2",
+          "text": "schema_version is still \"3.2\" even when no customers source exists — the empty array is the backward-compatible signal."
+        },
+        {
+          "name": "step-4-reports-zero",
+          "text": "Step 4 summary reports '0 named customer references' (or equivalent zero-count line)."
+        }
+      ]
+    }
+  ]
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/README.md
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/README.md
@@ -1,0 +1,47 @@
+# trends-bridge evals fixtures
+
+Minimal synthetic portfolio + TIPS project pairs used by `evals/evals.json` as
+repeatable smoke tests for the bridge. Each fixture is intentionally tiny —
+one product, one feature, one market, optional customers — so the test exercises
+the bridge's control flow without turning the eval into a data review.
+
+## Fixtures
+
+### `status-ready/`
+
+Portfolio with 1 product / 1 feature / 1 proposition / 1 market, TIPS project
+with a ranked `tips-value-model.json`, and a pre-existing
+`portfolio-context.json` at `schema_version: "3.2"`. Exercises the `status`
+operation's happy path — all hard gates pass and the readiness ladder should
+report v3.2.
+
+### `with-customers/`
+
+Portfolio with populated `portfolio/customers/{market-slug}.json →
+named_customers[]` (two entries with canonical enum `fit_score`). Exercises
+`portfolio-to-tips` Step 2.8 — the written `portfolio-context.json` should
+include a non-empty `named_customer_references[]` that passes the eval 2
+assertions (canonical enum, empty `feature_slugs`, portfolio-sourced
+`outcome_summary`).
+
+### `without-customers/`
+
+Same as `with-customers/` but with **no** `portfolio/customers/` directory at
+all. Exercises the Step 2.8 missing-file fallback — the written
+`portfolio-context.json` should still be v3.2 and contain
+`named_customer_references: []` cleanly, with Step 4 reporting zero refs.
+
+## Running the evals
+
+These fixtures are scaffolding for future skill-creator iteration loops or for
+manual smoke tests. They are **not** wired into CI today. To run eval 2
+manually:
+
+```
+cd cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers
+# Point the bridge at this directory pair and run:
+#   /bridge portfolio-to-tips
+# Then validate the written ./tips/portfolio-context.json against eval 2's
+# assertions (schema_version, named_customer_references contents, fit_score
+# enum, feature_slugs empty, outcome_summary traceability).
+```

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/portfolio/features/cloud-monitoring.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/portfolio/features/cloud-monitoring.json
@@ -1,0 +1,8 @@
+{
+  "slug": "cloud-monitoring",
+  "product_slug": "cloud-platform",
+  "name": "Cloud Infrastructure Monitoring",
+  "description": "Real-time monitoring with AI-correlated alerting reduces MTTR by 60 percent.",
+  "category": "observability",
+  "readiness": "ga"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/portfolio/markets/mid-market-saas-dach.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/portfolio/markets/mid-market-saas-dach.json
@@ -1,0 +1,9 @@
+{
+  "slug": "mid-market-saas-dach",
+  "name": "Mid-Market SaaS (DACH)",
+  "region": "dach",
+  "priority": "beachhead",
+  "segmentation": { "vertical_codes": ["saas"] },
+  "tam_value": 5000000000,
+  "currency": "EUR"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/portfolio/portfolio.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/portfolio/portfolio.json
@@ -1,0 +1,8 @@
+{
+  "slug": "status-ready-portfolio",
+  "company": {
+    "name": "Acme Cloud",
+    "industry": "Cloud Services"
+  },
+  "taxonomy_template": "b2b-ict"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/portfolio/products/cloud-platform.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/portfolio/products/cloud-platform.json
@@ -1,0 +1,7 @@
+{
+  "slug": "cloud-platform",
+  "name": "Cloud Platform",
+  "revenue_model": "subscription",
+  "maturity": "growth",
+  "description": "Managed European sovereign cloud platform."
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/portfolio/propositions/cloud-monitoring--mid-market-saas-dach.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/portfolio/propositions/cloud-monitoring--mid-market-saas-dach.json
@@ -1,0 +1,7 @@
+{
+  "feature_slug": "cloud-monitoring",
+  "market_slug": "mid-market-saas-dach",
+  "is_statement": "Cloud monitoring for SaaS operations teams",
+  "does_statement": "Reduces MTTR by 60 percent through AI-correlated alerting",
+  "means_statement": "Protects SaaS uptime SLAs in a market where churn from downtime costs 5 to 8 percent ARR"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/tips/portfolio-context.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/tips/portfolio-context.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "3.2",
+  "source": "cogni-portfolio",
+  "portfolio_slug": "status-ready-portfolio",
+  "extracted_at": "2026-04-20T10:00:00Z",
+  "differentiators": [],
+  "products": [],
+  "markets": [],
+  "named_customer_references": []
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/tips/tips-project.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/tips/tips-project.json
@@ -1,0 +1,5 @@
+{
+  "pursuit_slug": "saas-observability-2026",
+  "industry": { "primary": "ict", "subsector": "saas", "primary_en": "ICT", "subsector_en": "SaaS" },
+  "study_mode": "vendor"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/tips/tips-value-model.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/status-ready/tips/tips-value-model.json
@@ -1,0 +1,17 @@
+{
+  "pursuit_slug": "saas-observability-2026",
+  "solution_templates": [
+    {
+      "id": "st-001",
+      "name": "AI-Correlated Incident Response",
+      "description": "Machine-learning alert correlation reduces MTTR for SaaS ops teams.",
+      "ranking_value": 4.2,
+      "portfolio_mapping": {
+        "is_generic": false,
+        "product_slug": "cloud-platform",
+        "feature_slug": "cloud-monitoring",
+        "match_confidence": "high"
+      }
+    }
+  ]
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/portfolio/customers/mid-market-saas-dach.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/portfolio/customers/mid-market-saas-dach.json
@@ -1,0 +1,19 @@
+{
+  "market_slug": "mid-market-saas-dach",
+  "named_customers": [
+    {
+      "name": "Acme SaaS GmbH",
+      "domain": "acme-saas.example.com",
+      "fit_score": "high",
+      "pain_points": ["incident backlog exceeding SLA", "ops team burnout from after-hours alerts"],
+      "fit_rationale": "Reduced incident MTTR from 45 min to 12 min within 90 days of rollout"
+    },
+    {
+      "name": "Beta Cloud OG",
+      "domain": "beta-cloud.example.com",
+      "fit_score": "medium",
+      "pain_points": ["alert fatigue", "false positives during batch jobs"],
+      "fit_rationale": "Cut false-positive alerts by 80 percent after correlation rules went live"
+    }
+  ]
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/portfolio/features/cloud-monitoring.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/portfolio/features/cloud-monitoring.json
@@ -1,0 +1,8 @@
+{
+  "slug": "cloud-monitoring",
+  "product_slug": "cloud-platform",
+  "name": "Cloud Infrastructure Monitoring",
+  "description": "Real-time monitoring with AI-correlated alerting reduces MTTR by 60 percent.",
+  "category": "observability",
+  "readiness": "ga"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/portfolio/markets/mid-market-saas-dach.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/portfolio/markets/mid-market-saas-dach.json
@@ -1,0 +1,9 @@
+{
+  "slug": "mid-market-saas-dach",
+  "name": "Mid-Market SaaS (DACH)",
+  "region": "dach",
+  "priority": "beachhead",
+  "segmentation": { "vertical_codes": ["saas"] },
+  "tam_value": 5000000000,
+  "currency": "EUR"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/portfolio/portfolio.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/portfolio/portfolio.json
@@ -1,0 +1,8 @@
+{
+  "slug": "with-customers-portfolio",
+  "company": {
+    "name": "Acme Cloud",
+    "industry": "Cloud Services"
+  },
+  "taxonomy_template": "b2b-ict"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/portfolio/products/cloud-platform.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/portfolio/products/cloud-platform.json
@@ -1,0 +1,7 @@
+{
+  "slug": "cloud-platform",
+  "name": "Cloud Platform",
+  "revenue_model": "subscription",
+  "maturity": "growth",
+  "description": "Managed European sovereign cloud platform."
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/portfolio/propositions/cloud-monitoring--mid-market-saas-dach.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/portfolio/propositions/cloud-monitoring--mid-market-saas-dach.json
@@ -1,0 +1,7 @@
+{
+  "feature_slug": "cloud-monitoring",
+  "market_slug": "mid-market-saas-dach",
+  "is_statement": "Cloud monitoring for SaaS operations teams",
+  "does_statement": "Reduces MTTR by 60 percent through AI-correlated alerting",
+  "means_statement": "Protects SaaS uptime SLAs in a market where churn from downtime costs 5 to 8 percent ARR"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/tips/tips-project.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/tips/tips-project.json
@@ -1,0 +1,5 @@
+{
+  "pursuit_slug": "saas-observability-2026",
+  "industry": { "primary": "ict", "subsector": "saas", "primary_en": "ICT", "subsector_en": "SaaS" },
+  "study_mode": "vendor"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/tips/tips-value-model.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/with-customers/tips/tips-value-model.json
@@ -1,0 +1,17 @@
+{
+  "pursuit_slug": "saas-observability-2026",
+  "solution_templates": [
+    {
+      "id": "st-001",
+      "name": "AI-Correlated Incident Response",
+      "description": "Machine-learning alert correlation reduces MTTR for SaaS ops teams.",
+      "ranking_value": 4.2,
+      "portfolio_mapping": {
+        "is_generic": false,
+        "product_slug": "cloud-platform",
+        "feature_slug": "cloud-monitoring",
+        "match_confidence": "high"
+      }
+    }
+  ]
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/without-customers/portfolio/features/cloud-monitoring.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/without-customers/portfolio/features/cloud-monitoring.json
@@ -1,0 +1,8 @@
+{
+  "slug": "cloud-monitoring",
+  "product_slug": "cloud-platform",
+  "name": "Cloud Infrastructure Monitoring",
+  "description": "Real-time monitoring with AI-correlated alerting reduces MTTR by 60 percent.",
+  "category": "observability",
+  "readiness": "ga"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/without-customers/portfolio/markets/mid-market-saas-dach.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/without-customers/portfolio/markets/mid-market-saas-dach.json
@@ -1,0 +1,9 @@
+{
+  "slug": "mid-market-saas-dach",
+  "name": "Mid-Market SaaS (DACH)",
+  "region": "dach",
+  "priority": "beachhead",
+  "segmentation": { "vertical_codes": ["saas"] },
+  "tam_value": 5000000000,
+  "currency": "EUR"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/without-customers/portfolio/portfolio.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/without-customers/portfolio/portfolio.json
@@ -1,0 +1,8 @@
+{
+  "slug": "without-customers-portfolio",
+  "company": {
+    "name": "Acme Cloud",
+    "industry": "Cloud Services"
+  },
+  "taxonomy_template": "b2b-ict"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/without-customers/portfolio/products/cloud-platform.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/without-customers/portfolio/products/cloud-platform.json
@@ -1,0 +1,7 @@
+{
+  "slug": "cloud-platform",
+  "name": "Cloud Platform",
+  "revenue_model": "subscription",
+  "maturity": "growth",
+  "description": "Managed European sovereign cloud platform."
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/without-customers/portfolio/propositions/cloud-monitoring--mid-market-saas-dach.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/without-customers/portfolio/propositions/cloud-monitoring--mid-market-saas-dach.json
@@ -1,0 +1,7 @@
+{
+  "feature_slug": "cloud-monitoring",
+  "market_slug": "mid-market-saas-dach",
+  "is_statement": "Cloud monitoring for SaaS operations teams",
+  "does_statement": "Reduces MTTR by 60 percent through AI-correlated alerting",
+  "means_statement": "Protects SaaS uptime SLAs in a market where churn from downtime costs 5 to 8 percent ARR"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/without-customers/tips/tips-project.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/without-customers/tips/tips-project.json
@@ -1,0 +1,5 @@
+{
+  "pursuit_slug": "saas-observability-2026",
+  "industry": { "primary": "ict", "subsector": "saas", "primary_en": "ICT", "subsector_en": "SaaS" },
+  "study_mode": "vendor"
+}

--- a/cogni-portfolio/skills/trends-bridge/evals/fixtures/without-customers/tips/tips-value-model.json
+++ b/cogni-portfolio/skills/trends-bridge/evals/fixtures/without-customers/tips/tips-value-model.json
@@ -1,0 +1,17 @@
+{
+  "pursuit_slug": "saas-observability-2026",
+  "solution_templates": [
+    {
+      "id": "st-001",
+      "name": "AI-Correlated Incident Response",
+      "description": "Machine-learning alert correlation reduces MTTR for SaaS ops teams.",
+      "ranking_value": 4.2,
+      "portfolio_mapping": {
+        "is_generic": false,
+        "product_slug": "cloud-platform",
+        "feature_slug": "cloud-monitoring",
+        "match_confidence": "high"
+      }
+    }
+  ]
+}

--- a/cogni-portfolio/skills/trends-bridge/references/opportunity-pipeline.md
+++ b/cogni-portfolio/skills/trends-bridge/references/opportunity-pipeline.md
@@ -1,0 +1,140 @@
+# Blueprint-Aware Opportunity Pipeline
+
+Step 5.4 of the `tips-to-portfolio` operation produces `portfolio-opportunities.json`
+— a structured gap analysis of Solution Templates (STs) that lack strong portfolio
+matches, plus a taxonomy-level aggregate showing which portfolio dimensions need
+investment across the whole solution portfolio.
+
+This reference covers the **procedural logic** (scoring, classification, taxonomy
+aggregation). For the output file schema, see
+`references/opportunity-schema.md`.
+
+## Why two levels
+
+Per-ST opportunities answer "which individual gaps should we evaluate?" That's
+useful for tactical roadmap calls but misses the portfolio question: "which
+dimensions of our offering are systematically underinvested?" Aggregating
+building blocks across all STs — matched and unmatched — surfaces the taxonomy
+priorities that a single-ST view would hide. The strategic insight from this
+aggregation is typically the most valuable output of the bridge.
+
+## Level 1: Per-ST opportunities
+
+For each Solution Template with `match_confidence` of `"none"` or `"low"`,
+generate a structured opportunity assessment.
+
+### 1. Calculate opportunity score (0–10)
+
+```
+opportunity_score = (
+    (ranking_value / 5) × 0.4 +
+    tam_alignment × 0.3 +
+    competitive_whitespace × 0.3
+) × 10
+```
+
+- `ranking_value`: The ST's `ranking_value` from the TIPS value model (0–5).
+- `tam_alignment`: Fraction of portfolio markets with `market_relevance = "direct"`
+  or `"industry"` for this pursuit (0–1). Read from the market entries in
+  `portfolio-context.json`.
+- `competitive_whitespace`: If competitive analysis exists for related propositions,
+  estimate whitespace from competitor coverage gaps. Otherwise default to `0.7`
+  (moderate whitespace assumption — tune if the portfolio routinely has competitor
+  data and this default distorts scoring).
+
+### 2. Classify the opportunity
+
+- **build** — The company has adjacent expertise (existing features in the same
+  taxonomy dimension), the opportunity is core to differentiation, and no adequate
+  turnkey solution exists. Requires development investment.
+- **buy** — A commercial solution exists that covers 80%+ of the need. Faster
+  time-to-market through acquisition or licensing.
+- **partner** — Requires specialized domain expertise the company lacks. Best
+  addressed through co-development, white-label, or referral partnership.
+
+Use the ST's `category`, its blueprint building blocks (taxonomy dimensions), and
+the portfolio's existing feature landscape to guide classification. A gap in a
+consulting dimension (7.x) naturally suggests `partner`; a gap in a core
+technical dimension (4.x, 6.x) may suggest `build` or `buy`.
+
+### 3. Estimate revenue
+
+- Read portfolio markets and filter to those with `market_relevance = "direct"`.
+- Use TAM values with conservative penetration assumptions (0.05–0.2%).
+- Set confidence:
+  - `high` — validated TAM + comparable pricing.
+  - `medium` — TAM with assumptions.
+  - `low` — rough estimate.
+
+### 4. Generate feature spec (roadmap-ready)
+
+Each opportunity carries a `feature_spec` that can be promoted directly into a
+`portfolio/features/{slug}.json` entry on user approval:
+
+- `proposed_slug`: Derived from ST name (kebab-case).
+- `name` and `description`: Adapted from ST for feature language.
+- `category`: Derived from ST category.
+- `readiness`: Always `"planned"`.
+- `unmet_needs`: From blueprint building blocks with `coverage: "gap"` — each gap
+  block's `gaps` array provides specific unmet capabilities. Falls back to
+  `portfolio_anchor.theme_needs_undelivered` or ST description extraction.
+- `taxonomy_refs`: Array of taxonomy categories from the ST's blueprint gap blocks
+  (e.g., `["1.4", "7.2"]`) — shows which portfolio dimensions this opportunity
+  spans.
+- `source_themes` and `source_sts`: Traceability to the TIPS value model.
+
+### 5. Assign priority
+
+- `high` — `opportunity_score ≥ 7.0` AND `ranking_value ≥ 4.0`.
+- `medium` — `opportunity_score ≥ 4.0` OR `ranking_value ≥ 3.0`.
+- `low` — everything else.
+
+## Level 2: Taxonomy gap analysis
+
+After per-ST opportunities are generated, aggregate blueprint building blocks
+across **all** Solution Templates (not just unmatched ones) to produce a
+taxonomy-level gap report.
+
+1. **Collect all building blocks** from every ST's
+   `solution_blueprint.building_blocks`.
+2. **Group by taxonomy dimension** (0–7) and then by category (e.g., `6.6`).
+3. **Count coverage status** per category: how many STs need this category, and
+   of those how many are covered / partial / gap.
+4. **Generate the taxonomy gap report** — a table followed by a short strategic
+   insight paragraph:
+
+```
+Taxonomy Gap Analysis — Portfolio Investment Priorities
+
+| Dim | Taxonomy Category | STs Needing | Covered | Partial | Gap | Priority |
+|-----|-------------------|-------------|---------|---------|-----|----------|
+| 7   | Digital Transformation (7.2) | 5 | 0 | 1 | 4 | HIGH |
+| 1   | 5G & IoT Connectivity (1.4) | 4 | 1 | 2 | 1 | MEDIUM |
+| 2   | Cloud Security (2.4) | 3 | 0 | 0 | 3 | HIGH |
+| 7   | Program Management (7.4) | 2 | 0 | 0 | 2 | MEDIUM |
+
+Strategic Insight:
+- Consulting (Dim 7) is the #1 portfolio gap: 7 building blocks across 5 STs need
+  consulting capabilities that don't exist in the portfolio. Consider a consulting
+  partnership or practice build.
+- Security (Dim 2) gaps affect 3 high-ranked STs. Investing here would improve
+  readiness scores across the solution portfolio.
+```
+
+### Taxonomy gap priority thresholds
+
+- `HIGH` — ≥3 STs affected AND majority are `gap` (not `partial`).
+- `MEDIUM` — 2+ STs affected.
+- `LOW` — 1 ST affected.
+
+## Output
+
+Write `portfolio-opportunities.json` to the TIPS project directory (alongside
+`tips-value-model.json`). Include both per-ST opportunities and the taxonomy gap
+summary. The file schema is documented in `references/opportunity-schema.md`.
+
+Present the opportunities table sorted by `opportunity_score`, followed by the
+taxonomy gap report. The user can accept/defer/reject individual opportunities
+inline — accepted opportunities promote to `portfolio/features/{slug}.json`
+entries via the Step 3 new-feature-creation path, marked with
+`tips_ref: "{pursuit-slug}#st-{id}"` for traceability.

--- a/cogni-portfolio/skills/trends-bridge/references/portfolio-context-schema.md
+++ b/cogni-portfolio/skills/trends-bridge/references/portfolio-context-schema.md
@@ -1,0 +1,199 @@
+# portfolio-context.json — Schema Reference
+
+The v3.2 schema for the `portfolio-context.json` file that `trends-bridge` writes
+into the TIPS project directory. This file is the single source of truth for field
+names, types, and enums — both the SKILL.md procedural steps (Steps 2, 2.5, 2.7,
+2.8, 3) and downstream `cogni-trends` consumers read this spec.
+
+## Source-of-truth discipline
+
+`named_customer_references[]` mirrors data from the canonical `named_customers[]`
+schema in `cogni-portfolio/references/data-model.md § customers/{market-slug}.json`.
+If that upstream schema changes (field names, enum values, required/optional flags),
+update **both** files in the same commit — drift between these two specs caused a
+multi-commit churn during PR #120, where this bridge's field list drifted from the
+canonical `name` / `pain_points` / enum `high|medium|low` spec and silently emptied
+`named_customer_references[]` on every real portfolio until reviewers caught it.
+
+Cross-file citations in this document use **section anchors** (e.g.,
+`data-model.md § customers/{market-slug}.json`) rather than line numbers. Line
+numbers rot on every edit; anchors survive.
+
+## Worked example (v3.2)
+
+```json
+{
+  "schema_version": "3.2",
+  "source": "cogni-portfolio",
+  "portfolio_slug": "{portfolio-slug}",
+  "extracted_at": "{ISO-8601 timestamp}",
+  "differentiators": [
+    {
+      "domain": "sovereign-infrastructure",
+      "claim": "European sovereign cloud with BSI-C5 attestation and German-only data residency",
+      "evidence": "BSI-C5 attestation certificate, data center locations",
+      "swap_test_fails": true
+    }
+  ],
+  "products": [
+    {
+      "slug": "cloud-platform",
+      "name": "Cloud Platform",
+      "revenue_model": "subscription",
+      "maturity": "growth",
+      "features": [
+        {
+          "slug": "cloud-monitoring",
+          "name": "Cloud Infrastructure Monitoring",
+          "description": "Real-time monitoring...",
+          "category": "observability",
+          "readiness": "ga",
+          "propositions": [
+            {
+              "market_slug": "mid-market-saas-dach",
+              "is_statement": "Cloud monitoring for SaaS operations teams",
+              "does_statement": "Reduces MTTR by 60% through AI-correlated alerting",
+              "means_statement": "Protects SaaS uptime SLAs in a market where churn from downtime costs 5-8% ARR",
+              "evidence_count": 3,
+              "variant_count": 2,
+              "quality_assessment": {
+                "overall": "pass",
+                "does_score": {
+                  "buyer_centricity": "pass",
+                  "market_specificity": "pass",
+                  "differentiation": "pass",
+                  "status_quo_contrast": "warn",
+                  "conciseness": "pass"
+                },
+                "means_score": {
+                  "outcome_specificity": "pass",
+                  "escalation": "pass",
+                  "quantification": "pass",
+                  "emotional_resonance": "warn",
+                  "conciseness": "pass"
+                },
+                "assessed_at": "2026-03-12"
+              },
+              "solution_summary": {
+                "solution_type": "project",
+                "pricing_tiers": ["proof_of_value", "small", "medium", "large"],
+                "price_range": { "min": 15000, "max": 250000, "currency": "EUR" }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "markets": [
+    {
+      "slug": "mid-market-saas-dach",
+      "name": "Mid-Market SaaS (DACH)",
+      "region": "dach",
+      "priority": "beachhead",
+      "segmentation_summary": "SaaS companies, 50-500 employees",
+      "vertical_codes": ["saas"],
+      "tam_value": 5000000000,
+      "currency": "EUR",
+      "market_relevance": "direct",
+      "match_reason": "vertical_codes includes 'saas' matching TIPS subsector"
+    }
+  ],
+  "named_customer_references": [
+    {
+      "market_slug": "mid-market-saas-dach",
+      "customer_name": "Acme SaaS GmbH",
+      "domain": "acme-saas.example.com",
+      "outcome_summary": "Reduced incident MTTR from 45 min to 12 min within 90 days of rollout",
+      "fit_score": "high",
+      "feature_slugs": []
+    }
+  ]
+}
+```
+
+## Field contract
+
+### Top-level
+
+- `schema_version` (string, required): Always `"3.2"` for v3.2 exports.
+- `source` (string, required): Always `"cogni-portfolio"`.
+- `portfolio_slug` (string, required): Slug of the source portfolio project.
+- `extracted_at` (string, required): ISO-8601 timestamp of export.
+
+### `differentiators[]` (v3.1+, optional)
+
+Provider-specific competitive advantages. 3–6 entries typical; empty array is valid.
+
+- `domain` (string, required): One of `sovereign-infrastructure`, `network`, `security`,
+  `scale`, `industry-expertise`, `platform`, `regulatory`.
+- `claim` (string, required): One-sentence differentiator claim.
+- `evidence` (string, required): What substantiates the claim (certification, metric,
+  customer reference).
+- `swap_test_fails` (boolean, required): `true` only when swapping the provider name
+  for a competitor makes the claim false or implausible.
+
+### `products[]`, `markets[]`, `products[].features[]`, `features[].propositions[]`
+
+Structural content mirroring the portfolio project. `features[].propositions[]` carries
+the compacted IS/DOES/MEANS plus the v3.0+ `variant_count`, `quality_assessment`, and
+`solution_summary` fields.
+
+### `named_customer_references[]` (v3.2, optional)
+
+Structured customer references sourced from each market's
+`customers/{market-slug}.json → named_customers[]`
+(see `cogni-portfolio/references/data-model.md § customers/{market-slug}.json`).
+Enables `cogni-trends` value-modeler Step 2.6 Example Enrichment (vendor mode) to
+ground Solution Templates in concrete portfolio customers without re-reading the
+portfolio project directly.
+
+One reference per `named_customers[]` entry with a non-empty `name`:
+
+- `market_slug` (string, required): Market this customer belongs to.
+- `customer_name` (string, required): Copy of `named_customers[].name`.
+- `domain` (string, optional): Copy of `named_customers[].domain` if present.
+- `outcome_summary` (string, required): 1–2 sentences summarizing the engagement outcome.
+  Derive from `named_customers[].pain_points` combined with `named_customers[].fit_rationale`
+  when no explicit outcome text exists. **Must be portfolio-sourced — do not invent
+  web-origin prose.**
+- `fit_score` (string, optional): Copy of `named_customers[].fit_score` — canonical enum
+  `high` | `medium` | `low` (per `data-model.md § customers/{market-slug}.json`). Never
+  a float, never a percentage.
+- `feature_slugs` (string array, optional): **v3.2 reserved; always `[]`.** No proposition
+  or solution schema currently stores named-customer linkages, so there is no source to
+  derive feature slugs from. Kept on the contract so future schemas that add
+  `named_customer_refs[]` to propositions/solutions can populate it without a v3.3 bump.
+
+## Schema version notes
+
+Each version is a superset of the previous — new fields are additive. Consumers below
+a version ignore the fields added at that version, preserving backward compatibility.
+
+- **v3.2** adds `named_customer_references[]` — enables vendor-mode example enrichment
+  in cogni-trends value-modeler Step 2.6.
+- **v3.1** adds top-level `differentiators[]`. Pre-v3.2 consumers ignore
+  `named_customer_references[]`.
+- **v3.0** adds `variant_count` and `quality_assessment` per proposition.
+- **v2.0** propositions without quality or variant data.
+- **v1.0** (no `schema_version` field) no embedded propositions at all.
+
+### Backward compatibility
+
+The `schema_version` field is the contract boundary. `cogni-trends` value-modeler Phase 2
+branches on this field:
+
+- v3.2 enables vendor-reference surfacing.
+- v3.1 enables differentiator surfacing.
+- v3.0 enables quality-aware ST generation and variant tracking.
+- v2.0 enables proposition-grounded ST generation.
+- v1.0 (no field) falls back to basic feature matching.
+
+## Related schemas
+
+- `data-model.md § portfolio-context.json (Export to TIPS)` — the canonical data-model
+  entry that references this document.
+- `data-model.md § customers/{market-slug}.json` — the upstream source of the
+  `named_customers[]` records that feed `named_customer_references[]`.
+- `references/opportunity-schema.md` — the sibling `portfolio-opportunities.json`
+  schema (written alongside `portfolio-context.json` when `tips-to-portfolio` runs).

--- a/cogni-portfolio/skills/trends-bridge/references/validation-gates.md
+++ b/cogni-portfolio/skills/trends-bridge/references/validation-gates.md
@@ -1,0 +1,118 @@
+# Pre-flight Validation & Readiness Gates
+
+Every bridge operation runs a pre-flight check before doing any work. This catches
+data gaps and industry mismatches early — before wasting time on exports or imports
+that will produce poor results.
+
+The SKILL.md Prerequisites section is a short overview; this file holds the full
+gate and heuristic spec so the procedural steps stay scannable.
+
+## Shared pre-flight (all operations)
+
+1. **Discover projects** — Find the TIPS project (`*/tips-project.json`) and the
+   portfolio project (`*/portfolio.json`). If either is missing, stop and report
+   which one with a fix suggestion.
+2. **Industry alignment** — Compare TIPS and portfolio industries (see heuristic
+   below). The result is stored for use during market-relevance matching and
+   reported in the summary.
+
+## Industry alignment heuristic
+
+The TIPS project targets a specific industry (e.g., manufacturing/automotive)
+while the portfolio describes what you sell. Bridging across unrelated industries
+is unusual and likely a mistake — but sometimes intentional (e.g., cross-selling
+into a new vertical). The heuristic warns rather than blocks, so cross-industry
+intent is still possible with explicit confirmation.
+
+**How it works:**
+
+1. Read TIPS `industry.primary` and `industry.subsector` from `tips-project.json`.
+2. Read portfolio `company.industry` from `portfolio.json` (free text).
+3. Collect all `segmentation.vertical_codes` from `portfolio/markets/*.json`.
+4. Slugify `company.industry` (lowercase, replace non-alphanumeric with hyphens).
+
+Match using a 4-tier heuristic:
+
+- **exact** — Slugified `company.industry` matches `industry.primary` or
+  `industry.subsector`. Example: `company.industry` "Automotive OEM" → slug
+  `automotive-oem` contains `automotive` matching subsector. Proceed silently.
+- **vertical** — Any market `vertical_code` matches `industry.subsector`.
+  Example: market has `vertical_codes: ["automotive"]`, TIPS subsector is
+  `automotive`. Proceed silently.
+- **broad** — Any market `vertical_code` is a known subsector of
+  `industry.primary` (use the same parent-child logic as market-relevance
+  matching). Example: market has `vertical_codes: ["autonomous-vehicles"]`,
+  TIPS primary is `manufacturing`. Proceed with note:
+  > Portfolio markets have related verticals ({codes}) but no direct match to
+  > TIPS subsector '{subsector}'. Bridge results may need manual review.
+- **none** — No match found. Warn and require explicit user confirmation:
+  > Industry mismatch: TIPS analyzes {primary_en}/{subsector_en} but portfolio
+  > company.industry is '{company.industry}' with market verticals [{codes}].
+  > Cross-industry bridging is unusual — continue anyway?
+
+## portfolio-to-tips validation gates
+
+Run these after shared pre-flight when executing `portfolio-to-tips` or `sync`.
+
+**Hard gates (block execution):**
+
+- `portfolio.json` must exist and be valid JSON.
+- At least 1 product in `portfolio/products/`.
+- At least 1 feature in `portfolio/features/` with a valid `product_slug`
+  reference.
+
+If any hard gate fails, stop and report the fix:
+
+- "No products found. Create at least one product first: `/portfolio-setup`"
+- "No features found. Add features to your products: `/features create`"
+
+**Soft warnings (report and continue):**
+
+- No propositions: "No propositions found. The exported context will lack
+  IS/DOES/MEANS messaging — value-modeler Phase 2 will generate STs without
+  portfolio grounding. Consider running `/propositions create` first."
+- No markets: "No markets defined. The context file will have no
+  market-relevance tagging. Define markets with `/portfolio-setup`."
+- Features with descriptions under 15 words: "{N} features have thin
+  descriptions (under 15 words). Richer descriptions improve ST-to-feature
+  matching accuracy. Consider running `/features enrich` first."
+- No solutions: "No solutions found. The exported context will lack pricing
+  and delivery data."
+
+## tips-to-portfolio validation gates
+
+Run these after shared pre-flight when executing `tips-to-portfolio` or `sync`.
+
+**Hard gates (block execution):**
+
+- `tips-value-model.json` must exist in the TIPS project directory.
+- `solution_templates` array must be non-empty.
+- At least 1 ST must have `ranking_value` populated (not null) — confirms that
+  value-modeler Phase 4 (ranking) has completed.
+
+If any hard gate fails, stop and report the fix:
+
+- "Value model not found. Run the value modeler first: `/value-model`"
+- "No solution templates in value model. Complete value-modeler Phase 2:
+  `/value-model solutions`"
+- "Solution templates have no ranking values. Complete Phase 4 to calculate
+  rankings: `/value-model rank`"
+
+**Soft warnings (report and continue):**
+
+- No features in portfolio: "Portfolio has no features. All Solution Templates
+  will produce 'Create' actions (no enrichment possible). Consider adding
+  features first with `/features create`."
+- No propositions: "Portfolio has features but no propositions. Enrichment will
+  create new propositions rather than refining existing ones."
+- All STs have `business_relevance = null`: "No user-scored business relevance
+  found. Rankings use formula-only scores. Consider running `/value-model score`
+  for customer-specific prioritization."
+
+## sync mode
+
+`sync` runs **both** gate sets (`portfolio-to-tips` + `tips-to-portfolio`)
+after the shared pre-flight and reports them together. This prevents the
+common failure mode of running `portfolio-to-tips` successfully only to fail
+on `tips-to-portfolio` halfway through. If any hard gate from either direction
+fails, stop before executing either operation.

--- a/cogni-trends/.claude-plugin/plugin.json
+++ b/cogni-trends/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-trends",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-trends/.claude-plugin/plugin.json
+++ b/cogni-trends/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-trends",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-trends/agents/trend-report-investment-theme-writer.md
+++ b/cogni-trends/agents/trend-report-investment-theme-writer.md
@@ -257,8 +257,8 @@ The rendering shape depends on `STUDY_MODE`:
 
 - **No examples available** (empty `EXAMPLE_REFERENCES` for this theme). Fall
   back to the pre-change behavior — render capability prose and the portfolio
-  close (vendor only) without example weaving. This is the backward-compatible
-  path for projects that predate the `study_mode` field.
+  close (when `PORTFOLIO_PRODUCTS` is non-empty) without example weaving. This
+  is the backward-compatible path for projects that predate the `study_mode` field.
 
 **Portfolio close:** After all capability descriptions (and, in open mode, after
 the `Referenzbeispiele` block), close the Why You section with 2-3 sentences

--- a/cogni-trends/agents/trend-report-investment-theme-writer.md
+++ b/cogni-trends/agents/trend-report-investment-theme-writer.md
@@ -40,6 +40,11 @@ You receive these from trend-report Phase 2:
 - **SOLUTION_TEMPLATES** — JSON array of this theme's solution templates: `[{ st_id, name, category, enabler_type }]` (may be empty)
 - **PORTFOLIO_PROVIDER** — Display name of the portfolio provider (e.g., "T-Systems", "Telekom MMS"). Sourced from `portfolio-context.json` → `portfolio_slug` resolved to a display name. Used in the portfolio close sentence. Empty string if no portfolio context.
 - **PORTFOLIO_PRODUCTS** — JSON array of distinct portfolio products grounding this theme's solution templates: `[{ product_name, product_url }]` (may be empty). Derived from `portfolio_grounding` on each solution template. `product_url` may be null if no URL is available.
+- **STUDY_MODE** — Either `"vendor"` or `"open"` (default `"open"` when absent). Read from `tips-project.json → study_mode` by the orchestrator. Drives the Why You example-rendering rule — vendor mode weaves portfolio-internal references per ST; open mode renders a `Referenzbeispiele` block of published cases. See the "Practical examples per mode" subsection under Why You for the full rule.
+- **EXAMPLE_REFERENCES** — JSON object keyed by `st_id`, containing per-ST example data aggregated from `tips-value-model.json`. Shape depends on `STUDY_MODE`:
+  - `STUDY_MODE == "vendor"`: each ST entry has `{ mode: "vendor", entries: [{ customer_name, outcome_claim, roi_claim?, source, source_ref, publication_date? }, ...] }`. All entries have `source_origin == "vendor"`. Each `source_ref` resolves inside the connected cogni-portfolio project — the agent does NOT need to resolve absolute paths; it cites the `source_ref` verbatim in markdown links as `[{customer_name}](portfolio://{source_ref})` so the `portfolio://` scheme marks the citation as portfolio-internal for downstream verification.
+  - `STUDY_MODE == "open"`: each ST entry has `{ mode: "open", entries: [{ vendor_or_customer, outcome, source_url, source_authority, publication_date? }, ...] }`. All entries have `source_origin == "third_party"`.
+  - When a ST has no examples (empty array or missing key), fall back to plain capability prose for that ST with no example citations.
 - **SOLUTION_PRICING** — JSON array of solution pricing data for this theme's grounded features: `[{ feature_slug, market_slug, solution_type, pricing, cost_model, implementation }]` (may be empty). Extracted from portfolio solution files by the orchestrator. Used in Why Pay for proactive investment figures. See "Solution costing data" in Why Pay section.
 - **MARKET_REGION** — Target market region code (e.g., "dach", "de", "us", "uk"). Default: "dach". Used to load region-specific currency and organization size references from `$CLAUDE_PLUGIN_ROOT/skills/trend-report/references/region-authority-sources.json`.
 - **LABELS** — JSON object with i18n labels for section headings
@@ -222,10 +227,44 @@ must never see internal portfolio taxonomy. All capabilities are presented as
 flowing prose only. If you find yourself writing a markdown table inside Why You,
 stop and convert it to prose paragraphs instead.
 
-**Portfolio close:** After all capability descriptions, close the Why You section
-with 2-3 sentences that link the portfolio products to a provider-specific
-differentiator the reader cannot get elsewhere. The first sentence names the
-products. The second sentence names one concrete asset that creates exclusivity.
+**Practical examples per mode.** Each solution template's prose block must be
+grounded with concrete proof when `EXAMPLE_REFERENCES` carries entries for that ST.
+The rendering shape depends on `STUDY_MODE`:
+
+- **Vendor mode** (`STUDY_MODE == "vendor"`). Weave at least one reference **per ST
+  mentioned** directly into that ST's closing prose. Use vendor-authored phrasing
+  that treats the reference as proof the vendor has already delivered this
+  capability. Pattern (de): `"{PORTFOLIO_PROVIDER} hat dies bereits bei {customer_name} umgesetzt — {outcome_claim}"`.
+  Pattern (en): `"{PORTFOLIO_PROVIDER} has already implemented this for {customer_name} — {outcome_claim}"`.
+  Cite the source as a markdown link using the `portfolio://` scheme from
+  `EXAMPLE_REFERENCES` (e.g., `[Stadtwerke München](portfolio://customers/energy-utilities-dach.json#named_customers[2])`). This scheme is NOT a
+  public URL — it marks the citation as portfolio-internal for downstream
+  verification, and it replaces any generic "case-study recommended" placeholder
+  that prior report generations may have produced. Do NOT include a separate
+  `Referenzbeispiele` block in vendor mode — references belong inline with each ST.
+
+- **Open mode** (`STUDY_MODE == "open"` or absent). After all capability
+  descriptions and before the portfolio close, insert a mini-block labeled
+  `**{REFERENZBEISPIELE_LABEL}**` (label key `REFERENCES_BLOCK_LABEL` — e.g.
+  `"Referenzbeispiele"` in German, `"Industry reference cases"` in English).
+  The block is 2–3 short bullets, each citing one `published_cases[]` entry
+  from the theme's aggregated `EXAMPLE_REFERENCES` across all mentioned STs
+  (pick the highest-authority, most diverse set). Pattern:
+  `- **{vendor_or_customer}** ({publication_date}): {outcome} — [Quelle]({source_url})`.
+  Preserve citation diversity: do not repeat the same second-level domain more
+  than once in the block. When fewer than 2 entries exist across all STs in this
+  theme, omit the block entirely and rely on plain capability prose.
+
+- **No examples available** (empty `EXAMPLE_REFERENCES` for this theme). Fall
+  back to the pre-change behavior — render capability prose and the portfolio
+  close (vendor only) without example weaving. This is the backward-compatible
+  path for projects that predate the `study_mode` field.
+
+**Portfolio close:** After all capability descriptions (and, in open mode, after
+the `Referenzbeispiele` block), close the Why You section with 2-3 sentences
+that link the portfolio products to a provider-specific differentiator the reader
+cannot get elsewhere. The first sentence names the products. The second sentence
+names one concrete asset that creates exclusivity.
 
 Format examples (German):
 - "{PORTFOLIO_PROVIDER} kann Sie auf diesem Weg mit [Product A](url),
@@ -426,7 +465,7 @@ Now replace the placeholder heading markers in the written file with the actual 
 - Each element meets its proportional word target (+/-10%)
 - **Why Change:** PSB structure applied, Contrast Structure used, ends with competitive implication
 - **Why Now:** ≥2 forcing functions with specific timelines, before/after contrast, window closing statement. FF1 should be a regulatory deadline if evidence contains one. Each forcing function should be specific to this theme — reusing the same deadline (e.g., EU AI Act August 2026) as the primary forcing function in multiple themes makes the report feel repetitive and weakens urgency. If the same deadline applies across themes, reference it briefly ("alongside the EU AI Act deadline") but lead with a theme-specific forcing function.
-- **Why You:** IS-DOES-MEANS logic applied (invisibly) to ≥1 solution template or P-candidate. You-Phrasing for outcomes. No ST-IDs, no "Power Position", no visible IS/DOES/MEANS labels — flowing prose only. No solution table. Portfolio close present (if PORTFOLIO_PRODUCTS non-empty). Heading uses "Lösungen"/"solutions" and ties back to urgency.
+- **Why You:** IS-DOES-MEANS logic applied (invisibly) to ≥1 solution template or P-candidate. You-Phrasing for outcomes. No ST-IDs, no "Power Position", no visible IS/DOES/MEANS labels — flowing prose only. No solution table. Portfolio close present (if PORTFOLIO_PRODUCTS non-empty). Heading uses "Lösungen"/"solutions" and ties back to urgency. **Examples gate:** when `EXAMPLE_REFERENCES` carries at least one entry for any ST in this theme, the Why You section MUST cite at least one example — inline per ST in vendor mode, or via the `Referenzbeispiele` block in open mode. Vendor-mode citations use the `portfolio://` scheme; open-mode citations use public HTTPS URLs with no more than one entry per second-level domain. If `EXAMPLE_REFERENCES` is empty/absent for this theme, skip the examples gate (backward compatibility).
 - **Why Pay:** ≥2 cost dimensions with specific localized ranges in the region's currency (not global averages), 3-year horizon, closing ratio comparison. Every cost dimension should contain monetary amounts in the region's currency and reference a specific organization size (from `org_size_reference` in region config) — CDO and CFO readers immediately distrust global averages or unsized figures because they can't present them to their board. The proactive investment figure should be realistic for the scope of capabilities described — understating to inflate the ratio destroys credibility when readers do their own math.
 - Hook opens with quantified surprise from theme evidence
 - **Headings:** H2 is thesis statement (not topic label), all H3s are message-driven (not arc element names), each contains a number/date/entity

--- a/cogni-trends/agents/trend-report-investment-theme-writer.md
+++ b/cogni-trends/agents/trend-report-investment-theme-writer.md
@@ -245,15 +245,20 @@ The rendering shape depends on `STUDY_MODE`:
 
 - **Open mode** (`STUDY_MODE == "open"` or absent). After all capability
   descriptions and before the portfolio close, insert a mini-block labeled
-  `**{REFERENZBEISPIELE_LABEL}**` (label key `REFERENCES_BLOCK_LABEL` — e.g.
-  `"Referenzbeispiele"` in German, `"Industry reference cases"` in English).
-  The block is 2–3 short bullets, each citing one `published_cases[]` entry
+  `**{REFERENCES_BLOCK_LABEL}**` (e.g. `"Referenzbeispiele"` in German,
+  `"Industry reference cases"` in English — populated by the orchestrator
+  from the LABELS payload in `skills/trend-report/references/phase-2-strategic-themes.md` Step 2.2).
+  The block is 1–3 short bullets, each citing one `published_cases[]` entry
   from the theme's aggregated `EXAMPLE_REFERENCES` across all mentioned STs
-  (pick the highest-authority, most diverse set). Pattern:
+  (pick the highest-authority, most diverse set when more than one is
+  available). Pattern:
   `- **{vendor_or_customer}** ({publication_date}): {outcome} — [Quelle]({source_url})`.
   Preserve citation diversity: do not repeat the same second-level domain more
-  than once in the block. When fewer than 2 entries exist across all STs in this
-  theme, omit the block entirely and rely on plain capability prose.
+  than once in the block. When the theme has exactly one aggregated entry,
+  render a single-bullet block (the arc quality gate on line 468 requires a
+  citation whenever `EXAMPLE_REFERENCES` has ≥1 entry). Omit the block
+  entirely only when `EXAMPLE_REFERENCES` is empty for all STs in this
+  theme — this is the `No examples available` fallback below.
 
 - **No examples available** (empty `EXAMPLE_REFERENCES` for this theme). Fall
   back to the pre-change behavior — render capability prose and the portfolio

--- a/cogni-trends/references/data-model.md
+++ b/cogni-trends/references/data-model.md
@@ -105,7 +105,7 @@ project in the workspace. When `study_mode` is `"open"`, this field is omitted.
 ```
 
 - `portfolio_ref` (string, required): cogni-portfolio project slug (same as `portfolio_source.portfolio_slug`).
-- `vendor_slug` (string, required): kebab-case vendor identifier for display resolution.
+- `vendor_slug` (string, required): kebab-case vendor identifier for display resolution. When `trend-scout` Step 0.8c auto-populates `vendor_source`, this defaults to the same value as `portfolio_ref` (both reflect the connected portfolio's slug). Power users can manually override `vendor_slug` in `tips-project.json` when the published vendor brand differs from the portfolio slug (e.g., `portfolio_ref: "t-systems-corp"` with `vendor_slug: "t-systems"`).
 - `vendor_display_name` (string, required): Human-readable provider name for prose weaving (e.g., `"T-Systems"`).
 - `case_study_wiki` (string, optional): Path relative to workspace root pointing at a cogni-wiki instance to query for reference evidence.
 - `case_study_uploads` (string, optional): Path (relative to the portfolio project) to a directory of uploaded case study documents (PDF, DOCX, MD) for `local-researcher` dispatch. Defaults to the portfolio project's `uploads/` directory when omitted.
@@ -790,6 +790,14 @@ New fields (all optional, backward compatible — existing STs without these fie
 Mutual exclusivity: a given ST carries **either** `vendor_references[]` **or** `published_cases[]`, never both —
 the active array is determined by `tips-project.json → study_mode`. Both arrays are optional and absent on
 projects created before this feature landed (backward compatible).
+
+**Optional date fields — `null` vs field absence.** For optional date fields across TIPS schemas
+(`publication_date` in `vendor_references[]` and `published_cases[]`, and any similarly-shaped field added later),
+the canonical convention is: emit `null` when the field is semantically "unknown" for an entry that the pipeline
+did populate (e.g., a `named_customers[]`-sourced vendor reference with no engagement date recorded), and omit
+the field entirely only when the emitting pipeline has no concept of the field at all. Consumers should treat
+`null` and absence interchangeably — both mean "no date available" — but producers that emit explicit `null`
+signal the distinction to downstream readers that the entry passed through a date-aware producer.
 
 ### Re-Anchor Log
 

--- a/cogni-trends/references/data-model.md
+++ b/cogni-trends/references/data-model.md
@@ -53,7 +53,7 @@ Lightweight root manifest for project discovery and resume. Created during Phase
 ```
 
 Required fields: `slug`, `name`, `language`, `industry`, `research_topic`, `created`
-Optional fields: `updated`, `portfolio_source`
+Optional fields: `updated`, `portfolio_source`, `study_mode`, `vendor_source`
 
 The `portfolio_source` field is set when the project was initialized from a cogni-portfolio market (via Step 0.1c portfolio discovery). It links the TIPS project to a specific portfolio market for later bridge operations:
 
@@ -69,6 +69,46 @@ The `portfolio_source` field is set when the project was initialized from a cogn
 The `language` field is a lowercase ISO 639-1 code (`"de"` or `"en"`). Controls the language of all generated user-facing content. JSON field names and slugs remain in English.
 
 The `industry` object uses bilingual names for web research queries. The `primary` and `subsector` fields are slug-format identifiers; `_en` and `_de` variants are display names.
+
+#### study_mode (optional)
+
+Declares whether practical examples in the report should come from the connected portfolio's
+own references ("vendor") or from any published industry case studies ("open"). Set at
+`trend-scout` Phase 0 via an explicit prompt **only when a portfolio is connected**. When no
+portfolio is connected, the field is omitted and treated as `"open"`. Projects created before
+this field existed continue to behave as `"open"` (fully backward compatible).
+
+```json
+{
+  "study_mode": "vendor"
+}
+```
+
+Valid values: `"vendor"`, `"open"`. Default when absent: `"open"`.
+
+#### vendor_source (optional — required iff study_mode == "vendor")
+
+Identifies the portfolio project whose internal corpus supplies vendor references. When
+`study_mode` is `"vendor"`, `vendor_source` must be present and must point at a cogni-portfolio
+project in the workspace. When `study_mode` is `"open"`, this field is omitted.
+
+```json
+{
+  "vendor_source": {
+    "portfolio_ref": "t-systems-corp",
+    "vendor_slug": "t-systems",
+    "vendor_display_name": "T-Systems",
+    "case_study_wiki": "cogni-wiki/t-systems-cases",
+    "case_study_uploads": "uploads/case-studies/"
+  }
+}
+```
+
+- `portfolio_ref` (string, required): cogni-portfolio project slug (same as `portfolio_source.portfolio_slug`).
+- `vendor_slug` (string, required): kebab-case vendor identifier for display resolution.
+- `vendor_display_name` (string, required): Human-readable provider name for prose weaving (e.g., `"T-Systems"`).
+- `case_study_wiki` (string, optional): Path relative to workspace root pointing at a cogni-wiki instance to query for reference evidence.
+- `case_study_uploads` (string, optional): Path (relative to the portfolio project) to a directory of uploaded case study documents (PDF, DOCX, MD) for `local-researcher` dispatch. Defaults to the portfolio project's `uploads/` directory when omitted.
 
 ### trend-scout-output.json (Scout Output)
 
@@ -325,6 +365,8 @@ erDiagram
         string research_topic
         string created
         object portfolio_source "optional"
+        string study_mode "optional — vendor|open (default open)"
+        object vendor_source "optional — required iff study_mode=vendor"
     }
     ScoutOutput {
         string version "1.0.0"
@@ -410,6 +452,8 @@ erDiagram
         string generation_mode "portfolio-anchored|abstract"
         object portfolio_anchor "optional"
         array portfolio_grounding "optional"
+        array vendor_references "optional — study_mode=vendor"
+        array published_cases "optional — study_mode=open"
         string quality_flag "null|quality_investment_needed"
         float business_relevance "1-5 scale"
         float ranking_value
@@ -625,6 +669,28 @@ Groups 1-4 value chains into a CxO-level strategic investment area. German custo
       "evidence_available": true
     }
   ],
+  "vendor_references": [
+    {
+      "customer_name": "Stadtwerke München",
+      "outcome_claim": "Cut unplanned outages 38% after six-month rollout",
+      "roi_claim": "€4.2M avoided OPEX in year one",
+      "source": "customers",
+      "source_ref": "customers/energy-utilities-dach.json#named_customers[2]",
+      "portfolio_grounding_entry_ref": "predictive-analytics--energy-utilities-dach",
+      "source_origin": "vendor",
+      "publication_date": "2024-06"
+    }
+  ],
+  "published_cases": [
+    {
+      "vendor_or_customer": "Enel — Cisco Smart Grid deployment",
+      "outcome": "10M smart meters rolled out across Italy; 5% peak load reduction reported",
+      "source_url": "https://example.com/enel-smart-grid-case",
+      "source_authority": "tier-1",
+      "publication_date": "2024-03",
+      "source_origin": "third_party"
+    }
+  ],
   "quality_flag": null,
   "business_relevance": null,
   "business_relevance_calculated": null,
@@ -696,6 +762,34 @@ New fields (all optional, backward compatible — existing STs without these fie
 - **`quality_flag`** (string or null, optional): Set when the anchor feature's proposition has quality assessment failures.
   - `null` — No quality issues (or no quality data available)
   - `"quality_investment_needed"` — The matched proposition scored "fail" on one or more quality dimensions; the proposition should be improved before using this ST in customer-facing materials
+- **`vendor_references`** (array, optional — populated only when `tips-project.json → study_mode == "vendor"`):
+  Concrete reference engagements sourced from **inside** the connected cogni-portfolio project. Keyed to the
+  ST's existing `portfolio_grounding[]` (feature×market). Zero open-web URLs — every entry resolves under
+  `cogni-portfolio/{vendor_source.portfolio_ref}/`.
+  - `customer_name` (string, required): Named customer or project reference (e.g., `"Stadtwerke München"`).
+  - `outcome_claim` (string, required): Short outcome statement suitable for CxO prose (1–2 sentences).
+  - `roi_claim` (string, optional): Quantified ROI when available from portfolio evidence (e.g., `"€4.2M avoided OPEX"`).
+  - `source` (string, required): Where the reference came from inside the portfolio — `"customers"` (a `named_customers[]` entry),
+    `"propositions"` (an `evidence[]` entry tagged vendor-authored), `"uploads"` (document corpus via `cogni-research:local-researcher`),
+    or `"wiki"` (a `cogni-wiki:wiki-query` result).
+  - `source_ref` (string, required): Portfolio-relative path or entity ref with optional JSON Pointer. Must resolve inside `cogni-portfolio/{portfolio_ref}/`.
+  - `portfolio_grounding_entry_ref` (string, required): `{feature_slug}--{market_slug}` key linking this reference back to one of the ST's `portfolio_grounding[]` entries.
+  - `source_origin` (string, required): Always `"vendor"` for this array.
+  - `publication_date` (string, optional): ISO-8601 date (YYYY-MM) for recency sorting.
+- **`published_cases`** (array, optional — populated only when `tips-project.json → study_mode == "open"` or absent):
+  Published industry case studies sourced via a dedicated `cogni-research:section-researcher` dispatch in
+  value-modeler Step 2.6. Complements the trend-signal research with concrete implementation proof.
+  - `vendor_or_customer` (string, required): Who implemented the case (vendor or customer name).
+  - `outcome` (string, required): One-line outcome summary.
+  - `source_url` (string, required): Public URL to the case study.
+  - `source_authority` (string, required): Authority tier — `"tier-1"` (analyst, academic, regulator),
+    `"tier-2"` (trade press, major vendor site), `"tier-3"` (community, smaller vendor blog).
+  - `publication_date` (string, optional): ISO-8601 date (YYYY-MM).
+  - `source_origin` (string, required): Always `"third_party"` for this array.
+
+Mutual exclusivity: a given ST carries **either** `vendor_references[]` **or** `published_cases[]`, never both —
+the active array is determined by `tips-project.json → study_mode`. Both arrays are optional and absent on
+projects created before this feature landed (backward compatible).
 
 ### Re-Anchor Log
 

--- a/cogni-trends/skills/trend-report/references/phase-2-strategic-themes.md
+++ b/cogni-trends/skills/trend-report/references/phase-2-strategic-themes.md
@@ -122,7 +122,10 @@ Per agent:
       EXECUTIVE_SPONSOR, INVESTMENT_THESIS, VALUE_CHAINS, TREND,
       IMPLICATION, POSSIBILITY, FOUNDATION, SOLUTION_TEMPLATES,
       SOLUTION, CATEGORY, ENABLER_TYPE, STRATEGIC_ACTIONS,
-      WHY_CHANGE, WHY_NOW, WHY_YOU, WHY_PAY}
+      WHY_CHANGE, WHY_NOW, WHY_YOU, WHY_PAY,
+      REFERENCES_BLOCK_LABEL (de: "Referenzbeispiele", en: "Industry reference cases")
+        — used by the investment-theme writer to label the open-mode
+        references block.}
     NARRATIVE_ARC_PATH: {path to cogni-narrative theme-thesis arc-definition.md, or omit if not available}
     NARRATIVE_TECHNIQUES_PATH: {path to cogni-narrative techniques-overview.md, or omit if not available}
 ```

--- a/cogni-trends/skills/trend-report/references/phase-2-strategic-themes.md
+++ b/cogni-trends/skills/trend-report/references/phase-2-strategic-themes.md
@@ -39,6 +39,27 @@ Do NOT read the enriched-trends or claims JSON files at this step. Investment th
 1. Extract `portfolio_slug` → resolve to display name (e.g., `"t-systems"` → `"T-Systems"`). This becomes `PORTFOLIO_PROVIDER`.
 2. Build a `product_slug → { product_name, product_url }` lookup from `products[]`. This is used in Step 2.2 to resolve `PORTFOLIO_PRODUCTS` for each investment theme agent. `product_url` comes from `products[].url` if available (may be null).
 
+**Study mode + example reference resolution:**
+
+1. Read `{PROJECT_PATH}/tips-project.json → study_mode`. Default `"open"` when absent.
+   This becomes `STUDY_MODE` for every dispatched investment-theme agent.
+
+2. For each ST in `tips-value-model.json → solution_templates[]`, read the active
+   example array based on `STUDY_MODE`:
+   - `vendor` → `vendor_references[]` (each entry includes `source_ref` that resolves inside `cogni-portfolio/{vendor_source.portfolio_ref}/`)
+   - `open` → `published_cases[]` (each entry has a public `source_url` and tiered `source_authority`)
+
+3. Build a `st_id → { mode, entries[] }` lookup. Empty arrays and missing keys both
+   mean "no examples for this ST" — the agent falls back to plain capability prose.
+
+4. In Step 2.2, filter this lookup per theme (only include STs whose
+   `investment_theme_ref == theme.investment_theme_id`) and pass the filtered object
+   as `EXAMPLE_REFERENCES` to that theme's agent.
+
+When `study_mode` is missing on older projects, both `vendor_references[]` and
+`published_cases[]` will also be absent on all STs — `EXAMPLE_REFERENCES` will be an
+empty object, and the agent will render the pre-change output (backward compatible).
+
 ---
 
 ## Step 2.2: Dispatch Investment Theme Agents
@@ -89,6 +110,14 @@ Per agent:
       May be empty [] if no portfolio grounding or solution files not found.
       The orchestrator resolves the portfolio project path from portfolio-context.json →
       portfolio_slug → workspace discovery.}
+    STUDY_MODE: {"vendor" | "open" — read from tips-project.json → study_mode.
+      Default "open" when absent. Drives the Why You example-rendering rule.}
+    EXAMPLE_REFERENCES: {JSON object keyed by st_id for STs in this theme.
+      Shape depends on STUDY_MODE:
+      - vendor: { st_id: { mode: "vendor", entries: [{ customer_name, outcome_claim, roi_claim?, source, source_ref, publication_date? }, ...] } }
+      - open:   { st_id: { mode: "open",   entries: [{ vendor_or_customer, outcome, source_url, source_authority, publication_date? }, ...] } }
+      STs with no examples are omitted from the object. May be {} if no STs
+      in this theme have example arrays populated.}
     LABELS: {JSON object with relevant i18n labels:
       EXECUTIVE_SPONSOR, INVESTMENT_THESIS, VALUE_CHAINS, TREND,
       IMPLICATION, POSSIBILITY, FOUNDATION, SOLUTION_TEMPLATES,

--- a/cogni-trends/skills/trend-scout/references/workflow-phases/phase-0-initialize.md
+++ b/cogni-trends/skills/trend-scout/references/workflow-phases/phase-0-initialize.md
@@ -571,6 +571,85 @@ fi
 
 ---
 
+### Step 0.8c: Capture study_mode (only when a portfolio is connected)
+
+**Skip condition.** If `PORTFOLIO_SOURCE_SLUG` is empty (no portfolio was selected in Step 0.1c),
+skip this step entirely. The project implicitly operates in open-study mode — `study_mode` and
+`vendor_source` are omitted from `tips-project.json` and downstream skills treat the absence as
+`"open"`.
+
+When a portfolio **is** connected, ask the user explicitly which mode applies. The answer drives
+whether `value-modeler` Step 2.6 Example Enrichment sources references from inside the portfolio
+corpus (vendor mode) or dispatches a dedicated industry case-study research pass (open mode),
+and whether the investment-theme writer's "Why You" section weaves portfolio references or a
+`Referenzbeispiele` block of published cases.
+
+```yaml
+# Only when PORTFOLIO_SOURCE_SLUG is non-empty:
+AskUserQuestion:
+  question: |
+    {STUDY_MODE_PROMPT_TITLE}
+
+    {STUDY_MODE_PROMPT_INTRO}
+  options:
+    - label: "{STUDY_MODE_VENDOR_LABEL}"      # e.g. "Vendor study — use my portfolio references only"
+      description: "{STUDY_MODE_VENDOR_DESC}"
+    - label: "{STUDY_MODE_OPEN_LABEL}"        # e.g. "Neutral study — include any published industry cases"
+      description: "{STUDY_MODE_OPEN_DESC}"
+```
+
+Parse the selection into the `STUDY_MODE` variable (`vendor` | `open`). Then write it into
+`tips-project.json`, and for vendor mode also populate `vendor_source` from the connected
+portfolio's company record:
+
+```bash
+if [[ -n "$PORTFOLIO_SOURCE_SLUG" ]]; then
+  # STUDY_MODE captured above from AskUserQuestion: "vendor" or "open"
+  if [[ "$STUDY_MODE" == "vendor" ]]; then
+    # Resolve vendor display name from the portfolio's manifest (portfolio.json → company.name).
+    PORTFOLIO_MANIFEST="${PROJECT_AGENTS_OPS_ROOT:-$PWD}/cogni-portfolio/${PORTFOLIO_SOURCE_SLUG}/portfolio.json"
+    VENDOR_DISPLAY_NAME="${PORTFOLIO_SOURCE_SLUG}"
+    if [[ -f "$PORTFOLIO_MANIFEST" ]]; then
+      VENDOR_DISPLAY_NAME=$(jq -r '.company.name // .company_name // empty' "$PORTFOLIO_MANIFEST")
+      [[ -z "$VENDOR_DISPLAY_NAME" ]] && VENDOR_DISPLAY_NAME="$PORTFOLIO_SOURCE_SLUG"
+    fi
+
+    jq \
+      --arg portfolio_ref "$PORTFOLIO_SOURCE_SLUG" \
+      --arg vendor_slug "$PORTFOLIO_SOURCE_SLUG" \
+      --arg vendor_display_name "$VENDOR_DISPLAY_NAME" \
+      '.study_mode = "vendor"
+       | .vendor_source = {
+           portfolio_ref: $portfolio_ref,
+           vendor_slug: $vendor_slug,
+           vendor_display_name: $vendor_display_name
+         }' \
+      "$TIPS_PROJECT_FILE" > "${TIPS_PROJECT_FILE}.tmp" \
+      && mv "${TIPS_PROJECT_FILE}.tmp" "$TIPS_PROJECT_FILE"
+
+    log_conditional INFO "study_mode=vendor, vendor_display_name=${VENDOR_DISPLAY_NAME}"
+  else
+    jq '.study_mode = "open"' \
+      "$TIPS_PROJECT_FILE" > "${TIPS_PROJECT_FILE}.tmp" \
+      && mv "${TIPS_PROJECT_FILE}.tmp" "$TIPS_PROJECT_FILE"
+
+    log_conditional INFO "study_mode=open (portfolio connected but user chose neutral study)"
+  fi
+fi
+```
+
+**Optional wiki / uploads pointers.** `vendor_source.case_study_wiki` and
+`vendor_source.case_study_uploads` are not prompted here. They are advanced configuration that
+power users add by editing `tips-project.json` directly before running value-modeler. When
+absent, Step 2.6 falls back to reading the portfolio's default `uploads/` directory and skips
+wiki dispatch. See `$CLAUDE_PLUGIN_ROOT/references/data-model.md` for the full `vendor_source`
+schema.
+
+**Backward compatibility.** Projects created before this step landed have no `study_mode` field.
+Downstream skills treat the absence as `"open"` and render the report exactly as before.
+
+---
+
 ## Step 0.9: Initialize Logging
 
 ```bash
@@ -622,6 +701,7 @@ SKIP_TO_PHASE=1  # Proceed to web research
 - [ ] PROJECT_LANGUAGE confirmed by user (de/en)
 - [ ] Portfolio discovery attempted (scan result logged)
 - [ ] If portfolio selected: PORTFOLIO_SOURCE_SLUG and PORTFOLIO_MARKET_SLUG set
+- [ ] If portfolio selected: study_mode captured (vendor | open) and written to tips-project.json
 - [ ] Industry and subsector selected and validated (from portfolio or manual taxonomy)
 - [ ] RESEARCH_TOPIC captured
 - [ ] PROJECT_SLUG generated

--- a/cogni-trends/skills/value-modeler/references/workflow-phases/phase-2-solutions.md
+++ b/cogni-trends/skills/value-modeler/references/workflow-phases/phase-2-solutions.md
@@ -572,6 +572,155 @@ SPIs are the *how* (organizational and process changes needed to realize value f
 - Consider training, governance, workflow integration, and organizational alignment
 - SPIs are lightweight — they flag what needs to change, not how to change it
 
+## Step 2.6: Example Enrichment (vendor references or published cases)
+
+Enrich each Solution Template with concrete **practical examples**. The rendered trend report
+needs proof points — "who has done this, what happened, here is the source". Today's trend
+research surfaces quantitative claims from web signals, but not case-study evidence tied to a
+specific ST. Step 2.6 closes that gap.
+
+The enrichment source depends on `tips-project.json → study_mode` (captured in trend-scout
+Phase 0 Step 0.8c). The field is optional; when absent, treat as `"open"`.
+
+```bash
+STUDY_MODE=$(jq -r '.study_mode // "open"' "${PROJECT_PATH}/tips-project.json")
+```
+
+**Skip condition.** If `study_mode == "vendor"` but no `vendor_source.portfolio_ref` resolves to
+a readable portfolio project, log a WARNING and fall back to open-mode behavior for this run —
+do not HALT. A misconfigured vendor project should still produce a report.
+
+**Dispatch caps** (to bound latency and cost — enforce per ST):
+
+| Mode | Dispatch budget per ST |
+|------|-----------------------|
+| vendor | max 2 `cogni-research:local-researcher` calls + max 2 `cogni-wiki:wiki-query` calls + plain JSON reads (unbounded) |
+| open | max 1 `cogni-research:section-researcher` call with ≤ 4 sub-queries |
+
+### 2.6.A: Vendor Mode — Source References from the Portfolio Corpus
+
+Applies when `study_mode == "vendor"`. Zero open-web URLs are written — every `source_ref`
+resolves inside `cogni-portfolio/{vendor_source.portfolio_ref}/`.
+
+For each ST where the `solution_blueprint.building_blocks[]` contains any block with
+`coverage ∈ {"covered", "partial"}`:
+
+1. **Read `portfolio_grounding[]`.** Each entry is `{feature_slug, market_slug, does_echo, evidence_available}` — this
+   is the feature×market mapping to search against. STs with empty `portfolio_grounding[]` (pure
+   gap blueprints) receive an empty `vendor_references[]` and move on.
+
+2. **Named customers** — for each `market_slug` in `portfolio_grounding[]`, read
+   `cogni-portfolio/{portfolio_ref}/customers/{market_slug}.json`. Select `named_customers[]`
+   entries whose industry or pain_points resonate with the ST's lead building-block capability.
+   Prefer entries with higher `fit_score`. Emit one `vendor_references[]` entry per qualifying
+   customer:
+
+   ```json
+   {
+     "customer_name": "{named_customer.company_name}",
+     "outcome_claim": "{derived 1-2 sentence outcome from named_customer.key_pain_points + ST.name}",
+     "source": "customers",
+     "source_ref": "customers/{market_slug}.json#named_customers[{index}]",
+     "portfolio_grounding_entry_ref": "{feature_slug}--{market_slug}",
+     "source_origin": "vendor",
+     "publication_date": null
+   }
+   ```
+
+3. **Proposition evidence** — for each `(feature_slug, market_slug)` pair, read
+   `cogni-portfolio/{portfolio_ref}/propositions/{feature_slug}--{market_slug}.json` and scan
+   `evidence[]`. Include entries tagged `source_origin == "vendor"` (vendor-authored proof
+   points). When the tag is absent on older projects, include only entries whose `source_url`
+   is empty (portfolio-internal only) — never web-sourced evidence.
+
+4. **Uploaded collateral** — dispatch `cogni-research:local-researcher` once per ST against
+   `cogni-portfolio/{portfolio_ref}/{vendor_source.case_study_uploads || "uploads/"}`. Build
+   sub-questions from the ST name + lead building-block capability + investment theme name, e.g.:
+   *"Which uploaded case studies describe an implementation of {ST.name} in {industry.subsector_en} and what outcome was reported?"*.
+   Limit to max 4 sub-questions per dispatch. Each matching file becomes a `vendor_references[]`
+   entry with `source: "uploads"` and `source_ref: "uploads/{filename}"`.
+
+5. **Vendor wiki (optional)** — when `vendor_source.case_study_wiki` is set, dispatch
+   `cogni-wiki:wiki-query` once per ST against that wiki path with the same sub-question style.
+   Each hit becomes a `vendor_references[]` entry with `source: "wiki"` and
+   `source_ref: "{wiki_path}#{page_slug}"`.
+
+6. **Dedupe.** If the same underlying customer appears across sources (e.g., a customer entry
+   plus an uploaded case study describing the same engagement), keep the richest entry —
+   prefer `uploads` > `wiki` > `propositions` > `customers` when the engagement is confirmed by
+   an actual case-study artifact; otherwise keep the `customers` entry for the structured metadata.
+
+7. **Write `vendor_references[]` to the ST.** When no portfolio evidence matched, leave the
+   array empty — the writer downstream will fall back to the plain capability prose for that ST
+   (backward-compatible behavior).
+
+### 2.6.B: Open Mode — Research Published Industry Case Studies
+
+Applies when `study_mode == "open"` (explicitly set at Phase 0 or absent). This is the
+dedicated case-study research pass that complements today's trend-signal research — the report's
+"Why You" gains a `Referenzbeispiele` block of concrete industry implementations.
+
+For each ST, dispatch **one** `cogni-research:section-researcher` call with ≤ 4 sub-queries
+drawn from the templates below. The agent already handles market localization and parallel
+search — do not reinvent that here.
+
+**Query templates** (substitute `{st.name}`, `{lead_block.capability}`, `{industry.primary_en}`,
+`{industry.subsector_en}`, localized variants from `tips-project.json → industry.*_de`, and
+`{year_range}` = last 3 calendar years):
+
+- `"{st.name}" "case study" {industry.subsector_en} {year_range}`
+- `"{lead_block.capability}" implementation reference {industry.subsector_en} {year_range}`
+- `"{st.name}" pilot results OR rollout OR deployment {industry.primary_en}`
+- DACH localization (when `language == "de"` or `MARKET_REGION ∈ {"dach","de"}`): `"{st.name}" Referenz OR Kundenprojekt OR Umsetzung {industry.subsector_de}`
+
+**Authority classification.** For each returned hit, classify `source_authority` by domain:
+
+| Tier | Examples |
+|------|----------|
+| `tier-1` | Analyst firms (Gartner, Forrester, IDC), academic (.edu, Fraunhofer, arxiv), regulator (EUR-Lex, BSI, ENISA) |
+| `tier-2` | Trade press (Handelsblatt, FT, Computerwoche), major vendor reference pages |
+| `tier-3` | Community blogs, smaller vendor case pages |
+
+**Citation diversity cap.** No more than 1 entry may share the same second-level domain — e.g.,
+two hits from `cisco.com` collapse to the single strongest one. This prevents a single vendor's
+reference library from dominating the ST's evidence.
+
+**Target output.** 2–3 `published_cases[]` entries per ST when feasible. When the agent returns
+fewer than 2 usable hits, keep what was found and emit an empty array if nothing usable was
+returned — the writer downstream falls back to plain capability prose for that ST.
+
+```json
+{
+  "vendor_or_customer": "{implementer_name}",
+  "outcome": "{1-line outcome summary}",
+  "source_url": "{url}",
+  "source_authority": "tier-1|tier-2|tier-3",
+  "publication_date": "{YYYY-MM if available, else null}",
+  "source_origin": "third_party"
+}
+```
+
+### 2.6.C: Write Results
+
+After per-ST dispatch, update the in-memory `solution_templates[]` array and write
+`tips-value-model.json`. The two arrays are mutually exclusive per ST — emit **either**
+`vendor_references[]` (vendor mode) **or** `published_cases[]` (open mode), never both.
+
+Skipped STs (no blueprint, no grounding) keep both arrays absent — downstream consumers treat
+absence identically to empty.
+
+### 2.6.D: Quality Gate
+
+Log a WARNING (do not HALT) when:
+
+- **Vendor mode**: > 30% of STs with a `covered` or `partial` lead block ended up with empty
+  `vendor_references[]`. This usually means `customers/{market}.json` is thin or no case-study
+  uploads exist — surface the gap so the user can enrich the portfolio before re-running.
+- **Open mode**: > 30% of STs ended up with fewer than 2 `published_cases[]` entries.
+- **Any mode**: a `source_ref` points outside the allowed corpus (vendor mode: outside
+  `cogni-portfolio/{portfolio_ref}/`; open mode: not a URL). Acceptance criterion #2 depends on
+  this invariant.
+
 ## Step 2.7: Re-Anchor Existing Solution Templates
 
 Re-anchoring rebuilds solution blueprints on existing STs using **LLM solutioning intelligence**.


### PR DESCRIPTION
Closes #119.

## Summary

- Adds `study_mode` (vendor | open) to `tips-project.json` with explicit prompt at trend-scout Phase 0 when a portfolio is connected (default "open" when no portfolio).
- New value-modeler Phase 2 Step 2.6 "Example Enrichment" — vendor mode sources references from the connected portfolio; open mode dispatches `section-researcher` for published industry case studies.
- Investment-theme writer "Why You" section adapts per mode: vendor mode cites portfolio references inline via `portfolio://` scheme; open mode renders a `Referenzbeispiele` block with tiered authority cases.
- Bridge schema bumps to v3.2 — `portfolio-context.json` gains `named_customer_references[]` (additive; v3.1 consumers ignore).

Reuses existing primitives only: `cogni-research:section-researcher`, `cogni-research:local-researcher`, `cogni-wiki:wiki-query`, existing ST `portfolio_grounding[]`. Zero new agents, skills, or scripts.

## Files changed

- `cogni-trends/references/data-model.md` — schema docs
- `cogni-trends/skills/trend-scout/references/workflow-phases/phase-0-initialize.md` — Step 0.8c mode prompt
- `cogni-trends/skills/value-modeler/references/workflow-phases/phase-2-solutions.md` — new Step 2.6
- `cogni-trends/agents/trend-report-investment-theme-writer.md` — new STUDY_MODE + EXAMPLE_REFERENCES inputs and Why You rule
- `cogni-trends/skills/trend-report/references/phase-2-strategic-themes.md` — input marshalling
- `cogni-portfolio/skills/trends-bridge/SKILL.md` — portfolio-context v3.2
- Plugin versions: cogni-trends 0.4.10 → 0.4.11, cogni-portfolio 0.9.30 → 0.9.31 (plugin.json + marketplace.json)

## Backward compatibility

Projects without `study_mode` behave identically to before. All new fields are optional. Additive bridge schema. Byte-identical reports for pre-feature projects per acceptance criterion #5.

## Test plan

- [ ] Vendor path: connect a cogni-portfolio project with populated `customers/{market}.json`, set `study_mode:"vendor"` at scout Phase 0, run value-modeler through Phase 2, inspect `tips-value-model.json` for non-empty `vendor_references[]`, generate one theme, grep for `source_ref` values resolving inside the portfolio directory.
- [ ] Open path: new TIPS project with no portfolio, run value-modeler Phase 2, inspect `tips-value-model.json` for `published_cases[]`, generate one theme, verify the Referenzbeispiele block renders with ≥2 distinct `source_url` hosts.
- [ ] Regression: re-run an older TIPS project (no `study_mode`) — verify theme markdown matches prior release byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)