### PR TITLE
Deepen cogni-work theme: type scale, tokens, voice (#122)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -61,7 +61,7 @@
     {
       "name": "cogni-workspace",
       "source": "./cogni-workspace",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "maturity": "preview",
       "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
       "keywords": [

--- a/cogni-workspace/.claude-plugin/plugin.json
+++ b/cogni-workspace/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-workspace",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-workspace/themes/_template/theme.md
+++ b/cogni-workspace/themes/_template/theme.md
@@ -3,6 +3,7 @@
 {1-2 sentence description of the visual identity and mood.}
 
 ## Color Palette
+
 - **Primary**: `#HEXHEX` - main brand color, headers, key elements
 - **Secondary**: `#HEXHEX` - supporting color, subheaders
 - **Accent**: `#HEXHEX` - CTAs, highlights, interactive elements
@@ -12,24 +13,104 @@
 - **Text Muted**: `#HEXHEX` - secondary text, captions
 
 ### Status Colors
+
 - **Success**: `#2E7D32`
 - **Warning**: `#ED6C02`
 - **Danger**: `#D32F2F`
 - **Info**: `#0288D1`
 
 ## Typography
-- **Headers**: Font Bold / fallback: Calibri Bold
-- **Body**: Font Regular / fallback: Calibri
-- **Mono**: Font Mono / fallback: Consolas
+
+- **Headers**: {Font Bold} / fallback: Calibri Bold
+- **Body**: {Font Regular} / fallback: Calibri
+- **Mono**: {Font Mono} / fallback: Consolas
+
+### Type Scale
+
+- **Display**: {px} / {line-height} / {weight} / {tracking} — hero titles
+- **H1**: {px} / {line-height} / {weight} / {tracking} — page titles
+- **H2**: {px} / {line-height} / {weight} / {tracking} — section headers
+- **H3**: {px} / {line-height} / {weight} / {tracking} — subsection headers
+- **H4**: {px} / {line-height} / {weight} — small headings
+- **Body**: {px} / {line-height} / {weight} — running text
+- **Small**: {px} / {line-height} / {weight} — captions
+- **Eyebrow / Micro**: {px} / {line-height} / {weight} / {tracking} / UPPERCASE — section labels
+
+### Web Embedding (HTML)
+
+```html
+<!-- TODO: paste the <link> tag for the theme's web fonts (e.g. Google Fonts CSS API URL) -->
+```
+
+```css
+/* TODO: paste the canonical font-family declaration used in CSS / inline styles */
+font-family: '{Font}', system-ui, sans-serif;
+```
+
+## Spacing Scale
+
+4pt base. All vertical and horizontal spacing should snap to one of these values.
+
+- **0**: 0
+- **1**: {px} — tight inline spacing
+- **2**: {px} — small gaps, icon-text pairs
+- **3**: {px} — list item spacing
+- **4**: {px} — default paragraph margin
+- **5**: {px} — card interior padding, default section gap
+- **6**: {px} — content band gap
+- **7**: {px} — vertical padding inside content bands
+- **8**: {px} — major section breaks
+- **9**: {px} — hero band vertical padding
+
+**Layout rules:** {content max-width} for copy-heavy surfaces; {dashboard max-width} for dashboards. {grid-cols}-col grid with {gutter}px gutters.
+
+## Radii
+
+- **xs**: {px} — small pills, tags
+- **sm**: {px} — small buttons, badges
+- **md**: {px} — default (buttons, inputs)
+- **lg**: {px} — secondary cards
+- **xl**: {px} — primary cards
+- **2xl**: {px} — large feature panels
+- **pill**: 999px — fully rounded toggles, slider thumbs
+
+## Shadow Scale
+
+- **sm**: `{box-shadow string}` — default card resting
+- **md**: `{box-shadow string}` — panels, elevated surfaces
+- **lg**: `{box-shadow string}` — modals, popovers
+- **xl**: `{box-shadow string}` — major overlays
+- **accent-ring**: `{box-shadow string}` — focus and selection state
+
+## Motion
+
+- **Easing**: `{cubic-bezier(...)}` for most transitions
+- **Linear**: only for sliders and progress bars
+- **Fast**: {ms}ms — micro-interactions
+- **Medium**: {ms}ms — standard transitions
+- **Slow**: {ms}ms — section reveals, modal entry
 
 ## Design Principles
+
 1. {First principle}
 2. {Second principle}
 3. {Third principle}
 
+## Voice & Copy Guidelines
+
+- **Address**: {"you"/"we"/etc.}
+- **Casing**: {sentence/title/upper rules per role}
+- **Sentence length**: {target range} words.
+- **Numbers as heroes**: {how metrics are framed}
+- **Claims grounded**: {evidence/citation expectations}
+- **Language**: {EN / DE / etc.}
+- **Vibe**: {one-line voice summary}
+
 ## Best Used For
+
 {Target contexts: enterprise IT, sales decks, research reports, etc.}
 
 ## Source
+
 - **Origin**: {website URL, PPTX file, theme-factory preset, or custom}
 - **Extracted**: {date}

--- a/cogni-workspace/themes/cogni-work/theme.md
+++ b/cogni-workspace/themes/cogni-work/theme.md
@@ -1,51 +1,161 @@
 # Cogni Work
 
-A bold, modern theme pairing electric chartreuse with deep black foundations. High energy, forward-thinking, unapologetically contemporary. Rooted in Vitruvius' triad: firmitas through dark structural anchors, utilitas through high-contrast readability, venustas through vibrant lime accents.
+Bold, modern open-source identity pairing electric chartreuse with deep black foundations on warm white — inspired by Vitruvius' triad of *Firmitas · Utilitas · Venustas*. Restrained boldness for B2B knowledge work: dark structural anchors, high-contrast clarity, and a single signature accent used sparingly.
 
 ## Color Palette
 
-- **Primary**: `#111111` - Near-black — headers, navigation, structural anchors (firmitas)
-- **Secondary**: `#333333` - Dark charcoal — subheaders, supporting text
-- **Accent**: `#C8E62E` - Chartreuse/lime — CTAs, highlights, links, key data points (venustas)
-- **Accent Muted**: `#A8C424` - Olive lime — hover states, secondary highlights
-- **Accent Dark**: `#8BA31E` - Deep lime — active states, pressed buttons
-- **Background**: `#FAFAF8` - Warm white — page canvas, breathing room (utilitas)
-- **Surface**: `#F2F2EE` - Light warm gray — cards, panels, elevated containers
-- **Surface Dark**: `#111111` - Near-black — dark section backgrounds, hero areas
-- **Text**: `#111111` - Near-black — primary body text on light backgrounds
-- **Text Light**: `#FFFFFF` - White — primary text on dark backgrounds
-- **Text Muted**: `#6B7280` - Cool gray — captions, metadata, secondary content
-- **Border**: `#E0E0DC` - Warm light gray — subtle separators, card outlines
+- **Primary**: `#111111` — near-black structural anchor for headlines, navigation, dark hero bands, and primary text
+- **Secondary**: `#333333` — dark charcoal for subheads, supporting text, and pressed states on dark buttons
+- **Accent**: `#C8E62E` — chartreuse, the signature — CTAs, single-word highlights, key metrics, active states (never body runs)
+- **Accent Muted**: `#A8C424` — olive lime for hover states on accent buttons
+- **Accent Dark**: `#8BA31E` — deep lime for pressed/active states on accent buttons
+- **Background**: `#FAFAF8` — warm white canvas (never cool grey)
+- **Surface**: `#F2F2EE` — light warm gray for cards, panels, alternating sections
+- **Surface 2**: `#E8E8E4` — second elevation for nested surfaces
+- **Surface Dark**: `#111111` — dark sections, hero bands, closing slides
+- **Text**: `#111111` — primary body text on light backgrounds
+- **Text Light**: `#FFFFFF` — text on dark backgrounds
+- **Text Muted**: `#6B7280` — secondary text, captions, metadata
+- **Border**: `#E0E0DC` — warm 1px separators, card borders, form fields
 
 ### Status Colors
 
-- **Success**: `#2E7D32` - Confirmed, positive outcomes
-- **Warning**: `#E5A100` - Attention needed, warm amber
-- **Danger**: `#D32F2F` - Errors, critical alerts
-- **Info**: `#1565C0` - Informational, deep blue
+- **Success**: `#2E7D32` — saturated green for confirmations, completed states
+- **Warning**: `#E5A100` — amber for cautions, attention-needed states
+- **Danger**: `#D32F2F` — classic red for errors, destructive actions
+- **Info**: `#1565C0` — blue for informational callouts and tooltips
 
 ## Typography
 
-- **Headers**: DM Sans Bold / fallback: Inter Bold, Calibri Bold
-- **Body**: DM Sans Regular / fallback: Inter, Calibri
-- **Mono**: JetBrains Mono / fallback: Fira Code, Consolas
+- **Headers**: DM Sans Bold (700) / fallback: Inter, Calibri, system-ui, sans-serif
+- **Body**: DM Sans Regular (400) / fallback: Inter, Calibri, system-ui, sans-serif
+- **Eyebrows / Code / Numeric Data**: JetBrains Mono Regular (400/500) / fallback: Fira Code, Consolas, monospace
+
+### Type Scale
+
+- **Display**: 56px / 1.05 line-height / Bold / -0.035em tracking — hero titles, deck title slides
+- **H1**: 42px / 1.1 line-height / Bold / -0.03em tracking — page titles, primary headlines
+- **H2**: 32px / 1.15 line-height / Bold / -0.02em tracking — section headers
+- **H3**: 24px / 1.25 line-height / Semibold / -0.01em tracking — subsection headers, card titles
+- **H4**: 18px / 1.3 line-height / Semibold — small headings, label headlines
+- **Body**: 15px / 1.6 line-height / Regular — running text
+- **Small**: 13px / 1.55 line-height / Regular — captions, secondary copy
+- **Eyebrow / Micro**: 11px / 1.4 line-height / Mono Semibold / 0.12em tracking / UPPERCASE — section labels, tags
+
+### Web Embedding (HTML)
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..700;1,9..40,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+```
+
+```css
+font-family: 'DM Sans', 'Inter', system-ui, sans-serif;
+```
+
+> DM Sans + JetBrains Mono are loaded directly from Google Fonts — same files used in the production brand showcase.
+
+## Spacing Scale
+
+4pt base. All vertical and horizontal spacing should snap to one of these values.
+
+- **0**: 0
+- **1**: 4px — tight inline spacing
+- **2**: 8px — small gaps, icon-text pairs
+- **3**: 12px — list item spacing
+- **4**: 16px — default paragraph margin
+- **5**: 24px — card interior padding, default section gap
+- **6**: 32px — content band gap
+- **7**: 48px — vertical padding inside content bands
+- **8**: 64px — major section breaks
+- **9**: 96px — hero band vertical padding
+
+**Layout rules:** 960px content max-width for copy-heavy surfaces; 1200–1280px for dashboards. 12-col grid with 24px gutters. 40px desktop horizontal gutter.
+
+## Radii
+
+- **xs**: 4px — small pills, tags
+- **sm**: 6px — small buttons, badges
+- **md**: 8px — default (buttons, inputs)
+- **lg**: 10px — secondary cards
+- **xl**: 12px — primary cards
+- **2xl**: 16px — large feature panels
+- **pill**: 999px — toggles, slider thumbs, fully rounded
+
+Never sharp corners. Never fully rounded except true pills.
+
+## Shadow Scale
+
+Soft, restrained, warm-black at low alpha. No inner shadows. No neumorphism.
+
+- **sm**: `0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.06)` — default card resting
+- **md**: `0 4px 16px rgba(0,0,0,0.06), 0 1px 4px rgba(0,0,0,0.04)` — panels, elevated surfaces
+- **lg**: `0 12px 40px rgba(0,0,0,0.1), 0 4px 12px rgba(0,0,0,0.05)` — modals, popovers
+- **xl**: `0 24px 64px rgba(0,0,0,0.14), 0 8px 20px rgba(0,0,0,0.06)` — major overlays
+- **accent-ring**: `0 0 0 3px rgba(200,230,46,0.15)` — focus and selection state
+
+## Motion
+
+- **Easing**: `cubic-bezier(0.2, 0, 0, 1)` (deceleration) for most transitions
+- **Linear**: only for sliders and progress bars
+- **Fast**: 150ms — micro-interactions (hover color change)
+- **Medium**: 250ms — standard transitions
+- **Slow**: 400ms — section reveals, modal entry
+
+No bounces, springs, scale transforms, or theatrical effects. Fades and color transitions only.
 
 ## Design Principles
 
-1. **Firmitas — Dark structural anchors**: Near-black (#111111) provides the foundation. Title and closing slides use dark backgrounds for gravitas. Structure feels solid and grounded.
-2. **Utilitas — High-contrast readability**: Chartreuse on black, black on white — always maximum contrast. Content-first layouts with generous white space. Every element earns its place.
-3. **Venustas — Electric accent**: Chartreuse (#C8E62E) is the signature — bold, memorable, unmistakable. Used for CTAs, key metrics, highlights, and moments of energy. Never as body text.
-4. **Dark-light sandwich**: Title and closing slides use dark backgrounds; content slides use warm white. This creates visual rhythm and narrative structure.
-5. **Restrained boldness**: The lime is loud — so everything else stays quiet. Body text is near-black or white. No competing colors. Let the accent do the talking.
-6. **Modern confidence**: Clean lines, generous spacing, no ornamentation. The design says "we know what we're doing" without trying hard.
-7. **Knowledge hierarchy**: Background < surface < content < accent. Dark anchors frame light content areas. Lime draws the eye to what matters most.
+1. **Chartreuse leads, never overwhelms.** The accent (`#C8E62E`) is reserved for CTAs, single-word highlights, key metrics, and active states. Maximum 5–10% of any visual surface. Never used for body runs. Its power comes from restraint.
+2. **Dark-light sandwich for rhythm.** Alternate dark (`#111`) title and closing bands with warm-white content bands. White text on near-black creates visual punctuation that guides the eye through narratives, decks, and long-form pages.
+3. **Numbers are heroes.** "3.2×", "47%", "60% of their day" — large numeric callouts paired with plain-language labels are the core rhythm of decks and dashboards. Set hero numbers in DM Sans Bold at display size; labels in mono micro.
+4. **Generous whitespace, non-negotiable.** 4pt spacing base. 48px vertical padding inside content bands. 24px card interior. 40px desktop gutter. Sections breathe. Density is achieved through hierarchy, not compression.
+5. **Mono eyebrows, sentence-case body.** UPPERCASE JetBrains Mono with 0.12em tracking for short eyebrow labels ("THE CHALLENGE", "THE OPPORTUNITY"). Title Case for section headers. Sentence case for body. This three-register typography carries the entire visual rhythm.
+6. **Quiet motion, no flourish.** 150–250ms standard transitions; `cubic-bezier(0.2, 0, 0, 1)` deceleration. Fades and color transitions only — no bounces, springs, scale transforms, or theatrical effects.
+7. **Selection rings, not shadow shifts.** Cards lift on hover via a 3px chartreuse selection ring (`rgba(200,230,46,0.15)`) and a 2px chartreuse border swap — not by changing shadow elevation. Shadows stay soft and warm.
+8. **No emoji, no gradients, no decoration.** No emoji ever. No background gradients. No backdrop-blur. No hand-drawn illustrations. No telco/SaaS visual clichés. Restraint is the brand.
+9. **Two-tone discipline.** The brand is intentionally `#111` + `#C8E62E` plus warm neutrals and four status colors — no extended 50–900 ramps. If a chart needs more colors, derive them from the existing palette rather than introducing new hues.
+10. **Tight tracking, confident headlines.** Headings carry -0.02em to -0.035em letter-spacing for a modern, deliberate feel. DM Sans's geometric precision does the work — no condensed, light, or italic display variants.
+
+## Voice & Copy Guidelines
+
+Voice is **executive, confident, methodology-driven, quietly European**. Aligned with the `cogni-copywriting` plugin (BLUF, Pyramid, SCQA frameworks).
+
+- **Address**: "you" to the reader, "we" for cogni-work. Never "I".
+- **Casing**: Sentence case for body. Title Case for section headers ("Knowledge Workers Deserve Better Tools"). UPPERCASE mono for short eyebrows ("THE CHALLENGE").
+- **Sentence length**: 15–20 words. 3–5 sentence paragraphs. Short clauses land harder.
+- **Numbers as heroes**: pair every metric with a plain-language label. "3.2×", "47%", "60% of their day".
+- **Claims grounded**: outputs include inline citations and quality gates. Never invent statistics.
+- **Trilingual motto**: `Firmitas · Utilitas · Venustas` appears verbatim in taglines and footers (middle-dot separator, Latin).
+- **Bilingual capability**: EN + DE. German copy follows Wolf-Schneider style (short sentences, concrete verbs).
+- **No emoji**. No exclamation marks beyond the rare CTA. No em-dash filler.
+- **Vibe**: *"we know what we're doing, without trying hard."* The chartreuse is loud, so the prose stays quiet.
+
+**Example (deck flow):**
+
+- *Title:* "Cogni Work — Smarter Knowledge Work"
+- *Eyebrow:* "THE CHALLENGE"
+- *Subhead:* "Knowledge Workers Deserve Better Tools"
+- *Body:* "Professionals spend 60% of their day on low-value coordination — emails, status updates, and searching for information across siloed tools."
+- *CTA:* "Ready to Work Smarter?" / "Get Started"
 
 ## Best Used For
 
-Consulting deliverables, executive presentations, sales decks, strategy reports, workshop materials, client-facing proposals, innovation pitches, product launches
+- Open-source platform marketing sites (cogni-work.ai surface)
+- B2B SaaS pitch decks and product narratives
+- Knowledge-work consulting deliverables (project charters, capability decks)
+- Portfolio dashboards and capability overviews
+- Methodology-driven research reports and trend analyses
+- Plugin and developer-tool documentation surfaces
+- Partner program pitches and ecosystem messaging
+- Internal tools and dashboards for B2B knowledge workers (consulting, sales, marketing, research)
 
 ## Source
 
-- **Origin**: Custom — cogni-work.ai brand identity inspired by "Creation" (chartreuse + black)
-- **Philosophy**: Vitruvius' architectural triad (firmitas, utilitas, venustas)
-- **Extracted**: 2026-03-06
+- **Origin**: cogni-work.ai brand identity + insight-wave open-source plugin ecosystem
+- **Brand Mark**: chartreuse point-up triangle; wordmark `cogni` + chartreuse hyphen + `work` + chartreuse `.ai` in DM Sans Bold (-0.02em tracking)
+- **Tagline**: `Firmitas · Utilitas · Venustas` (Latin triad, middle-dot separator)
+- **Typography**: DM Sans + JetBrains Mono (Google Fonts)
+- **Voice Reference**: cogni-copywriting plugin (BLUF, Pyramid, SCQA frameworks); bilingual EN/DE
+- **Design System Reference**: companion design-system project covering tokens, UI kits (website + plugin), 7-slide deck template, preview cards, and asset library
+- **Showcase Component**: `themes/cogni-work/cogni-work-theme-showcase.jsx`
+- **Updated**: 2026-04-25


### PR DESCRIPTION
## Summary

- Replaces `cogni-workspace/themes/cogni-work/theme.md` with a deeper brand spec adding type scale, web-embedding font snippet, spacing/radii/shadow/motion tokens, expanded design principles (10), and voice & copy guidelines — all sourced from the production `cogni-work-theme-showcase.jsx`.
- Extends `cogni-workspace/themes/_template/theme.md` with placeholder versions of the new sections so future themes inherit the richer structure (manage-themes Operations 3–6).
- Bumps `cogni-workspace` 0.6.8 → 0.6.9 in both `plugin.json` and `marketplace.json`.

Backwards-compatible with `discover-themes.py`: H1, first description line, **Primary**/**Accent**/**Background** hex codes, and **Headers** font remain at the same anchor patterns.

## Test plan

- [x] `python3 cogni-workspace/skills/pick-theme/scripts/discover-themes.py --plugin-root cogni-workspace --pretty --no-discover` returns the `cogni-work` entry with `name`, `description`, `primary`, `accent`, `background`, `font` all populated correctly
- [x] Markdown fence balance check on both `theme.md` files (4 fences each, balanced)
- [x] No orphaned references to `themes/cogni-work/*` paths
- [x] Color tokens in new `theme.md` match the production `theme = {...}` object in `cogni-work-theme-showcase.jsx` lines 3–19

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)