### PR TITLE
cogni-workspace: drop dead insight-wave-pro reference from pick-theme

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -61,7 +61,7 @@
     {
       "name": "cogni-workspace",
       "source": "./cogni-workspace",
-      "version": "0.6.11",
+      "version": "0.6.12",
       "maturity": "preview",
       "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
       "keywords": [

--- a/cogni-workspace/.claude-plugin/plugin.json
+++ b/cogni-workspace/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-workspace",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-workspace/skills/pick-theme/SKILL.md
+++ b/cogni-workspace/skills/pick-theme/SKILL.md
@@ -11,8 +11,8 @@ description: >-
   "select a theme", or when any visual output skill needs theme resolution. Also
   triggers when skills internally need theme selection as a prerequisite step.
   Also triggers on "apply a theme", "use this theme", or "theme my output".
-  This is the single standard entry point for theme selection across both
-  insight-wave and insight-wave-pro marketplaces.
+  This is the single standard entry point for theme selection across the
+  insight-wave marketplace.
 version: 0.2.0
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion
 ---


### PR DESCRIPTION
Closes #133.

## Summary
- Remove `and insight-wave-pro` from the pick-theme SKILL.md description (line 14-15) — `insight-wave-pro` is not a real marketplace.
- Bump cogni-workspace 0.6.11 → 0.6.12 in `plugin.json` + `marketplace.json` per repo convention.

## Why
The hallucinated marketplace reference already propagated once: RFC #124 (Theme System v2) was authored with an open question Q6 about "How does this interact with insight-wave-pro?" — built on the false premise that this dead reference implied. We resolved Q6 as N/A in #132. Removing the source prevents the same false context from re-seeding into future LLM-authored RFCs or skill descriptions.

## Test plan
- [x] `grep -r "insight-wave-pro" .` from repo root → zero hits.
- [x] pick-theme/SKILL.md description still reads coherently as "the single standard entry point for theme selection across the insight-wave marketplace".
- [x] cogni-workspace plugin.json version 0.6.12 mirrors marketplace.json.
- [x] skill-quality-reviewer: pass with zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
