### PR TITLE
cogni-workspace: manage-themes deep authoring (Operation 7) + manifest by default

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -61,7 +61,7 @@
     {
       "name": "cogni-workspace",
       "source": "./cogni-workspace",
-      "version": "0.6.12",
+      "version": "0.6.13",
       "maturity": "preview",
       "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
       "keywords": [

--- a/cogni-workspace/.claude-plugin/plugin.json
+++ b/cogni-workspace/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-workspace",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -28,7 +28,7 @@ In the Claude Cowork plugin model, workspace-level state (paths, env vars, insta
 ## What it does
 
 1. **Manage workspace** — initialize or update a workspace with auto-detection, dependency checks, plugin discovery, preference gathering, settings generation, backup and rollback → `references/supported-markets-registry.json` → doc-generate, doc-power, doc-hub, doc-readme-root, doc-audit
-2. **Manage themes** — extract from websites (via Chrome), PPTX files, or presets; audit for contrast and harmony; apply to downstream skills
+2. **Manage themes** — extract from websites (via Chrome), PPTX files, or presets; audit for contrast and harmony; author tiered theme systems (tokens → assets → components → templates) per Theme System v2; apply to downstream skills
 3. **Pick themes** — centralized theme picker used by all visual plugins
 4. **Discover plugins** — scan installed cogni-x plugins, detect versions, compute env var names
 5. **Diagnose** workspace health — five-tier report (foundation, env vars, plugin registry, themes, dependencies)
@@ -87,7 +87,7 @@ Claude checks dependencies, discovers installed plugins, asks for your language 
 | Component | Type | What it does |
 |-----------|------|--------------|
 | `manage-workspace` | skill | Initialize or update workspace — auto-detects mode, dependencies, discovery, preferences, settings, themes, backup and rollback |
-| `manage-themes` | skill | 8 theme operations: recommend, list, grab from website, grab from PPTX, create from preset, audit, generate showcase, apply |
+| `manage-themes` | skill | 9 theme operations: recommend, list, grab from website, grab from PPTX, create from preset, audit, author deep theme system, generate showcase, apply |
 | `pick-theme` | skill | Centralized theme picker — discovers themes, presents interactive selection, returns path |
 | `workspace-status` | skill | Five-tier diagnostic: foundation, env vars, plugin registry, themes, dependencies |
 | `install-mcp` | skill | End-to-end MCP server installation — clone and build git-based MCPs, configure native app MCPs, and patch Claude Desktop config |

--- a/cogni-workspace/skills/manage-themes/SKILL.md
+++ b/cogni-workspace/skills/manage-themes/SKILL.md
@@ -14,8 +14,10 @@ description: >-
   theme", "I need a visual identity for my startup". Even if the user just says
   "make it match our brand", "use our company colors", or "grab the style from
   that site", this skill applies. Also triggers on "brand guidelines", "design
-  system", "brand identity", or "visual standards".
-version: 0.3.0
+  system", "brand identity", or "visual standards", or when the user wants to
+  "author tokens", "build a tiered theme system", "deepen a theme", or "match
+  the cogni-work pattern".
+version: 0.4.0
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, Skill, mcp__claude-in-chrome__navigate, mcp__claude-in-chrome__read_page, mcp__claude-in-chrome__computer, mcp__claude-in-chrome__tabs_create_mcp, mcp__claude-in-chrome__tabs_context_mcp, mcp__claude-in-chrome__get_page_text
 ---
 
@@ -71,7 +73,7 @@ When the user asks for theme advice — e.g., "what theme for my brand?", "help 
 | Nothing concrete, just a description | → **Operation #5** (Create from Preset) — recommend 2-3 theme-factory presets that match their mood/industry, let them pick or blend |
 | An existing workspace theme that's close | → **Operation #6** (Audit/Improve) — review it and suggest targeted tweaks |
 
-After creating or selecting a theme, always run a quick audit (Operation #6) on the result before finalizing — this catches contrast issues and missing sections early. Then offer to generate a theme showcase (Operation #7) so the user can see all tokens in action.
+After creating or selecting a theme, always run a quick audit (Operation #6) on the result before finalizing — this catches contrast issues and missing sections early. Then offer to generate a theme showcase (Operation #8) so the user can see all tokens in action.
 
 ### 2. List Themes
 
@@ -106,7 +108,9 @@ Extract a visual theme from a live website using claude-in-chrome (the user's Ch
 6. Calculate WCAG contrast ratios for extracted color pairs
 7. Generate theme.md following the template (see Theme File Format below)
 8. Save to `{themes-dir}/{theme-slug}/theme.md`
-9. Offer to generate a theme showcase (Operation #7)
+9. Emit a starter `manifest.json` next to `theme.md` (see [Starter Manifest](#starter-manifest) below) and validate with `validate-theme-manifest.py` before completing
+10. Offer to deepen this into a tiered theme system (Operation #7)
+11. Offer to generate a theme showcase (Operation #8)
 
 **Tips for accurate extraction**: Take multiple screenshots (hero section, navigation,
 footer) to capture the full palette. Use WebSearch to find the brand's official style
@@ -133,7 +137,9 @@ Extract theme from a PowerPoint template file. PPTX files embed theme XML in the
    - `a:minorFont` → Body font family
 4. Generate theme.md following the template (see Theme File Format below)
 5. Save to `{themes-dir}/{theme-slug}/theme.md`
-6. Offer to generate a theme showcase (Operation #7)
+6. Emit a starter `manifest.json` next to `theme.md` (see [Starter Manifest](#starter-manifest) below) and validate with `validate-theme-manifest.py` before completing
+7. Offer to deepen this into a tiered theme system (Operation #7)
+8. Offer to generate a theme showcase (Operation #8)
 
 ### 5. Create Theme from Preset
 
@@ -143,7 +149,9 @@ Delegate to `document-skills:theme-factory` for preset theme creation:
 2. Once user selects/creates a theme, capture the color palette and typography
 3. Generate a theme.md following the template (see Theme File Format below)
 4. Save to `{themes-dir}/{theme-slug}/theme.md`
-5. Offer to generate a theme showcase (Operation #7)
+5. Emit a starter `manifest.json` next to `theme.md` (see [Starter Manifest](#starter-manifest) below) and validate with `validate-theme-manifest.py` before completing
+6. Offer to deepen this into a tiered theme system (Operation #7)
+7. Offer to generate a theme showcase (Operation #8)
 
 This bridges theme-factory's preset system with the workspace's theme storage.
 
@@ -175,9 +183,69 @@ When the user wants feedback on an existing theme — e.g., "my theme feels off"
 - Check whether the stated principles are actionable and specific enough for a downstream skill to follow
 - Flag vague principles (e.g., "make it look good") and suggest concrete rewrites
 
-**Output format**: Present findings as a checklist grouped by dimension, with pass/fail/warning per item and concrete suggestions for anything that fails. If the user agrees with suggestions, apply the fixes directly to the theme.md. After applying fixes, offer to regenerate the theme showcase (Operation #7) so the user can verify the changes visually.
+**Output format**: Present findings as a checklist grouped by dimension, with pass/fail/warning per item and concrete suggestions for anything that fails. If the user agrees with suggestions, apply the fixes directly to the theme.md. After applying fixes, offer to regenerate the theme showcase (Operation #8) so the user can verify the changes visually.
 
-### 7. Generate Theme Showcase
+**Manifest handling**: If the theme already has a `manifest.json`, leave it untouched (the audit fixes go in `theme.md`). If the theme is tier-0 and the audit surfaces structural needs that tokens would solve — e.g., the same hex repeats across many surfaces, downstream skills hard-code values that should swap by theme — offer to promote the theme via Operation #7 (Author a Deep Theme System) rather than expanding `theme.md` further. If the theme has neither, emit a starter `manifest.json` (see [Starter Manifest](#starter-manifest) below) so the next operation has an entry point.
+
+### 7. Author a Deep Theme System
+
+When a theme outgrows the single-file `theme.md` and the user wants structured authoring — variable swap-out by downstream skills, component primitives, voice/copy templates — promote the theme to a **tiered** layout per Theme System v2 (RFC #124). This operation is opt-in: tier-0 themes (`theme.md` only, no manifest) remain valid forever.
+
+**When to offer**: After a successful Operation 3, 4, or 5 (ask: *"Want to deepen this into a tiered theme system?"*), or when the user explicitly asks to "build a deep theme", "author tokens", "make this brand a system", or "match the cogni-work pattern". The migration guide (forward link `references/theme-migration-guide.md`, lands with [#130](https://github.com/cogni-work/insight-wave/issues/130)) walks an existing tier-0 theme through the upgrade end-to-end.
+
+**Reference implementation**: `themes/cogni-work/` is the canonical Phase-2 pilot. Read its `manifest.json` and `tokens/` layout before authoring any new tiered theme — that file shape is the contract every downstream consumer expects.
+
+**The four tiers** — populate in this order; each tier is independently optional, but tokens is the foundation:
+
+1. **Tier 1 — Tokens** (`tokens/`). Canonical design variables as flat JSON maps. Six canonical files: `colors.json`, `typography.json`, `spacing.json`, `radii.json`, `shadows.json`, `motion.json`. Each is a `{key: value}` map with primitive values (string, integer, or float — nested values are silently skipped in v1.0). Generate `tokens/tokens.css` deterministically from these JSON sources — never hand-edit the CSS:
+   ```bash
+   python3 cogni-workspace/scripts/generate-tokens-css.py \
+       --tokens-dir <themes-dir>/<slug>/tokens --write
+   ```
+   The generator emits a single `:root { ... }` block with `--<stem>-<key>` custom properties in canonical-file then alphabetical-key order. Re-running it must produce a byte-identical file (idempotency check via `git diff --exit-code`).
+
+2. **Tier 2 — Assets** (`assets/`). Brand-bound static files — logos (SVG preferred), reference fonts, sample documents, hero imagery. Flat layout is fine; nested directories are allowed where the asset family naturally groups (e.g., `assets/logos/`).
+
+3. **Tier 3 — Components** (`components/`). Portable HTML primitives that downstream skills can copy-on-use (per RFC open question 2 resolution: copy-on-use is the default, opt-in live-theme is reserved). JSX is allowed but optional; HTML is the contract per RFC open question 3 resolution. Each component is one file; reference the theme's tokens via CSS custom properties (e.g., `var(--colors-primary)`) so consumers inherit the active palette without rewriting markup.
+
+4. **Tier 4 — Templates** (`templates/`). Voice-and-copy scaffolds — IS/DOES/MEANS messaging templates, headline patterns, CTA wording. Out of scope for Phase 2 (deferred to Phase 3 per RFC open question 5); the directory is reserved but most themes will not populate it yet.
+
+**Manifest update**: Each tier you populate gets a corresponding entry in `manifest.json`. The `tiers` map is the contract — `discover-themes` and downstream consumers route exclusively through it:
+
+```json
+{
+  "schema_version": "1.0",
+  "name": "<Theme Name>",
+  "slug": "<theme-slug>",
+  "tiers": {
+    "tokens": "tokens/",
+    "assets": "assets/",
+    "components": "components/"
+  }
+}
+```
+
+Reserved keys `live`, `live_within_session`, and `copy` must never appear at any nesting depth (the validator hard-fails on them).
+
+**Validate before completing**: Always run the validator after touching a tiered theme — it checks schema conformance, that declared tier paths exist, and (when `tokens.css` is present) that it matches `generate()` byte-for-byte:
+
+```bash
+python3 cogni-workspace/scripts/validate-theme-manifest.py <themes-dir>/<slug>
+```
+
+A non-zero exit means the theme is not shippable; fix the failure before declaring the operation complete.
+
+**Workflow** (typical promotion of an existing tier-0 theme):
+
+1. Read the existing `theme.md` to extract palette, typography, and design principles.
+2. Create `tokens/`; split the palette into `colors.json`, fonts into `typography.json`, and any spacing/radii/shadow/motion values into the corresponding canonical files.
+3. Run `generate-tokens-css.py --write` to emit `tokens.css`; verify the diff is what you expect.
+4. Update `manifest.json` to declare `tiers.tokens: "tokens/"`.
+5. Optionally populate `assets/` and `components/` — only what the user actually needs.
+6. Run `validate-theme-manifest.py` and confirm `success: true`.
+7. Offer to regenerate the theme showcase (Operation #8) so the tokens render against the canonical primitives.
+
+### 8. Generate Theme Showcase
 
 After creating, extracting, or improving a theme, offer to generate an interactive React showcase component that demonstrates every design token in context — colors, typography, buttons, cards, tables, forms, status badges, KPI panels, pricing layouts, and navigation patterns.
 
@@ -201,7 +269,7 @@ After creating, extracting, or improving a theme, offer to generate an interacti
 
 **Reference**: See `themes/cogni-work/cogni-work-theme-showcase.jsx` as the canonical example of quality, structure, and completeness.
 
-### 8. Apply Theme
+### 9. Apply Theme
 
 When the user asks to apply a theme, read the theme.md and feed its contents into the downstream skill that produces the output.
 
@@ -225,6 +293,28 @@ Follow the template at `{themes-dir}/_template/theme.md`. Key sections:
 - **Design Principles**: 3-8 rules for visual consistency
 - **Best Used For**: Target contexts
 - **Source**: Origin (URL, PPTX file, preset name) and extraction date
+
+## Starter Manifest
+
+Operations 3, 4, and 5 emit a minimal `manifest.json` next to `theme.md` for every newly-created theme. The file is the entry point that lets a tier-0 theme opt in to Theme System v2 later (via Operation #7) without renaming or restructuring anything that already shipped:
+
+```json
+{
+  "schema_version": "1.0",
+  "name": "<Theme Name>",
+  "slug": "<theme-slug>",
+  "tiers": {}
+}
+```
+
+- `schema_version` is always `"1.0"` for now — it pins the file to the current `references/theme-manifest.schema.json`.
+- `name` is the human-readable theme name (e.g., `"Cogni Work"`).
+- `slug` matches the directory name (kebab-case, see [Naming Convention](#naming-convention) below).
+- `tiers` starts empty (`{}`); tiers are added by Operation #7 only when the user explicitly populates them.
+
+Operations 3–5 finish by running `python3 cogni-workspace/scripts/validate-theme-manifest.py <themes-dir>/<slug>` to confirm the manifest is schema-valid before the operation reports success.
+
+**Backwards-compat:** `_template/` and any pre-existing tier-0 theme without a manifest stay valid forever — Operation 6 (Audit/Improve) preserves the manifestless layout unless the user explicitly asks to promote via Operation #7.
 
 ## Naming Convention
 

--- a/cogni-workspace/skills/manage-themes/SKILL.md
+++ b/cogni-workspace/skills/manage-themes/SKILL.md
@@ -104,13 +104,13 @@ Extract a visual theme from a live website using claude-in-chrome (the user's Ch
    - Font families from headings and body text
    - Background colors and surface patterns
    - Border radius, spacing patterns
-5. Research the brand via WebSearch for design philosophy context and official brand colors
-6. Calculate WCAG contrast ratios for extracted color pairs
-7. Generate theme.md following the template (see Theme File Format below)
-8. Save to `{themes-dir}/{theme-slug}/theme.md`
-9. Emit a starter `manifest.json` next to `theme.md` (see [Starter Manifest](#starter-manifest) below) and validate with `validate-theme-manifest.py` before completing
-10. Offer to deepen this into a tiered theme system (Operation #7)
-11. Offer to generate a theme showcase (Operation #8)
+6. Research the brand via WebSearch for design philosophy context and official brand colors
+7. Calculate WCAG contrast ratios for extracted color pairs
+8. Generate theme.md following the template (see Theme File Format below)
+9. Save to `{themes-dir}/{theme-slug}/theme.md`
+10. Emit a starter `manifest.json` next to `theme.md` (see [Starter Manifest](#starter-manifest) below) and validate with `validate-theme-manifest.py` before completing
+11. Offer to deepen this into a tiered theme system (Operation #7)
+12. Offer to generate a theme showcase (Operation #8)
 
 **Tips for accurate extraction**: Take multiple screenshots (hero section, navigation,
 footer) to capture the full palette. Use WebSearch to find the brand's official style
@@ -185,13 +185,13 @@ When the user wants feedback on an existing theme — e.g., "my theme feels off"
 
 **Output format**: Present findings as a checklist grouped by dimension, with pass/fail/warning per item and concrete suggestions for anything that fails. If the user agrees with suggestions, apply the fixes directly to the theme.md. After applying fixes, offer to regenerate the theme showcase (Operation #8) so the user can verify the changes visually.
 
-**Manifest handling**: If the theme already has a `manifest.json`, leave it untouched (the audit fixes go in `theme.md`). If the theme is tier-0 and the audit surfaces structural needs that tokens would solve — e.g., the same hex repeats across many surfaces, downstream skills hard-code values that should swap by theme — offer to promote the theme via Operation #7 (Author a Deep Theme System) rather than expanding `theme.md` further. If the theme has neither, emit a starter `manifest.json` (see [Starter Manifest](#starter-manifest) below) so the next operation has an entry point.
+**Manifest handling**: If the theme already has a `manifest.json`, leave it untouched (the audit fixes go in `theme.md`). If the theme is tier-0 and the audit surfaces structural needs that tokens would solve — e.g., the same hex repeats across many surfaces, downstream skills hard-code values that should swap by theme — offer to promote the theme via Operation #7 (Author a Deep Theme System) rather than expanding `theme.md` further. If the theme has neither a `theme.md` nor a `manifest.json` (rare — Op 6 mostly acts on existing themes), emit a starter `manifest.json` (see [Starter Manifest](#starter-manifest) below) so the next operation has an entry point.
 
 ### 7. Author a Deep Theme System
 
 When a theme outgrows the single-file `theme.md` and the user wants structured authoring — variable swap-out by downstream skills, component primitives, voice/copy templates — promote the theme to a **tiered** layout per Theme System v2 (RFC #124). This operation is opt-in: tier-0 themes (`theme.md` only, no manifest) remain valid forever.
 
-**When to offer**: After a successful Operation 3, 4, or 5 (ask: *"Want to deepen this into a tiered theme system?"*), or when the user explicitly asks to "build a deep theme", "author tokens", "make this brand a system", or "match the cogni-work pattern". The migration guide (forward link `references/theme-migration-guide.md`, lands with [#130](https://github.com/cogni-work/insight-wave/issues/130)) walks an existing tier-0 theme through the upgrade end-to-end.
+**When to offer**: After a successful Operation 3, 4, or 5 (ask: *"Want to deepen this into a tiered theme system?"*), or when the user explicitly asks to "build a deep theme", "author tokens", "make this brand a system", or "match the cogni-work pattern". A migration guide that walks an existing tier-0 theme through the upgrade end-to-end is tracked in [#130](https://github.com/cogni-work/insight-wave/issues/130) — once that lands, the file will be available at `references/theme-migration-guide.md`.
 
 **Reference implementation**: `themes/cogni-work/` is the canonical Phase-2 pilot. Read its `manifest.json` and `tokens/` layout before authoring any new tiered theme — that file shape is the contract every downstream consumer expects.
 
@@ -249,7 +249,7 @@ A non-zero exit means the theme is not shippable; fix the failure before declari
 
 After creating, extracting, or improving a theme, offer to generate an interactive React showcase component that demonstrates every design token in context — colors, typography, buttons, cards, tables, forms, status badges, KPI panels, pricing layouts, and navigation patterns.
 
-**When to offer**: After any successful theme creation or update (Operations 3–6), ask the user: *"Want me to generate a theme showcase component so you can see all the tokens in action?"*
+**When to offer**: After any successful theme creation, deepening, or update (Operations 3–7), ask the user: *"Want me to generate a theme showcase component so you can see all the tokens in action?"*
 
 **Workflow**:
 
@@ -296,7 +296,7 @@ Follow the template at `{themes-dir}/_template/theme.md`. Key sections:
 
 ## Starter Manifest
 
-Operations 3, 4, and 5 emit a minimal `manifest.json` next to `theme.md` for every newly-created theme. The file is the entry point that lets a tier-0 theme opt in to Theme System v2 later (via Operation #7) without renaming or restructuring anything that already shipped:
+Operations 3, 4, 5, and (conditionally) 6 emit a minimal `manifest.json` next to `theme.md` for every newly-created theme. The file is the entry point that lets a tier-0 theme opt in to Theme System v2 later (via Operation #7) without renaming or restructuring anything that already shipped:
 
 ```json
 {


### PR DESCRIPTION
Closes #128. Refs #132 (Phase 2 epic).

## Summary

- Operations 3–6 (Grab Website, Grab PPTX, Create from Preset, Audit/Improve) emit a starter `manifest.json` (`schema_version: "1.0"`, `name`, `slug`, empty `tiers: {}`) for new themes — opt-in entry point to Theme System v2; tier-0 themes (no manifest) stay valid forever.
- New **Operation 7: Author a Deep Theme System** — walks tokens → assets → components → templates with `themes/cogni-work/` as the canonical Phase-2 reference; forward-links the migration guide that lands with #130.
- Operation 7 invokes `cogni-workspace/scripts/generate-tokens-css.py --tokens-dir <theme>/tokens --write` for deterministic CSS regeneration; `validate-theme-manifest.py` runs before any operation completes.
- Existing Operation 7 (Generate Showcase) → 8 and Operation 8 (Apply Theme) → 9; the five `Operation #7` cross-references in Operations 1, 3, 4, 5, 6 now point to `#8` so showcase routing stays intact.
- New "Starter Manifest" reference section so Operations 3–5 defer to one canonical description rather than restating the manifest shape four times.
- README "What it does" bullet for Manage Themes and the Components table description (8 → 9 ops) synced.
- Patch version bump 0.6.12 → 0.6.13 in `plugin.json` and `marketplace.json`; SKILL.md frontmatter version 0.3.0 → 0.4.0 (minor — new operation).

## Phase context

Epic #132 phase-1 child. Phase-1 deps already merged on main:
- #125 — `validate-theme-manifest.py` + `references/theme-manifest.schema.json`
- #126 — `discover-themes.py` reads `manifest.json` with tier-0 fallback
- #127 — `themes/cogni-work/manifest.json` + `tokens/` tier-1 implementation

This change is the authoring surface that wires those scripts into the user-facing skill. No script changes are in scope.

## Scope decisions

- **In:** SKILL.md edits, version bumps in both `plugin.json` and `marketplace.json`, README description sync for the new operation.
- **Out:** No changes to `generate-tokens-css.py` or `validate-theme-manifest.py` — both already expose the contracts Operation 7 needs (importable `generate()`, `--write` CLI, tokens-parity check, tier-0 fallback).
- **Out:** Migration guide content (child #130) — Operation 7 references it as a forward link with the issue number for traceability; the link target lands when #130 ships.

## Test plan

- [x] `python3 cogni-workspace/scripts/validate-theme-manifest.py cogni-workspace/themes/cogni-work` returns `success: true` with `tier: "tiered"` (cogni-work pilot validates).
- [x] `python3 cogni-workspace/scripts/generate-tokens-css.py --tokens-dir cogni-workspace/themes/cogni-work/tokens --write` reports `success: true` and leaves `cogni-work/tokens/tokens.css` byte-identical (`git diff --exit-code` clean — idempotency confirmed).
- [x] `python3 cogni-workspace/scripts/validate-theme-manifest.py cogni-workspace/themes/_template` returns `tier: 0` success (manifestless tier-0 theme stays valid).
- [x] Starter manifest with empty `tiers: {}` validates as `tier: "tiered", tiers_present: []` per the schema's "advisory metadata only" allowance — confirms Operations 3–5 emit a schema-valid file.
- [x] `cogni-workspace/skills/manage-themes/SKILL.md` operation headers verified: 9 operations (1 Recommend, 2 List, 3 Grab Website, 4 Grab PPTX, 5 Create Preset, 6 Audit, 7 Author Deep Theme, 8 Showcase, 9 Apply); all 16 `Operation #X` cross-references resolve correctly.
- [x] `plugin.json` and `marketplace.json` both show `0.6.13`.

## Deferred follow-ups

- **Migration guide content (#130):** Operation 7's forward link is a placeholder `references/theme-migration-guide.md` that lands when child #130 ships.
- **Tier-3 component and tier-4 template patterns:** Operation 7 walks all four tiers conceptually, but in-depth component/template extraction patterns ship as Phase-2 follow-ups under epic #132.
