### PR TITLE
Anchor .gitignore cogni-issues/ pattern to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,4 @@ cogni-research/test-diagram-pipeline/
 **/.cogni-wiki/.lock
 
 # cogni-help local issue queue (per-user draft issues, not shared state)
-cogni-issues/
+/cogni-issues/


### PR DESCRIPTION
Closes #144.

## Summary
- Change `.gitignore` line 44 from `cogni-issues/` to `/cogni-issues/` so the pattern only matches the repo-root local-state directory created by `cogni-help/skills/cogni-issues/scripts/issue-store.sh init`, not the skill's own source directory at `cogni-help/skills/cogni-issues/`.
- Removes the silent-ignore trap that forced PR #142 to use `git add -f` for `gh-issues-helper.sh` and would have hit every future contributor adding files under the skill source tree.

## Scope decisions
- **In scope:** single-character anchor fix on line 44 of the repo-root `.gitignore`. This is the entire fix as documented in the issue's Suggested fix section.
- **Out of scope:** no plugin code, SKILL.md, plugin.json, or marketplace.json changes — this is repo-root tooling infrastructure with no plugin behavior change, so no version bump is warranted.
- **Not deferred:** there is no follow-up work; the fix is complete and self-contained.

## Test plan
- [x] After checkout, run `git check-ignore cogni-help/skills/cogni-issues/scripts/gh-issues.sh` — expect exit code 1 (not ignored). **Verified locally on branch:** exit=1.
- [x] Run `git check-ignore cogni-issues/` from the repo root — expect exit code 0 (still ignored). **Verified locally on branch:** exit=0, pattern matches.
- [x] Run `touch cogni-help/skills/cogni-issues/scripts/_test-staging.sh && git add ...` — expect clean stage without `-f`. **Verified locally on branch:** staged OK.
- [ ] CI confirms no regression in tracked-file detection.
