### PR TITLE
cogni-help: Course #2 cogni-issues exercise — gh CLI transport

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -127,7 +127,7 @@
     {
       "name": "cogni-help",
       "source": "./cogni-help",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "maturity": "preview",
       "description": "Central help hub for the insight-wave ecosystem. Interactive courses (12-course curriculum), plugin discovery, cross-plugin workflow guides, troubleshooting, quick-reference cheatsheets, and GitHub issue filing.",
       "keywords": [

--- a/cogni-help/.claude-plugin/plugin.json
+++ b/cogni-help/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-help",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Central help hub for the insight-wave ecosystem. Interactive courses (12-course curriculum), plugin discovery, cross-plugin workflow guides, troubleshooting, quick-reference cheatsheets, and GitHub issue filing.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-help/skills/teach/references/courses/02-workspace-obsidian.md
+++ b/cogni-help/skills/teach/references/courses/02-workspace-obsidian.md
@@ -343,17 +343,24 @@ always sees the full draft before it goes to GitHub.
 
 ### Exercise
 
-Before starting, check if claude-in-chrome is available and the user is logged into GitHub:
+Before starting, check that the GitHub CLI (`gh`) is installed and authenticated:
 
-1. Try `mcp__claude-in-chrome__tabs_context_mcp` — if the tool is not available,
-   the Claude-in-Chrome extension may not be installed or active.
-   Guide the user to install the extension in Chrome.
-2. Open a new tab with `mcp__claude-in-chrome__tabs_create_mcp`, navigate to
-   `https://github.com`, and use `mcp__claude-in-chrome__read_page` to check
-   login state — look for a logged-in indicator (profile menu, avatar) vs a "Sign in" link.
-3. If not logged in, ask the user to sign into GitHub in their Chrome browser.
+1. Run `command -v gh`. If nothing is returned, install it: `brew install gh`
+   on macOS, or follow the platform install at https://cli.github.com/.
+2. Run `gh auth status`. If the user isn't authenticated, run
+   `gh auth login` and walk them through the prompts (GitHub.com, HTTPS,
+   browser-based login).
 
-Once the browser is connected and logged in, ask the user to file their first issue:
+If anything is still missing, the cogni-issues skill's setup mode will catch
+it on first run and walk the user through the rest — no need to verify every
+edge case here.
+
+> **Migrating from the old browser flow?** Earlier versions of this course
+> used the Claude-in-Chrome MCP extension to file issues. That path is gone —
+> if you still have the extension installed, you can uninstall it; nothing
+> in cogni-help uses it anymore.
+
+Once `gh` is ready, ask the user to file their first issue:
 
 > "Tell Claude: **I have a question about insight-wave — which course should I
 > take after finishing Course 2?**"


### PR DESCRIPTION
Closes #143.

## Summary
- Rewrite Course #2 Module 6 Exercise (lines 344–367 of `cogni-help/skills/teach/references/courses/02-workspace-obsidian.md`) to use the `gh` CLI transport that landed in #142 (commit c81ff2e).
- Replace Claude-in-Chrome MCP probe steps with a `command -v gh` + `gh auth status` check and a `gh auth login` walkthrough; defer to the cogni-issues skill's own setup mode for anything missing.
- Add a one-sentence migration callout for learners who previously completed the course on the old browser transport (uninstall-extension hint).
- Bump `cogni-help/.claude-plugin/plugin.json` 0.1.0 → 0.1.1 and the matching entry in `.claude-plugin/marketplace.json` (per repo version-management convention).

## Scope decisions
- **In:** Course #2 exercise rewrite + version bumps in both `plugin.json` and `marketplace.json`.
- **Out (matches issue Out-of-scope):** Re-opening the cogni-issues skill itself (already on gh CLI in main since #142). Migration notes for non-course users.
- **Single-file change confirmed:** `grep -rln 'claude-in-chrome\|Chrome-extension' cogni-help/skills/teach/` returns only `02-workspace-obsidian.md`. The exercise template `references/exercises/first-issue.md` is transport-agnostic and needs no edit. The Course Completion checklist (lines 389–399) is already transport-agnostic.
- **Migration note:** Acceptance criteria marked it optional; including it because it's a single sentence and helps existing learners cleanly transition.

## Test plan
- [x] Open `cogni-help/skills/teach/references/courses/02-workspace-obsidian.md` and confirm the Exercise section names `gh` and `gh auth login`, with no remaining functional `claude-in-chrome` / `mcp__claude-in-chrome__*` / `Chrome-extension` references. **Verified locally on branch:** the only remaining `Claude-in-Chrome` token is the migration callout breadcrumb on line 359 by design.
- [x] Run `grep -rn 'claude-in-chrome\|Chrome-extension\|Claude-in-Chrome' cogni-help/skills/teach/` and confirm only the migration callout matches. **Verified locally on branch.**
- [ ] Run Course #2 end-to-end (`/teach 2` or equivalent) on a clean machine without `gh` installed and confirm the cogni-issues skill's own setup mode walks the user through `brew install gh` + `gh auth login`, then files a `[Question]` issue successfully.
- [x] Confirm `cogni-help/.claude-plugin/plugin.json` `version` reads `0.1.1` and the `cogni-help` entry in `.claude-plugin/marketplace.json` also reads `0.1.1`. **Verified locally on branch.**
