### PR TITLE
cogni-help: canonical-workflows reconciliation reference (Phase 1 foundation)

### DIFF
--- a/cogni-help/skills/workflow/SKILL.md
+++ b/cogni-help/skills/workflow/SKILL.md
@@ -44,6 +44,19 @@ Six bundled templates covering the most common plugin chains:
 | `new-engagement` | consulting setup → 4 phases | Consultant starting a structured engagement |
 | `full-onboarding` | workspace → help courses 1-11 | New user learning the full ecosystem |
 
+## Canonical Workflow IDs
+
+`docs/workflows/` is the canonical source for workflow IDs and pipeline shape;
+the templates in this skill are operational presentation copies that align to
+those canonical IDs. The reconciliation table — every cogni-help template ID
+and every `docs/workflows/<name>.md` filename mapped to a single canonical ID
+with a migration action — lives at `references/canonical-workflows.md`.
+
+The current template IDs above may not yet match the canonical IDs (migration
+is tracked there). When a workflow is referenced from another surface
+(`teach`, `guide`, `cheatsheet`, `docs/`), use the canonical ID — never the
+legacy template filename.
+
 ## How to Present Workflows
 
 1. **Read the matching template** from `references/workflows/`.

--- a/cogni-help/skills/workflow/SKILL.md
+++ b/cogni-help/skills/workflow/SKILL.md
@@ -28,21 +28,28 @@ If still unclear, default to English.
 Keep in English regardless of language setting:
 - Plugin names (`cogni-trends`, `cogni-narrative`, etc.)
 - Command names (`/workflow`, `/consult`, etc.)
-- Workflow IDs (`research-to-slides`, `trend-to-marketing`, etc.)
+- Canonical workflow IDs (`research-to-report`, `trends-to-solutions`, etc.)
 - Technical terms, file paths, code snippets
 
 ## Available Workflows
 
 Six bundled templates covering the most common plugin chains:
 
-| Workflow | Pipeline | Use case |
-|----------|----------|----------|
-| `research-to-slides` | research → narrative → visual | Analyst producing a presentation from research |
-| `trend-to-marketing` | tips → portfolio → marketing | GTM team turning trends into campaigns |
-| `portfolio-to-pitch` | portfolio → narrative → sales → visual | Sales creating a customer pitch deck |
-| `docs-pipeline` | doc-start → audit → generate → sync → power → claude → hub → bridge | Maintainer documenting the monorepo |
-| `new-engagement` | consulting setup → 4 phases | Consultant starting a structured engagement |
-| `full-onboarding` | workspace → help courses 1-11 | New user learning the full ecosystem |
+| Canonical ID | Current template file | Pipeline | Use case |
+|--------------|-----------------------|----------|----------|
+| `research-to-report` | `research-to-slides` (rename tracked by #146) | research → narrative → visual | Analyst producing a presentation from research |
+| `trends-to-solutions` | `trend-to-marketing` (rename tracked by #146) | tips → portfolio → marketing | GTM team turning trends into campaigns |
+| `portfolio-to-pitch` | `portfolio-to-pitch` (aligned) | portfolio → narrative → sales → visual | Sales creating a customer pitch deck |
+| `consulting-engagement` | `new-engagement` (rename tracked by #146) | consulting setup → 4 phases | Consultant starting a structured engagement |
+| — (operational-only) | `docs-pipeline` | doc-start → audit → generate → sync → power → claude → hub → bridge | Maintainer documenting the monorepo |
+| — (operational-only) | `full-onboarding` | workspace → help courses 1-11 | New user learning the full ecosystem |
+
+The first column is the canonical workflow ID from `docs/workflows/`; the
+second is the current filename in `references/workflows/` (which may differ
+until #146 lands the renames). Reference workflows from other surfaces
+(`teach`, `guide`, `cheatsheet`, `docs/`) by canonical ID, not template
+filename. Operational-only rows have no canonical ID — see
+`references/canonical-workflows.md` Table B for the policy.
 
 ## Canonical Workflow IDs
 
@@ -52,10 +59,16 @@ those canonical IDs. The reconciliation table — every cogni-help template ID
 and every `docs/workflows/<name>.md` filename mapped to a single canonical ID
 with a migration action — lives at `references/canonical-workflows.md`.
 
-The current template IDs above may not yet match the canonical IDs (migration
-is tracked there). When a workflow is referenced from another surface
-(`teach`, `guide`, `cheatsheet`, `docs/`), use the canonical ID — never the
-legacy template filename.
+The current template filenames in the table above may not yet match the
+canonical IDs (migration is tracked in the reference file). When a workflow
+is referenced from another surface (`teach`, `guide`, `cheatsheet`, `docs/`),
+use the canonical ID — never the legacy template filename.
+
+Propagation of canonical IDs into the downstream surfaces is tracked
+alongside the rename/add work: template renames in #146, missing-template
+adds in #147, operational-only template prunes in #148, `teach` curriculum
+extension in #149, course reference scaffolding in #150, and `guide`
+plugin-catalog plus `cheatsheet` cross-reference updates in #151.
 
 ## How to Present Workflows
 
@@ -85,13 +98,15 @@ cogni-docs. These complement the bundled templates above — the templates here 
 step-by-step playbooks with commands and tips; the docs/ guides are narrative tutorials
 with context and variations.
 
-| docs/ workflow | Related template | Notes |
-|----------------|-----------------|-------|
-| `docs/workflows/research-to-report.md` | `research-to-slides` | Same pipeline, docs version focuses on the report |
-| `docs/workflows/portfolio-to-pitch.md` | `portfolio-to-pitch` | Same pipeline |
-| `docs/workflows/trends-to-solutions.md` | `trend-to-marketing` | Same starting point, different end goal |
-| `docs/workflows/consulting-engagement.md` | `new-engagement` | Same pipeline |
-| `docs/workflows/content-pipeline.md` | `trend-to-marketing` | Marketing-focused variant |
+| Canonical workflow (`docs/workflows/<id>.md`) | Current cogni-help template | Notes |
+|-----------------------------------------------|------------------------------|-------|
+| `research-to-report` | `research-to-slides` (rename in #146) | Same pipeline, docs version focuses on the report |
+| `trends-to-solutions` | `trend-to-marketing` (rename in #146) | Same starting point, different end goal |
+| `portfolio-to-pitch` | `portfolio-to-pitch` (aligned) | Same pipeline |
+| `consulting-engagement` | `new-engagement` (rename in #146) | Same pipeline |
+| `content-pipeline` | — (add in #147) | Marketing pipeline from trends to campaign assets |
+| `install-to-infographic` | — (add in #147) | Install-to-deliverable pipeline ending in an infographic |
+| `portfolio-to-website` | — (add in #147) | Portfolio rendered as a static website |
 
 When presenting a workflow, mention the corresponding docs/ guide if it exists:
 "For a narrative walkthrough with more context, see `docs/workflows/<name>.md`."

--- a/cogni-help/skills/workflow/references/canonical-workflows.md
+++ b/cogni-help/skills/workflow/references/canonical-workflows.md
@@ -1,0 +1,110 @@
+# Canonical Workflow IDs — Reconciliation Map
+
+**Purpose.** Single source of truth for cross-plugin workflow IDs in the
+insight-wave ecosystem. Downstream surfaces — the `workflow` skill's
+templates, the `teach` skill's course tracks, the `guide` skill's plugin
+catalog, the `cheatsheet` skill's quick references — must align to the
+canonical IDs declared here, so a user following one workflow is always
+seeing the same name across surfaces.
+
+This file is read by issues #146, #147, #148, #149, #150, and #151. It is
+the foundation that lets those phase-2 / phase-3 children proceed without
+re-deriving the canonical set.
+
+## Canonical policy
+
+`docs/workflows/` is the **canonical source** for workflow IDs and pipeline
+shape. Every user-facing workflow ID in the canonical set has a one-to-one
+backing file at `docs/workflows/<canonical-id>.md`. The presentation
+templates in `cogni-help/skills/workflow/references/workflows/` are
+operational copies — step-by-step playbooks the `workflow` skill uses at
+runtime — and their filenames must align to canonical IDs.
+
+The canonical surface is `docs/workflows/` because:
+
+- `docs/` is the **publishing-grade** surface, generated and maintained by
+  `cogni-docs` for end-user consumption.
+- `cogni-help` templates are operational (commands, tips, exercises) and
+  derive from the canonical pipeline shape — they should not invent new IDs.
+- Three phase-2 children (#146 rename, #147 add, #148 prune), the guide
+  plugin catalog (#151), and the cheatsheet workflow cross-reference (#151)
+  all need to read from a single source. Without this declaration they
+  drift again.
+
+## Canonical workflow ID set
+
+Seven canonical user-facing workflows. The set is fixed by this file; new
+canonical IDs are added by adding a `docs/workflows/<id>.md` file and a
+matching row to the table below.
+
+1. `research-to-report`
+2. `trends-to-solutions`
+3. `portfolio-to-pitch`
+4. `consulting-engagement`
+5. `content-pipeline`
+6. `install-to-infographic`
+7. `portfolio-to-website`
+
+Two cogni-help templates remain outside this set — they are operational
+plugin maintenance pipelines, not user-facing workflows. See Table B.
+
+## Table A — Canonical ID reconciliation
+
+One row per canonical ID. Each row maps the canonical ID to the existing
+`docs/workflows/<id>.md` file and to the legacy cogni-help template (if any),
+and names the migration action that the phase-2 children must execute.
+
+| Canonical ID | docs/workflows/ guide | cogni-help template (legacy) | Migration action | Tracked by | Notes |
+|---|---|---|---|---|---|
+| `research-to-report` | `docs/workflows/research-to-report.md` | `research-to-slides` | `rename` (template) | #146 | Pipeline unchanged. Rename template file and update SKILL.md cross-references. |
+| `trends-to-solutions` | `docs/workflows/trends-to-solutions.md` | `trend-to-marketing` | `rename` (template) | #146 | Pipeline unchanged. Rename template file and update SKILL.md cross-references. |
+| `portfolio-to-pitch` | `docs/workflows/portfolio-to-pitch.md` | `portfolio-to-pitch` | `unchanged` | — | Already aligned on both sides. |
+| `consulting-engagement` | `docs/workflows/consulting-engagement.md` | `new-engagement` | `rename` (template) | #146 | Pipeline unchanged. Rename template file and update SKILL.md cross-references. |
+| `content-pipeline` | `docs/workflows/content-pipeline.md` | — | `add` (template) | #147 | docs/ guide is canonical; cogni-help adds presentation template. |
+| `install-to-infographic` | `docs/workflows/install-to-infographic.md` | — | `add` (template) | #147 | docs/ guide is canonical; cogni-help adds presentation template. |
+| `portfolio-to-website` | `docs/workflows/portfolio-to-website.md` | — | `add` (template) | #147 | docs/ guide is canonical; cogni-help adds presentation template. |
+
+Migration action vocabulary:
+
+- `rename` — the cogni-help template exists under a non-canonical filename; rename the file to `<canonical-id>.md` and update SKILL.md and any cross-references.
+- `add` — no cogni-help template exists yet; create one that walks through the canonical pipeline.
+- `unchanged` — the template filename already matches the canonical ID; no migration action needed.
+- `prune-or-keep-internal` — the cogni-help template is operational-only and not part of the canonical user-facing set (see Table B).
+
+## Table B — Operational-only templates (out of canonical user-facing set)
+
+Two cogni-help templates do not have a `docs/workflows/` companion and are
+flagged as operational-only: they describe plugin-maintenance or onboarding
+meta-pipelines, not user-facing analyst/sales/consultant workflows.
+
+| cogni-help template | Migration action | Notes |
+|---|---|---|
+| `docs-pipeline` | `prune-or-keep-internal` | cogni-docs maintenance pipeline (audit → generate → sync → power → claude → hub → bridge). Not a user-facing workflow. **Default decision: keep internal** as a cogni-help-only operational template until `docs/workflows/` adds a public companion guide. Tracked by #148. |
+| `full-onboarding` | `prune-or-keep-internal` | New-user meta-pipeline (workspace setup → courses 1-12). Not a workflow in the cross-plugin pipeline sense; it is a learning track that cogni-help already exposes via the `teach` and `courses` skills. **Default decision: keep internal** as the orchestration entry point for the onboarding track. Tracked by #148. |
+
+Either of these graduates to the canonical set if and only if a matching
+`docs/workflows/<id>.md` file lands in a future PR. At that point the row
+moves from Table B to Table A and the template (if kept) is renamed to
+match the canonical ID.
+
+## Coverage check
+
+- **cogni-help templates** (current contents of `cogni-help/skills/workflow/references/workflows/`):
+  `docs-pipeline`, `full-onboarding`, `new-engagement`, `portfolio-to-pitch`, `research-to-slides`, `trend-to-marketing` — **6 templates, each appears in exactly one row** (4 in Table A, 2 in Table B).
+- **docs/workflows/ guides** (current contents):
+  `consulting-engagement`, `content-pipeline`, `install-to-infographic`, `portfolio-to-pitch`, `portfolio-to-website`, `research-to-report`, `trends-to-solutions` — **7 guides, each appears in exactly one row** (all in Table A).
+
+No orphans on either side.
+
+## Updating this file
+
+When the canonical set changes (a new `docs/workflows/<id>.md` lands, or a
+canonical ID is retired):
+
+1. Update the canonical ID list above.
+2. Add or remove the matching row in Table A (or Table B for
+   operational-only templates).
+3. Re-run the coverage check at the bottom.
+4. If a template rename is implied, file or update an issue against
+   `cogni-help/skills/workflow/` so the template filename and SKILL.md
+   cross-reference table stay aligned.


### PR DESCRIPTION
Closes #145.

## Summary
- Add `cogni-help/skills/workflow/references/canonical-workflows.md` declaring `docs/workflows/` as the canonical source for workflow IDs and publishing the reconciliation table (6 cogni-help templates × 7 docs/ guides → canonical IDs + migration action).
- Update `cogni-help/skills/workflow/SKILL.md` to link the canonical reference and declare the docs-as-canonical policy.

## Scope decisions
- **In scope**: the reference file and the SKILL.md pointer/policy line. This is the foundation issue #145 — every Phase-2 child (#146 rename, #147 add, #148 prune, #149-151 teach/guide/cheatsheet alignment) depends on it.
- **Out of scope (deferred to children)**: renaming `research-to-slides` → `research-to-report`, `trend-to-marketing` → `trends-to-solutions`, `new-engagement` → `consulting-engagement` (#146); adding `content-pipeline`, `install-to-infographic`, `portfolio-to-website` templates (#147); pruning or repurposing `docs-pipeline` and `full-onboarding` (#148); teach/guide/cheatsheet cross-reference updates (#149-151).
- **Canonical ID set fixed in this PR**: `research-to-report`, `trends-to-solutions`, `portfolio-to-pitch`, `consulting-engagement`, `content-pipeline`, `install-to-infographic`, `portfolio-to-website`. `docs-pipeline` and `full-onboarding` are flagged as operational-only (not canonical user-facing) per the issue body.
- The reconciliation table sits in a dedicated `references/canonical-workflows.md` rather than inline in SKILL.md so it stays grep-able by the Phase-2 children.

## Test plan
- [ ] `cogni-help/skills/workflow/references/canonical-workflows.md` exists and contains a reconciliation table with one row per current cogni-help template (6) and one row per current `docs/workflows/<name>.md` filename (7), with no orphans on either side.
- [ ] Every row has a `migration_action` of `rename`, `add`, `prune-or-keep-internal`, or `unchanged`.
- [ ] The canonical ID set in the table matches: `research-to-report`, `trends-to-solutions`, `portfolio-to-pitch`, `consulting-engagement`, `content-pipeline`, `install-to-infographic`, `portfolio-to-website`.
- [ ] `docs-pipeline` and `full-onboarding` rows are explicitly flagged as `prune-or-keep-internal` with a note that they are cogni-help-only operational workflows.
- [ ] `cogni-help/skills/workflow/SKILL.md` has a new section linking `references/canonical-workflows.md` and stating the docs-as-canonical policy.
- [ ] No template files under `references/workflows/` are renamed, added, or removed in this PR (those land in #146/#147/#148).
