### PR TITLE
cogni-help: rename workflow templates to canonical IDs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -127,7 +127,7 @@
     {
       "name": "cogni-help",
       "source": "./cogni-help",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "maturity": "preview",
       "description": "Central help hub for the insight-wave ecosystem. Interactive courses (12-course curriculum), plugin discovery, cross-plugin workflow guides, troubleshooting, quick-reference cheatsheets, and GitHub issue filing.",
       "keywords": [

--- a/cogni-help/.claude-plugin/plugin.json
+++ b/cogni-help/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-help",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Central help hub for the insight-wave ecosystem. Interactive courses (12-course curriculum), plugin discovery, cross-plugin workflow guides, troubleshooting, quick-reference cheatsheets, and GitHub issue filing.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-help/CLAUDE.md
+++ b/cogni-help/CLAUDE.md
@@ -19,7 +19,7 @@ skills/                         7 help skills
       known-issues.md             Known issues and resolution patterns
   workflow/                       Pipeline templates — 5 cross-plugin workflow playbooks
     references/
-      workflows/                  6 workflow definitions (research-to-slides, trend-to-marketing, etc.)
+      workflows/                  6 workflow definitions (research-to-report, trends-to-solutions, etc.)
   cheatsheet/                     Quick reference — one-screen cards for any plugin
   cogni-issues/                   Issue lifecycle — create, list, status via GitHub browser automation
 
@@ -67,11 +67,11 @@ Each course ~45 minutes with ~5 modules: Theory → Demo → Exercise → Quiz �
 
 | Workflow | Pipeline |
 |----------|----------|
-| research-to-slides | cogni-research → cogni-narrative → cogni-visual |
-| trend-to-marketing | cogni-trends → cogni-portfolio → cogni-marketing |
+| research-to-report | cogni-research → cogni-narrative → cogni-visual |
+| trends-to-solutions | cogni-trends → cogni-portfolio → cogni-marketing |
 | portfolio-to-pitch | cogni-portfolio → cogni-narrative → cogni-sales → cogni-visual |
 | docs-pipeline | cogni-docs: doc-start → audit → generate → sync → power → claude → hub → bridge |
-| new-engagement | cogni-consulting phases (Discover → Define → Develop → Deliver) |
+| consulting-engagement | cogni-consulting phases (Discover → Define → Develop → Deliver) |
 | full-onboarding | cogni-workspace → cogni-help courses 1-12 |
 
 ## Data Model

--- a/cogni-help/README.md
+++ b/cogni-help/README.md
@@ -23,7 +23,7 @@ A meta-plugin for the insight-wave ecosystem. While other plugins produce conten
 
 1. **Teach** through 12 interactive courses — adaptive pacing, hands-on exercises, quizzes, and progress tracking across the full plugin ecosystem
 2. **Guide** users to the right plugin — match natural-language task descriptions to capabilities across 12 plugins and 70+ skills
-3. **Chain** plugins into pipelines — 6 cross-plugin workflow templates from research-to-slides through full consulting engagements
+3. **Chain** plugins into pipelines — 6 cross-plugin workflow templates from research-to-report through full consulting engagements
 4. **Diagnose** plugin problems — check integrity, dependencies, workspace health, and known issues before they surface as runtime failures
 5. **Summarize** any plugin — generate one-screen quick-reference cheatsheets with commands, capabilities, and tips
 6. **Generate** training decks — PPTX slide decks for curriculum overview or per-course introductions
@@ -33,7 +33,7 @@ A meta-plugin for the insight-wave ecosystem. While other plugins produce conten
 
 - **Skip the memorization.** Describe your task in plain language and the guide skill routes it to the exact plugin and skill across 12 plugins and 70+ skills — first productive result in under 5 minutes.
 - **Build real skills in 9 hours.** Complete all 12 courses (~45 minutes each) with hands-on exercises that produce real output. Resume any course mid-module — progress is tracked to the lesson.
-- **Collapse multi-plugin work into 3–4 steps.** Run any of 6 workflow templates to chain plugins into repeatable pipelines — research-to-slides in 3 steps, portfolio-to-pitch in 4.
+- **Collapse multi-plugin work into 3–4 steps.** Run any of 6 workflow templates to chain plugins into repeatable pipelines — research-to-report in 3 steps, portfolio-to-pitch in 4.
 - **Catch failures before they surface.** Run the 5-tier health check to surface missing dependencies, stale configs, and integrity issues before they become cryptic runtime errors.
 
 ## Install
@@ -51,7 +51,7 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 ```
 /guide "I need to create a sales pitch"   # find the right plugin
 /teach 1                                   # start Course 1: Cowork Fundamentals
-/workflow research-to-slides               # see a cross-plugin pipeline
+/workflow research-to-report               # see a cross-plugin pipeline
 /cheatsheet cogni-trends                   # quick reference for a plugin
 /troubleshoot                              # run diagnostics
 cogni-issues                               # file a bug or feature request (skill, no slash command)
@@ -111,10 +111,10 @@ Each course is ~45 minutes with ~5 modules: Theory → Demo → Exercise → Qui
 
 | Workflow | Pipeline |
 |----------|----------|
-| `research-to-slides` | cogni-research → cogni-narrative → cogni-visual |
-| `trend-to-marketing` | cogni-trends → cogni-portfolio → cogni-marketing |
+| `research-to-report` | cogni-research → cogni-narrative → cogni-visual |
+| `trends-to-solutions` | cogni-trends → cogni-portfolio → cogni-marketing |
 | `portfolio-to-pitch` | cogni-portfolio → cogni-narrative → cogni-sales → cogni-visual |
-| `new-engagement` | cogni-consulting phases (Discover → Define → Develop → Deliver) |
+| `consulting-engagement` | cogni-consulting phases (Discover → Define → Develop → Deliver) |
 | `docs-pipeline` | cogni-docs: doc-start → audit → generate → sync → power → claude → hub → bridge |
 | `full-onboarding` | cogni-workspace → cogni-help courses 1-12 |
 

--- a/cogni-help/commands/workflow.md
+++ b/cogni-help/commands/workflow.md
@@ -10,8 +10,8 @@ allowed-tools:
 Show step-by-step workflow templates for chaining insight-wave plugins.
 
 Accept either:
-- A workflow name (research-to-slides, trend-to-marketing, portfolio-to-pitch,
-  new-engagement, full-onboarding) — show that specific workflow
+- A workflow name (research-to-report, trends-to-solutions, portfolio-to-pitch,
+  consulting-engagement, full-onboarding) — show that specific workflow
 - No argument — list all available workflows
 
 Steps:

--- a/cogni-help/skills/guide/evals/evals.json
+++ b/cogni-help/skills/guide/evals/evals.json
@@ -10,7 +10,7 @@
     {
       "id": 1,
       "prompt": "Which plugins should I use to go from a trend analysis to a marketing campaign?",
-      "expected_output": "Suggests the pipeline: cogni-trends (scouting) → cogni-portfolio (propositions) → cogni-marketing (content). Mentions /workflow command for the trend-to-marketing template",
+      "expected_output": "Suggests the pipeline: cogni-trends (scouting) → cogni-portfolio (propositions) → cogni-marketing (content). Mentions /workflow command for the trends-to-solutions template",
       "files": []
     },
     {

--- a/cogni-help/skills/workflow/SKILL.md
+++ b/cogni-help/skills/workflow/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Cross-plugin workflow templates for common multi-plugin pipelines. Use this skill
   whenever the user asks about workflows, pipelines, end-to-end processes, "how do I
   go from X to Y", "what's the process for", "show me the steps", "workflow for",
-  "pipeline from research to slides", "how do these plugins work together", or wants
+  "pipeline from research to a report", "how do these plugins work together", or wants
   guidance on chaining multiple insight-wave plugins. Also trigger when a user describes
   a multi-step task that spans plugins — even if they don't say "workflow" explicitly.
 version: 0.1.0
@@ -35,21 +35,21 @@ Keep in English regardless of language setting:
 
 Six bundled templates covering the most common plugin chains:
 
-| Canonical ID | Current template file | Pipeline | Use case |
-|--------------|-----------------------|----------|----------|
-| `research-to-report` | `research-to-slides` (rename tracked by #146) | research → narrative → visual | Analyst producing a presentation from research |
-| `trends-to-solutions` | `trend-to-marketing` (rename tracked by #146) | tips → portfolio → marketing | GTM team turning trends into campaigns |
-| `portfolio-to-pitch` | `portfolio-to-pitch` (aligned) | portfolio → narrative → sales → visual | Sales creating a customer pitch deck |
-| `consulting-engagement` | `new-engagement` (rename tracked by #146) | consulting setup → 4 phases | Consultant starting a structured engagement |
+| Canonical ID | Template file | Pipeline | Use case |
+|--------------|---------------|----------|----------|
+| `research-to-report` | `research-to-report` | research → narrative → visual | Analyst producing a report-and-presentation deliverable from research |
+| `trends-to-solutions` | `trends-to-solutions` | tips → portfolio → marketing | GTM team turning trends into campaigns |
+| `portfolio-to-pitch` | `portfolio-to-pitch` | portfolio → narrative → sales → visual | Sales creating a customer pitch deck |
+| `consulting-engagement` | `consulting-engagement` | consulting setup → 4 phases | Consultant starting a structured engagement |
 | — (operational-only) | `docs-pipeline` | doc-start → audit → generate → sync → power → claude → hub → bridge | Maintainer documenting the monorepo |
 | — (operational-only) | `full-onboarding` | workspace → help courses 1-11 | New user learning the full ecosystem |
 
 The first column is the canonical workflow ID from `docs/workflows/`; the
-second is the current filename in `references/workflows/` (which may differ
-until #146 lands the renames). Reference workflows from other surfaces
-(`teach`, `guide`, `cheatsheet`, `docs/`) by canonical ID, not template
-filename. Operational-only rows have no canonical ID — see
-`references/canonical-workflows.md` Table B for the policy.
+second is the corresponding filename in `references/workflows/`. The 4
+user-facing canonical workflows share the same ID as their template
+filename — reference them by canonical ID from any surface (`teach`,
+`guide`, `cheatsheet`, `docs/`). Operational-only rows have no canonical
+ID — see `references/canonical-workflows.md` Table B for the policy.
 
 ## Canonical Workflow IDs
 
@@ -59,16 +59,10 @@ those canonical IDs. The reconciliation table — every cogni-help template ID
 and every `docs/workflows/<name>.md` filename mapped to a single canonical ID
 with a migration action — lives at `references/canonical-workflows.md`.
 
-The current template filenames in the table above may not yet match the
-canonical IDs (migration is tracked in the reference file). When a workflow
-is referenced from another surface (`teach`, `guide`, `cheatsheet`, `docs/`),
-use the canonical ID — never the legacy template filename.
-
-Propagation of canonical IDs into the downstream surfaces is tracked
-alongside the rename/add work: template renames in #146, missing-template
-adds in #147, operational-only template prunes in #148, `teach` curriculum
-extension in #149, course reference scaffolding in #150, and `guide`
-plugin-catalog plus `cheatsheet` cross-reference updates in #151.
+When a workflow is referenced from another surface (`teach`, `guide`,
+`cheatsheet`, `docs/`), use the canonical ID. The reconciliation table in
+`references/canonical-workflows.md` is the source of truth for which IDs
+are user-facing vs operational-only and for any pending alignment work.
 
 ## How to Present Workflows
 
@@ -98,15 +92,15 @@ cogni-docs. These complement the bundled templates above — the templates here 
 step-by-step playbooks with commands and tips; the docs/ guides are narrative tutorials
 with context and variations.
 
-| Canonical workflow (`docs/workflows/<id>.md`) | Current cogni-help template | Notes |
-|-----------------------------------------------|------------------------------|-------|
-| `research-to-report` | `research-to-slides` (rename in #146) | Same pipeline, docs version focuses on the report |
-| `trends-to-solutions` | `trend-to-marketing` (rename in #146) | Same starting point, different end goal |
-| `portfolio-to-pitch` | `portfolio-to-pitch` (aligned) | Same pipeline |
-| `consulting-engagement` | `new-engagement` (rename in #146) | Same pipeline |
-| `content-pipeline` | — (add in #147) | Marketing pipeline from trends to campaign assets |
-| `install-to-infographic` | — (add in #147) | Install-to-deliverable pipeline ending in an infographic |
-| `portfolio-to-website` | — (add in #147) | Portfolio rendered as a static website |
+| Canonical workflow (`docs/workflows/<id>.md`) | cogni-help template | Notes |
+|-----------------------------------------------|---------------------|-------|
+| `research-to-report` | `research-to-report` | Same pipeline, docs version focuses on the report |
+| `trends-to-solutions` | `trends-to-solutions` | Same starting point, different end goal |
+| `portfolio-to-pitch` | `portfolio-to-pitch` | Same pipeline |
+| `consulting-engagement` | `consulting-engagement` | Same pipeline |
+| `content-pipeline` | — (no template yet) | Marketing pipeline from trends to campaign assets — refer the user to `docs/workflows/content-pipeline.md` |
+| `install-to-infographic` | — (no template yet) | Install-to-deliverable pipeline — refer the user to `docs/workflows/install-to-infographic.md` |
+| `portfolio-to-website` | — (no template yet) | Portfolio rendered as a static website — refer the user to `docs/workflows/portfolio-to-website.md` |
 
 When presenting a workflow, mention the corresponding docs/ guide if it exists:
 "For a narrative walkthrough with more context, see `docs/workflows/<name>.md`."

--- a/cogni-help/skills/workflow/evals/evals.json
+++ b/cogni-help/skills/workflow/evals/evals.json
@@ -4,7 +4,7 @@
     {
       "id": 0,
       "prompt": "How do I go from trend research to a marketing campaign?",
-      "expected_output": "Presents the trend-to-marketing workflow: cogni-trends → cogni-portfolio → cogni-marketing, with step-by-step commands and tips",
+      "expected_output": "Presents the trends-to-solutions workflow: cogni-trends → cogni-portfolio → cogni-marketing, with step-by-step commands and tips",
       "files": []
     },
     {

--- a/cogni-help/skills/workflow/references/canonical-workflows.md
+++ b/cogni-help/skills/workflow/references/canonical-workflows.md
@@ -56,10 +56,10 @@ and names the migration action that the phase-2 children must execute.
 
 | Canonical ID | docs/workflows/ guide | cogni-help template (legacy) | Migration action | Tracked by | Notes |
 |---|---|---|---|---|---|
-| `research-to-report` | `docs/workflows/research-to-report.md` | `research-to-slides` | `rename` (template) | #146 | Pipeline unchanged. Rename template file and update SKILL.md cross-references. |
-| `trends-to-solutions` | `docs/workflows/trends-to-solutions.md` | `trend-to-marketing` | `rename` (template) | #146 | Pipeline unchanged. Rename template file and update SKILL.md cross-references. |
+| `research-to-report` | `docs/workflows/research-to-report.md` | `research-to-slides` → `research-to-report` | `completed by #146` | #146 | Template renamed in #146. Pipeline unchanged. |
+| `trends-to-solutions` | `docs/workflows/trends-to-solutions.md` | `trend-to-marketing` → `trends-to-solutions` | `completed by #146` | #146 | Template renamed in #146. Pipeline unchanged. |
 | `portfolio-to-pitch` | `docs/workflows/portfolio-to-pitch.md` | `portfolio-to-pitch` | `unchanged` | — | Already aligned on both sides. |
-| `consulting-engagement` | `docs/workflows/consulting-engagement.md` | `new-engagement` | `rename` (template) | #146 | Pipeline unchanged. Rename template file and update SKILL.md cross-references. |
+| `consulting-engagement` | `docs/workflows/consulting-engagement.md` | `new-engagement` → `consulting-engagement` | `completed by #146` | #146 | Template renamed in #146. Pipeline unchanged. |
 | `content-pipeline` | `docs/workflows/content-pipeline.md` | — | `add` (template) | #147 | docs/ guide is canonical; cogni-help adds presentation template. |
 | `install-to-infographic` | `docs/workflows/install-to-infographic.md` | — | `add` (template) | #147 | docs/ guide is canonical; cogni-help adds presentation template. |
 | `portfolio-to-website` | `docs/workflows/portfolio-to-website.md` | — | `add` (template) | #147 | docs/ guide is canonical; cogni-help adds presentation template. |
@@ -69,6 +69,7 @@ Migration action vocabulary:
 - `rename` — the cogni-help template exists under a non-canonical filename; rename the file to `<canonical-id>.md` and update SKILL.md and any cross-references.
 - `add` — no cogni-help template exists yet; create one that walks through the canonical pipeline.
 - `unchanged` — the template filename already matches the canonical ID; no migration action needed.
+- `completed by #N` — the migration shipped in PR/issue N; row preserved as historical record.
 - `prune-or-keep-internal` — the cogni-help template is operational-only and not part of the canonical user-facing set (see Table B).
 
 ## Table B — Operational-only templates (out of canonical user-facing set)
@@ -90,7 +91,7 @@ match the canonical ID.
 ## Coverage check
 
 - **cogni-help templates** (current contents of `cogni-help/skills/workflow/references/workflows/`):
-  `docs-pipeline`, `full-onboarding`, `new-engagement`, `portfolio-to-pitch`, `research-to-slides`, `trend-to-marketing` — **6 templates, each appears in exactly one row** (4 in Table A, 2 in Table B).
+  `consulting-engagement`, `docs-pipeline`, `full-onboarding`, `portfolio-to-pitch`, `research-to-report`, `trends-to-solutions` — **6 templates, each appears in exactly one row** (4 in Table A, 2 in Table B).
 - **docs/workflows/ guides** (current contents):
   `consulting-engagement`, `content-pipeline`, `install-to-infographic`, `portfolio-to-pitch`, `portfolio-to-website`, `research-to-report`, `trends-to-solutions` — **7 guides, each appears in exactly one row** (all in Table A).
 

--- a/cogni-help/skills/workflow/references/workflows/consulting-engagement.md
+++ b/cogni-help/skills/workflow/references/workflows/consulting-engagement.md
@@ -1,4 +1,4 @@
-# Workflow: New Consulting Engagement
+# Workflow: Consulting Engagement
 
 **Pipeline**: cogni-consulting setup → Discover → Define → Develop → Deliver
 **Duration**: Days to weeks depending on engagement scope

--- a/cogni-help/skills/workflow/references/workflows/research-to-report.md
+++ b/cogni-help/skills/workflow/references/workflows/research-to-report.md
@@ -1,4 +1,4 @@
-# Workflow: Research to Slides
+# Workflow: Research to Report
 
 **Pipeline**: cogni-research → cogni-narrative → cogni-visual
 **Duration**: 2-4 hours depending on research depth

--- a/cogni-help/skills/workflow/references/workflows/trends-to-solutions.md
+++ b/cogni-help/skills/workflow/references/workflows/trends-to-solutions.md
@@ -1,4 +1,4 @@
-# Workflow: Trend to Marketing
+# Workflow: Trends to Solutions
 
 **Pipeline**: cogni-trends → cogni-portfolio → cogni-marketing
 **Duration**: 3-6 hours for a full campaign


### PR DESCRIPTION
Closes #146.

## Summary
- Renames 3 workflow templates in `cogni-help/skills/workflow/references/workflows/` to match the canonical IDs declared in #145:
  - `research-to-slides.md` → `research-to-report.md`
  - `trend-to-marketing.md` → `trends-to-solutions.md`
  - `new-engagement.md` → `consulting-engagement.md`
- Each template's H1 is updated to match the new ID.
- Updates every cogni-help cross-reference: SKILL.md tables + trigger phrase, `canonical-workflows.md` Table A migration_action (now `completed by #146`) + coverage check, README.md (4 sites), CLAUDE.md (2 sites), `commands/workflow.md` argument hints, 2 evals JSON files.
- Bumps `cogni-help` patch version 0.1.1 → 0.1.2 in `plugin.json` and mirrors to `marketplace.json`.

## Scope decisions
- **In scope:** every legacy-ID reference inside `cogni-help/`. `portfolio-to-pitch` is unchanged (already aligned). Operational-only templates (`docs-pipeline`, `full-onboarding`) are unchanged.
- **Out of scope:** `docs/workflows/` (canonical surface, already correct); phase-2/3 children — #147 add new templates, #148 prune operational-only, #149-151 teach/guide/cheatsheet propagation.
- **Migration row preservation:** `canonical-workflows.md` Table A keeps the 3 affected rows with their `legacy → canonical` mapping in the "cogni-help template (legacy)" column as a historical record; migration_action moves from `rename` to `completed by #146`.

## Test plan
- [ ] `grep -rn 'research-to-slides\|trend-to-marketing\|new-engagement' cogni-help/` returns hits only inside the intentional migration notes in `canonical-workflows.md` Table A.
- [ ] `ls cogni-help/skills/workflow/references/workflows/` shows the 3 renamed files plus unchanged `portfolio-to-pitch.md`, `docs-pipeline.md`, `full-onboarding.md`.
- [ ] Each renamed template's H1 matches its new canonical ID.
- [ ] `/workflow` with no argument lists the renamed IDs in the Available Workflows table.
- [ ] `/workflow research-to-report`, `/workflow trends-to-solutions`, `/workflow consulting-engagement` each load the right template.
- [ ] `cogni-help/.claude-plugin/plugin.json` shows version `0.1.2` and matches the `cogni-help` entry in `.claude-plugin/marketplace.json`.
