### PR TITLE
cogni-help: add install-to-infographic, portfolio-to-website, content-pipeline templates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -127,7 +127,7 @@
     {
       "name": "cogni-help",
       "source": "./cogni-help",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "maturity": "preview",
       "description": "Central help hub for the insight-wave ecosystem. Interactive courses (12-course curriculum), plugin discovery, cross-plugin workflow guides, troubleshooting, quick-reference cheatsheets, and GitHub issue filing.",
       "keywords": [

--- a/cogni-help/.claude-plugin/plugin.json
+++ b/cogni-help/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-help",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Central help hub for the insight-wave ecosystem. Interactive courses (12-course curriculum), plugin discovery, cross-plugin workflow guides, troubleshooting, quick-reference cheatsheets, and GitHub issue filing.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-help/CLAUDE.md
+++ b/cogni-help/CLAUDE.md
@@ -114,3 +114,4 @@ they point to stable paths (`docs/plugin-guide/<plugin>.md`), not specific conte
 - Exercises create temporary artifacts in `_teacher-exercises/` (gitignored)
 - Plugin catalog in guide/references/plugin-catalog.md must be updated when plugins are added
 - Workflow definitions are standalone markdown files in workflow/references/workflows/
+- Skill-level `version` fields in `SKILL.md` frontmatter track sibling-skill convention (often staying at `0.1.0` while the plugin version moves) — `cogni-help/.claude-plugin/plugin.json` and the matching `.claude-plugin/marketplace.json` entry are the single source of truth for the plugin version

--- a/cogni-help/CLAUDE.md
+++ b/cogni-help/CLAUDE.md
@@ -17,9 +17,9 @@ skills/                         7 help skills
   troubleshoot/                   Diagnostics — plugin integrity, dependencies, stale state
     references/
       known-issues.md             Known issues and resolution patterns
-  workflow/                       Pipeline templates — 5 cross-plugin workflow playbooks
+  workflow/                       Pipeline templates — 9 cross-plugin workflow playbooks (7 user-facing + 2 operational-only)
     references/
-      workflows/                  6 workflow definitions (research-to-report, trends-to-solutions, etc.)
+      workflows/                  9 workflow definitions (research-to-report, trends-to-solutions, install-to-infographic, portfolio-to-website, content-pipeline, etc.)
   cheatsheet/                     Quick reference — one-screen cards for any plugin
   cogni-issues/                   Issue lifecycle — create, list, status via GitHub browser automation
 
@@ -67,11 +67,14 @@ Each course ~45 minutes with ~5 modules: Theory → Demo → Exercise → Quiz �
 
 | Workflow | Pipeline |
 |----------|----------|
+| install-to-infographic | cogni-workspace → cogni-workspace (themes) → cogni-visual |
 | research-to-report | cogni-research → cogni-narrative → cogni-visual |
 | trends-to-solutions | cogni-trends → cogni-portfolio → cogni-marketing |
 | portfolio-to-pitch | cogni-portfolio → cogni-narrative → cogni-sales → cogni-visual |
-| docs-pipeline | cogni-docs: doc-start → audit → generate → sync → power → claude → hub → bridge |
+| portfolio-to-website | cogni-portfolio → cogni-workspace → cogni-website |
+| content-pipeline | cogni-marketing → cogni-narrative → cogni-copywriting → cogni-visual |
 | consulting-engagement | cogni-consulting phases (Discover → Define → Develop → Deliver) |
+| docs-pipeline | cogni-docs: doc-start → audit → generate → sync → power → claude → hub → bridge |
 | full-onboarding | cogni-workspace → cogni-help courses 1-12 |
 
 ## Data Model

--- a/cogni-help/skills/workflow/SKILL.md
+++ b/cogni-help/skills/workflow/SKILL.md
@@ -35,7 +35,7 @@ Keep in English regardless of language setting:
 
 ## Available Workflows
 
-Nine bundled templates covering the most common plugin chains:
+Nine bundled templates covering the most common plugin chains: seven user-facing (canonical IDs) plus two operational-only (no canonical ID, marked with —).
 
 | Canonical ID | Primary plugins | Pipeline | Use case |
 |--------------|-----------------|----------|----------|
@@ -44,19 +44,18 @@ Nine bundled templates covering the most common plugin chains:
 | `trends-to-solutions` | cogni-trends, cogni-portfolio, cogni-marketing | tips → portfolio → marketing | GTM team turning trends into campaigns |
 | `portfolio-to-pitch` | cogni-portfolio, cogni-narrative, cogni-sales, cogni-visual | portfolio → narrative → sales → visual | Sales creating a customer pitch deck |
 | `portfolio-to-website` | cogni-portfolio, cogni-workspace, cogni-website | portfolio → workspace → website | Generate a deployable static site from the portfolio model |
-| `content-pipeline` | cogni-marketing, cogni-narrative, cogni-copywriting, cogni-visual | marketing → narrative → copywriting → visual | Multi-channel marketing content production |
+| `content-pipeline` | cogni-marketing, cogni-narrative, cogni-copywriting, cogni-visual | marketing → narrative (long-form) → copywriting → visual | Multi-channel marketing content production |
 | `consulting-engagement` | cogni-consulting | consulting setup → 4 phases | Consultant starting a structured engagement |
 | — (operational-only, docs) | cogni-docs | doc-start → audit → generate → sync → power → claude → hub → bridge | Maintainer documenting the monorepo (`docs-pipeline` template) |
 | — (operational-only, onboarding) | cogni-workspace, cogni-help | workspace → help courses 1-12 | New user learning the full ecosystem (`full-onboarding` template) |
 
 The first column is the canonical workflow ID from `docs/workflows/`; the
-second lists the primary plugins involved (template files in
-`references/workflows/` share the canonical ID's filename). The 7
-user-facing canonical workflows are referenced by canonical ID from any
-surface (`teach`, `guide`, `cheatsheet`, `docs/`). Operational-only rows
-have no canonical ID and are suffixed with their context (docs vs
-onboarding) — see `references/canonical-workflows.md` Table B for the
-policy.
+second lists the primary plugins involved. Template files live at
+`references/workflows/<canonical-id>.md`. The 7 user-facing canonical
+workflows are referenced by canonical ID from any surface (`teach`,
+`guide`, `cheatsheet`, `docs/`). Operational-only rows have no canonical
+ID and are suffixed with their context (docs vs onboarding) — see
+`references/canonical-workflows.md` Table B for the policy.
 
 ## Canonical Workflow IDs
 

--- a/cogni-help/skills/workflow/SKILL.md
+++ b/cogni-help/skills/workflow/SKILL.md
@@ -4,9 +4,11 @@ description: >-
   Cross-plugin workflow templates for common multi-plugin pipelines. Use this skill
   whenever the user asks about workflows, pipelines, end-to-end processes, "how do I
   go from X to Y", "what's the process for", "show me the steps", "workflow for",
-  "pipeline from research to a report", "how do these plugins work together", or wants
-  guidance on chaining multiple insight-wave plugins. Also trigger when a user describes
-  a multi-step task that spans plugins — even if they don't say "workflow" explicitly.
+  "pipeline from research to a report", "install to first infographic", "portfolio to
+  website", "marketing content pipeline", "multi-channel content production", "how do
+  these plugins work together", or wants guidance on chaining multiple insight-wave
+  plugins. Also trigger when a user describes a multi-step task that spans plugins —
+  even if they don't say "workflow" explicitly.
 version: 0.1.0
 allowed-tools: Read, Glob
 ---
@@ -35,24 +37,26 @@ Keep in English regardless of language setting:
 
 Nine bundled templates covering the most common plugin chains:
 
-| Canonical ID | Template file | Pipeline | Use case |
-|--------------|---------------|----------|----------|
-| `install-to-infographic` | `install-to-infographic` | workspace → themes → visual | First-run capstone — install, theme, render an infographic |
-| `research-to-report` | `research-to-report` | research → narrative → visual | Analyst producing a report-and-presentation deliverable from research |
-| `trends-to-solutions` | `trends-to-solutions` | tips → portfolio → marketing | GTM team turning trends into campaigns |
-| `portfolio-to-pitch` | `portfolio-to-pitch` | portfolio → narrative → sales → visual | Sales creating a customer pitch deck |
-| `portfolio-to-website` | `portfolio-to-website` | portfolio → workspace → website | Generate a deployable static site from the portfolio model |
-| `content-pipeline` | `content-pipeline` | marketing → narrative → copywriting → visual | Multi-channel marketing content production |
-| `consulting-engagement` | `consulting-engagement` | consulting setup → 4 phases | Consultant starting a structured engagement |
-| — (operational-only) | `docs-pipeline` | doc-start → audit → generate → sync → power → claude → hub → bridge | Maintainer documenting the monorepo |
-| — (operational-only) | `full-onboarding` | workspace → help courses 1-11 | New user learning the full ecosystem |
+| Canonical ID | Primary plugins | Pipeline | Use case |
+|--------------|-----------------|----------|----------|
+| `install-to-infographic` | cogni-workspace, cogni-visual | cogni-workspace → cogni-workspace (themes) → cogni-visual | First-run capstone — install, theme, render an infographic |
+| `research-to-report` | cogni-research, cogni-narrative, cogni-visual | research → narrative → visual | Analyst producing a report-and-presentation deliverable from research |
+| `trends-to-solutions` | cogni-trends, cogni-portfolio, cogni-marketing | tips → portfolio → marketing | GTM team turning trends into campaigns |
+| `portfolio-to-pitch` | cogni-portfolio, cogni-narrative, cogni-sales, cogni-visual | portfolio → narrative → sales → visual | Sales creating a customer pitch deck |
+| `portfolio-to-website` | cogni-portfolio, cogni-workspace, cogni-website | portfolio → workspace → website | Generate a deployable static site from the portfolio model |
+| `content-pipeline` | cogni-marketing, cogni-narrative, cogni-copywriting, cogni-visual | marketing → narrative → copywriting → visual | Multi-channel marketing content production |
+| `consulting-engagement` | cogni-consulting | consulting setup → 4 phases | Consultant starting a structured engagement |
+| — (operational-only, docs) | cogni-docs | doc-start → audit → generate → sync → power → claude → hub → bridge | Maintainer documenting the monorepo (`docs-pipeline` template) |
+| — (operational-only, onboarding) | cogni-workspace, cogni-help | workspace → help courses 1-12 | New user learning the full ecosystem (`full-onboarding` template) |
 
 The first column is the canonical workflow ID from `docs/workflows/`; the
-second is the corresponding filename in `references/workflows/`. The 7
-user-facing canonical workflows share the same ID as their template
-filename — reference them by canonical ID from any surface (`teach`,
-`guide`, `cheatsheet`, `docs/`). Operational-only rows have no canonical
-ID — see `references/canonical-workflows.md` Table B for the policy.
+second lists the primary plugins involved (template files in
+`references/workflows/` share the canonical ID's filename). The 7
+user-facing canonical workflows are referenced by canonical ID from any
+surface (`teach`, `guide`, `cheatsheet`, `docs/`). Operational-only rows
+have no canonical ID and are suffixed with their context (docs vs
+onboarding) — see `references/canonical-workflows.md` Table B for the
+policy.
 
 ## Canonical Workflow IDs
 

--- a/cogni-help/skills/workflow/SKILL.md
+++ b/cogni-help/skills/workflow/SKILL.md
@@ -33,19 +33,22 @@ Keep in English regardless of language setting:
 
 ## Available Workflows
 
-Six bundled templates covering the most common plugin chains:
+Nine bundled templates covering the most common plugin chains:
 
 | Canonical ID | Template file | Pipeline | Use case |
 |--------------|---------------|----------|----------|
+| `install-to-infographic` | `install-to-infographic` | workspace → themes → visual | First-run capstone — install, theme, render an infographic |
 | `research-to-report` | `research-to-report` | research → narrative → visual | Analyst producing a report-and-presentation deliverable from research |
 | `trends-to-solutions` | `trends-to-solutions` | tips → portfolio → marketing | GTM team turning trends into campaigns |
 | `portfolio-to-pitch` | `portfolio-to-pitch` | portfolio → narrative → sales → visual | Sales creating a customer pitch deck |
+| `portfolio-to-website` | `portfolio-to-website` | portfolio → workspace → website | Generate a deployable static site from the portfolio model |
+| `content-pipeline` | `content-pipeline` | marketing → narrative → copywriting → visual | Multi-channel marketing content production |
 | `consulting-engagement` | `consulting-engagement` | consulting setup → 4 phases | Consultant starting a structured engagement |
 | — (operational-only) | `docs-pipeline` | doc-start → audit → generate → sync → power → claude → hub → bridge | Maintainer documenting the monorepo |
 | — (operational-only) | `full-onboarding` | workspace → help courses 1-11 | New user learning the full ecosystem |
 
 The first column is the canonical workflow ID from `docs/workflows/`; the
-second is the corresponding filename in `references/workflows/`. The 4
+second is the corresponding filename in `references/workflows/`. The 7
 user-facing canonical workflows share the same ID as their template
 filename — reference them by canonical ID from any surface (`teach`,
 `guide`, `cheatsheet`, `docs/`). Operational-only rows have no canonical
@@ -94,13 +97,13 @@ with context and variations.
 
 | Canonical workflow (`docs/workflows/<id>.md`) | cogni-help template | Notes |
 |-----------------------------------------------|---------------------|-------|
+| `install-to-infographic` | `install-to-infographic` | Same first-run pipeline, docs version covers platform-specific Claude Code setup |
 | `research-to-report` | `research-to-report` | Same pipeline, docs version focuses on the report |
 | `trends-to-solutions` | `trends-to-solutions` | Same starting point, different end goal |
 | `portfolio-to-pitch` | `portfolio-to-pitch` | Same pipeline |
+| `portfolio-to-website` | `portfolio-to-website` | Same pipeline, docs version includes deployment hints and prerequisite matrix |
+| `content-pipeline` | `content-pipeline` | Same pipeline, docs version covers campaign orchestration and content-calendar scheduling |
 | `consulting-engagement` | `consulting-engagement` | Same pipeline |
-| `content-pipeline` | — (no template yet) | Marketing pipeline from trends to campaign assets — refer the user to `docs/workflows/content-pipeline.md` |
-| `install-to-infographic` | — (no template yet) | Install-to-deliverable pipeline — refer the user to `docs/workflows/install-to-infographic.md` |
-| `portfolio-to-website` | — (no template yet) | Portfolio rendered as a static website — refer the user to `docs/workflows/portfolio-to-website.md` |
 
 When presenting a workflow, mention the corresponding docs/ guide if it exists:
 "For a narrative walkthrough with more context, see `docs/workflows/<name>.md`."

--- a/cogni-help/skills/workflow/references/canonical-workflows.md
+++ b/cogni-help/skills/workflow/references/canonical-workflows.md
@@ -60,9 +60,9 @@ and names the migration action that the phase-2 children must execute.
 | `trends-to-solutions` | `docs/workflows/trends-to-solutions.md` | `trend-to-marketing` → `trends-to-solutions` | `completed by #146` | #146 | Template renamed in #146. Pipeline unchanged. |
 | `portfolio-to-pitch` | `docs/workflows/portfolio-to-pitch.md` | `portfolio-to-pitch` | `unchanged` | — | Already aligned on both sides. |
 | `consulting-engagement` | `docs/workflows/consulting-engagement.md` | `new-engagement` → `consulting-engagement` | `completed by #146` | #146 | Template renamed in #146. Pipeline unchanged. |
-| `content-pipeline` | `docs/workflows/content-pipeline.md` | — | `add` (template) | #147 | docs/ guide is canonical; cogni-help adds presentation template. |
-| `install-to-infographic` | `docs/workflows/install-to-infographic.md` | — | `add` (template) | #147 | docs/ guide is canonical; cogni-help adds presentation template. |
-| `portfolio-to-website` | `docs/workflows/portfolio-to-website.md` | — | `add` (template) | #147 | docs/ guide is canonical; cogni-help adds presentation template. |
+| `content-pipeline` | `docs/workflows/content-pipeline.md` | `content-pipeline` | `completed by #147` | #147 | Template added in #147. Pipeline matches docs/ guide. |
+| `install-to-infographic` | `docs/workflows/install-to-infographic.md` | `install-to-infographic` | `completed by #147` | #147 | Template added in #147. Pipeline matches docs/ guide. |
+| `portfolio-to-website` | `docs/workflows/portfolio-to-website.md` | `portfolio-to-website` | `completed by #147` | #147 | Template added in #147. Pipeline matches docs/ guide. |
 
 Migration action vocabulary:
 
@@ -91,7 +91,7 @@ match the canonical ID.
 ## Coverage check
 
 - **cogni-help templates** (current contents of `cogni-help/skills/workflow/references/workflows/`):
-  `consulting-engagement`, `docs-pipeline`, `full-onboarding`, `portfolio-to-pitch`, `research-to-report`, `trends-to-solutions` — **6 templates, each appears in exactly one row** (4 in Table A, 2 in Table B).
+  `consulting-engagement`, `content-pipeline`, `docs-pipeline`, `full-onboarding`, `install-to-infographic`, `portfolio-to-pitch`, `portfolio-to-website`, `research-to-report`, `trends-to-solutions` — **9 templates, each appears in exactly one row** (7 in Table A, 2 in Table B).
 - **docs/workflows/ guides** (current contents):
   `consulting-engagement`, `content-pipeline`, `install-to-infographic`, `portfolio-to-pitch`, `portfolio-to-website`, `research-to-report`, `trends-to-solutions` — **7 guides, each appears in exactly one row** (all in Table A).
 

--- a/cogni-help/skills/workflow/references/workflows/content-pipeline.md
+++ b/cogni-help/skills/workflow/references/workflows/content-pipeline.md
@@ -92,4 +92,4 @@ graph LR
 
 ---
 
-For the narrative tutorial — including the full content-type-to-skill table, parallel generation patterns, campaign orchestration, content-calendar scheduling, and variations matrix — see [`docs/workflows/content-pipeline.md`](../../../../docs/workflows/content-pipeline.md).
+For the narrative tutorial — including the full content-type-to-skill table, parallel generation patterns, campaign orchestration, content-calendar scheduling, and variations matrix — see [`docs/workflows/content-pipeline.md`](../../../../../docs/workflows/content-pipeline.md).

--- a/cogni-help/skills/workflow/references/workflows/content-pipeline.md
+++ b/cogni-help/skills/workflow/references/workflows/content-pipeline.md
@@ -1,0 +1,95 @@
+# Workflow: Content Pipeline
+
+**Pipeline**: cogni-marketing → cogni-narrative (long-form only) → cogni-copywriting → cogni-visual
+**Duration**: 2–6 hours for a complete content batch, depending on format count and polish depth
+**Use case**: Multi-channel marketing content production — articles, battle cards, email nurtures, plus optional slide deck or web narrative — sourced from portfolio propositions and TIPS themes
+
+```mermaid
+graph LR
+    A[marketing-setup] -->|content-strategy.json| B[Content generation]
+    B -->|raw content pieces| N[cogni-narrative]
+    N -->|arc-shaped long-form| C[cogni-copywriting]
+    C -->|polished content| D[cogni-visual]
+    D -->|slides / web| E[Deliverable]
+```
+
+**Narrative bridge.** For long-form formats (thought leadership, whitepapers, keynote abstracts), `cogni-narrative` sits between content generation and polish — it applies a story arc framework and writes `arc_id` frontmatter that `cogni-copywriting` reads for arc-aware polishing. Short-form formats (LinkedIn posts, battle cards, emails) skip this step and go straight from generation to polish.
+
+## Step 1: Set Up the Marketing Project (cogni-marketing)
+
+**Command**: `/marketing-setup`
+
+**Input**: A cogni-portfolio project, optionally a TIPS project from cogni-trends
+**Output**: `marketing-project.json` with brand voice, target markets, and GTM-path-to-theme mapping
+
+**Tips**:
+- Set tone, language, and industry conventions during setup — they apply to every generated piece
+- Without a TIPS project the engine uses generic themes; for strategy-connected content, run `/trend-scout` first
+- Bilingual projects: pick `de` or `en` as primary — content can later be regenerated in the other language
+
+## Step 2: Build the Content Strategy (cogni-marketing)
+
+**Command**: `/content-strategy`
+
+**Input**: `marketing-project.json` plus portfolio and trends data
+**Output**: A 3D matrix across markets × GTM paths × content types with priority sequencing
+
+**Tips**:
+- The matrix surfaces gaps — start with the highest-priority cell at the intersection of your most important market and strongest theme
+- Treat the matrix as a plan, not a target — you don't have to fill every cell to ship a campaign
+- Re-run after adding new propositions; the diff shows where coverage changed
+
+## Step 3: Generate Content (cogni-marketing)
+
+**Command**: One per funnel stage:
+
+| Funnel stage | Content type | Command |
+|--------------|--------------|---------|
+| Awareness | Thought leadership | `/thought-leadership` |
+| Engagement | Demand generation | `/demand-gen` |
+| Conversion | Lead generation | `/lead-gen` |
+| Decision | Sales enablement | `/sales-enablement` |
+| Account-specific | ABM | `/abm` |
+
+**Input**: `content-strategy.json` plus the format and theme you're targeting
+**Output**: Raw content pieces in up to 16 formats — blog posts, LinkedIn articles and posts, whitepapers, email nurtures, battle cards, one-pagers, video scripts, carousels
+
+**Tips**:
+- Content-writer agents run in parallel — request multiple pieces in one prompt to generate a batch
+- Each piece references the TIPS claims and portfolio propositions it draws from — sourced content traces back to data
+- For named-account work, skip Steps 2–3 and go straight to `/abm` with the target account
+
+## Step 4: Polish with cogni-copywriting
+
+**Command**: `/copywrite <content-path>` per piece, or describe the batch task
+
+**Input**: Raw content from Step 3 (or `arc_id`-tagged narrative for long-form)
+**Output**: Polished pieces optimized for executive readability and channel conventions
+
+**Tips**:
+- Pyramid Principle, BLUF, active voice, readability scoring — the polish skill applies framework-aware rewrites
+- For multi-stakeholder content (whitepapers, executive briefings), run `/review-doc` after polish — five reader personas score and synthesize feedback
+- German content auto-detects and applies Wolf Schneider rules with Amstad readability scoring
+
+## Step 5: Render to Visual (Optional, cogni-visual)
+
+**Command**: Describe the output you want — `/render-html-slides`, web narrative, or a campaign summary deck
+
+**Input**: Long-form polished content from Step 4
+**Output**: A PPTX deck, a scrollable web narrative, or a campaign-summary deck
+
+**Tips**:
+- cogni-visual reads the polished narrative, detects the story arc, and maps content to slide layouts with assertion headlines
+- For a leave-behind document or a microsite, prefer the web-narrative format over slides
+- Stop at Step 4 if the content stays in markdown; visual rendering is opt-in
+
+## Common Pitfalls
+
+- **Channel overload.** 16 formats is what cogni-marketing supports — not a target for one sprint. Start with 3–4 priority channels and expand after the first batch performs.
+- **Skipping the content strategy.** Generating content without the matrix means no coverage visibility. You end up with content for the topics that feel interesting, not the gaps that matter strategically.
+- **Polishing before the strategy is final.** Polish a blog post and then change the GTM path it targets, and you redo the work. Generate first, validate strategy fit, then polish.
+- **Generic content from generic themes.** Shallow TIPS themes or portfolio propositions without market-specific DOES/MEANS produce generic filler. Invest in specific input data before scaling generation.
+
+---
+
+For the narrative tutorial — including the full content-type-to-skill table, parallel generation patterns, campaign orchestration, content-calendar scheduling, and variations matrix — see [`docs/workflows/content-pipeline.md`](../../../../docs/workflows/content-pipeline.md).

--- a/cogni-help/skills/workflow/references/workflows/content-pipeline.md
+++ b/cogni-help/skills/workflow/references/workflows/content-pipeline.md
@@ -73,7 +73,7 @@ graph LR
 
 ## Step 5: Render to Visual (Optional, cogni-visual)
 
-**Command**: Describe the output you want — `/render-html-slides`, web narrative, or a campaign summary deck
+**Command**: Describe the output you want — a presentation, a scrollable web narrative, or a campaign summary deck
 
 **Input**: Long-form polished content from Step 4
 **Output**: A PPTX deck, a scrollable web narrative, or a campaign-summary deck

--- a/cogni-help/skills/workflow/references/workflows/install-to-infographic.md
+++ b/cogni-help/skills/workflow/references/workflows/install-to-infographic.md
@@ -79,4 +79,4 @@ The first-run workflow is complete — you have a working workspace, a branded t
 
 ---
 
-For the narrative tutorial — including platform-specific Claude Code setup links, screenshots, and per-error troubleshooting tables — see [`docs/workflows/install-to-infographic.md`](../../../../docs/workflows/install-to-infographic.md).
+For the narrative tutorial — including platform-specific Claude Code setup links, screenshots, and per-error troubleshooting tables — see [`docs/workflows/install-to-infographic.md`](../../../../../docs/workflows/install-to-infographic.md).

--- a/cogni-help/skills/workflow/references/workflows/install-to-infographic.md
+++ b/cogni-help/skills/workflow/references/workflows/install-to-infographic.md
@@ -1,0 +1,82 @@
+# Workflow: Install to Infographic
+
+**Pipeline**: cogni-workspace → cogni-workspace (themes) → cogni-visual
+**Duration**: 30–60 minutes for first-run setup and a rendered infographic
+**Use case**: First-run capstone — install insight-wave, pick or extract a theme, and render your first infographic to verify Pencil and Excalidraw MCP are wired up
+
+```mermaid
+graph LR
+    A[/plugin marketplace add/] -->|install plugins| B[cogni-workspace]
+    B -->|/manage-workspace + /install-mcp| C[Themes]
+    C -->|/manage-themes + /pick-theme| D[cogni-visual]
+    D -->|.excalidraw + .pen| E[Infographics]
+```
+
+## Step 1: Add the Marketplace and Install Plugins
+
+**Command**: `/plugin marketplace add cogni-work/insight-wave` then `/plugin install <plugin>@insight-wave` for each plugin
+
+**Input**: A working Claude Code session with subscription auth
+**Output**: insight-wave plugins available as slash commands
+
+**Tips**:
+- Start with `cogni-workspace` — it's the foundation every other plugin depends on
+- Enable auto-update inside `/plugin → Marketplaces → insight-wave` so new versions arrive without re-running this step
+- For this workflow you minimally need `cogni-workspace` and `cogni-visual`; install the rest when you reach a follow-on workflow that needs them
+
+## Step 2: Initialize the Workspace and Install MCP Servers
+
+**Command**: `/manage-workspace` then `/install-mcp`
+
+**Input**: A target directory for the workspace
+**Output**: Workspace folder structure on disk; Pencil, Excalidraw, and claude-in-chrome MCP servers installed
+
+**Tips**:
+- Accept the defaults — `/install-mcp` wires up all three MCP servers in one pass
+- Step 3 uses claude-in-chrome MCP to read your company website; Step 4 uses Pencil and Excalidraw to render
+- Verify with `/workspace-status` — every MCP should report green before continuing
+
+## Step 3: Build a Theme
+
+**Command**: `/manage-themes extract https://your-company.com` then `/pick-theme`
+
+**Input**: A public-facing company URL (or a PowerPoint template, or a preset)
+**Output**: A workspace theme that every visual plugin inherits
+
+**Tips**:
+- The extractor reads the live site via claude-in-chrome MCP and pulls colors, fonts, and logo
+- Sites behind a login wall — pass a PowerPoint template or pick a preset instead
+- `/pick-theme` makes the theme the default for slides, infographics, dashboards, and websites
+
+## Step 4: Render the First Infographic
+
+**Command**: `/story-to-infographic --style=sketchnote` then `/story-to-infographic --style=economist`
+
+**Input**: A short narrative paragraph (a 4–6 sentence story works well as the first try)
+**Output**: An `.excalidraw` file (sketchnote preset, hand-drawn) and a `.pen` file (economist preset, editorial)
+
+**Tips**:
+- Run both presets — together they double as a live check that both Pencil and Excalidraw MCP are wired up correctly
+- Both inherit the theme from Step 3, so colors should match your company website
+- Style → renderer mapping: `sketchnote`/`whiteboard` → Excalidraw, `economist`/`editorial`/`data-viz`/`corporate` → Pencil. A blank file usually means a mismatch
+
+## Step 5: Pick a Follow-On Workflow
+
+The first-run workflow is complete — you have a working workspace, a branded theme, and two rendered infographics. From here, pick what you want to produce next:
+
+- **Research a topic with verified sources** → `research-to-report`
+- **Position a product for a market** → `portfolio-to-pitch`
+- **Scout industry trends** → `trends-to-solutions`
+- **Build multi-channel marketing content** → `content-pipeline`
+- **Generate a website from your portfolio** → `portfolio-to-website`
+- **Run a structured consulting engagement** → `consulting-engagement`
+
+## Common Pitfalls
+
+- **MCP not running.** A "Pencil MCP not available" or "Excalidraw MCP not available" error almost always means the MCP server is installed but not started. Run `/mcp` to see status, or re-run `/install-mcp <name>` and restart the Claude session.
+- **Style/renderer mismatch.** The renderer dispatches off the `--style` flag. `sketchnote` produces an Excalidraw file; `economist` produces a Pencil file. Asking for a preset whose MCP isn't running fails silently — confirm both work in Step 4 before relying on either downstream.
+- **Workspace not initialized.** Skipping `/manage-workspace` leaves theme extraction with nowhere to write the theme. Always run it before `/manage-themes`.
+
+---
+
+For the narrative tutorial — including platform-specific Claude Code setup links, screenshots, and per-error troubleshooting tables — see [`docs/workflows/install-to-infographic.md`](../../../../docs/workflows/install-to-infographic.md).

--- a/cogni-help/skills/workflow/references/workflows/portfolio-to-website.md
+++ b/cogni-help/skills/workflow/references/workflows/portfolio-to-website.md
@@ -94,4 +94,4 @@ graph LR
 
 ---
 
-For the narrative tutorial — including the full prerequisite matrix, deployable artifact list, and related-guide cross-references — see [`docs/workflows/portfolio-to-website.md`](../../../../docs/workflows/portfolio-to-website.md).
+For the narrative tutorial — including the full prerequisite matrix, deployable artifact list, and related-guide cross-references — see [`docs/workflows/portfolio-to-website.md`](../../../../../docs/workflows/portfolio-to-website.md).

--- a/cogni-help/skills/workflow/references/workflows/portfolio-to-website.md
+++ b/cogni-help/skills/workflow/references/workflows/portfolio-to-website.md
@@ -1,0 +1,97 @@
+# Workflow: Portfolio to Website
+
+**Pipeline**: cogni-portfolio → cogni-workspace → cogni-website
+**Duration**: 2–4 hours for a complete multi-page customer website
+**Use case**: Generate a deployable static site directly from the portfolio model — service pages, product pages, customer landing pages — themed to match the rest of your deliverables
+
+```mermaid
+graph LR
+    A[cogni-portfolio] -->|propositions + features + customers| B[cogni-website]
+    T[cogni-workspace] -->|theme + brand vars| B
+    M[cogni-marketing] -.->|blog + lead-gen| B
+    R[cogni-trends] -.->|insights pages| B
+    B -->|website/| D[Deployable site]
+```
+
+## Step 1: Confirm Portfolio is Ready (cogni-portfolio)
+
+**Command**: `/portfolio-resume` (or check via `Show portfolio status`)
+
+**Input**: An existing cogni-portfolio project with at least one product, propositions, and customer profiles
+**Output**: Confirmation of which portfolio entities the website will draw from
+
+**Tips**:
+- Propositions become page headlines, features become capability lists, customer narratives become case-study blocks
+- If propositions or customer profiles are missing, generate them first via `/propositions` and `/customers` — the website plan keys off them
+- Operational-only portfolio entities (markets without propositions) won't reach the site
+
+## Step 2: Pick or Confirm a Theme (cogni-workspace)
+
+**Command**: `/pick-theme`
+
+**Input**: An available workspace theme (extracted via `/manage-themes` or a preset)
+**Output**: A workspace-stored active theme that cogni-website inherits
+
+**Tips**:
+- Theme drives colors, fonts, and design variables across every page
+- Switching the theme later and re-running `/website-build` reskins the entire site — theme changes are global
+- If you don't have a theme yet, run the `install-to-infographic` workflow first to extract one
+
+## Step 3: Set Up the Website Project (cogni-website)
+
+**Command**: `/website-setup`
+
+**Input**: A target directory plus a few configuration answers (target market, primary CTA, language)
+**Output**: `website-project.json` with discovered portfolio entities and project config
+
+**Tips**:
+- The setup walks through optional content sources — cogni-marketing for blog/lead-gen pages, cogni-trends for insights pages, cogni-research for whitepapers
+- Skip optional sources you don't have content for; they can be added on a later run
+- The chosen language is the site's primary language — German content lands as `de`
+
+## Step 4: Plan the Sitemap (cogni-website)
+
+**Command**: `/website-plan`
+
+**Input**: `website-project.json` plus the available content sources
+**Output**: `website-plan.json` — sitemap, content map, navigation flow
+
+**Tips**:
+- Review and adjust priorities before building — the planner picks defaults but the running order shapes the homepage
+- Pages with shallow content sources (a proposition without a customer narrative) generate thin landing pages — fill the gap in cogni-portfolio first or drop the page from the plan
+- Re-run `/website-plan` after adding new propositions; the diff shows what the build will change
+
+## Step 5: Build the Site (cogni-website)
+
+**Command**: `/website-build`
+
+**Input**: `website-plan.json`
+**Output**: Rendered `website/{page-slug}.html` files plus `website/assets/` (themed CSS, JS, hero imagery)
+
+**Tips**:
+- Build dispatches the `site-assembler` agent, which renders every page from the plan in parallel
+- If Pencil MCP is available, the `hero-renderer` agent generates hero imagery for landing pages — without Pencil, hero blocks fall back to themed gradients
+- Only modified pages rebuild on subsequent runs; full rebuild on theme change
+
+## Step 6: Preview and Iterate (cogni-website)
+
+**Command**: `/website-preview`
+
+**Input**: The built `website/` directory
+**Output**: A local browser preview via claude-in-chrome MCP
+
+**Tips**:
+- Iterate on theme tweaks, copy edits, or page additions by re-running `/website-build` after changes
+- For deployment, the `website/` directory is self-contained — push it to any static host (Netlify, GitHub Pages, S3)
+- Add legally required pages — `/website-legal` generates Impressum, Datenschutzerklärung, and cookie notices for the configured jurisdiction
+
+## Common Pitfalls
+
+- **Missing propositions or customers.** The website plan needs propositions to fill service-page headlines and customer profiles to seed landing pages. Generating the site before the portfolio is populated produces a thin three-page placeholder.
+- **Theme not picked before build.** `/website-build` reads the active theme from workspace state. Without a chosen theme, the build falls back to the default and the site visually drifts from your slides and dashboards.
+- **Pencil MCP missing for hero imagery.** The `hero-renderer` agent needs Pencil MCP. Without it, hero sections render as themed gradients — usable, but not the AI-generated imagery you're seeing in demos.
+- **Optional sources not installed.** Adding cogni-marketing or cogni-trends after `/website-plan` requires re-running plan and build to pick up the new pages.
+
+---
+
+For the narrative tutorial — including the full prerequisite matrix, deployable artifact list, and related-guide cross-references — see [`docs/workflows/portfolio-to-website.md`](../../../../docs/workflows/portfolio-to-website.md).

--- a/cogni-help/skills/workflow/references/workflows/portfolio-to-website.md
+++ b/cogni-help/skills/workflow/references/workflows/portfolio-to-website.md
@@ -83,7 +83,6 @@ graph LR
 **Tips**:
 - Iterate on theme tweaks, copy edits, or page additions by re-running `/website-build` after changes
 - For deployment, the `website/` directory is self-contained — push it to any static host (Netlify, GitHub Pages, S3)
-- Add legally required pages — `/website-legal` generates Impressum, Datenschutzerklärung, and cookie notices for the configured jurisdiction
 
 ## Common Pitfalls
 


### PR DESCRIPTION
Closes #147.

## Summary
- Add three workflow playbook templates so `/workflow` covers every canonical ID in `docs/workflows/`: `install-to-infographic.md`, `portfolio-to-website.md`, `content-pipeline.md`.
- Update `cogni-help/skills/workflow/SKILL.md`: bump bundled-count from six to nine, add three rows to the Available Workflows table, and replace the three `— (no template yet)` rows in the docs/ cross-reference table with proper 1:1 pairs. User-facing count updated from 4 to 7.
- Update `cogni-help/skills/workflow/references/canonical-workflows.md`: flip the three `add` rows to `completed by #147` and refresh the coverage check (6 → 9 templates).
- Bump `cogni-help` version 0.1.2 → 0.1.3 in both `plugin.json` and `marketplace.json` (per insight-wave version mirroring rule).

## Scope decisions
- **In scope:** the three templates, the SKILL.md table updates, the reconciliation map flip, the version bump. Pipeline shape, step count, and step labels for each new template are sourced verbatim from the corresponding `docs/workflows/<id>.md` guide — no invented steps. Tutorial-voiced "why" narrative and variations stay docs-side; templates link back to the docs guide from a footer.
- **Voice:** templates follow the existing `portfolio-to-pitch.md` / `research-to-report.md` shape — Pipeline header, mermaid diagram, per-step `Command` / `Input` / `Output` / `Tips` blocks, then a `Common Pitfalls` section, and a footer line referencing the docs guide.
- **Out of scope (deferred):** Phase-3 workflow-tour course reference files (#150), guide plugin-catalog and cheatsheet cross-reference updates (#151). Both were gated by templates existing — this PR unblocks them.

## Test plan
- [ ] `ls cogni-help/skills/workflow/references/workflows/` shows nine `.md` files including the three new ones.
- [ ] Each new template opens with a valid mermaid block, a numbered step list, and a Common Pitfalls section.
- [ ] `/workflow install-to-infographic`, `/workflow portfolio-to-website`, `/workflow content-pipeline` each render the new template end-to-end.
- [ ] `/workflow` with no argument shows the updated Available Workflows table with all nine entries.
- [ ] `cogni-help/.claude-plugin/plugin.json` `version` reads `0.1.3` and the `cogni-help` entry in `.claude-plugin/marketplace.json` mirrors it.
- [ ] Each new template's footer links back to the matching `docs/workflows/<id>.md`.
- [ ] No step in the new templates references a command or plugin not present in the source docs guide.
