### PR TITLE
cogni-help: scaffold 7 workflow-tour course files

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -127,7 +127,7 @@
     {
       "name": "cogni-help",
       "source": "./cogni-help",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "maturity": "preview",
       "description": "Central help hub for the insight-wave ecosystem. Interactive courses (12-course curriculum), plugin discovery, cross-plugin workflow guides, troubleshooting, quick-reference cheatsheets, and GitHub issue filing.",
       "keywords": [

--- a/cogni-help/.claude-plugin/plugin.json
+++ b/cogni-help/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-help",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Central help hub for the insight-wave ecosystem. Interactive courses (12-course curriculum), plugin discovery, cross-plugin workflow guides, troubleshooting, quick-reference cheatsheets, and GitHub issue filing.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-help/skills/teach/references/courses/tours/tour-consulting-engagement.md
+++ b/cogni-help/skills/teach/references/courses/tours/tour-consulting-engagement.md
@@ -1,0 +1,279 @@
+# Tour: Consulting Engagement
+
+**Duration**: 75 minutes | **Modules**: 5 | **Track**: Workflow-tour
+**Pipeline**: cogni-consulting setup → Discover → Define → Develop → Deliver
+**Prerequisites**: Course 11 (Consulting Orchestration); Courses 4-8 deepen each phase
+**Audience**: Consultants running structured Double Diamond engagements
+
+---
+
+This tour walks the cogni-consulting Double Diamond engagement as one workflow.
+You set up an engagement, run the four phases (Discover → Define → Develop →
+Deliver) with their dispatched plugins, and produce final deliverables. Plugin-track
+prerequisites cover the dispatched plugins in depth; this tour focuses on the
+phase orchestration.
+
+## Module 1: Setup & Vision Framing
+
+### Theory (6 min)
+
+`cogni-consulting` orchestrates the British Design Council's Double Diamond model:
+divergent-convergent thinking applied twice — once to the problem (Discover →
+Define) and once to the solution (Develop → Deliver). Each phase has gates;
+each gate has success criteria.
+
+The setup phase frames the engagement: client name, scope, vision statement,
+phase gate criteria. The vision statement is high-leverage — every subsequent
+phase tests itself against the vision. Without it, phases drift.
+
+`consulting-project.json` tracks phase progress, dispatched plugins, and gate
+sign-offs. This is the engagement's audit trail.
+
+### Demo
+
+Run `/consulting-setup`:
+1. Enter client name, scope, and a draft vision statement.
+2. Define gate criteria for each phase (what does "Discover complete" mean?).
+3. Show the produced `consulting-project.json`.
+4. Show how the orchestrator will dispatch to plugins per phase.
+
+### Exercise
+
+Have the learner draft a vision statement for a real engagement they're working
+on (or a hypothetical one). Test it: is it specific enough that you could fail
+to deliver it?
+
+### Quiz
+
+1. Why does the Double Diamond apply divergence-convergence twice?
+   **Answer**: First diamond explores the problem space (Discover diverges, Define
+   converges); second explores the solution space (Develop diverges, Deliver
+   converges). Solving the wrong problem with the right solution is the failure
+   mode each diamond prevents.
+
+2. **Hands-on**: Open `consulting-project.json` after setup and find the gate
+   criteria. Are they testable?
+
+### Recap
+
+- Double Diamond: Discover → Define → Develop → Deliver, each with gates
+- Vision statement is high-leverage — it tests every phase's output
+- `consulting-project.json` is the engagement audit trail
+- Set gate criteria upfront; they prevent ambiguous phase advances
+
+---
+
+## Module 2: Discover Phase
+
+### Theory (6 min)
+
+The Discover phase diverges to build a rich understanding of the problem
+landscape. `/consulting-discover` dispatches to `cogni-research` (targeted
+deep-dives on specific questions) and `cogni-trends` (mapping the strategic
+trend landscape).
+
+The phase is about breadth. Cast a wide net — gathering signals you'll converge
+on in Define. The temptation is to skip ahead to solutions; resist it. Define
+phase quality depends on Discover thoroughness.
+
+Key outputs: research findings, trend analysis, landscape map, stakeholder
+interview notes (if conducted offline).
+
+### Demo
+
+Run `/consulting-discover`:
+1. Dispatch cogni-research with a specific deep-dive question.
+2. Dispatch cogni-trends to map the trend landscape.
+3. Show the produced research artifacts and TIPS project.
+4. Walk through the landscape map output.
+
+If the engagement has stakeholder interview notes, show how to import them as
+structured context for Define.
+
+### Exercise
+
+For the engagement framed in Module 1, draft three Discover questions: one for
+deep research, one for trend scouting, one for stakeholder interviews. Run at
+least one via `/consulting-discover`.
+
+### Quiz
+
+1. Why is Discover about breadth, not depth?
+   **Answer**: Depth on the wrong question wastes time; breadth surfaces the right
+   questions. Define is where breadth converges to focus — Discover's job is to
+   give Define enough material.
+
+2. **Hands-on**: After running `/consulting-discover`, find one finding you didn't
+   anticipate. That's the value of breadth — surfacing the unknown unknowns.
+
+### Recap
+
+- Discover diverges; gather signals broadly
+- Dispatches to cogni-research (deep-dives) and cogni-trends (landscape)
+- Don't skip to solutions; Define depends on Discover thoroughness
+- Stakeholder interview notes can be imported as structured context
+
+---
+
+## Module 3: Define Phase
+
+### Theory (6 min)
+
+The Define phase converges from discovery insights to a clear problem statement.
+`/consulting-define` dispatches to `cogni-portfolio` (propositions),
+`cogni-consulting` lean canvas methods (business-model-hypothesis vision class),
+and `cogni-narrative` (problem framing).
+
+This is where breadth becomes focus. Select the strongest opportunities surfaced
+in Discover; reject the rest. The lean canvas methods test business model
+hypotheses quickly — does this opportunity make sense as a business?
+
+Key outputs: defined problem space, portfolio propositions, business model
+hypothesis, problem-framing narrative.
+
+### Demo
+
+Run `/consulting-define`:
+1. Review Discover artifacts.
+2. Pick 1-3 opportunities to converge on.
+3. Dispatch cogni-portfolio for IS/DOES/MEANS propositions.
+4. Use lean canvas methods to test business model viability.
+5. Run cogni-narrative for problem framing.
+
+### Exercise
+
+For the engagement, take three opportunities from Discover and rank them by:
+business model viability, alignment with the vision, evidence strength. Pick the
+top one to converge on.
+
+### Quiz
+
+1. **Multiple choice**: Define produces a problem statement. What's the test for "good"?
+   - a) Specific enough that you could fail to solve it — b) Broad enough to cover
+     all opportunities — c) Aligned with the vision — d) Approved by the client
+   **Answer**: a (specificity is the test; broad statements lead to fuzzy solutions)
+
+2. **Hands-on**: Compare your problem statement to the engagement vision. Does
+   solving the problem advance the vision? If not, redefine.
+
+### Recap
+
+- Define converges; pick the strongest opportunities
+- Dispatches to cogni-portfolio (propositions), lean canvas (hypothesis), cogni-narrative (framing)
+- Test business model viability before committing
+- Problem statement test: specific enough to fail
+
+---
+
+## Module 4: Develop Phase
+
+### Theory (6 min)
+
+The Develop phase diverges to generate and explore solution options.
+`/consulting-develop` dispatches to `cogni-copywriting` (polish), `cogni-narrative`
+(solution story), and `cogni-claims` (verify).
+
+Develop is about quality — take time to polish and verify. Run claims verification
+before any client-facing content. The Develop phase produces the artifacts that
+will become Deliverables, so quality compounds.
+
+Stakeholder review (via `cogni-copywriting`) pressure-tests the narrative from
+multiple perspectives — buyer, sales, marketer, technical reviewer. Verbal
+agreement in a meeting is not the same as multi-stakeholder review.
+
+Key outputs: polished solution narrative, verified claims, refined content.
+
+### Demo
+
+Run `/consulting-develop`:
+1. Take the problem statement from Define.
+2. Generate 2-3 solution options via cogni-narrative.
+3. Polish each via `/copywrite`.
+4. Run `/verify-claims` against the polished narrative.
+5. Run `/review-doc` for stakeholder-perspective scoring.
+
+### Exercise
+
+For one solution option, run the full polish + verify + review chain. Note where
+each step caught issues the previous didn't.
+
+### Quiz
+
+1. Why run claims verification in Develop, not Deliver?
+   **Answer**: Verification surfaces source quality issues that take time to fix.
+   In Deliver, you don't have time. Verifying in Develop keeps Deliver focused
+   on packaging.
+
+2. **Hands-on**: After `/review-doc`, identify one stakeholder perspective that
+   raised an issue the others missed. That's why multi-perspective review matters.
+
+### Recap
+
+- Develop diverges (solution options) but emphasizes quality
+- Dispatches to cogni-copywriting (polish), cogni-narrative (story), cogni-claims (verify)
+- Multi-stakeholder review pressure-tests beyond verbal agreement
+- Verify in Develop; Deliver focuses on packaging
+
+---
+
+## Module 5: Deliver Phase
+
+### Theory (6 min)
+
+The Deliver phase converges on validated, actionable outcomes.
+`/consulting-deliver` dispatches to `cogni-visual` (slides/maps), `cogni-sales`
+(pitch), and `cogni-marketing` (go-to-market materials).
+
+Match deliverable format to audience: exec deck for sponsors, detailed report for
+operations, sales pitch for revenue teams, marketing campaign for external launch.
+Often a single engagement produces multiple deliverable formats from the same
+Develop output.
+
+For sales-oriented engagements, dispatch cogni-sales for the pitch deck. For
+marketing-oriented engagements, dispatch cogni-marketing for GTM materials. For
+strategic engagements, both.
+
+`/consulting-export` packages final deliverables into a single bundle — PPTX,
+DOCX, XLSX, Excalidraw, themed HTML — for client handoff.
+
+### Demo
+
+Run `/consulting-deliver` followed by `/consulting-export`:
+1. Pick deliverable formats based on the engagement's audience mix.
+2. Dispatch cogni-visual for slides and any architecture diagrams.
+3. Dispatch cogni-sales if a pitch is needed.
+4. Dispatch cogni-marketing if GTM materials are needed.
+5. Run `/consulting-export` for the bundled handoff.
+
+### Exercise
+
+For the engagement, decide the audience mix (sponsor, ops, sales, external) and
+pick the matching deliverable formats. Justify each format choice in one sentence.
+
+### Quiz
+
+1. Why does Deliver produce multiple formats from one Develop output?
+   **Answer**: Different audiences consume content differently. Same insight, three
+   formats — exec deck for board, detailed report for ops, pitch for sales.
+
+2. **Hands-on**: Run `/consulting-export` and open the bundle. Confirm every
+   deliverable is present and themed consistently.
+
+### Recap
+
+- Deliver converges on validated outcomes; multiple formats possible
+- Dispatches to cogni-visual (slides), cogni-sales (pitch), cogni-marketing (GTM)
+- Match format to audience: sponsor, ops, sales, external
+- `/consulting-export` bundles the handoff package
+
+---
+
+## Tour Complete
+
+Next steps:
+- Run the engagement against a real client problem
+- Use `tour-research-to-report` for deeper Discover work
+- Use `tour-portfolio-to-pitch` for sales-oriented engagements
+- Use `tour-trends-to-solutions` for marketing-oriented engagements
+- See the canonical playbook: `cogni-help/skills/workflow/references/workflows/consulting-engagement.md`
+- See the narrative tutorial: `docs/workflows/consulting-engagement.md`

--- a/cogni-help/skills/teach/references/courses/tours/tour-content-pipeline.md
+++ b/cogni-help/skills/teach/references/courses/tours/tour-content-pipeline.md
@@ -1,0 +1,288 @@
+# Tour: Content Pipeline
+
+**Duration**: 75 minutes | **Modules**: 5 | **Track**: Workflow-tour
+**Pipeline**: cogni-marketing → cogni-narrative (long-form only) → cogni-copywriting → cogni-visual
+**Prerequisites**: Course 9 (B2B Marketing), Course 3 (Basic Tools), Course 7 (Visual Deliverables)
+**Audience**: Marketing teams producing multi-channel content sourced from portfolio + trends data
+
+---
+
+This tour walks the content-pipeline workflow as one continuous chain. You set up
+a marketing project, build a content strategy, generate raw content, polish it,
+and optionally render it visually. Plugin-track prerequisites cover each plugin
+in depth; this tour focuses on the chain — especially the narrative-bridge
+decision (skip for short-form, run for long-form).
+
+## Module 1: Set Up the Marketing Project (cogni-marketing)
+
+### Theory (6 min)
+
+`cogni-marketing` orchestrates content production around a project that links
+brand voice, target markets, and GTM-path-to-theme mapping. The setup step
+configures all three.
+
+Brand voice: tone, language, industry conventions, voice attributes.
+Target markets: the markets the content will address (DACH, US, FR, etc.).
+GTM-path-to-theme mapping: which strategic themes drive which go-to-market paths.
+
+Two upstream dependencies feed the project: `cogni-portfolio` provides
+propositions (the IS/DOES/MEANS the content sells), `cogni-trends` provides
+investment themes (the strategic context). Without portfolio, content has no
+"what we sell"; without trends, content has no "why now". Both can be optional —
+the engine uses generic themes if cogni-trends is missing — but the result is
+generic content.
+
+For DACH content, set `language: de` during setup. The pipeline auto-applies
+Wolf Schneider rules with Amstad readability scoring during polish.
+
+### Demo
+
+Run `/marketing-setup`:
+1. Link the cogni-portfolio project.
+2. Optionally link a cogni-trends TIPS project.
+3. Configure brand voice (tone, language, voice attributes).
+4. Configure target markets.
+5. Map GTM paths to themes.
+6. Show the produced `marketing-project.json`.
+
+### Exercise
+
+For a real campaign the team needs, draft the brand voice (3-5 voice attributes)
+and decide which markets and GTM paths apply. Run setup with these answers.
+
+### Quiz
+
+1. Why does the marketing project need both portfolio and trends as inputs?
+   **Answer**: Portfolio provides "what we sell" (IS/DOES/MEANS), trends provide
+   "why now" (strategic context). Without both, content is either feature-list
+   or trend-talk — not GTM content.
+
+2. **Hands-on**: Open `marketing-project.json` and confirm the GTM-path-to-theme
+   mapping. Does each GTM path have at least one theme?
+
+### Recap
+
+- Setup configures brand voice, markets, and GTM-path-to-theme mapping
+- Portfolio + trends are upstream dependencies; both feed the engine
+- DACH content auto-applies Wolf Schneider + Amstad readability scoring
+- The mapping is the planning grid for downstream content generation
+
+---
+
+## Module 2: Build the Content Strategy (cogni-marketing)
+
+### Theory (6 min)
+
+`/content-strategy` produces a 3D matrix: markets × GTM paths × content types.
+The matrix surfaces gaps — which intersections lack content. Treat the matrix
+as a plan, not a target — you don't need to fill every cell to ship a campaign.
+
+The strategy step is the converging move: with the matrix in hand, you pick
+high-priority cells (most important market × strongest theme × highest-leverage
+format) and commit to producing content for those. Without strategy, you produce
+content for whatever felt interesting last week.
+
+Re-run after adding new propositions or themes; the diff shows where coverage
+changed.
+
+### Demo
+
+Run `/content-strategy`:
+1. Watch the matrix assemble across markets × GTM paths × content types.
+2. Identify the highest-priority cell (where market importance × theme strength × format leverage is maximal).
+3. Show the gap visualization — cells with no content yet.
+4. Open `content-strategy.json` and review priorities.
+
+### Exercise
+
+Pick three high-priority cells from the matrix. For each, decide which content
+format and which funnel stage best fits. Justify in one sentence per cell.
+
+### Quiz
+
+1. Why is the strategy step converging while the matrix is comprehensive?
+   **Answer**: The matrix shows possibility; strategy picks priorities. Without
+   prioritization, teams produce a uniform spread of content with no campaign
+   shape.
+
+2. **Hands-on**: Find one cell in the matrix that has shallow input data (a
+   market without a TIPS theme). Decide: drop the cell, or fill the input?
+
+### Recap
+
+- 3D matrix: markets × GTM paths × content types — surfaces gaps
+- Strategy converges from possibility to priority
+- Re-run after upstream changes; the diff drives campaign updates
+- Matrix is the planning grid; strategy is the prioritized plan
+
+---
+
+## Module 3: Generate Content (cogni-marketing)
+
+### Theory (8 min)
+
+`cogni-marketing` exposes one skill per funnel stage:
+
+| Funnel stage | Skill | Output formats |
+|--------------|-------|----------------|
+| Awareness | `/thought-leadership` | Blog, LinkedIn article, keynote, podcast outline, op-ed |
+| Engagement | `/demand-gen` | LinkedIn posts, SEO articles, carousels, video scripts, infographics |
+| Conversion | `/lead-gen` | Whitepaper, landing page, email nurture, webinar outline, gated checklist |
+| Decision | `/sales-enablement` | Battle card, one-pager, demo script, objection handler, proposal section |
+| Account-specific | `/abm` | Account plan, personalized email sequence, executive briefing |
+
+Each skill reads the marketing project, picks relevant propositions and themes,
+and generates content tagged with provenance — every piece references the
+propositions and themes it draws from.
+
+Content-writer agents run in parallel — request multiple pieces in one prompt to
+generate a batch. For named-account work, skip strategy and go straight to
+`/abm` with the target account.
+
+### Demo
+
+Pick the highest-priority cell from Module 2. Run the matching skill:
+1. Pick funnel stage and content type.
+2. Configure: market, GTM path, propositions to anchor.
+3. Watch the content-writer produce raw content.
+4. Open the produced file — show the provenance tags (proposition refs, theme refs).
+
+### Exercise
+
+Generate two pieces from different funnel stages for the same market × GTM path:
+one awareness piece (`/thought-leadership`) and one conversion piece (`/lead-gen`).
+Compare how each adapts the same source data to channel conventions.
+
+### Quiz
+
+1. **Multiple choice**: A team needs a battle card for a specific competitor in
+   a specific market. Which skill?
+   - a) `/demand-gen` — b) `/sales-enablement` — c) `/abm` — d) `/lead-gen`
+   **Answer**: b (battle cards are decision-stage sales enablement)
+
+2. **Hands-on**: Compare a `/thought-leadership` blog post to a `/demand-gen`
+   LinkedIn carousel for the same theme. How does channel convention shape voice?
+
+### Recap
+
+- Five funnel-stage skills covering 16 content formats
+- Provenance tags on every piece — content traces back to data
+- Parallel generation: request batches in one prompt
+- ABM bypasses strategy; goes account-first
+
+---
+
+## Module 4: Polish with cogni-copywriting
+
+### Theory (6 min)
+
+`cogni-copywriting` polishes raw content for executive readability and channel
+conventions. The polish skill applies framework-aware rewrites: Pyramid Principle,
+BLUF (Bottom Line Up Front), active voice, readability scoring.
+
+For long-form content (thought leadership, whitepapers, keynote abstracts),
+`cogni-narrative` should run between generation and polish — it applies a story
+arc framework and writes `arc_id` frontmatter that cogni-copywriting reads for
+arc-aware polishing. Short-form formats (LinkedIn posts, battle cards, emails)
+skip the narrative step.
+
+For multi-stakeholder content (whitepapers, executive briefings), run
+`/review-doc` after polish — five reader personas score and synthesize feedback.
+This is the closest thing to a real audience test before publication.
+
+For German content, the polish skill auto-detects and applies Wolf Schneider
+rules with Amstad readability scoring (German equivalent of Flesch-Kincaid).
+
+### Demo
+
+Polish one long-form piece from Module 3:
+1. Run `/narrate` on the raw content (long-form only).
+2. Run `/copywrite <path>` on the narrative-shaped content.
+3. Run `/review-doc` for stakeholder feedback.
+4. Compare raw, narrated, polished, reviewed versions.
+
+### Exercise
+
+For one short-form piece (e.g. LinkedIn post), run `/copywrite` directly (skip
+the narrative step). For one long-form piece (e.g. whitepaper), run the full
+chain. Compare how the narrative step shapes the long-form differently.
+
+### Quiz
+
+1. Why skip cogni-narrative for short-form content?
+   **Answer**: Short-form content (a 200-word LinkedIn post) doesn't have room
+   for a story arc. The narrative step adds overhead without adding insight.
+
+2. **Hands-on**: Run `/review-doc` and identify one finding from a stakeholder
+   perspective you didn't anticipate. That's the value of multi-perspective review.
+
+### Recap
+
+- Polish applies framework-aware rewrites: Pyramid, BLUF, active voice, readability
+- Long-form gets cogni-narrative first; short-form skips it
+- `/review-doc` for multi-stakeholder content — five reader personas
+- DACH content auto-applies Wolf Schneider + Amstad
+
+---
+
+## Module 5: Render Visually & Recap (cogni-visual, optional)
+
+### Theory (4 min)
+
+`cogni-visual` is optional in the content pipeline. Stop at Step 4 if the content
+stays in markdown — blog posts, LinkedIn articles, whitepapers don't need a
+slide layer. Run cogni-visual when the content needs a visual deliverable:
+
+- **Presentation deck** — `/render-slides` for keynote, exec briefing, sales deck
+- **Web narrative** — `/story-to-web` for scrollable single-page documents
+- **Infographic** — `/story-to-infographic` for one-page visual summaries
+- **Campaign summary deck** — for internal review or board updates
+
+The renderer reads the story arc from the polished narrative and maps content to
+slide layouts with assertion headlines. Theme inheritance applies — the active
+workspace theme drives every visual deliverable.
+
+For campaign orchestration, `/campaign-builder` chains pieces into a multi-channel
+sequence with day-based timelines. `/marketing-dashboard` visualizes content
+coverage and campaign progress.
+
+### Demo
+
+Render one polished long-form piece as both a deck and a web narrative:
+1. Run `/render-slides` on the polished whitepaper.
+2. Run `/story-to-web` on the same source.
+3. Compare the two outputs.
+4. Run `/marketing-dashboard` to see the full project state.
+
+### Exercise
+
+For the engagement, decide which pieces need a visual layer and which stay in
+markdown. Justify each choice based on the consumption channel.
+
+### Quiz
+
+1. Why is cogni-visual optional in this pipeline?
+   **Answer**: Most marketing content is consumed in markdown-rendering channels
+   (blog, email, social). Visual rendering is for presentation, web-narrative,
+   and infographic deliverables.
+
+2. **Hands-on**: Open `/marketing-dashboard` and find one campaign with thin
+   visual coverage. Decide whether to render or leave as markdown.
+
+### Recap
+
+- cogni-visual is opt-in; not every content piece needs a visual layer
+- Render targets: slides, web narrative, infographic, campaign deck
+- `/campaign-builder` sequences touchpoints; `/marketing-dashboard` visualizes coverage
+- Match render format to consumption channel
+
+---
+
+## Tour Complete
+
+Next steps:
+- Run the pipeline for a real campaign
+- Combine with `tour-trends-to-solutions` for trend-anchored content
+- Combine with `tour-portfolio-to-pitch` for sales enablement chains
+- See the canonical playbook: `cogni-help/skills/workflow/references/workflows/content-pipeline.md`
+- See the narrative tutorial: `docs/workflows/content-pipeline.md`

--- a/cogni-help/skills/teach/references/courses/tours/tour-install-to-infographic.md
+++ b/cogni-help/skills/teach/references/courses/tours/tour-install-to-infographic.md
@@ -1,0 +1,309 @@
+# Tour: Install to Infographic
+
+**Duration**: 45 minutes | **Modules**: 5 | **Track**: Workflow-tour
+**Pipeline**: cogni-workspace → cogni-workspace (themes) → cogni-visual
+**Prerequisites**: Course 2 (Workspace & Obsidian), Course 7 (Visual Deliverables)
+**Audience**: First-time installers — verify the toolchain end-to-end by rendering an infographic
+
+---
+
+This tour is the first-run capstone for the insight-wave ecosystem. You install
+plugins, initialize the workspace, install MCP servers, build a theme from your
+company website (or pick a preset), and render your first infographic. By the
+end, the toolchain is wired up and you've shipped a real deliverable.
+
+If you've already run `install-to-infographic` once, this tour is the refresher
+showing the chain end-to-end. The exercises confirm the chain is healthy.
+
+## Module 1: Install the Marketplace and Plugins
+
+### Theory (5 min)
+
+insight-wave is a 13-plugin Claude Code marketplace. Plugins are installed via
+`/plugin marketplace add cogni-work/insight-wave` followed by
+`/plugin install <plugin>@insight-wave` for each desired plugin.
+
+For this tour you minimally need `cogni-workspace` and `cogni-visual`. Install
+the rest when you reach a follow-on workflow that needs them.
+
+Auto-update: enable inside `/plugin → Marketplaces → insight-wave` so new
+versions arrive without re-running install. Plugin versions live in
+`plugin.json` and are mirrored in the marketplace manifest — auto-update
+detects new versions via marketplace.json.
+
+The 13 plugins span four tiers:
+- Foundation: cogni-workspace, cogni-help, cogni-claims, cogni-wiki
+- Content production: cogni-research, cogni-narrative, cogni-copywriting, cogni-visual
+- Domain pipelines: cogni-trends, cogni-portfolio, cogni-sales, cogni-marketing, cogni-website
+- Meta: cogni-consulting (orchestrates the rest)
+
+### Demo
+
+Install the foundation:
+1. Run `/plugin marketplace add cogni-work/insight-wave`.
+2. Install cogni-workspace: `/plugin install cogni-workspace@insight-wave`.
+3. Install cogni-visual: `/plugin install cogni-visual@insight-wave`.
+4. Confirm via `/plugin` — both should appear as installed.
+5. Show how to enable auto-update.
+
+### Exercise
+
+For the learner's actual setup, confirm the marketplace is added and the two
+foundation plugins are installed. If they want to install more for follow-on
+workflows, do it now in the same step.
+
+### Quiz
+
+1. **Multiple choice**: To run the `research-to-report` workflow, which plugins
+   beyond `cogni-workspace` and `cogni-visual` are needed?
+   - a) cogni-research, cogni-narrative — b) cogni-research only —
+     c) cogni-narrative, cogni-portfolio — d) cogni-trends, cogni-narrative
+   **Answer**: a (research-to-report chains research → narrative → visual)
+
+2. Why does insight-wave use a marketplace pattern rather than per-plugin installs?
+   **Answer**: Centralized version detection, shared dependencies (themes, MCP
+   servers), and atomic updates across the ecosystem.
+
+### Recap
+
+- 13-plugin marketplace; install via `/plugin marketplace add` + per-plugin install
+- For this tour: cogni-workspace + cogni-visual minimum
+- Auto-update via marketplace; marketplace.json mirrors plugin.json versions
+- Install other plugins when reaching follow-on workflows
+
+---
+
+## Module 2: Initialize the Workspace and Install MCP Servers
+
+### Theory (6 min)
+
+`cogni-workspace` is the foundation every other plugin depends on — it owns
+shared state: themes, environment variables, MCP server configuration, and
+workspace health diagnostics.
+
+`/manage-workspace` initializes the workspace folder structure on disk —
+themes/ directory, design-variables defaults, project-config templates.
+`/install-mcp` then installs three MCP servers in one pass:
+- **claude-in-chrome** — browser automation (theme extraction, website preview, claims verification)
+- **excalidraw** — diagram rendering (infographics, concept diagrams, architecture diagrams)
+- **pencil** — editorial visual rendering (Economist-style infographics, slides, posters)
+
+All three are Node-based; install handles dependency setup. The three MCP servers
+together unlock the full visual rendering capability — Excalidraw for hand-drawn
+sketchnote/whiteboard styles, Pencil for editorial styles, claude-in-chrome for
+live web extraction.
+
+### Demo
+
+Initialize the workspace:
+1. Run `/manage-workspace`.
+2. Choose a target directory.
+3. Show the produced folder structure.
+4. Run `/install-mcp` (accept defaults to install all three).
+5. Run `/workspace-status` — every MCP should report green.
+
+If a MCP install fails, show the diagnostic path (`/workspace-status` reports
+red, `/install-mcp <name>` retries the specific server, restart Claude session
+for MCP to reattach).
+
+### Exercise
+
+For the learner's setup, run `/manage-workspace` and `/install-mcp`. Confirm via
+`/workspace-status` that all three MCPs are green. If any are red, troubleshoot
+before continuing.
+
+### Quiz
+
+1. Why does the toolchain need three MCP servers rather than one?
+   **Answer**: Each handles a different rendering style — Excalidraw for hand-drawn,
+   Pencil for editorial, claude-in-chrome for browser-based extraction. They're
+   complementary, not redundant.
+
+2. **Hands-on**: Run `/workspace-status` and identify one component that's not
+   yet configured. Decide whether to fix it now or defer.
+
+### Recap
+
+- `/manage-workspace` initializes folder structure
+- `/install-mcp` installs claude-in-chrome, excalidraw, pencil
+- `/workspace-status` is the health check — all MCPs should be green
+- MCP servers complement: hand-drawn (Excalidraw), editorial (Pencil), browser (chrome)
+
+---
+
+## Module 3: Build a Theme
+
+### Theory (6 min)
+
+A theme is the visual contract every plugin honors. `cogni-workspace` owns themes:
+the active theme drives colors, fonts, and design variables across slides,
+infographics, dashboards, and websites.
+
+Three ways to build a theme:
+- **Extract from a live website** — `/manage-themes extract https://your-company.com`
+  reads the site via claude-in-chrome MCP and pulls colors, fonts, logo
+- **Import from a PowerPoint template** — `/manage-themes import` reads a .pptx
+  template and extracts the slide-master theme
+- **Pick a preset** — `/manage-themes presets` lists curated themes (Economist,
+  Bauhaus, Cogni Default, etc.)
+
+For sites behind a login wall, the extractor can't read them — pass a PowerPoint
+template or pick a preset instead.
+
+`/pick-theme` makes a theme the active default for every visual plugin. Theme
+switches are deliberately global — re-render any deliverable and it picks up
+the new theme.
+
+### Demo
+
+Build a theme:
+1. Pick the source: live website, PowerPoint template, or preset.
+2. For live extraction: `/manage-themes extract https://example.com`.
+3. Watch the extraction phases (claude-in-chrome reads → colors/fonts/logo parsed → theme stored).
+4. Run `/pick-theme` to make it the active default.
+5. Show the design variables the theme defines.
+
+### Exercise
+
+Extract a theme from your own company URL (or pick a preset if the site is
+inaccessible). Make it the active theme via `/pick-theme`. Confirm the design
+variables match your brand.
+
+### Quiz
+
+1. Why is theme switching deliberately global?
+   **Answer**: Visual consistency across deliverables. Per-deliverable theming
+   produces drift; global switching forces deliberate brand decisions.
+
+2. **Hands-on**: Run `/manage-themes` and find one design variable (e.g. primary
+   color hex) that would change if your brand updated.
+
+### Recap
+
+- Themes drive colors, fonts, design variables across all visual plugins
+- Three sources: extract from URL, import from PPTX, pick a preset
+- `/pick-theme` makes a theme global; switches reskin everything
+- Sites behind login walls: use PPTX or preset instead of extraction
+
+---
+
+## Module 4: Render the First Infographic
+
+### Theory (6 min)
+
+`cogni-visual` produces visual deliverables. For first-run verification, the
+ideal test is rendering an infographic in two presets — one Excalidraw-backed
+(sketchnote or whiteboard), one Pencil-backed (economist or editorial). If both
+render successfully, both MCP servers are wired correctly.
+
+Style → renderer mapping:
+- `sketchnote` / `whiteboard` → Excalidraw
+- `economist` / `editorial` / `data-viz` / `corporate` → Pencil
+
+The user provides a short narrative paragraph (a 4-6 sentence story works well as
+the first try). The renderer extracts hero numbers, key claims, and the story
+arc, then assembles the infographic.
+
+A blank file on render usually means the MCP server isn't running. Run `/mcp` to
+check status; re-run `/install-mcp <name>` if needed and restart the session for
+the MCP to reattach.
+
+### Demo
+
+Render two infographics:
+1. Provide a short narrative (4-6 sentences) — a real one from your work, or a
+   sample about a recent industry development.
+2. Run `/story-to-infographic --style=sketchnote` — produces a hand-drawn
+   `.excalidraw` file.
+3. Run `/story-to-infographic --style=economist` — produces an editorial
+   `.pen` file.
+4. Open both. Confirm the theme from Module 3 is applied (colors should match
+   your brand).
+
+### Exercise
+
+For the rendered files, switch the workspace theme via `/pick-theme` and re-render.
+Confirm the theme switch propagates to both the Excalidraw and Pencil outputs.
+
+### Quiz
+
+1. Why render two presets rather than one for the verification test?
+   **Answer**: Two presets confirm both MCP servers are working — Excalidraw for
+   sketchnote, Pencil for economist. One preset only confirms one MCP.
+
+2. **Hands-on**: Run `/story-to-infographic --style=whiteboard`. The output
+   should be a different visual style but the same theme. Confirm.
+
+### Recap
+
+- Two presets verify both MCPs: sketchnote/whiteboard (Excalidraw), economist/editorial (Pencil)
+- A short narrative (4-6 sentences) is enough to test rendering
+- Both presets inherit the active workspace theme
+- Blank file = MCP not running; check `/mcp`, reinstall, restart
+
+---
+
+## Module 5: Pick a Follow-On Workflow
+
+### Theory (5 min)
+
+Install-to-infographic is the bootstrap workflow. By the end of Module 4, the
+toolchain is verified end-to-end — workspace, MCPs, theme, and rendering all work.
+From here, every other workflow in insight-wave builds on this foundation.
+
+Six follow-on workflows cover the most-used paths:
+
+| If you want to... | Run the workflow |
+|-------------------|------------------|
+| Research a topic with verified sources | `tour-research-to-report` |
+| Position a product for a market | `tour-portfolio-to-pitch` |
+| Scout industry trends | `tour-trends-to-solutions` |
+| Build multi-channel marketing content | `tour-content-pipeline` |
+| Generate a website from your portfolio | `tour-portfolio-to-website` |
+| Run a structured consulting engagement | `tour-consulting-engagement` |
+
+Each tour assumes you've completed install-to-infographic — they don't re-explain
+workspace setup, MCP installation, or theme management. They focus on the
+plugin-specific chain.
+
+### Demo
+
+Show the follow-on tour map:
+1. Open `cogni-help/skills/workflow/references/workflows/` — show all 7 templates.
+2. Open `cogni-help/skills/teach/references/courses/tours/` — show all 7 tour courses.
+3. Run `/teach courses` to see the full curriculum.
+4. Pick the most relevant follow-on for the team's actual next deliverable.
+
+### Exercise
+
+Have the learner identify the deliverable they need next quarter. Pick the
+matching follow-on tour. Confirm the prerequisites (plugin-track courses) are
+either complete or the learner accepts the inline-summary fallback.
+
+### Quiz
+
+1. Why does install-to-infographic come first regardless of the team's eventual goal?
+   **Answer**: Every other workflow depends on the workspace + theme + MCP
+   foundation. Skipping the bootstrap leads to broken renders and missing themes
+   downstream.
+
+2. **Hands-on**: Pick a follow-on tour and read its prerequisites. Are the
+   plugin-track courses complete? If not, what's the path to fill them?
+
+### Recap
+
+- install-to-infographic is the bootstrap; every other workflow builds on it
+- Six follow-on tours cover the most-used pipelines
+- Each follow-on assumes workspace + MCP + theme are already set up
+- Pick the follow-on that matches the team's actual next deliverable
+
+---
+
+## Tour Complete
+
+Next steps:
+- Pick a follow-on tour and run it against a real engagement
+- Iterate on the theme as the brand evolves (`/manage-themes` for new extractions)
+- Install additional plugins when a follow-on workflow needs them
+- See the canonical playbook: `cogni-help/skills/workflow/references/workflows/install-to-infographic.md`
+- See the narrative tutorial: `docs/workflows/install-to-infographic.md`

--- a/cogni-help/skills/teach/references/courses/tours/tour-portfolio-to-pitch.md
+++ b/cogni-help/skills/teach/references/courses/tours/tour-portfolio-to-pitch.md
@@ -1,0 +1,266 @@
+# Tour: Portfolio to Pitch
+
+**Duration**: 60 minutes | **Modules**: 5 | **Track**: Workflow-tour
+**Pipeline**: cogni-portfolio → cogni-narrative → cogni-sales → cogni-visual
+**Prerequisites**: Course 6 (Portfolio Messaging), Course 10 (Sales Pitches); Course 7 (Visual) helpful
+**Audience**: Sales creating customer-specific or segment-specific pitch presentations
+
+---
+
+This tour walks the portfolio-to-pitch pipeline as one workflow. You start from
+portfolio propositions, optionally shape a narrative arc, run the Why Change
+methodology, and render an executive pitch deck. Plugin-track prerequisites
+cover each plugin in depth; this tour focuses on the chain.
+
+## Module 1: Pipeline Overview & Customer Setup
+
+### Theory (5 min)
+
+The portfolio-to-pitch pipeline produces a customer-specific or segment-specific
+pitch deck: `cogni-portfolio` provides the proposition (IS/DOES/MEANS) and
+competitive context, `cogni-narrative` shapes a story arc (often optional —
+cogni-sales has Why Change built in), `cogni-sales` runs the Corporate Visions
+Why Change methodology, and `cogni-visual` renders the deck.
+
+Two pitch modes:
+- **Named-customer pitch** — deal-specific, includes customer research, ABM-shaped
+- **Segment pitch** — reusable across similar customers in a market segment
+
+Customer research strengthens named-customer pitches. Without it, the pitch is a
+proposition deck rebranded as a sales tool.
+
+### Demo
+
+Walk the audience through what a pitch artifact set looks like:
+1. Open an example portfolio project — show one proposition.
+2. Open the matching pitch project (if exists) — show `sales-presentation.md`.
+3. Open the rendered slides — point at one Why Change moment.
+
+### Exercise
+
+Have the learner pick a real prospect or market segment they need a pitch for in
+the next quarter. Decide: named-customer or segment? What's the deal value, and
+how much customer research is justified?
+
+### Quiz
+
+1. **Multiple choice**: A sales lead asks for a pitch deck for a new vertical they
+   haven't sold into yet. Named-customer or segment?
+   - a) named-customer — b) segment
+   **Answer**: b (segment — no specific customer yet; reusable across the vertical)
+
+2. Why does the cogni-narrative step sometimes get skipped in this pipeline?
+   **Answer**: cogni-sales has the Why Change arc built in. Adding cogni-narrative
+   on top is for cases where a different arc fits better (SCQA for problem-first audiences).
+
+### Recap
+
+- Two modes: named-customer (deal-specific) or segment (reusable)
+- Pipeline: portfolio → optional narrative → sales (Why Change) → visual
+- Customer research is what turns a deck into a pitch
+
+---
+
+## Module 2: Confirm Portfolio Propositions (cogni-portfolio)
+
+### Theory (6 min)
+
+The pitch deck stands on portfolio data. `cogni-portfolio` provides:
+- **Propositions** — IS/DOES/MEANS per Feature × Market combination
+- **Competitor analysis** — battle cards, positioning, differentiation
+- **Customer profiles** — ICP, buyer personas, buying centers
+- **Market sizing** — TAM/SAM/SOM data for the target segment
+
+For pitches, the most-used outputs are the proposition (the "what we sell"), the
+competitor analysis (the "why us"), and the customer profile (the "who we sell to").
+
+If portfolio data is incomplete (no proposition for the target market, no competitor
+for the named account), the pitch will have gaps that show up as soft assertions.
+Fill the data first; pitch second.
+
+### Demo
+
+Run `/portfolio-resume` or check status:
+1. Confirm a proposition exists for the target market.
+2. Run `/compete` if competitor data is missing.
+3. Run `/customers` if the buyer persona is missing.
+4. Open `portfolio-architecture` to visualize the product-feature structure — confirm
+   nothing is misaligned before building the pitch.
+
+### Exercise
+
+For the prospect/segment chosen in Module 1, confirm portfolio coverage. List which
+of (proposition, competitors, customer profile) are present and which are missing.
+Generate any missing pieces before continuing.
+
+### Quiz
+
+1. Why visualize the portfolio architecture before building a pitch?
+   **Answer**: Architecture surfaces structural gaps (orphan features, propositions
+   without customers); easier to fix at the data layer than at the pitch layer.
+
+2. **Hands-on**: Run `/portfolio-architecture` and find one orphan entity (a feature
+   without a proposition, or a proposition without customer evidence).
+
+### Recap
+
+- Pitches stand on three pillars: proposition, competitor analysis, customer profile
+- Fill portfolio data first; pitch second
+- `portfolio-architecture` surfaces gaps before they hit the pitch
+- Customer-specific pitches need customer-specific value — don't reuse segment DOES/MEANS
+
+---
+
+## Module 3: Optional Narrative Shaping (cogni-narrative)
+
+### Theory (5 min)
+
+For most sales pitches, skip cogni-narrative — `cogni-sales` has the Why Change arc
+built in (Corporate Visions methodology: Why Change → Why Now → Why You → Why Pay).
+That arc fits enterprise B2B pitch deals.
+
+When to add cogni-narrative on top:
+- The audience is problem-first (SCQA fits better than Why Change)
+- The deal is consultative (Hero's Journey fits the transformation story)
+- The pitch leads with a strategic point of view (Minto Pyramid fits)
+
+If unsure, skip the narrative step. cogni-sales produces a workable arc by default.
+
+### Demo
+
+Show one named-customer pitch with `cogni-sales` only, and one with `cogni-narrative`
+in front. Compare the opening slide:
+- Sales-only: opens with a "Why Change" provocation (the unconsidered need)
+- Narrative-shaped: opens with the arc the narrative chose (often Situation/Complication)
+
+### Exercise
+
+For the pitch chosen in Module 1, decide: skip the narrative step, or run it. Justify
+the choice in one sentence based on the audience.
+
+### Quiz
+
+1. **Multiple choice**: A pitch to a CFO who wants the recommendation upfront — which arc?
+   - a) Why Change — b) SCQA — c) Minto Pyramid — d) Hero's Journey
+   **Answer**: c (Minto leads with the recommendation; CFOs want the answer first)
+
+2. Why is "skip cogni-narrative" the default for sales pitches?
+   **Answer**: cogni-sales has Why Change built in; doubling up adds overhead without
+   improving most enterprise B2B pitches.
+
+### Recap
+
+- Skip cogni-narrative by default — Why Change is built into cogni-sales
+- Add it for problem-first audiences (SCQA), consultative arcs (Hero's), or recommendation-first (Minto)
+- One sentence of justification before adding overhead
+
+---
+
+## Module 4: Run the Why Change Pitch (cogni-sales)
+
+### Theory (8 min)
+
+`cogni-sales` runs the Corporate Visions Why Change methodology in four phases:
+- **Why Change** — surface the unconsidered need (the prospect's status quo is broken)
+- **Why Now** — establish urgency (the cost of inaction is rising)
+- **Why You** — differentiate (your point of view, your provider strengths)
+- **Why Pay** — quantify (business case, pricing model, expected outcome)
+
+Each phase is a researched, sourced section. The unconsidered need is the
+methodology's hardest move — without it, the pitch is just a feature list.
+
+For named accounts, customer research feeds the Why Now and Why Pay phases. For
+segments, the research draws on cogni-portfolio market sizing and cogni-trends
+themes (if present).
+
+The output is two artifacts: `sales-presentation.md` (the deck content) and
+`sales-proposal.md` (the leave-behind). Both are arc-shaped.
+
+### Demo
+
+Run `/why-change` against the prospect/segment chosen in Module 1:
+1. Pick named-customer or segment mode.
+2. Watch the four phases run sequentially with stakeholder review at the end.
+3. Open `sales-presentation.md` and `sales-proposal.md` — compare structures.
+4. Run `/pitch-review` for stakeholder-perspective scoring.
+
+### Exercise
+
+Open the produced `sales-presentation.md` and find the Why Change unconsidered need.
+Ask: would the prospect actually agree this is a need they're missing? If not, the
+pitch is too generic — re-run with sharper customer research.
+
+### Quiz
+
+1. Why is the unconsidered need the hardest move in Why Change?
+   **Answer**: It requires a specific insight about the prospect's blind spot;
+   generic insights produce a feature list, not a pitch.
+
+2. **Hands-on**: Compare the Why You section to your competitor battle cards. Does
+   the pitch differentiate based on real provider strengths or generic claims?
+
+### Recap
+
+- Four-phase Why Change methodology: Change → Now → You → Pay
+- The unconsidered need is the hardest move; generic = feature list
+- Two artifacts: presentation (deck) and proposal (leave-behind)
+- `/pitch-review` scores stakeholder perspectives (buyer / sales / marketing)
+
+---
+
+## Module 5: Render the Deck (cogni-visual)
+
+### Theory (4 min)
+
+`cogni-visual` renders `sales-presentation.md` as PPTX or HTML slides. The renderer
+reads the Why Change arc from frontmatter and maps each phase to slide layouts —
+provocation slides for Why Change, urgency slides for Why Now, differentiation
+slides for Why You, business-case slides for Why Pay.
+
+Theme inheritance applies: the active workspace theme drives colors, fonts, and
+design variables. Don't add per-deck styling.
+
+For pitches with a leave-behind, also render `sales-proposal.md` as a web narrative
+(`/story-to-web`) — a scrollable single-page document the prospect can browse
+asynchronously after the meeting.
+
+### Demo
+
+Run `/render-slides` on `sales-presentation.md`:
+1. Pick slide count (10-15 for executive pitches).
+2. Watch layout assignment — Why Change phases map to specific slide types.
+3. Run `/story-to-web` on `sales-proposal.md` for the leave-behind.
+4. Open both side by side.
+
+### Exercise
+
+The learner shows the rendered deck to a colleague (real or imagined). Does the
+opening slide land the unconsidered need within 30 seconds? If not, the Why Change
+text needs sharpening — go back and re-run.
+
+### Quiz
+
+1. Why render both the deck and the proposal?
+   **Answer**: The deck drives the meeting; the proposal is the leave-behind.
+   Different consumption modes need different formats.
+
+2. **Hands-on**: Switch the workspace theme via `/pick-theme` and re-render. Note
+   that no slide content needed to change.
+
+### Recap
+
+- The pipeline produces an arc-shaped deck + leave-behind proposal
+- Theme inheritance from cogni-workspace — no per-deck styling
+- Executive pitches: 10-15 slides; the opening must land the unconsidered need
+- Leave-behind via `/story-to-web` for asynchronous review
+
+---
+
+## Tour Complete
+
+Next steps:
+- Run the pipeline for a real prospect
+- Combine with `tour-trends-to-solutions` for trend-anchored pitches
+- Use `/pitch-review` for stakeholder feedback before client delivery
+- See the canonical playbook: `cogni-help/skills/workflow/references/workflows/portfolio-to-pitch.md`
+- See the narrative tutorial: `docs/workflows/portfolio-to-pitch.md`

--- a/cogni-help/skills/teach/references/courses/tours/tour-portfolio-to-website.md
+++ b/cogni-help/skills/teach/references/courses/tours/tour-portfolio-to-website.md
@@ -1,0 +1,284 @@
+# Tour: Portfolio to Website
+
+**Duration**: 60 minutes | **Modules**: 5 | **Track**: Workflow-tour
+**Pipeline**: cogni-portfolio → cogni-workspace → cogni-website
+**Prerequisites**: Course 6 (Portfolio Messaging), Course 2 (Workspace & Obsidian)
+**Audience**: Teams generating a deployable static site directly from portfolio data
+
+---
+
+This tour walks the portfolio-to-website pipeline as one workflow. You confirm
+your portfolio data, pick a workspace theme, plan a sitemap, build the site, and
+preview the result. The portfolio model drives the page content — propositions
+become page headlines, customer narratives become landing pages, features
+become capability lists.
+
+## Module 1: Pipeline Overview & Portfolio Check
+
+### Theory (5 min)
+
+The portfolio-to-website pipeline produces a self-contained static site rendered
+from portfolio data. Three plugins:
+- `cogni-portfolio` — proposition, feature, customer profile content
+- `cogni-workspace` — theme inheritance (colors, fonts, design variables)
+- `cogni-website` — page generation, hero rendering, sitemap, preview
+
+Optional content sources: cogni-marketing (blog, lead-gen pages), cogni-trends
+(insights pages), cogni-research (whitepapers). The site is deployable to any
+static host (Netlify, GitHub Pages, S3) — no backend.
+
+The portfolio model drives the IA: propositions are top-level pages, features are
+capability lists inside service pages, customer narratives are landing pages. If
+the portfolio is thin, the site is thin.
+
+### Demo
+
+Walk the audience through the data flow:
+1. Open the portfolio project — show one proposition, one feature, one customer narrative.
+2. Open an example built site — show the proposition page, the capability section
+   driven by features, the landing page driven by the customer narrative.
+3. Show how a single change in cogni-portfolio cascades to the generated page.
+
+### Exercise
+
+Have the learner check their portfolio status: at least one product, propositions,
+and customer profiles. Identify gaps. The website plan keys off all three; missing
+data produces thin landing pages.
+
+### Quiz
+
+1. **Multiple choice**: Without any cogni-portfolio data, what does the website pipeline produce?
+   - a) A complete site with placeholder text — b) A three-page minimum site — c) An
+     error — d) A blank site
+   **Answer**: b (a thin three-page placeholder; the pipeline runs but the IA collapses)
+
+2. Why does the site IA depend on the portfolio model?
+   **Answer**: The IA mirrors the IS/DOES/MEANS structure — propositions become
+   pages, features become capability lists, customers become landing pages. Without
+   the structure, there are no pages to generate.
+
+### Recap
+
+- Pipeline: portfolio → workspace (theme) → website
+- The portfolio drives the IA — fill data first, generate site second
+- Optional content sources: cogni-marketing, cogni-trends, cogni-research
+- The site is deployable to any static host — no backend
+
+---
+
+## Module 2: Pick or Confirm a Theme (cogni-workspace)
+
+### Theory (5 min)
+
+The website inherits the workspace theme — colors, fonts, design variables.
+`cogni-workspace` provides the theme via `/pick-theme`; a theme can be a preset, a
+PowerPoint template, or extracted from a live website via `/manage-themes extract`.
+
+Theme inheritance is global: the same theme drives slides, infographics, dashboards,
+and the website. A theme switch + `/website-build` reskins the entire site — theme
+changes are deliberately broad.
+
+If the team has no theme yet, run the `install-to-infographic` workflow first to
+extract one (it's the bootstrap workflow for theme + MCP setup).
+
+### Demo
+
+Run `/pick-theme`:
+1. List available themes.
+2. Pick one — show the design variables it sets.
+3. Run `/manage-themes` to see how to extract a new theme from a company website.
+
+If the team has a company URL handy, run `/manage-themes extract <url>` live and
+show the extraction phases (claude-in-chrome reads the site → colors/fonts/logo
+parsed → theme stored).
+
+### Exercise
+
+Pick a theme that matches the brand the website should reflect. If no matching
+theme exists, run `/manage-themes extract` against the company URL or pick a preset
+and accept that the result is preliminary.
+
+### Quiz
+
+1. Why does the website inherit the workspace theme instead of accepting per-build styling?
+   **Answer**: Visual consistency across all deliverables (slides, dashboards, site).
+   Per-build styling produces drift; theme inheritance keeps the brand intact.
+
+2. **Hands-on**: Run `/manage-themes` and find one theme attribute (e.g. primary
+   color, body font) that would change if the brand updated.
+
+### Recap
+
+- Themes drive colors, fonts, design variables across all visual plugins
+- `/pick-theme` selects, `/manage-themes extract` builds new from a live URL
+- Theme switching reskins the site — no per-page styling
+- For first-run setup, run `install-to-infographic` to bootstrap a theme
+
+---
+
+## Module 3: Set Up & Plan the Site (cogni-website)
+
+### Theory (6 min)
+
+Two cogni-website skills cover setup and planning:
+- `/website-setup` — initializes `website-project.json` with discovered portfolio
+  entities and project config (target market, primary CTA, language)
+- `/website-plan` — produces `website-plan.json` with the sitemap, content map,
+  and navigation flow
+
+Setup walks through optional content sources: cogni-marketing for blog/lead-gen
+pages, cogni-trends for insights pages, cogni-research for whitepapers. Skip
+optional sources you don't have content for; they can be added on a later run.
+
+The plan picks defaults but the running order shapes the homepage. Review and
+adjust priorities before `/website-build`. Pages with shallow content sources
+(a proposition without a customer narrative) generate thin landing pages — fill
+the gap or drop the page from the plan.
+
+For German sites, set `language: de` during setup; bilingual sites need separate
+runs per language for now.
+
+### Demo
+
+Run `/website-setup` followed by `/website-plan`:
+1. Pick a target directory.
+2. Configure: target market, primary CTA, language.
+3. Watch entity discovery — the setup finds propositions, features, customer narratives.
+4. Run `/website-plan` — review the sitemap and reorder priorities.
+5. Open `website-plan.json` and discuss the page list.
+
+### Exercise
+
+Have the learner review the plan and identify one page that should be reordered or
+dropped. Justify the change in one sentence.
+
+### Quiz
+
+1. **Multiple choice**: A proposition has no matching customer narrative. What does the planner do?
+   - a) Drops the page — b) Generates a thin landing page — c) Errors —
+     d) Replaces it with placeholder content
+   **Answer**: b (generates a thin landing page; the planner doesn't enforce content
+   completeness — review and drop or fill)
+
+2. Why doesn't the planner auto-fill optional content sources?
+   **Answer**: Optional sources reflect real-world variability — not every team has
+   marketing content or trend research. Forcing them produces fake content; opting
+   in keeps the site honest.
+
+### Recap
+
+- `/website-setup` discovers portfolio entities and configures project
+- `/website-plan` produces the sitemap and content map
+- Optional sources (marketing, trends, research) opt-in via setup
+- Review the plan and adjust priorities before building
+
+---
+
+## Module 4: Build the Site (cogni-website)
+
+### Theory (5 min)
+
+`/website-build` generates `website/{page-slug}.html` files plus
+`website/assets/` (themed CSS, JS, hero imagery). The build dispatches the
+`site-assembler` agent, which renders every page from the plan in parallel.
+
+Hero imagery: if Pencil MCP is available, the `hero-renderer` agent generates AI
+hero images for landing pages. Without Pencil, hero blocks fall back to themed
+gradients — usable, but not the AI-generated imagery in demos.
+
+Subsequent runs do incremental rebuilds — only modified pages rebuild. Theme
+changes trigger a full rebuild because every page's CSS variables change.
+
+### Demo
+
+Run `/website-build`:
+1. Watch the parallel page rendering.
+2. Show the produced `website/` directory — pages, assets, hero images.
+3. Modify one proposition in cogni-portfolio and re-run — show the incremental rebuild.
+
+If Pencil MCP isn't running, point at the gradient fallback and explain the
+upgrade path (`/install-mcp pencil` then re-run build).
+
+### Exercise
+
+After the build, open one page in a browser. Confirm: theme is applied, hero block
+renders, content reflects the portfolio data. Note any thin pages — they trace to
+shallow portfolio data.
+
+### Quiz
+
+1. Why does the build use parallel rendering?
+   **Answer**: Pages are independent — proposition pages don't depend on customer
+   pages. Parallel rendering produces a 7-page site in roughly the time it takes
+   to render one page sequentially.
+
+2. **Hands-on**: Open one built page's HTML source. Find the theme CSS variables
+   and trace one back to the workspace theme.
+
+### Recap
+
+- `/website-build` runs the site-assembler in parallel
+- Pencil MCP enables AI hero imagery; without it, themed gradients
+- Incremental rebuilds on subsequent runs; full rebuild on theme change
+- Open the build and confirm theme + content before iterating
+
+---
+
+## Module 5: Preview, Iterate, & Deploy (cogni-website)
+
+### Theory (4 min)
+
+`/website-preview` opens the built site in a browser via claude-in-chrome MCP and
+validates internal links. Use it for visual review and to catch link breakage
+before deployment.
+
+For legal pages — Impressum, Datenschutzerklärung, Cookie-Hinweis (or EU equivalents)
+— `/website-legal` generates them based on the publishing entity. Required for
+DACH/EU deployment.
+
+Deployment: the `website/` directory is self-contained — push it to any static
+host. No backend, no database, no API keys. The team can iterate on theme tweaks
+or copy edits by re-running `/website-build` after changes.
+
+### Demo
+
+Run `/website-preview` followed by `/website-legal`:
+1. Preview the site in the browser — click through pages.
+2. Show a broken link if one exists (or simulate by editing a link).
+3. Run `/website-legal` to generate Impressum + Datenschutz.
+4. Show the deployable directory layout.
+
+### Exercise
+
+Have the learner deploy the built site to a temporary host (Netlify drop zone, or
+local `python3 -m http.server`). Browse the live site. Identify two improvements to
+make in the next iteration.
+
+### Quiz
+
+1. Why are legal pages handled by a separate skill rather than auto-generated by `/website-build`?
+   **Answer**: Legal content depends on the publishing entity (sole proprietorship,
+   GmbH, AG, etc.) and target jurisdiction. The build can't infer those; the legal
+   skill asks explicitly.
+
+2. **Hands-on**: After preview, edit one proposition in cogni-portfolio. Re-run
+   `/website-build` and `/website-preview`. Confirm only the affected pages updated.
+
+### Recap
+
+- `/website-preview` validates the built site (visual + link check)
+- `/website-legal` generates Impressum, Datenschutz, Cookie-Hinweis (DACH/EU)
+- Deployable to any static host — `website/` is self-contained
+- Iterate on portfolio data; re-run build; preview; deploy
+
+---
+
+## Tour Complete
+
+Next steps:
+- Run the pipeline against your real portfolio
+- Add cogni-marketing for blog and lead-gen pages
+- Use `/website-legal` before publishing to a DACH/EU audience
+- Combine with `tour-content-pipeline` for editorial content layered onto the site
+- See the canonical playbook: `cogni-help/skills/workflow/references/workflows/portfolio-to-website.md`
+- See the narrative tutorial: `docs/workflows/portfolio-to-website.md`

--- a/cogni-help/skills/teach/references/courses/tours/tour-research-to-report.md
+++ b/cogni-help/skills/teach/references/courses/tours/tour-research-to-report.md
@@ -1,0 +1,275 @@
+# Tour: Research to Report
+
+**Duration**: 60 minutes | **Modules**: 5 | **Track**: Workflow-tour
+**Pipeline**: cogni-research → cogni-narrative → cogni-visual
+**Prerequisites**: Course 8 (Research Reports), Course 7 (Visual Deliverables); Course 3 (Basic Tools) helpful
+**Audience**: Analysts producing presentations from original research
+
+---
+
+This tour walks the full research-to-presentation pipeline as one continuous workflow.
+You author a research question, generate a sourced report, shape it into an executive
+narrative, and render the result as a deliverable — without re-explaining each plugin
+in isolation. If a prerequisite course is missing, run it first or accept the
+inline-summary fallback offered at the start of the tour.
+
+## Module 1: Pipeline Overview & Question Framing
+
+### Theory (5 min)
+
+The research-to-report pipeline chains three plugins: `cogni-research` produces a
+sourced report from a question, `cogni-narrative` reshapes the report into a story
+arc, and `cogni-visual` renders the narrative as slides or a web deliverable. Each
+plugin owns one transformation; the deliverable quality is the product of all three.
+
+Three decisions frame the tour:
+
+| Decision | Options | Default for tour |
+|----------|---------|------------------|
+| Research depth | basic / detailed / deep / outline / resource | detailed |
+| Source mode | web / local / hybrid | web |
+| Story arc | SCQA / Minto Pyramid / Hero's Journey | SCQA (problem-solution) |
+
+A sharp question is the highest-leverage input. "What are AI trends?" produces a
+generic report; "Which generative AI capabilities have moved from research to
+production-grade in the last 18 months in the DACH manufacturing sector?" produces
+a useful one.
+
+### Demo
+
+Walk through framing one research question end-to-end:
+1. Pick a topic the learner cares about (a market, a technology, a competitor).
+2. Tighten it: add a time horizon, a region, and a target audience.
+3. Decide depth (basic for a quick scan, detailed for a client deliverable, deep for
+   strategic intelligence) and source mode (web for current signals, hybrid when
+   internal documents add depth).
+4. Pick the story arc up front — SCQA fits problem-solution narratives, Minto fits
+   recommendation-first executive briefings.
+
+### Exercise
+
+Have the learner draft a research question for their own context, then test it against
+the sharpening checklist: time horizon? region? audience? specific enough to fail?
+If it can't be wrong, it's not specific enough.
+
+### Quiz
+
+1. **Multiple choice**: Which depth fits a 10-page market analysis with full citations?
+   - a) basic — b) detailed — c) deep — d) outline
+   **Answer**: b (detailed; basic is too short, deep is overkill, outline is framework only)
+
+2. **Hands-on**: Sharpen "What are renewable energy trends?" into a question a
+   `detailed` report could answer in 5 sub-questions.
+
+### Recap
+
+- The pipeline is research → narrative → visual; pick depth, source mode, and arc upfront
+- A sharp, falsifiable question is the highest-leverage input
+- SCQA suits problem-solution narratives, Minto suits exec recommendations
+
+---
+
+## Module 2: Generate the Research Report (cogni-research)
+
+### Theory (6 min)
+
+`cogni-research` is a STORM-inspired multi-agent editorial workflow. Behind the
+single command, specialized agents decompose the question into sub-questions,
+research them in parallel, write sections, verify claims, and review the draft.
+Claims are auto-logged to `cogni-claims` with provenance — you can trace any
+sentence to a source.
+
+Five report types: basic (3-5K words, 5 sub-questions), detailed (5-10K, 5-10
+sections), deep (recursive tree exploration, 8-15K), outline (1-2K framework only),
+resource (1.5-3K bibliography). Three source modes: web, local, hybrid.
+
+For DACH, set language to DE — the curated authority sources (fraunhofer.de,
+bitkom.org, vdma.org, destatis.de) replace the EN/US default set.
+
+### Demo
+
+Run `/research-report` against the question framed in Module 1:
+1. Configure depth (detailed), tone (analytical), citation format (APA), language (EN or DE).
+2. Pick a project storage location.
+3. Watch the pipeline: question decomposition → parallel research → claim logging →
+   section writing → review.
+4. Open the produced `report.md` in Obsidian or VS Code — show the inline citations
+   and the per-source markdown files.
+
+### Exercise
+
+Run `/research-report` with the learner's own question at `basic` depth (faster than
+detailed for a teaching pass). When it finishes, ask the learner to find one claim,
+trace it to its source markdown file, and confirm the original source supports it.
+
+### Quiz
+
+1. Why does cogni-research log claims to cogni-claims during research instead of after?
+   **Answer**: Provenance is fresh at write time; back-filling provenance later is
+   error-prone. Claims-during-research enables the correction-cascade pattern.
+
+2. **Hands-on**: Open the `report.md` from the demo, copy the `[Source: …]` format
+   inline citation, and find the matching file under `sources/`.
+
+### Recap
+
+- Five report types — basic / detailed / deep / outline / resource — pick by deliverable scope
+- Three source modes — web / local / hybrid
+- Claims auto-logged with provenance, verified during the research loop
+- DACH/EU markets get curated authority sources via `language` setting
+
+---
+
+## Module 3: Shape the Narrative (cogni-narrative)
+
+### Theory (6 min)
+
+The research report has all the facts but not the story. `cogni-narrative` applies a
+story arc framework — SCQA, Minto Pyramid, Why Change, Hero's Journey, and others —
+to rebuild the report as an executive narrative. The arc determines order: SCQA leads
+with situation, Minto leads with the recommendation.
+
+Citations are preserved end-to-end. A `bridge-citations.py` step converts inline
+`[Source: Publisher](URL)` citations into per-source markdown files before narrative
+Phase 1; the narrative reads them as entities, so every claim in the polished
+narrative still traces to a source.
+
+For research-to-report, SCQA is the typical default — research is naturally
+problem-led and the audience needs context before recommendations.
+
+### Demo
+
+Run `/narrate` on the report from Module 2:
+1. Pick the SCQA arc.
+2. Watch narrative Phase 1 (extract claims and sources), Phase 2 (compose), Phase 3 (review).
+3. Open `narrative.md` — note how the claims are reorganized into Situation /
+   Complication / Question / Answer order.
+4. Run `/narrative-review` to score the arc compliance, BLUF, and citation density.
+
+### Exercise
+
+Compare the research report's Module 1 (introduction) to the narrative's Situation
+section. The same facts; different sequence. Ask: which version would an executive
+read first?
+
+### Quiz
+
+1. **Multiple choice**: For a 5-page recommendation memo to a CFO, which arc fits best?
+   - a) SCQA — b) Minto Pyramid — c) Hero's Journey — d) Why Change
+   **Answer**: b (Minto leads with the recommendation; CFOs want the answer first)
+
+2. **Hands-on**: Re-run `/narrate` with the Minto arc instead of SCQA. Compare opening lines.
+
+### Recap
+
+- The story arc determines the deliverable's reading order
+- SCQA fits problem-solution; Minto fits exec recommendations
+- Citations bridge from research to narrative — provenance survives
+- `/narrative-review` scores arc compliance and citation density
+
+---
+
+## Module 4: Render the Deliverable (cogni-visual)
+
+### Theory (5 min)
+
+`cogni-visual` renders the polished narrative as a slide deck (`/render-html-slides`
+or `/render-slides` for PPTX), a scrollable web narrative (`/story-to-web`), an
+infographic (`/story-to-infographic`), or a printed storyboard (`/story-to-storyboard`).
+
+The renderer reads the story arc from the narrative's frontmatter and maps each arc
+section to slide layouts with assertion headlines. The active workspace theme drives
+colors, fonts, and design variables — no per-deliverable styling needed.
+
+For exec audiences with limited time, prefer slides. For a leave-behind asset that
+the audience will browse asynchronously, prefer the web narrative.
+
+### Demo
+
+Run `/render-html-slides` on the narrative from Module 3:
+1. Pick a slide count appropriate for the audience (10-15 for execs).
+2. Watch slide layout selection — each arc section gets matched to title, content,
+   pull-quote, or comparison layouts.
+3. Open the resulting `slides.html` in a browser and walk through with arrow keys.
+
+### Exercise
+
+Render the same narrative twice — once as slides, once as a web narrative
+(`/story-to-web`). Ask the learner which they'd send to a client and why.
+
+### Quiz
+
+1. Why does cogni-visual ignore manual styling instructions and read the workspace theme instead?
+   **Answer**: Theme inheritance keeps every deliverable visually consistent across
+   plugins. Per-deliverable styling produces drift.
+
+2. **Hands-on**: Switch the workspace theme via `/pick-theme` and re-render. Note
+   that nothing in the narrative needed to change.
+
+### Recap
+
+- Slides for exec audiences, web narrative for leave-behinds, infographic for one-pagers
+- Theme inheritance from cogni-workspace — no per-deliverable styling
+- Slide layouts auto-mapped from the story arc's sections
+
+---
+
+## Module 5: End-to-End Recap & Iteration
+
+### Theory (4 min)
+
+The research-to-report tour produces three durable artifacts: a sourced research
+report, an arc-shaped narrative, and a rendered deliverable. Each is reusable —
+the report seeds future narratives, the narrative seeds future visuals, the
+visuals seed future client conversations.
+
+When iterating: corrections to claims propagate. Edit a source via `cogni-claims`,
+and the staleness cascade marks the narrative and slide deck for refresh. Don't
+manually re-edit downstream artifacts when the upstream source changes.
+
+Common pitfalls: skipping the narrative step (data-heavy slides, no story);
+mismatching depth to deliverable (deep research for a 5-slide deck wastes time);
+bypassing claims verification on imported content.
+
+### Demo
+
+Walk the learner backwards through their three artifacts:
+1. Open the slide deck — point at one assertion headline.
+2. Open the narrative — find the matching section.
+3. Open the research report — find the cited source.
+
+Show how `cogni-claims` would mark a downstream artifact stale if the source were
+edited.
+
+### Exercise
+
+Have the learner identify the deliverable they would actually need for an upcoming
+real engagement (client brief, internal sync, board update). Recommend a depth/arc
+combination based on audience. Don't run it — the planning is the exercise.
+
+### Quiz
+
+1. Why is the narrative step often skipped, and what breaks when it is?
+   **Answer**: Slides go directly from data to layout; story shape is lost. Audiences
+   see organized facts but no insight.
+
+2. **Hands-on**: Pick one of these audiences — board, sales team, prospect, internal
+   ops — and name the depth + arc + render format you'd choose for each.
+
+### Recap
+
+- The pipeline produces three durable artifacts; each seeds future work
+- Corrections cascade via cogni-claims — don't hand-edit downstream
+- Match depth to scope: don't deep-research a 5-slide deck
+- Skipping the narrative step trades insight for organized data
+
+---
+
+## Tour Complete
+
+Next steps:
+- Run the pipeline against a real engagement question
+- Try `/research-report` at `deep` depth for a strategic intelligence dossier
+- Combine with `tour-trends-to-solutions` for trend-to-content pipelines
+- See the canonical playbook: `cogni-help/skills/workflow/references/workflows/research-to-report.md`
+- See the narrative tutorial: `docs/workflows/research-to-report.md`

--- a/cogni-help/skills/teach/references/courses/tours/tour-trends-to-solutions.md
+++ b/cogni-help/skills/teach/references/courses/tours/tour-trends-to-solutions.md
@@ -1,0 +1,285 @@
+# Tour: Trends to Solutions
+
+**Duration**: 75 minutes | **Modules**: 5 | **Track**: Workflow-tour
+**Pipeline**: cogni-trends → cogni-portfolio → cogni-marketing
+**Prerequisites**: Courses 4-5 (Trend Scouting + Trend Reporting), Course 6 (Portfolio Messaging), Course 9 (B2B Marketing)
+**Audience**: GTM teams turning strategic trends into marketing campaigns
+
+---
+
+This tour walks the trends-to-solutions pipeline as a single workflow. You scout
+strategic trends, anchor them to portfolio propositions, and fan them out into
+multi-channel marketing content — all sourced from the same evidence trail.
+Plugin-track prerequisites cover each plugin in depth; this tour focuses on the
+hand-offs between them.
+
+## Module 1: Pipeline Overview & TIPS Foundations
+
+### Theory (6 min)
+
+The trends-to-solutions pipeline chains three plugins around a single thread of
+evidence: `cogni-trends` produces investment themes (Handlungsfelder) backed by
+trend signals; `cogni-portfolio` translates themes into market-specific propositions;
+`cogni-marketing` produces channel-ready content tagged with both trend and proposition
+provenance.
+
+The TIPS framework — Technology, Innovation, People, Strategy — drives trend scouting.
+Each scouted trend is scored on multi-framework criteria (TIPS dimension, Ansoff
+matrix, Rogers adoption curve, CRAAP source quality). The output isn't a single ranked
+list; it's investment themes that bundle related trends into a strategic narrative.
+
+For trends-to-solutions, the connecting fiber is the investment theme. A theme drives
+which propositions you build (Step 2) and which campaigns you launch (Step 3). Without
+themes, you produce content for whatever felt interesting last week.
+
+### Demo
+
+Walk the audience through the data flow:
+1. Open an existing TIPS project, find one investment theme.
+2. Open a portfolio project, find a proposition that traces back to that theme.
+3. Open a marketing campaign, find content that cites both the theme and the proposition.
+
+If the team has no TIPS project yet, sketch the chain on a whiteboard: theme →
+proposition → campaign content. The artifacts come alive in Module 2.
+
+### Exercise
+
+Ask the learner to identify three industry shifts they think matter for the next 12
+months. Don't research them yet — just name them. We'll test in Module 2 whether
+cogni-trends produces matching evidence.
+
+### Quiz
+
+1. Why does the pipeline anchor on investment themes rather than individual trends?
+   **Answer**: Themes bundle related trends into a strategic narrative; individual
+   trends produce fragmented content with no through-line.
+
+2. **Multiple choice**: A team scouts 60 trends, scores them on TIPS dimensions, and
+   produces 4 themes. What's the next plugin in the pipeline?
+   - a) cogni-marketing — b) cogni-portfolio — c) cogni-narrative — d) cogni-research
+   **Answer**: b (themes hand off to portfolio for proposition mapping)
+
+### Recap
+
+- The pipeline anchors on investment themes, not raw trends
+- TIPS framework drives multi-dimensional scoring (T/I/P/S, Ansoff, Rogers, CRAAP)
+- Provenance flows: theme → proposition → campaign content
+
+---
+
+## Module 2: Scout Trends and Lock Themes (cogni-trends)
+
+### Theory (8 min)
+
+`cogni-trends` runs a multi-phase scouting workflow: bilingual web research (DE/EN)
+across regional authority sources, signal curation, candidate generation (60 trends
+scored across frameworks), stakeholder review, deep research on top candidates, and
+investment-theme construction.
+
+For DACH/EU markets, the regional authority source set is critical — `fraunhofer.de`,
+`bitkom.org`, `vdma.org`, `destatis.de`, `handelsblatt.com` produce different
+evidence than the EN/US default. Set `region` in the scout configuration.
+
+The output of `/scout` is not a trend report; it's the input to `/report`, which
+generates a polished trend report organized around themes (Handlungsfelder). For
+trends-to-solutions, the themes are what cogni-portfolio consumes — the report is
+optional unless stakeholders want a written justification.
+
+### Demo
+
+Run `/scout` against an industry the team cares about:
+1. Configure: industry, language (DE/EN), region (DACH/US/EU), depth.
+2. Watch the phases: web research → signal curation → 60 candidates → stakeholder
+   review → deep research → investment themes.
+3. Open the produced TIPS project — show the candidates table, the agreed themes,
+   and the per-theme evidence pack.
+
+If `/scout` already ran for this industry, use `/trends-resume` to skip to the
+themes view.
+
+### Exercise
+
+Ask the learner to compare the themes cogni-trends produced to the three shifts they
+named in Module 1. How many overlap? Where did cogni-trends find evidence the learner
+didn't anticipate?
+
+### Quiz
+
+1. Why is the regional authority source set important for DACH scouting?
+   **Answer**: DACH-specific sources (Fraunhofer, BITKOM, VDMA) surface evidence
+   the EN/US default sources miss; without them, the scout produces a US-flavored
+   view of a DACH market.
+
+2. **Hands-on**: Open one investment theme and read the evidence trail. Find one
+   trend signal that contradicts a common industry narrative.
+
+### Recap
+
+- `/scout` produces 60 scored candidates → reviewed → top candidates deep-researched → themes
+- Regional authority sources matter — set `region` correctly for DACH/EU
+- Themes (Handlungsfelder) are the hand-off to cogni-portfolio
+- `/report` is optional; themes feed the next pipeline stage directly
+
+---
+
+## Module 3: Anchor Themes to Propositions (cogni-portfolio)
+
+### Theory (6 min)
+
+`cogni-portfolio` builds a structured product/market model — features (IS, market-
+independent), advantages (DOES, market-specific), benefits (MEANS, market-specific).
+The IS/DOES/MEANS triangle is what you sell.
+
+For trends-to-solutions, the connecting move is binding investment themes to
+propositions. A theme like "Edge AI for industrial maintenance" maps to features
+(predictive-maintenance models, edge runtime, anomaly detection), advantages
+(downtime reduction, data sovereignty), and benefits (uptime guarantees, regulatory
+fit). One theme can drive multiple propositions across markets.
+
+The `trends-bridge` skill imports TIPS themes as portfolio anchors — solution
+templates from cogni-trends become structured features in cogni-portfolio. This
+keeps provenance: every proposition traces to the trend evidence that justified it.
+
+### Demo
+
+Run `/portfolio-setup` (or `/portfolio-resume` if one exists) and the proposition
+chain:
+1. Confirm the portfolio project is configured for the target market(s).
+2. Run `/trends-bridge` to import TIPS themes as portfolio anchors.
+3. Run `/propositions` to generate IS/DOES/MEANS for one Feature × Market pair.
+4. Open the produced proposition file — show the trend evidence in the lineage block.
+
+### Exercise
+
+Have the learner pick one TIPS theme and one of their target markets. Predict the
+proposition's DOES (advantage) and MEANS (benefit) before running `/propositions`.
+Compare against what the agent generates.
+
+### Quiz
+
+1. Why are features (IS) market-independent but advantages (DOES) and benefits (MEANS)
+   market-specific?
+   **Answer**: Features are what the product technically does; advantages and benefits
+   are how the market interprets value, which varies by buyer context.
+
+2. **Hands-on**: Open one proposition file and trace its lineage backward — find the
+   TIPS theme it imported from and the trend signals that justified the theme.
+
+### Recap
+
+- IS = market-independent features, DOES/MEANS = market-specific advantages and benefits
+- `trends-bridge` imports TIPS themes as portfolio anchors (provenance preserved)
+- One theme drives multiple propositions across markets
+- Proposition files include source lineage — corrections cascade
+
+---
+
+## Module 4: Generate Marketing Content (cogni-marketing)
+
+### Theory (6 min)
+
+`cogni-marketing` operates on a 3D content matrix: markets × GTM paths × content
+formats. With propositions and themes in place, the matrix surfaces gaps — which
+market × GTM-path × format intersections lack content. The strategy step
+(`/content-strategy`) converts the matrix into a prioritized content plan.
+
+Per funnel stage, dedicated skills produce content: `/thought-leadership` for
+awareness, `/demand-gen` for engagement, `/lead-gen` for conversion,
+`/sales-enablement` for decision, `/abm` for account-specific work. Each piece
+references the propositions and themes it draws from — content traces back to
+data, not to a writer's intuition.
+
+For DACH content, language is set in the marketing brief — German content
+auto-applies Wolf Schneider rules with Amstad readability scoring.
+
+### Demo
+
+Run `/marketing-setup` followed by `/content-strategy` and one content skill:
+1. Setup: link the cogni-portfolio and cogni-trends projects.
+2. Strategy: review the 3D matrix, pick the highest-priority cell.
+3. Generate: pick a funnel stage and content type that matches the cell, run the
+   matching skill (e.g. `/thought-leadership` for an awareness blog post).
+4. Open the produced content — show the proposition + theme references in the metadata.
+
+### Exercise
+
+Pick one priority cell from the matrix. Run two pieces from different funnel stages
+for the same market × GTM path (e.g. a thought-leadership blog and a demand-gen
+LinkedIn carousel). Compare how each adapts the same source data to channel
+conventions.
+
+### Quiz
+
+1. Why does cogni-marketing tag every produced piece with proposition + theme references?
+   **Answer**: Provenance enables claim verification, correction cascades, and
+   campaign-level attribution analysis. Untagged content is opaque.
+
+2. **Hands-on**: Generate the same blog post twice — once with `language: de` and
+   once with `language: en`. Compare opening sentence cadence.
+
+### Recap
+
+- 3D matrix: markets × GTM paths × formats — surfaces coverage gaps
+- Five funnel-stage skills, 16 content formats supported
+- Every piece tagged with provenance to propositions and themes
+- DACH content auto-applies Wolf Schneider + Amstad scoring
+
+---
+
+## Module 5: End-to-End Recap & Campaign Orchestration
+
+### Theory (4 min)
+
+The trends-to-solutions tour produces a connected campaign-ready content set: a TIPS
+project with themes, a cogni-portfolio project with propositions, and a cogni-marketing
+project with multi-channel content. All three are linked by a single evidence trail.
+
+For campaign orchestration, the `/campaign-builder` skill chains these into a
+multi-channel sequence — touchpoints across LinkedIn, email, blog, and ABM, scheduled
+on a day-based timeline. The campaign is the consumable artifact for the GTM team;
+the pipeline produced the underlying content.
+
+When iterating: a corrected trend signal (via `cogni-claims`) cascades through the
+proposition layer to the content layer. Don't manually re-edit a campaign when the
+upstream theme shifts — re-run the affected content skills and let the lineage
+update propagate.
+
+### Demo
+
+Run `/campaign-builder`:
+1. Pick a target market and a GTM path.
+2. Watch the campaign timeline assemble — touchpoints sequenced across channels.
+3. Open `/marketing-dashboard` to see content coverage and campaign progress.
+
+### Exercise
+
+Have the learner sketch a real campaign they need to ship in the next quarter. Map
+the inputs back: which TIPS themes drive it? which propositions? which markets? If
+any input is missing, that's a gap to fill before content generation.
+
+### Quiz
+
+1. Why use `/campaign-builder` instead of just generating content piece by piece?
+   **Answer**: Campaigns sequence touchpoints — content alone is unstructured. The
+   campaign's day-based timeline turns pieces into a buyer journey.
+
+2. **Hands-on**: Open `/marketing-dashboard` and find one content gap (a market ×
+   GTM path with no content). Decide which skill would fill it.
+
+### Recap
+
+- The pipeline produces a connected three-project artifact set with full lineage
+- `/campaign-builder` sequences touchpoints; `/marketing-dashboard` visualizes coverage
+- Corrections cascade — re-run skills, don't hand-edit campaigns
+- Match GTM path to funnel stage to channel — the matrix is the planning grid
+
+---
+
+## Tour Complete
+
+Next steps:
+- Run the pipeline against a real industry/market combination
+- Combine with `tour-portfolio-to-pitch` for proposition-to-pitch conversion
+- Combine with `tour-content-pipeline` for deeper content polish workflows
+- See the canonical playbook: `cogni-help/skills/workflow/references/workflows/trends-to-solutions.md`
+- See the narrative tutorial: `docs/workflows/trends-to-solutions.md`


### PR DESCRIPTION
Closes #150. Child of #152 (workflow-tour epic), depends on merged #149/#160.

## Summary
- Adds 7 scaffolded course files under `cogni-help/skills/teach/references/courses/tours/`, one per canonical workflow, so `/teach tour-<id>` delivers an integrated walk-through instead of falling back to plugin-track prerequisites.
- Each file follows the canonical 5-module structure (Theory / Demo / Exercise / Quiz / Recap) used by courses 01-12, with module boundaries aligned to the corresponding workflow template's pipeline steps.
- Pipeline structure sourced from `cogni-help/skills/workflow/references/workflows/<id>.md`; narrative context and 'why' sourced from `docs/workflows/<id>.md`.
- Bumps `cogni-help` from 0.1.5 to 0.1.6 in both `plugin.json` and `marketplace.json`.

## Scope decisions
- **Path resolution**: The issue body proposes numbered files (`13-tour-...`) directly under `references/courses/`. The teach SKILL.md (lines 225-238, shipped via merged #160) is the canonical spec and places these files under `references/courses/tours/` with `tour-<id>.md` names (no number prefix). This PR follows SKILL.md — the issue body predates that decision.
- **All 7 scaffolds in one PR (not phased)**: Acceptance is 'complete-enough skeleton', and per-file work is template-driven against lean (60-96 line) workflow templates. Shipping a subset would leave SKILL.md's forthcoming-tour fallback covering some tours but not others — a worse half-state.
- **Out of scope** (deferred to follow-up issues): polished pedagogical pacing, German-language versions, exercise artifact templates under `references/exercises/`, cross-tour navigation, tour-specific assessments. The acceptance criterion explicitly excludes polish.
- **No SKILL.md edits**: The skill already references the seven `tour-<id>.md` paths and contains the forthcoming-tour fallback note (lines 89-91). That note remains accurate — once these files land it becomes a no-op because `/teach <tour-id>` will load the actual tour content. A follow-up may remove the note as cleanup; not required to satisfy this issue.

## Test plan
- [ ] `ls cogni-help/skills/teach/references/courses/tours/` lists all 7 expected files.
- [ ] Each tour file has a top-level title, metadata block (Duration / Modules / Track / Pipeline / Prerequisites / Audience), and 5 numbered modules each containing Theory + Demo + Exercise + Quiz + Recap subsections.
- [ ] Module structure for each tour aligns with the steps in the matching `cogni-help/skills/workflow/references/workflows/<id>.md`.
- [ ] Run `/teach tour-research-to-report` — confirm it loads the new course file and starts Module 1, no longer the plugin-track fallback.
- [ ] Spot-check `/teach tour-trends-to-solutions` and `/teach tour-portfolio-to-pitch` — confirm same.
- [ ] `cogni-help/.claude-plugin/plugin.json` version is `0.1.6`; matching marketplace.json entry version is `0.1.6`.
- [ ] `cogni-workspace/scripts/check-skill-names.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
