### PR TITLE
cogni-trends 0.5.9: content-hash stale detection (#187)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     {
       "name": "cogni-trends",
       "source": "./cogni-trends",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "maturity": "preview",
       "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Trend reports support two narrative skeletons: flat-themes (themes as H2) and the new theme-aware smarter-service macro skeleton (4 dimensions as H2 with anchored theme-cases as H3, closes on a Capability Imperative synthesis). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
       "keywords": [

--- a/cogni-trends/.claude-plugin/plugin.json
+++ b/cogni-trends/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-trends",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Strategic trend scouting and reporting pipeline. Combines the Smarter Service Trendradar (4-dimension structure) with the TIPS content framework (Trends, Implications, Possibilities, Solutions). Trend reports support two narrative skeletons: flat-themes (themes as H2) and the new theme-aware smarter-service macro skeleton (4 dimensions as H2 with anchored theme-cases as H3, closes on a Capability Imperative synthesis). Multilingual trend scouting, investment theme modeling, evidence-backed CxO reports, and reusable industry catalogs. European markets (DE/FR/IT/PL/NL/ES) + US/UK.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-trends/scripts/project-status.sh
+++ b/cogni-trends/scripts/project-status.sh
@@ -774,35 +774,97 @@ next_actions="$next_actions]"
 stale_warnings="[]"
 if $HEALTH_CHECK; then
   stale_warnings=$(python3 -c "
-import json, os
+import json, os, hashlib
 from datetime import datetime
 
 warnings = []
 proj = '$PROJECT_DIR'
 
-# Check if report is stale relative to candidates
+# Hash helpers — must match cogni-trends/skills/trend-report Phase 4.1 exactly.
+# Drift is detected by content hash, not mtime, because Phase 4.1 mirrors
+# report_tier and other report metadata back into trend-scout-output.json
+# (which would otherwise bump mtime on every report run — see issue #187).
+def _key(c):
+    return c.get('id') or c.get('title') or ''
+def _candidate_items(scout_doc):
+    return sorted((scout_doc.get('tips_candidates') or {}).get('items') or [], key=_key)
+def _scout_content_hash(scout_doc):
+    items = _candidate_items(scout_doc)
+    return 'sha256:' + hashlib.sha256(
+        json.dumps(items, sort_keys=True, separators=(',', ':'), ensure_ascii=False).encode('utf-8')
+    ).hexdigest()
+def _candidate_signature(scout_doc):
+    sig = {}
+    for c in _candidate_items(scout_doc):
+        k = _key(c)
+        if not k:
+            continue
+        sig[k] = hashlib.sha256(
+            json.dumps(c, sort_keys=True, separators=(',', ':'), ensure_ascii=False).encode('utf-8')
+        ).hexdigest()[:12]
+    return sig
+def _vm_sorted(seq, key):
+    return sorted(seq or [], key=lambda x: (x.get(key) or '') if isinstance(x, dict) else '')
+def _vm_content_hash(vm_doc):
+    payload = {
+        'investment_themes': _vm_sorted(vm_doc.get('investment_themes'), 'theme_id'),
+        'solutions':         _vm_sorted(vm_doc.get('solutions'),         'solution_id'),
+        'blueprints':        _vm_sorted(vm_doc.get('blueprints'),        'solution_id'),
+    }
+    return 'sha256:' + hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(',', ':'), ensure_ascii=False).encode('utf-8')
+    ).hexdigest()
+
 scout_file = os.path.join(proj, '.metadata', 'trend-scout-output.json')
 report_file = os.path.join(proj, 'tips-trend-report.md')
-
-if os.path.exists(scout_file) and os.path.exists(report_file):
-    scout_mtime = os.path.getmtime(scout_file)
-    report_mtime = os.path.getmtime(report_file)
-    if scout_mtime > report_mtime:
-        warnings.append({
-            'type': 'stale_report',
-            'message': 'Trend-scout output was modified after the report was generated — report may need refresh'
-        })
-
-# Check if report is stale relative to value model
 value_model_file = os.path.join(proj, 'tips-value-model.json')
-if os.path.exists(value_model_file) and os.path.exists(report_file):
-    vm_mtime = os.path.getmtime(value_model_file)
-    report_mtime = os.path.getmtime(report_file)
-    if vm_mtime > report_mtime:
-        warnings.append({
-            'type': 'stale_report',
-            'message': 'Value model was modified after the report was generated — report may need refresh'
-        })
+
+scout_doc = None
+if os.path.exists(scout_file):
+    try:
+        scout_doc = json.load(open(scout_file))
+    except Exception:
+        scout_doc = None
+
+# Scout-output drift check — anchored on content_hash_at_report.
+# Legacy projects without an anchor stay silent (mtime was the bug; we don't
+# fall back to it). They will get a clean anchor on the next /trend-report run.
+if scout_doc is not None and os.path.exists(report_file):
+    anchor = scout_doc.get('content_hash_at_report')
+    if anchor:
+        current = _scout_content_hash(scout_doc)
+        if current != anchor:
+            old_sig = scout_doc.get('candidate_signature') or {}
+            new_sig = _candidate_signature(scout_doc)
+            old_keys, new_keys = set(old_sig), set(new_sig)
+            added   = sorted(new_keys - old_keys)
+            removed = sorted(old_keys - new_keys)
+            changed = sorted(k for k in (old_keys & new_keys) if old_sig[k] != new_sig[k])
+            warnings.append({
+                'type': 'stale_report',
+                'subtype': 'scout_drift',
+                'message': 'Trend candidates changed since the report was generated — report no longer reflects current candidate set',
+                'added':   added,
+                'removed': removed,
+                'changed': changed,
+            })
+
+# Value-model drift check — anchored on value_model_hash_at_report (stored in
+# the same scout-output metadata block, since the report is the join point).
+if scout_doc is not None and os.path.exists(value_model_file) and os.path.exists(report_file):
+    vm_anchor = scout_doc.get('value_model_hash_at_report')
+    if vm_anchor:
+        try:
+            vm_doc = json.load(open(value_model_file))
+            vm_current = _vm_content_hash(vm_doc)
+            if vm_current != vm_anchor:
+                warnings.append({
+                    'type': 'stale_report',
+                    'subtype': 'value_model_drift',
+                    'message': 'Value model changed since the report was generated — report no longer reflects current themes/solutions',
+                })
+        except Exception:
+            pass
 
 # Check if portfolio context is newer than value model (re-anchor needed)
 portfolio_ctx = os.path.join(proj, 'portfolio-context.json')
@@ -905,6 +967,49 @@ except:
         ;;
     esac
   fi
+
+  # Inject concrete trend-report action for real candidate / value-model drift.
+  # The stale_report warning carries subtype scout_drift or value_model_drift
+  # plus added/removed/changed candidate id lists — see issue #187.
+  next_actions=$(echo "$stale_warnings" | STALE_WARNINGS_JSON="$stale_warnings" PRIOR_ACTIONS_JSON="$next_actions" python3 -c "
+import json, os, sys
+try:
+    warnings = json.loads(os.environ.get('STALE_WARNINGS_JSON') or '[]')
+    actions  = json.loads(os.environ.get('PRIOR_ACTIONS_JSON')  or '[]')
+    inject = []
+    for w in warnings:
+        if w.get('type') != 'stale_report':
+            continue
+        sub = w.get('subtype')
+        if sub == 'scout_drift':
+            a = len(w.get('added')   or [])
+            r = len(w.get('removed') or [])
+            c = len(w.get('changed') or [])
+            parts = []
+            if a: parts.append(f'{a} added')
+            if r: parts.append(f'{r} removed')
+            if c: parts.append(f'{c} changed')
+            detail = ', '.join(parts) if parts else 'content changed'
+            inject.append({
+                'skill': 'cogni-trends:trend-report',
+                'reason': f'Trend candidates changed since report was generated ({detail}) — re-run /trend-report to refresh'
+            })
+        elif sub == 'value_model_drift':
+            inject.append({
+                'skill': 'cogni-trends:trend-report',
+                'reason': 'Value model changed since report was generated — re-run /trend-report to refresh'
+            })
+    # Prepend in warning order, dedupe against existing actions by skill+reason.
+    existing = {(a.get('skill'), a.get('reason')) for a in actions}
+    for new in reversed(inject):
+        key = (new.get('skill'), new.get('reason'))
+        if key not in existing:
+            actions.insert(0, new)
+            existing.add(key)
+    print(json.dumps(actions))
+except Exception:
+    sys.stdout.write(os.environ.get('PRIOR_ACTIONS_JSON') or '[]')
+" 2>/dev/null || echo "$next_actions")
 fi
 
 cat << EOF

--- a/cogni-trends/skills/trend-report/SKILL.md
+++ b/cogni-trends/skills/trend-report/SKILL.md
@@ -707,13 +707,59 @@ Add to `{PROJECT_PATH}/.metadata/trend-scout-output.json`:
   "trend_report_investment_theme_count": N,
   "trend_report_generated_at": "ISO-8601",
   "report_tier": "{REPORT_TIER}",
-  "report_target_words": {REPORT_TARGET_WORDS}
+  "report_target_words": {REPORT_TARGET_WORDS},
+  "content_hash_at_report": "sha256:<hex>",
+  "value_model_hash_at_report": "sha256:<hex>",
+  "candidate_signature": { "<id>": "<short-hash>", ... }
 }
 ```
 
 `trend_report_mode` is `"smarter-service-themed"` when `REPORT_ARC_ID == "smarter-service"`, else `"strategic-themes"` (legacy value preserved for verify-trend-report and downstream consumers that already key off this field).
 
 `report_tier` and `report_target_words` are mirrored into trend-scout-output.json so `verify-trend-report` can read the prose-word target without re-loading `tips-project.json` — the reviewer uses it for tier-aware Completeness scoring.
+
+`content_hash_at_report`, `value_model_hash_at_report`, and `candidate_signature` are the **drift anchor** consumed by `project-status.sh --health-check` so the next `trends-resume` can tell real candidate / value-model drift apart from the metadata mirroring done by this same step (which would otherwise update mtime on every report run and trigger a false `stale_report` warning, see issue #187).
+
+Compute the anchor immediately **before** writing the metadata block (so the hash reflects pre-mirror content, not the file we are about to write):
+
+```python
+import hashlib, json
+
+# trend-scout-output.json content hash — only the candidate items, sorted.
+scout = json.load(open(scout_path))
+items = scout.get('tips_candidates', {}).get('items', []) or []
+def _key(c): return c.get('id') or c.get('title') or ''
+items_sorted = sorted(items, key=_key)
+content_hash = 'sha256:' + hashlib.sha256(
+    json.dumps(items_sorted, sort_keys=True, separators=(',', ':'), ensure_ascii=False).encode('utf-8')
+).hexdigest()
+candidate_signature = {
+    _key(c): hashlib.sha256(
+        json.dumps(c, sort_keys=True, separators=(',', ':'), ensure_ascii=False).encode('utf-8')
+    ).hexdigest()[:12]
+    for c in items_sorted if _key(c)
+}
+
+# tips-value-model.json content hash — only the substantive sections, sorted.
+vm = json.load(open(vm_path))
+def _sorted(seq, key):
+    return sorted(seq or [], key=lambda x: (x.get(key) or '') if isinstance(x, dict) else '')
+vm_payload = {
+    'investment_themes': _sorted(vm.get('investment_themes'), 'theme_id'),
+    'solutions':         _sorted(vm.get('solutions'),         'solution_id'),
+    'blueprints':        _sorted(vm.get('blueprints'),        'solution_id'),
+}
+value_model_hash = 'sha256:' + hashlib.sha256(
+    json.dumps(vm_payload, sort_keys=True, separators=(',', ':'), ensure_ascii=False).encode('utf-8')
+).hexdigest()
+```
+
+Hashing rules:
+
+- Always `json.dumps(..., sort_keys=True, separators=(',', ':'), ensure_ascii=False)` — deterministic across re-runs and locales.
+- Hash only candidate items (scout-output) and the three substantive value-model sections — never timestamps, mtimes, `report_*` fields, or any field this same step writes back.
+- Use `id`/`title` (scout) and `theme_id`/`solution_id` (value-model) for the canonical sort. Items missing the canonical key still hash, just under the empty-string sort bucket.
+- `candidate_signature` is `{id_or_title: short_hash[:12]}`. It lets `project-status.sh` name added/removed candidates without persisting the full snapshot.
 
 #### Step 4.2: Display Summary
 

--- a/cogni-trends/tests/test-stale-detection.sh
+++ b/cogni-trends/tests/test-stale-detection.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# Regression test for cogni-trends/scripts/project-status.sh stale-report
+# detection. Pins the script's contract for issue #187:
+#
+#   1. Mirroring is not drift  — Phase 4.1 of /trend-report writes report_tier
+#      back into .metadata/trend-scout-output.json, bumping its mtime. The
+#      pre-#187 mtime check fired stale_report on every resume after a report.
+#      The post-#187 hash anchor must NOT fire.
+#
+#   2. Real candidate drift fires — when a candidate id-set or item content
+#      actually changes, stale_report must fire with subtype scout_drift, and
+#      the action injector must prepend a cogni-trends:trend-report next_action
+#      naming the diff (added / removed / changed counts).
+#
+#   3. Legacy projects stay silent — projects whose report was generated before
+#      this fix have no content_hash_at_report anchor; the script must not fall
+#      back to the buggy mtime check, so no stale_report is emitted.
+#
+# Stdlib-only (bash + python3, no pip deps). Sister to test-project-status.sh.
+#
+# Usage: bash cogni-trends/tests/test-stale-detection.sh
+# Exits non-zero on any assertion failure.
+
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+SCRIPT="$PLUGIN_DIR/scripts/project-status.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: script not found at $SCRIPT" >&2
+  exit 1
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# Helper: hash a scout-output document the same way Phase 4.1 / project-status.sh
+# do. Keeps the test independent of the script's internals — if either side
+# changes its hashing rule without the other, this test fails loudly.
+HASH_HELPER="$TMPROOT/hash.py"
+cat > "$HASH_HELPER" <<'PYEOF'
+import json, hashlib, sys
+def _key(c): return c.get('id') or c.get('title') or ''
+def scout_hash(items):
+    items_sorted = sorted(items, key=_key)
+    return 'sha256:' + hashlib.sha256(
+        json.dumps(items_sorted, sort_keys=True, separators=(',', ':'), ensure_ascii=False).encode('utf-8')
+    ).hexdigest()
+def signature(items):
+    sig = {}
+    for c in sorted(items, key=_key):
+        k = _key(c)
+        if not k: continue
+        sig[k] = hashlib.sha256(
+            json.dumps(c, sort_keys=True, separators=(',', ':'), ensure_ascii=False).encode('utf-8')
+        ).hexdigest()[:12]
+    return sig
+def vm_sorted(seq, key):
+    return sorted(seq or [], key=lambda x: (x.get(key) or '') if isinstance(x, dict) else '')
+def vm_hash(vm_doc):
+    payload = {
+        'investment_themes': vm_sorted(vm_doc.get('investment_themes'), 'theme_id'),
+        'solutions':         vm_sorted(vm_doc.get('solutions'),         'solution_id'),
+        'blueprints':        vm_sorted(vm_doc.get('blueprints'),        'solution_id'),
+    }
+    return 'sha256:' + hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(',', ':'), ensure_ascii=False).encode('utf-8')
+    ).hexdigest()
+
+# CLI: hash.py scout SCOUT_FILE  ->  prints content_hash, signature_json, vm_hash
+mode = sys.argv[1]
+if mode == 'anchor':
+    scout_path, vm_path = sys.argv[2], sys.argv[3]
+    items = (json.load(open(scout_path)).get('tips_candidates') or {}).get('items') or []
+    vm = json.load(open(vm_path))
+    print(json.dumps({
+        'content_hash_at_report':     scout_hash(items),
+        'value_model_hash_at_report': vm_hash(vm),
+        'candidate_signature':        signature(items),
+    }))
+PYEOF
+
+# ---------------------------------------------------------------------------
+# Shared fixture builder — produces a project workspace that has reached
+# "complete" phase: scout-output with 4 candidates (one per dimension/horizon
+# slot the script checks), value-model with one investment theme, and a
+# trend-report file. The hash anchor is then computed and embedded.
+# ---------------------------------------------------------------------------
+build_project() {
+  local proj="$1"
+  mkdir -p "$proj/.metadata" "$proj/.logs"
+
+  cat > "$proj/tips-project.json" <<EOF
+{
+  "project_id": "stale-test",
+  "project_slug": "stale-test",
+  "project_language": "en",
+  "industry": "test",
+  "subsector": "test",
+  "research_topic": "test"
+}
+EOF
+
+  cat > "$proj/.metadata/trend-scout-output.json" <<'EOF'
+{
+  "tips_candidates": {
+    "total": 2,
+    "items": [
+      {"id": "t-001", "title": "First trend",  "dimension": "externe-effekte", "horizon": "act",  "source": "training"},
+      {"id": "t-002", "title": "Second trend", "dimension": "neue-horizonte",  "horizon": "plan", "source": "training"}
+    ]
+  },
+  "execution": {"workflow_state": "candidates_agreed"}
+}
+EOF
+
+  cat > "$proj/tips-value-model.json" <<'EOF'
+{
+  "investment_themes": [
+    {"theme_id": "th-001", "name": "Test theme", "value_chain": ["a", "b"]}
+  ],
+  "solutions":  [{"solution_id": "s-001", "name": "Sol-A"}],
+  "blueprints": [{"solution_id": "s-001", "readiness": 1.0}]
+}
+EOF
+
+  printf 'tips trend report body\n' > "$proj/tips-trend-report.md"
+
+  # Compute and embed the hash anchor — simulates trend-report Phase 4.1.
+  local anchor
+  anchor="$(python3 "$HASH_HELPER" anchor "$proj/.metadata/trend-scout-output.json" "$proj/tips-value-model.json")"
+  python3 - "$proj/.metadata/trend-scout-output.json" "$anchor" <<'PYEOF'
+import json, sys
+path, anchor = sys.argv[1], json.loads(sys.argv[2])
+doc = json.load(open(path))
+doc.update({
+    'trend_report_complete': True,
+    'trend_report_path': 'tips-trend-report.md',
+    'trend_report_generated_at': '2026-04-30T00:00:00Z',
+    'report_tier': 'standard',
+    'report_target_words': 6000,
+    'content_hash_at_report':     anchor['content_hash_at_report'],
+    'value_model_hash_at_report': anchor['value_model_hash_at_report'],
+    'candidate_signature':        anchor['candidate_signature'],
+})
+open(path, 'w').write(json.dumps(doc, indent=2))
+PYEOF
+}
+
+# Helper: extract stale_warnings + next_actions from --health-check output.
+extract() {
+  python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+print(json.dumps({
+    "warnings": d.get("stale_warnings") or [],
+    "actions":  d.get("next_actions")   or [],
+}))
+'
+}
+
+run_health() {
+  local proj="$1"
+  bash "$SCRIPT" "$proj" --health-check 2>/dev/null
+}
+
+FAIL_COUNT=0
+fail() { echo "FAIL $1" >&2; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+ok()   { echo "OK   $1"; }
+
+# ---------------------------------------------------------------------------
+# Case 1: Mirroring is not drift.
+# After build_project(), simulate the next /trends-resume: the user has done
+# nothing, but Phase 4.1 has already mirrored report_tier into the file (which
+# we did during build). Just touch the file to bump mtime past the report.
+# ---------------------------------------------------------------------------
+P1="$TMPROOT/case1-mirroring"
+build_project "$P1"
+sleep 1
+touch "$P1/.metadata/trend-scout-output.json"
+
+OUT="$(run_health "$P1" | extract)"
+HAS_STALE="$(echo "$OUT" | python3 -c 'import json,sys; w=json.load(sys.stdin)["warnings"]; print(any(x.get("type")=="stale_report" for x in w))')"
+if [ "$HAS_STALE" = "False" ]; then
+  ok "case 1 — mirroring did not fire stale_report"
+else
+  fail "case 1 — stale_report fired even though candidate content is unchanged"
+  echo "$OUT" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: Real candidate drift fires + concrete action injected.
+# Mutate one candidate's title and add a brand-new candidate so the diff
+# reports both a `changed` id and an `added` id.
+# ---------------------------------------------------------------------------
+P2="$TMPROOT/case2-drift"
+build_project "$P2"
+python3 - "$P2/.metadata/trend-scout-output.json" <<'PYEOF'
+import json, sys
+path = sys.argv[1]
+doc = json.load(open(path))
+items = doc['tips_candidates']['items']
+items[0]['title'] = 'First trend (revised)'
+items.append({'id': 't-003', 'title': 'Third trend', 'dimension': 'digitale-wertetreiber', 'horizon': 'observe', 'source': 'training'})
+doc['tips_candidates']['total'] = len(items)
+open(path, 'w').write(json.dumps(doc, indent=2))
+PYEOF
+
+OUT="$(run_health "$P2" | extract)"
+SUMMARY="$(echo "$OUT" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+warns = [w for w in d["warnings"] if w.get("type") == "stale_report"]
+acts  = d["actions"]
+report_actions = [a for a in acts if a.get("skill") == "cogni-trends:trend-report"]
+print(json.dumps({
+    "stale_count": len(warns),
+    "subtype":     warns[0].get("subtype") if warns else None,
+    "added":       warns[0].get("added")   if warns else None,
+    "changed":     warns[0].get("changed") if warns else None,
+    "first_action_skill":  acts[0].get("skill")  if acts else None,
+    "first_action_reason": acts[0].get("reason") if acts else None,
+    "report_actions":      report_actions,
+}))
+')"
+
+# Parse SUMMARY for assertions.
+python3 - "$SUMMARY" <<'PYEOF'
+import json, sys
+s = json.loads(sys.argv[1])
+problems = []
+if s["stale_count"] < 1:
+    problems.append("stale_report did not fire on real drift")
+if s["subtype"] != "scout_drift":
+    problems.append(f"subtype={s['subtype']!r} (expected 'scout_drift')")
+if "t-003" not in (s["added"] or []):
+    problems.append(f"added={s['added']!r} (expected to contain 't-003')")
+if "t-001" not in (s["changed"] or []):
+    problems.append(f"changed={s['changed']!r} (expected to contain 't-001')")
+if s["first_action_skill"] != "cogni-trends:trend-report":
+    problems.append(f"first action skill={s['first_action_skill']!r} (expected cogni-trends:trend-report)")
+reason = s["first_action_reason"] or ""
+for fragment in ("1 added", "1 changed", "/trend-report"):
+    if fragment not in reason:
+        problems.append(f"first action reason missing fragment {fragment!r}: {reason!r}")
+if problems:
+    print("\n".join("FAIL case 2 — " + p for p in problems), file=sys.stderr)
+    sys.exit(1)
+print("OK   case 2 — drift fired with subtype=scout_drift, added={t-003}, changed={t-001}")
+print("OK   case 2 — concrete cogni-trends:trend-report action prepended naming the diff")
+PYEOF
+RC=$?
+if [ $RC -ne 0 ]; then FAIL_COUNT=$((FAIL_COUNT + 1)); fi
+
+# ---------------------------------------------------------------------------
+# Case 3: Legacy project (no anchor) stays silent.
+# Build a project, then strip content_hash_at_report and friends from the
+# scout-output metadata. Touch the file so its mtime > report mtime.
+# ---------------------------------------------------------------------------
+P3="$TMPROOT/case3-legacy"
+build_project "$P3"
+python3 - "$P3/.metadata/trend-scout-output.json" <<'PYEOF'
+import json, sys
+path = sys.argv[1]
+doc = json.load(open(path))
+for k in ('content_hash_at_report', 'value_model_hash_at_report', 'candidate_signature'):
+    doc.pop(k, None)
+open(path, 'w').write(json.dumps(doc, indent=2))
+PYEOF
+sleep 1
+touch "$P3/.metadata/trend-scout-output.json"
+
+OUT="$(run_health "$P3" | extract)"
+HAS_STALE="$(echo "$OUT" | python3 -c 'import json,sys; w=json.load(sys.stdin)["warnings"]; print(any(x.get("type")=="stale_report" for x in w))')"
+if [ "$HAS_STALE" = "False" ]; then
+  ok "case 3 — legacy project (no anchor) stayed silent"
+else
+  fail "case 3 — stale_report fired on a legacy project (no hash anchor present)"
+  echo "$OUT" >&2
+fi
+
+if [ $FAIL_COUNT -gt 0 ]; then
+  echo
+  echo "$FAIL_COUNT case(s) failed" >&2
+  exit 1
+fi
+echo
+echo "All stale-detection assertions passed."


### PR DESCRIPTION
Closes #187.

## Summary

- Switch `project-status.sh --health-check` stale-report detection from file-mtime comparison to content-hash comparison anchored at report-generation time.
- `/trend-report` Phase 4.1 now writes `content_hash_at_report`, `value_model_hash_at_report`, and a `candidate_signature` map into `.metadata/trend-scout-output.json` alongside the existing `trend_report_*` mirror.
- When real drift is detected, the `stale_report` warning carries a `subtype` (`scout_drift` | `value_model_drift`) plus added/removed/changed candidate id lists, and a concrete `cogni-trends:trend-report` next_action is prepended naming the diff (e.g. _"Trend candidates changed since report was generated (1 added, 1 changed) — re-run /trend-report to refresh"_).
- Legacy projects (report generated before this fix, no hash anchor) stay silent — we don't fall back to the buggy mtime check; they get a clean anchor on next `/trend-report`.

## Why

`trends-resume` was firing `stale_report` on every resume after a report run, because Phase 4.1 mirrors `report_tier` and other report metadata back into the scout-output file — bumping its mtime even though no candidate content changed. The user got a 30-min "just-in-case" full re-run instead of a clean welcome-back. Same pattern applied to the value-model vs. report mtime check.

## Test plan

- [x] `bash cogni-trends/tests/test-stale-detection.sh` — new regression test, three cases (mirroring-is-not-drift, real-drift-fires-with-action, legacy-project-silent). All pass.
- [x] `bash cogni-trends/tests/test-project-status.sh` — existing value-modeler-counts contract test still passes (no regression).
- [ ] End-to-end on a real project at `complete` phase: run `/trends-resume` and confirm no stale-report banner, then mutate a candidate id and confirm the warning + concrete action surface.

## Files

- `cogni-trends/scripts/project-status.sh` — replaces mtime checks with hash checks; adds drift-action injection.
- `cogni-trends/skills/trend-report/SKILL.md` Step 4.1 — extends the metadata block + documents the hashing rules.
- `cogni-trends/tests/test-stale-detection.sh` — new.
- `cogni-trends/.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` — `0.5.8` → `0.5.9`.

## Out of scope (deferred)

- The `stale_blueprints` check (portfolio-context vs. value-model) is still mtime-based — it has no analogous Phase-4.1 write-back, so the false-positive mechanism doesn't apply. Migrating it to hashes is a follow-up if it ever bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)