### PR TITLE
cogni-trends: remove vestigial MICRO_ARC parameter

### DIFF
--- a/cogni-trends/agents/trend-report-composer.md
+++ b/cogni-trends/agents/trend-report-composer.md
@@ -12,7 +12,7 @@ You are a dimension-scoped composer for the smarter-service report arc. You rece
 
 You are dispatched **sequentially** — once per macro dimension, in TIPS order (T → I → P → S). Each invocation is independent: you write one file, return JSON, and exit. The orchestrator runs you four times in series (not parallel) so the arc voice carries cleanly across the four macro sections.
 
-You do **not** rewrite theme-cases — those are written by `trend-report-investment-theme-writer` in slim mode (`MICRO_ARC = "investment-case"`) and are read-only inputs to you. Your job is only the dimension narrative + the H2 heading + secondary callouts + clean concatenation.
+You do **not** rewrite theme-cases — those are written by `trend-report-investment-theme-writer` as slim 3-beat cases (Stake / Move / Cost-of-Inaction) and are read-only inputs to you. Your job is only the dimension narrative + the H2 heading + secondary callouts + clean concatenation.
 
 Return ONLY compact JSON — all verbose output goes to the macro-section file.
 

--- a/cogni-trends/agents/trend-report-investment-theme-writer.md
+++ b/cogni-trends/agents/trend-report-investment-theme-writer.md
@@ -58,7 +58,6 @@ consistent within each locale; reserve ASCII `"` for the JSON envelope only.
 
 You receive these from trend-synthesis Phase 2.1:
 
-- **MICRO_ARC** — Always `"investment-case"`. Vestigial enum-of-1 — the legacy `theme-thesis` branch was removed; the parameter remains in the prompt schema for backward compatibility and will be removed in a follow-up cleanup.
 - **ANCHOR_DIMENSION** — Required. The Smarter Service dimension this theme is anchored to: `"externe-effekte"`, `"digitale-wertetreiber"`, `"neue-horizonte"`, or `"digitales-fundament"`. Determines which dimension's primer paragraph you must reference in the Stake beat.
 - **SECONDARY_POLES** — Optional. JSON array of secondary TIPS poles where this theme has at least one candidate but did not win the anchor. Used to render one-line callouts at the end of the theme-case.
 - **SHARED_PRIMER_PATH** — Required. Absolute path to the shared dimension primer file written by the orchestrator at Step 2.0b. The Stake beat must quote/reference this primer's framing for `ANCHOR_DIMENSION`.
@@ -308,7 +307,6 @@ Return ONLY this JSON — nothing else:
 ```json
 {
   "ok": true,
-  "micro_arc": "investment-case",
   "investment_theme_id": "it-001",
   "investment_theme_name": "Theme Name",
   "anchor_dimension": "neue-horizonte",

--- a/cogni-trends/skills/trend-synthesis/SKILL.md
+++ b/cogni-trends/skills/trend-synthesis/SKILL.md
@@ -34,7 +34,7 @@ Transform the research manifest plus enriched per-trend evidence into a CxO-grad
 3. Pick a length tier and compute per-section word budgets (smarter-service formula only)
 4. Anchor each investment theme to its dominant TIPS dimension
 5. Write the shared dimension primer (orchestrator)
-6. Dispatch N parallel theme-case writers (`MICRO_ARC: "investment-case"`)
+6. Dispatch N parallel theme-case writers
 7. Dispatch 4 sequential dimension composers (T → I → P → S, voice consistency)
 8. Compose the executive summary (over the 4 dimensions, naming anchored themes)
 9. Build the claims registry with a dimension column
@@ -291,7 +291,6 @@ Task:
   model: sonnet
   prompt: |
     PROJECT_PATH: {PROJECT_PATH}
-    MICRO_ARC: "investment-case"
     INVESTMENT_THEME_ID: {theme.investment_theme_id}
     INVESTMENT_THEME_NAME: {theme.name}
     STRATEGIC_QUESTION: {theme.strategic_question}
@@ -315,8 +314,6 @@ Task:
     NARRATIVE_ARC_PATH: {path to cogni-narrative smarter-service arc-definition.md, optional}
     NARRATIVE_TECHNIQUES_PATH: {path to cogni-narrative techniques-overview.md, optional}
 ```
-
-> `MICRO_ARC: "investment-case"` is currently a vestigial enum-of-1 (the `theme-thesis` branch was removed in this same PR — see C5). Pass it literally for now; full removal of the parameter is queued as a follow-up cleanup.
 
 Resume: skip if `.logs/theme-case-{theme_id}.md` exists and is >600 bytes. Validation per agent: `ok == true`, `primer_referenced == true`, `cost_ratio` and `cost_window` non-empty, `quality_gate_pass == true`. Retry once on failure.
 

--- a/cogni-trends/skills/trend-synthesis/references/report-length-tiers.md
+++ b/cogni-trends/skills/trend-synthesis/references/report-length-tiers.md
@@ -28,7 +28,7 @@ The reviewer in `verify-trend-report` measures prose the same way — by summing
 
 ## Per-element minimums (slim 3-beat theme case)
 
-When the writer agent runs in `MICRO_ARC = "investment-case"` mode it produces three beats with these proportions and minimums applied to `THEME_CASE_TARGET_WORDS`:
+The writer agent produces a slim 3-beat theme case (Stake / Move / Cost-of-Inaction) with these proportions and minimums applied to `THEME_CASE_TARGET_WORDS`:
 
 | Beat | Proportion | Minimum |
 |---|---|---|

--- a/cogni-trends/skills/trend-synthesis/references/synthesis-skeleton.md
+++ b/cogni-trends/skills/trend-synthesis/references/synthesis-skeleton.md
@@ -7,7 +7,7 @@ Phase 2 produces a report whose H2 spine is the four Smarter Service dimensions,
 **Three structural pillars:**
 
 1. **A shared dimension primer (Step 2.0)** — written once by the orchestrator before any theme-case dispatch — gives theme writers the macro framing they must reference instead of re-establishing.
-2. **Slim 3-beat theme-cases (Step 2.1)** — `trend-report-investment-theme-writer` runs in `MICRO_ARC=investment-case` mode, producing Stake / Move / Cost-of-Inaction. Themes do not own macro framing.
+2. **Slim 3-beat theme-cases (Step 2.1)** — `trend-report-investment-theme-writer` produces Stake / Move / Cost-of-Inaction. Themes do not own macro framing.
 3. **Sequential dimension composer (Step 2.2)** — `trend-report-composer` is invoked four times, once per macro section, with manageable context (one dimension's evidence). The composer integrates dimension narrative + nested theme-cases into a single voice per macro section.
 
 ---
@@ -132,9 +132,9 @@ Display `"{PHASE_2_PRIMER_WRITTEN}"`.
 
 ---
 
-## Step 2.1: Dispatch Theme-Case Writers (slim mode, parallel)
+## Step 2.1: Dispatch Theme-Case Writers (parallel)
 
-For each investment theme, dispatch a `cogni-trends:trend-report-investment-theme-writer` agent with `MICRO_ARC = "investment-case"`. Dispatch all agents in a single message (parallel tool calls).
+For each investment theme, dispatch a `cogni-trends:trend-report-investment-theme-writer` agent. Dispatch all agents in a single message (parallel tool calls). The writer produces a slim 3-beat case (Stake / Move / Cost-of-Inaction) — that is the only output shape this agent supports.
 
 ### Resume Check
 
@@ -148,7 +148,6 @@ Per agent:
   model: sonnet
   prompt: |
     PROJECT_PATH: {PROJECT_PATH}
-    MICRO_ARC: "investment-case"
     INVESTMENT_THEME_ID: {theme.investment_theme_id}
     INVESTMENT_THEME_NAME: {theme.name}
     STRATEGIC_QUESTION: {theme.strategic_question}
@@ -176,7 +175,7 @@ Per agent:
     NARRATIVE_TECHNIQUES_PATH: {path to cogni-narrative techniques-overview.md}
 ```
 
-### Beat Rules (the slim 3-beat micro-arc)
+### Beat Rules (the slim 3-beat structure)
 
 The agent produces output with exactly 3 beats. Beat headers are **silent** — they do not appear as visible markdown headings; they're rhetorical structure only. The output looks like:
 


### PR DESCRIPTION
Deferred cleanup follow-up to #192.

#192 collapsed the theme-case writer's `MICRO_ARC` parameter to an enum-of-1 (`"investment-case"` only — the `theme-thesis` branch was deleted) but kept the parameter in the prompt schema. This PR removes the now-dead parameter from:

- `cogni-trends/agents/trend-report-investment-theme-writer.md` — removes the `MICRO_ARC` entry from Input Parameters and the `"micro_arc": "investment-case"` field from the return JSON.
- `cogni-trends/skills/trend-synthesis/SKILL.md` — removes `MICRO_ARC: "investment-case"` from the Phase 2.1 dispatch prompt template, drops the trailing blockquote that flagged it as vestigial, and trims the Purpose item that mentioned it.

Pure textual cleanup — no behavioral change. The agent already only does `investment-case` mode.

## Note for reviewer

GitHub code search still shows `MICRO_ARC` references in three additional files — explicitly out of scope per the task instructions, surfaced here for follow-up:

- `cogni-trends/agents/trend-report-composer.md` — one explanatory mention of `MICRO_ARC = "investment-case"` describing the writer agent.
- `cogni-trends/skills/trend-synthesis/references/synthesis-skeleton.md` — multiple references in the Step 2.1 dispatch template and surrounding prose.
- `cogni-trends/skills/trend-synthesis/references/report-length-tiers.md` — one mention in the per-element minimums section.

These are stale documentation only (no scripts parse them), but they should be cleaned up in a separate sweep so the docs are consistent with the agent contract removed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxaPP4tpJAHx4svfVf8rkz)_