### PR TITLE
cogni-wiki 0.0.20: wiki-claims-resweep citation re-verify (Punkt 4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -254,7 +254,7 @@
     {
       "name": "cogni-wiki",
       "source": "./cogni-wiki",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "maturity": "incubating",
       "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
       "keywords": [

--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-wiki/CLAUDE.md
+++ b/cogni-wiki/CLAUDE.md
@@ -42,6 +42,10 @@ skills/                         9 wiki skills
   wiki-refresh/                   Stale-page refresh loop. Pull-mode: matches lint-flagged stale pages to sub-questions of an existing cogni-research project (Jaccard token overlap), then dispatches wiki-update per match. Sequential, batch-confirmed.
     scripts/
       refresh_planner.py            Reads stale wiki pages + research entities; emits per-page match plan as JSON
+  wiki-claims-resweep/            Re-verify claims embedded in existing wiki pages against their cited source URLs. Pull-mode, report-only: extracts inline-cited statements deterministically, dispatches cogni-claims:claims (submit + verify), and writes a sweep report to raw/claims-resweep-<date>/ plus a lint-bridge JSON. Never mutates wiki/pages/.
+    scripts/
+      extract_page_claims.py        Deterministic claim-candidate extractor (sentences near URLs); never network-touches
+      resweep_planner.py            Two-phase: materialises sweep workspace (plan), aggregates verification results (aggregate); writes lint-bridge under lock
 
 references/
   karpathy-pattern.md             Shared Karpathy-pattern reference, cited by all skills
@@ -51,11 +55,11 @@ references/
 
 | Type | Count | Items |
 |------|-------|-------|
-| Skills | 9 | wiki-setup, wiki-ingest, wiki-query, wiki-lint, wiki-update, wiki-resume, wiki-dashboard, wiki-from-research, wiki-refresh |
+| Skills | 10 | wiki-setup, wiki-ingest, wiki-query, wiki-lint, wiki-update, wiki-resume, wiki-dashboard, wiki-from-research, wiki-refresh, wiki-claims-resweep |
 | Agents | 1 | ingest-worker (per-source fan-out worker for wiki-ingest batch mode; not directly dispatchable) |
 | Commands | 0 | — (skills serve as slash commands per plugin-dev guidance) |
 | Hooks | 0 | — (all bookkeeping lives inside skills) |
-| Scripts | 7 | backlink_audit.py, wiki_index_update.py, batch_builder.py, lint_wiki.py, wiki_status.sh, render_dashboard.py, refresh_planner.py |
+| Scripts | 9 | backlink_audit.py, wiki_index_update.py, batch_builder.py, lint_wiki.py, wiki_status.sh, render_dashboard.py, refresh_planner.py, extract_page_claims.py, resweep_planner.py |
 
 ## Wiki Data Layout (outside the plugin)
 
@@ -112,6 +116,7 @@ sources: [../raw/paper-xyz.pdf, https://...]
 | `wiki/index.md` | Insert/update entry line | `wiki_index_update.py::update_index` (line 335) |
 | `wiki/pages/<target>.md` | Backlink append into an *existing* page | `backlink_audit.py::apply_plan` (lines 489, 590) |
 | `.cogni-wiki/config.json` | `entries_count` bump (and any future counters) | `config_bump.py::main` (line 105) |
+| `.cogni-wiki/last-resweep.json` | Sweep summary write at end of `wiki-claims-resweep` aggregate phase | `resweep_planner.py::phase_aggregate` |
 
 **When adding a new shared-state file**, the author MUST:
 
@@ -133,6 +138,7 @@ insight-wave already uses Claude Code's auto-memory system at `~/.claude/project
 - **cogni-research → cogni-wiki** (v0.0.17, sub-question-centric — Option B). `wiki-ingest --discover research:<project-slug>` enumerates one batch entry per sub-question of a completed cogni-research project, materialises per-sub-question synthesis files under `<wiki-root>/raw/research-<slug>/sq-NN-<short>.md`, and feeds them through the standard batch-mode pipeline (Steps 1–8 per source). The synthesis bundles findings (from contexts), verified claims (filtered to `verification_status: verified`), and source URLs. Materialisation is the one deviation from the discovery-is-read-only rule and is unavoidable: cogni-research spreads each sub-question's evidence across four entity types, and the per-source ingest-worker reads one file. Materialisation is deterministic and idempotent. See `skills/wiki-ingest/references/batch-mode.md` §"Discovery → research" for the full contract. The reverse path (`wiki-researcher` agent reading a wiki as a RAG source for a research project) is owned by cogni-research and pre-dates this integration.
 - **wiki-from-research cold-start** (v0.0.18). The `wiki-from-research` skill chains `cogni-research:research-setup` → `cogni-research:research-report` (auto-chained internally) → `cogni-wiki:wiki-setup` → `cogni-wiki:wiki-ingest --discover research:<slug>` in one dispatch. Mode A starts from a free-text `--topic`; Mode B starts from an existing `--research-slug`. The skill is a pure orchestrator — it writes nothing directly; every artefact comes from its sub-skills' contracts. Pre-flight is fail-fast: wiki-target collisions are detected before any cogni-research dispatch (so an unusable target never burns research budget). Mode B verifies `output/report.md` exists, refuses `report_source ∈ {wiki, hybrid}` projects (circular-evidence risk), and nudges the user to run `verify-report` first if zero claims are verified.
 - **wiki-refresh stale-page loop** (v0.0.19, pull-mode only). The `wiki-refresh` skill closes the *update* loop — stale wiki pages get fresh evidence from a completed cogni-research project. Calls `lint_wiki.py` directly to enumerate `stale_page` (>365d) and `stale_draft` (>180d) findings, runs `refresh_planner.py` to match each stale page to the highest-scoring sub-question via Jaccard token overlap on `(title + tags + type)` vs `(query + parent_topic)`, prints a batch plan for one user confirmation, then materialises one synthesis file per match under `<wiki-root>/raw/refresh-<research-slug>-<YYYY-MM-DD>/<page-slug>.md` and dispatches `wiki-update` sequentially per page. Default match threshold `0.30`, tunable via `--match-threshold` or interactively via the `refine` action in the plan-review prompt. Push-mode auto-research per stale page is deferred (cost-prohibitive at scale). The entity-loading helpers in `refresh_planner.py` mirror those in `batch_builder.py` — known tech debt, parallel to the `_wiki_lock` duplication noted in §"Concurrency Invariant".
+- **wiki-claims-resweep citation re-verify** (v0.0.20, pull-mode only). The `wiki-claims-resweep` skill closes the *citation-drift* loop — existing wiki pages have their cited source URLs re-checked against current content. `extract_page_claims.py` walks `wiki/pages/` and yields one claim candidate per sentence containing an inline `[text](http(s)://...)` link or bare URL (deterministic, no LLM, no network). The orchestrator runs `resweep_planner.py --phase plan` to materialise per-page claim manifests under `<wiki-root>/raw/claims-resweep-<YYYY-MM-DD>/`, batch-confirms with the user, then dispatches `cogni-claims:claims` (`submit` then `verify`) sequentially per page. The cogni-claims source-cache (`cogni-claims/sources/{url-hash}.json`) keeps repeat WebFetches free across pages within one sweep. After verification, `resweep_planner.py --phase aggregate` writes `report.md` to the workspace and `last-resweep.json` (lock-wrapped) to `.cogni-wiki/`. **Report-only**: this skill never modifies `wiki/pages/`. Stale-marker decisions go through `wiki-update` manually. Circular sources (URLs pointing back into the wiki tree) are skipped per claim and counted, mirroring the `report_source ∈ {wiki, hybrid}` refusal pattern from `wiki-from-research`/`wiki-refresh`. A future `claim_drift` warning class in `wiki-lint` can read `last-resweep.json` to surface flagged pages — deferred to a follow-up PR (the JSON contract exists today).
 
 ## Future Integration Points
 
@@ -140,7 +146,7 @@ Deferred to post-MVP, documented here so the contract stays visible:
 
 - **cogni-narrative ← cogni-wiki** — narrative skill reads wiki pages as structured input
 - **cogni-consulting → cogni-wiki** — engagement knowledge (interviews, decisions, constraints) persists beyond the engagement slug
-- **cogni-claims ↔ cogni-wiki** — wiki claim extraction and verification via cogni-claims (today only one direction: verified claims from cogni-research arrive via the research deposit pipeline above)
+- **cogni-claims ↔ cogni-wiki** — initial direction live as of v0.0.20 via `wiki-claims-resweep` (re-verifies inline-cited claims in existing wiki pages against their source URLs). Reverse direction — propagating cogni-claims resolutions back into wiki pages — remains deferred
 
 ## Pipeline Position
 

--- a/cogni-wiki/skills/wiki-claims-resweep/SKILL.md
+++ b/cogni-wiki/skills/wiki-claims-resweep/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: wiki-claims-resweep
+description: "Re-verify claims embedded in existing wiki pages against their cited source URLs. Extracts inline-cited statements deterministically (sentences containing http(s) URLs or markdown links — no LLM extraction), submits them as a batch to cogni-claims for re-verification (WebFetch + LLM compare per source), and writes a sweep report under <wiki-root>/raw/claims-resweep-<date>/ plus a machine-readable .cogni-wiki/last-resweep.json bridge for future lint integration. Report-only — never mutates wiki/pages/. Trigger when the user says 're-verify wiki claims', 'check if wiki sources still hold up', 'sweep wiki for stale citations', 'run a claims re-check on the wiki', 'audit wiki citations against sources', or 'wiki-claims-resweep'. Pull-mode only; the user picks scope (--all, --page <slug>, or --stale-only)."
+allowed-tools: Read, Write, Bash, Glob, AskUserQuestion, Skill
+---
+
+# Wiki Claims Re-Verify Sweep
+
+Wiki pages cite sources but no mechanism re-checks those citations after ingest. URLs 404, paywalls appear, content gets rewritten. This skill closes that loop: it extracts cited statements from existing wiki pages, dispatches them through cogni-claims for verification (which already does the WebFetch + LLM compare against the live source), and writes a sweep report so the user can see drift at a glance.
+
+This is a **report-only** skill. It does not edit wiki/pages/. The report tells the user which pages have deviated or unavailable claims; the user decides whether to run `wiki-update` to mark them stale. This keeps diff-before-write inside `wiki-update` where it belongs.
+
+This is a **pull-mode** primitive — the user invokes it on a schedule that fits their workflow. There is no auto-trigger.
+
+Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once before proceeding to re-anchor on the three-layer model — sweep artefacts land in `raw/`, never in `wiki/pages/`.
+
+## When to run
+
+- User asks to re-verify, sweep, or audit existing wiki citations
+- After a long stretch (months) of accumulated wiki growth, to surface URL drift
+- Before a major wiki release or share-out, to spot embarrassing dead citations
+- Targeted: "re-verify just the ai-safety-evals page" → `--page <slug>`
+
+## Never run when
+
+- The wiki has no pages with `sources:` populated — there's nothing to re-verify
+- The user wants to mutate page bodies (set `## Stale` markers etc.) — that's `wiki-update`'s job; this skill is report-only and never touches `wiki/pages/`
+- The user wants to create new claims from scratch — that's `wiki-ingest`'s job
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--all` | No | (Default) Sweep every page that has a non-empty `sources:` field. |
+| `--page <slug>` | No | Sweep a single page only. Mutually exclusive with `--all` and `--stale-only`. |
+| `--stale-only` | No | Sweep only pages older than `STALE_PAGE_DAYS` (365) — or `--days N`. |
+| `--days <N>` | No | Override staleness threshold; only valid with `--stale-only`. |
+| `--wiki-root <path>` | No | Override auto-detected wiki root. |
+| `--dry-run` | No | Run extract + plan; print the plan and stop. No cogni-claims dispatch, no report. The materialised manifests under `raw/claims-resweep-<date>/` are still written (audit trail). |
+
+## Workflow
+
+### 0. Pre-flight (always; fail-fast)
+
+1. Resolve `wiki_root` (walk up for `.cogni-wiki/config.json`).
+2. Compute `today = YYYY-MM-DD`.
+3. If neither `--all`, `--page`, nor `--stale-only` is set, default to `--all`.
+4. If `--days` is set without `--stale-only`, abort with "--days requires --stale-only".
+
+### 1. Extract claim candidates (deterministic, read-only)
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/wiki-claims-resweep/scripts/extract_page_claims.py \
+  --wiki-root <wiki_root> \
+  [--all | --page <slug> | --stale-only] \
+  [--days <N>]
+```
+
+The script parses each selected page's body and emits claim candidates: every sentence that contains an inline `[text](http(s)://...)` link or a bare `http(s)://` URL becomes a candidate, with the URL as the source. Sentences shorter than 30 characters are dropped (heading/list-item noise). The script never makes network calls.
+
+Pages with **circular sources** (URLs pointing back into the wiki tree, e.g. relative paths under `wiki/`) have those specific claims dropped and counted in `circular_skipped` — same circular-evidence rule as `wiki-from-research` and `wiki-refresh`.
+
+Parse stdout JSON. If `data.stats.total_claims == 0`, emit one line — "no cited claims to re-verify in scope" — and exit 0.
+
+### 2. Materialise sweep workspace
+
+Pipe the extract output into the planner's `plan` phase:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/wiki-claims-resweep/scripts/resweep_planner.py \
+  --phase plan \
+  --extract-file - \
+  --date <today>
+```
+
+The planner creates `<wiki-root>/raw/claims-resweep-<today>/` and writes one `<slug>-claims.md` manifest per page (YAML frontmatter + statement/source list) plus an `index.json` with the dispatch plan. Re-runs on the same day overwrite deterministically; reruns on different days preserve the audit trail.
+
+The planner only writes inside the per-day workspace dir (isolated, no lock contention).
+
+### 3. Print plan, batch-confirm
+
+Render the planner output as a table:
+
+```
+Claims re-verify plan (mode: <mode>, date: <today>):
+  <K> pages, <total_claims> claims, <unique_sources> unique source URLs
+
+  page                       claims  sources  age
+  ai-safety-evals               8       3     412d
+  llm-jailbreaks                3       2     198d
+  …
+```
+
+If `--dry-run` was set, stop here. Exit 0. The materialised manifests stay on disk for inspection.
+
+Otherwise, AskUserQuestion with three options:
+
+| Label | Action |
+|---|---|
+| `proceed` | Dispatch cogni-claims (Steps 4–6) |
+| `refine` | Re-prompt for a tighter scope (suggest switching to `--stale-only` or naming a `--page`); loop back to Step 1 |
+| `abort` | Exit 0; manifests stay on disk for the user to inspect |
+
+### 4. Submit + verify per page (sequential)
+
+For each entry in `data.plan[]`:
+
+1. Read the manifest at `<wiki-root>/<entry.manifest>` and parse the `## Claims` section into a list of `{statement, source_url, source_title}` records.
+2. Dispatch:
+
+   ```
+   Skill("cogni-claims:claims",
+         args="submit working_dir=<wiki-root> claims=<list> submitted_by=wiki-claims-resweep")
+   ```
+
+   Pass each record verbatim. The claims skill assigns IDs and appends to `<wiki-root>/cogni-claims/claims.json`.
+
+3. Capture the submission's claim IDs. Then dispatch:
+
+   ```
+   Skill("cogni-claims:claims",
+         args="verify working_dir=<wiki-root> ids=<list-of-just-submitted-ids>")
+   ```
+
+   The claim-verifier agent groups by source URL, fetches each URL once (cached at `cogni-claims/sources/{url-hash}.json`), and updates each claim's status to `verified | deviated | source_unavailable`.
+
+**Sequential per page**, not parallel — keeps the orchestration trivial and the cogni-claims source-cache hot for any URLs shared across pages within the same sweep.
+
+If a `cogni-claims:claims` dispatch fails for a specific page (e.g. WebFetch network blip, store init error), capture the error in a per-page failure entry and continue. Per-page failures never halt the sweep.
+
+### 5. Build verification-results JSON
+
+After all per-page dispatches complete, read `<wiki-root>/cogni-claims/claims.json` and group by page (using the manifest IDs you captured in Step 4). Construct:
+
+```json
+{
+  "success": true,
+  "data": {
+    "pages": [
+      {
+        "slug": "<page-slug>",
+        "claims": [
+          {"id": "<claim-id>", "statement": "...", "source_url": "...",
+           "status": "verified | deviated | source_unavailable",
+           "deviations": [...]}
+        ]
+      }
+    ]
+  },
+  "error": ""
+}
+```
+
+This is the input shape for `--phase aggregate` below.
+
+### 6. Aggregate report + lint-bridge
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/wiki-claims-resweep/scripts/resweep_planner.py \
+  --phase aggregate \
+  --workspace <wiki_root>/raw/claims-resweep-<today> \
+  --results-file - <<<'<json from Step 5>'
+```
+
+The planner writes:
+
+- `<wiki_root>/raw/claims-resweep-<today>/report.md` — human-readable per-page findings
+- `<wiki_root>/.cogni-wiki/last-resweep.json` — machine-readable bridge (sweep_date, mode, deviated_pages, unavailable_pages, report_path). **Lock-wrapped** via `_wiki_lock` since `last-resweep.json` is shared state.
+
+### 7. Final summary
+
+Plain prose, ≤8 lines:
+
+- Sweep date + mode used
+- `N` pages scanned, `T` claims checked
+- `V` verified, `D` deviated (across `K` pages), `U` source_unavailable (across `M` pages)
+- Per-page failures (if any), with verbatim error per failure
+- Path to the report markdown (relative to wiki-root)
+- Path to `last-resweep.json` (for the future lint integration)
+- Suggested next: `wiki-update --page <slug>` for any flagged page where the user wants to add a `## Stale (date)` marker, or `claim-verify --id <id> cobrowse` for source_unavailable claims that may be recoverable interactively
+
+## Edge cases
+
+- **No claims found.** Step 1 emits `total_claims == 0`; skill exits 0 with "no cited claims to re-verify in scope". No workspace dir created (planner short-circuits when pages list is empty).
+- **All claims circular.** All extract candidates dropped because their URLs point back into the wiki. Step 1 reports `circular_skipped > 0` but `total_claims == 0`. Skill exits 0 with the same nothing-to-do message.
+- **Page newer than the sweep.** No problem — re-verification is independent of page age. The user can sweep stale or fresh pages alike.
+- **Per-page cogni-claims failure.** Captured, sweep continues for remaining pages. Failure list surfaces in Step 7. The user re-runs the skill or runs `cogni-claims:claims verify` manually for the failed slugs later.
+- **Re-run same day.** Workspace path is `claims-resweep-<today>`; per-page manifests overwrite deterministically. `last-resweep.json` is replaced under lock.
+- **Source-cache hit.** If a URL was verified within the cogni-claims cache TTL, the claim-verifier agent reuses the cached source body — no extra WebFetch. Sweep cost scales with unique URLs, not total claims.
+- **`--page` for an unknown slug.** `extract_page_claims.py` aborts with "page not found"; SKILL surfaces the error verbatim.
+- **Source URL list contains duplicates across pages.** Same URL appearing in 5 pages = 1 WebFetch (claim-verifier groups by URL within a single cogni-claims run). Across pages we dispatch sequentially; the source-cache still saves the WebFetch on the second page.
+
+## Out of scope
+
+- **Page-body mutation.** Report-only by design. The user runs `wiki-update` if they want to mark stale claims.
+- **LLM-based claim extraction.** Deterministic extraction (sentences near URLs) is sufficient for cited prose; an agent-driven extractor would over-yield on synthetic wiki text and add cost. If the user has a wiki where claims are made *without* inline citations, they should add citations during ingest — that's the wiki-ingest contract.
+- **Auto-trigger from lint.** A future `claim_drift` warning class in `wiki-lint` could read `last-resweep.json` and surface flagged pages, but the sweep itself is always user-invoked. Not in this skill's scope.
+- **Cross-wiki sweeps.** One wiki per invocation. Run the skill from inside each wiki's tree.
+- **Push-mode auto re-verify.** No background scheduler. The user invokes when they want a fresh check.
+- **Resolve / cobrowse mode dispatch.** This skill stops at verify. The user runs `claims:claims resolve <id>` or `claims:claims cobrowse` manually for findings that need interactive recovery.
+
+## Output
+
+The skill produces:
+
+- A populated `<wiki-root>/raw/claims-resweep-<today>/` directory with:
+  - One `<slug>-claims.md` manifest per page (audit trail)
+  - `index.json` (dispatch plan, machine-readable)
+  - `report.md` (human-readable findings)
+- `<wiki-root>/.cogni-wiki/last-resweep.json` — lint-bridge JSON, lock-wrapped write
+- New / updated entries in `<wiki-root>/cogni-claims/claims.json` (managed by cogni-claims, not this skill)
+
+No file outside `<wiki-root>/` is created. No `wiki/pages/` file is modified.
+
+## References
+
+- `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` — the three-layer model (raw / wiki / schema)
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-lint/scripts/lint_wiki.py` — `STALE_PAGE_DAYS` / `STALE_DRAFT_DAYS` constants mirrored in `extract_page_claims.py`
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-refresh/SKILL.md` — sibling pull-mode skill; same batch-confirm + materialise-then-enumerate pattern
+- `cogni-claims/skills/claims/SKILL.md` — `submit` and `verify` modes (Step 4 dispatch contracts)
+- `cogni-claims/agents/claim-verifier.md` — the WebFetch + 5-dimension comparison agent that does the actual re-verification work

--- a/cogni-wiki/skills/wiki-claims-resweep/scripts/extract_page_claims.py
+++ b/cogni-wiki/skills/wiki-claims-resweep/scripts/extract_page_claims.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""
+extract_page_claims.py — deterministic claim candidate extraction from wiki page prose.
+
+Walks <wiki-root>/wiki/pages/, parses each page's frontmatter and body, and emits
+claim candidates that the wiki-claims-resweep skill submits to cogni-claims for
+re-verification.
+
+Boundary: this script is **read-only** and **never** makes network calls. It reads
+markdown, parses frontmatter, and prints JSON. WebFetch happens later, inside the
+cogni-claims:claim-verifier agent that the SKILL dispatches.
+
+Extraction rule (deterministic, no LLM):
+    For each inline-link `[text](http(s)://...)` and each bare `http(s)://...` URL
+    in the page body, take the containing sentence as the claim statement and the
+    URL as the source. Sentences are split on `.`, `!`, `?` followed by whitespace
+    and on blank lines. Markdown link syntax is stripped from the rendered claim.
+    Sentences shorter than MIN_CLAIM_CHARS are dropped (heuristically reduces
+    list-item / heading noise). Identical (statement, url) pairs dedupe.
+
+Page selection (mode is mutually exclusive):
+    --all          Every page that has a non-empty `sources:` frontmatter.
+    --page <slug>  Single-page sweep.
+    --stale-only   Pages whose `updated:` date is older than STALE_PAGE_DAYS
+                   (mirrors wiki-lint's threshold; status=draft uses
+                   STALE_DRAFT_DAYS).
+
+Refusal: pages where any extracted claim's source URL points back into the same
+wiki tree (relative wikilink or path under <wiki-root>) are dropped from that
+page's claim list and counted in `circular_skipped`. Pattern from PRs #198/#199.
+
+Output contract:
+    {
+      "success": true,
+      "data": {
+        "wiki_root": "...",
+        "mode": "all|page|stale-only",
+        "pages": [
+          {
+            "slug": "...",
+            "title": "...",
+            "page_path": "wiki/pages/<slug>.md",
+            "updated": "YYYY-MM-DD",
+            "age_days": <int|null>,
+            "claims": [
+              {"statement": "...", "source_url": "https://...",
+               "source_title": "...", "line": <int>}
+            ],
+            "circular_skipped": <int>
+          }
+        ],
+        "stats": {
+          "pages_scanned": <int>,
+          "pages_with_claims": <int>,
+          "total_claims": <int>,
+          "total_unique_sources": <int>,
+          "circular_skipped": <int>,
+          "pages_skipped_no_sources": <int>
+        }
+      },
+      "error": ""
+    }
+
+stdlib-only, Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+from pathlib import Path
+
+
+STALE_DRAFT_DAYS = 180
+STALE_PAGE_DAYS = 365
+
+MIN_CLAIM_CHARS = 30
+MAX_CLAIMS_PER_PAGE = 50
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+INLINE_LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^)\s]+)\)")
+BARE_URL_RE = re.compile(r"(?<![\(\[\"'])\bhttps?://[^\s)\]<>\"']+")
+SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z\[(])|\n\s*\n")
+WIKILINK_RE = re.compile(r"\[\[[^\]]+\]\]")
+MD_LINK_STRIP_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+WHITESPACE_RE = re.compile(r"\s+")
+
+
+def fail(msg: str) -> None:
+    print(json.dumps({"success": False, "data": {}, "error": msg}))
+    sys.exit(1)
+
+
+def ok(data: dict) -> None:
+    print(json.dumps({"success": True, "data": data, "error": ""}))
+    sys.exit(0)
+
+
+def parse_frontmatter(text: str) -> dict:
+    """Lightweight YAML subset parser, mirrors lint_wiki.py for consistency."""
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return {}
+    out: dict = {}
+    current_key = None
+    for line in m.group(1).splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if line.startswith("  - ") and current_key:
+            out.setdefault(current_key, []).append(line[4:].strip())
+            continue
+        if ":" in line:
+            k, _, v = line.partition(":")
+            k = k.strip()
+            v = v.strip()
+            current_key = k
+            if v.startswith("[") and v.endswith("]"):
+                inside = v[1:-1].strip()
+                out[k] = [x.strip() for x in inside.split(",") if x.strip()] if inside else []
+            elif v:
+                out[k] = v
+            else:
+                out[k] = []
+    return out
+
+
+def _unquote(s: str) -> str:
+    s = s.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
+        return s[1:-1]
+    return s
+
+
+def parse_date(s: str):
+    try:
+        return dt.datetime.strptime(s.strip(), "%Y-%m-%d").date()
+    except (ValueError, AttributeError):
+        return None
+
+
+def split_body(text: str) -> str:
+    m = FRONTMATTER_RE.match(text)
+    return text[m.end():] if m else text
+
+
+def strip_markdown(s: str) -> str:
+    """Render claim text as plain prose: drop markdown link syntax, wikilinks,
+    code-fences, and squash whitespace. Keep the link's anchor text."""
+    s = MD_LINK_STRIP_RE.sub(r"\1", s)
+    s = WIKILINK_RE.sub("", s)
+    s = s.replace("`", "")
+    s = s.lstrip("-*> \t").strip()
+    s = WHITESPACE_RE.sub(" ", s)
+    return s.strip()
+
+
+def is_circular_source(url: str, wiki_root: Path) -> bool:
+    """A URL is circular if it points back into this wiki: a relative path
+    starting with `wiki/` or an absolute path under <wiki-root>. Outside
+    URLs (http/https) are always non-circular."""
+    if url.startswith(("http://", "https://")):
+        return False
+    if url.startswith("wiki/") or url.startswith("../wiki/") or url.startswith("./wiki/"):
+        return True
+    try:
+        resolved = (wiki_root / url).resolve()
+        wiki_pages = (wiki_root / "wiki").resolve()
+        return str(resolved).startswith(str(wiki_pages))
+    except (OSError, ValueError):
+        return False
+
+
+def extract_claims_from_body(body: str, wiki_root: Path) -> tuple[list[dict], int]:
+    """Return (claims, circular_skipped_count)."""
+    claims: list[dict] = []
+    circular = 0
+    seen: set = set()
+
+    sentences = SENTENCE_SPLIT_RE.split(body)
+    line_offsets: list[int] = []
+    cursor = 0
+    for sent in sentences:
+        line_offsets.append(body[:cursor].count("\n") + 1)
+        cursor += len(sent) + 1
+
+    for idx, raw_sent in enumerate(sentences):
+        sent = raw_sent.strip()
+        if not sent:
+            continue
+
+        urls: list[tuple[str, str]] = []
+        for m in INLINE_LINK_RE.finditer(sent):
+            urls.append((m.group(2), m.group(1).strip()))
+        for m in BARE_URL_RE.finditer(sent):
+            url = m.group(0).rstrip(".,;:!?")
+            if not any(url == u for u, _ in urls):
+                urls.append((url, ""))
+
+        if not urls:
+            continue
+
+        statement = strip_markdown(sent)
+        if len(statement) < MIN_CLAIM_CHARS:
+            continue
+
+        for url, anchor_text in urls:
+            if is_circular_source(url, wiki_root):
+                circular += 1
+                continue
+            key = (statement, url)
+            if key in seen:
+                continue
+            seen.add(key)
+            claims.append({
+                "statement": statement,
+                "source_url": url,
+                "source_title": anchor_text or url,
+                "line": line_offsets[idx] if idx < len(line_offsets) else 0,
+            })
+            if len(claims) >= MAX_CLAIMS_PER_PAGE:
+                return claims, circular
+    return claims, circular
+
+
+def find_wiki_root(start: Path) -> Path:
+    current = start.resolve()
+    while True:
+        if (current / ".cogni-wiki" / "config.json").is_file():
+            return current
+        if current.parent == current:
+            fail(f"not inside a cogni-wiki (no .cogni-wiki/config.json at or above {start})")
+        current = current.parent
+
+
+def select_pages(pages_dir: Path, mode: str, page_arg: str | None,
+                 days_override: int | None) -> list[Path]:
+    today = dt.date.today()
+    all_paths = sorted(p for p in pages_dir.glob("*.md") if not p.name.startswith("lint-"))
+
+    if mode == "page":
+        target = pages_dir / f"{page_arg}.md"
+        if not target.is_file():
+            fail(f"page not found: {target}")
+        return [target]
+
+    if mode == "stale-only":
+        out: list[Path] = []
+        for path in all_paths:
+            try:
+                fm = parse_frontmatter(path.read_text(encoding="utf-8"))
+            except OSError:
+                continue
+            updated = parse_date(_unquote(fm.get("updated", "")))
+            if not updated:
+                continue
+            age = (today - updated).days
+            status = _unquote(fm.get("status", "")).lower()
+            threshold = days_override if days_override is not None else (
+                STALE_DRAFT_DAYS if status == "draft" else STALE_PAGE_DAYS
+            )
+            if age > threshold:
+                out.append(path)
+        return out
+
+    return all_paths  # mode == "all"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract claim candidates from wiki pages (deterministic, no network).")
+    parser.add_argument("--wiki-root", help="Override auto-detected wiki root.")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--all", action="store_true", help="Every page with non-empty sources (default).")
+    group.add_argument("--page", metavar="SLUG", help="Single-page sweep.")
+    group.add_argument("--stale-only", action="store_true",
+                       help="Only pages older than STALE_PAGE_DAYS (or --days).")
+    parser.add_argument("--days", type=int, default=None,
+                        help="Override staleness threshold (used with --stale-only).")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    wiki_root = Path(args.wiki_root).resolve() if args.wiki_root else find_wiki_root(Path.cwd())
+    if not (wiki_root / ".cogni-wiki" / "config.json").is_file():
+        fail(f"not a cogni-wiki: {wiki_root}/.cogni-wiki/config.json not found")
+
+    pages_dir = wiki_root / "wiki" / "pages"
+    if not pages_dir.is_dir():
+        fail(f"wiki/pages/ missing under {wiki_root}")
+
+    if args.page:
+        mode = "page"
+    elif args.stale_only:
+        mode = "stale-only"
+    else:
+        mode = "all"
+
+    if args.days is not None and mode != "stale-only":
+        fail("--days requires --stale-only")
+
+    selected = select_pages(pages_dir, mode, args.page, args.days)
+
+    today = dt.date.today()
+    pages_out: list[dict] = []
+    pages_skipped_no_sources = 0
+    total_circular = 0
+    unique_sources: set = set()
+
+    for path in selected:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        fm = parse_frontmatter(text)
+        sources = fm.get("sources", [])
+        if isinstance(sources, list) and not sources:
+            pages_skipped_no_sources += 1
+            continue
+        if not isinstance(sources, list):
+            pages_skipped_no_sources += 1
+            continue
+
+        body = split_body(text)
+        claims, circular = extract_claims_from_body(body, wiki_root)
+        total_circular += circular
+        if not claims:
+            continue
+
+        updated = parse_date(_unquote(fm.get("updated", "")))
+        age = (today - updated).days if updated else None
+
+        for c in claims:
+            unique_sources.add(c["source_url"])
+
+        pages_out.append({
+            "slug": path.stem,
+            "title": _unquote(fm.get("title", "")) or path.stem,
+            "page_path": str(path.relative_to(wiki_root)),
+            "updated": _unquote(fm.get("updated", "")),
+            "age_days": age,
+            "claims": claims,
+            "circular_skipped": circular,
+        })
+
+    ok({
+        "wiki_root": str(wiki_root),
+        "mode": mode,
+        "pages": pages_out,
+        "stats": {
+            "pages_scanned": len(selected),
+            "pages_with_claims": len(pages_out),
+            "total_claims": sum(len(p["claims"]) for p in pages_out),
+            "total_unique_sources": len(unique_sources),
+            "circular_skipped": total_circular,
+            "pages_skipped_no_sources": pages_skipped_no_sources,
+        },
+    })
+
+
+if __name__ == "__main__":
+    main()

--- a/cogni-wiki/skills/wiki-claims-resweep/scripts/resweep_planner.py
+++ b/cogni-wiki/skills/wiki-claims-resweep/scripts/resweep_planner.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""
+resweep_planner.py — workspace materialiser and report aggregator for
+wiki-claims-resweep.
+
+Two phases, selected via --phase:
+
+    --phase plan       Read extract JSON (from --extract-file or stdin), create the
+                       per-day sweep workspace under <wiki-root>/raw/claims-resweep-
+                       <YYYY-MM-DD>/, write one claim-manifest markdown per page
+                       and index.json, then emit a dispatch plan on stdout. The
+                       SKILL hands each manifest to cogni-claims:claims (submit +
+                       verify).
+
+    --phase aggregate  Read verification results (from --results-file or stdin) +
+                       the workspace dir, write report.md alongside the manifests,
+                       and write/refresh <wiki-root>/.cogni-wiki/last-resweep.json
+                       (lock-wrapped — last-resweep.json is shared state per the
+                       Concurrency Invariant in cogni-wiki/CLAUDE.md). Emit summary
+                       stats on stdout.
+
+Boundary: this script writes only to (a) the per-day sweep workspace under
+`raw/claims-resweep-<date>/` (isolated, no lock needed) and (b) the lock-wrapped
+`.cogni-wiki/last-resweep.json`. It never touches `wiki/pages/`, `wiki/index.md`,
+or `.cogni-wiki/config.json` — page mutations are out of scope (report-only by
+design; user runs wiki-update manually if they want stale markers).
+
+stdlib-only, Python 3.8+. Output contract for plan phase:
+
+    {
+      "success": true,
+      "data": {
+        "workspace": "<abs path>",
+        "workspace_rel": "raw/claims-resweep-<date>",
+        "sweep_date": "YYYY-MM-DD",
+        "plan": [
+          {
+            "slug": "<page-slug>",
+            "manifest": "raw/claims-resweep-<date>/<slug>-claims.md",
+            "claim_count": <int>,
+            "source_count": <int>
+          }
+        ],
+        "stats": {
+          "pages": <int>,
+          "total_claims": <int>,
+          "total_unique_sources": <int>
+        }
+      },
+      "error": ""
+    }
+
+For aggregate phase, output adds report_path, last_resweep_path, and per-status
+counts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import fcntl
+import json
+import os
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+
+def fail(msg: str) -> None:
+    print(json.dumps({"success": False, "data": {}, "error": msg}))
+    sys.exit(1)
+
+
+def ok(data: dict) -> None:
+    print(json.dumps({"success": True, "data": data, "error": ""}))
+    sys.exit(0)
+
+
+@contextmanager
+def _wiki_lock(wiki_root: Path):
+    """Mirror of wiki_index_update.py::_wiki_lock — same advisory lock so this
+    script participates in the existing concurrency contract for shared state."""
+    lock_dir = wiki_root / ".cogni-wiki"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / ".lock"
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+def atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _yaml_escape(s: str) -> str:
+    if any(c in s for c in ":#\n\"'"):
+        return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    return s
+
+
+def render_manifest(page: dict, sweep_date: str) -> str:
+    lines = [
+        "---",
+        f"page_slug: {page['slug']}",
+        f"page_title: {_yaml_escape(page.get('title', page['slug']))}",
+        f"sweep_date: {sweep_date}",
+        f"claim_count: {len(page['claims'])}",
+        f"source_count: {len({c['source_url'] for c in page['claims']})}",
+        f"page_updated: {page.get('updated', '')}",
+        "---",
+        "",
+        f"# Claims to re-verify — {page.get('title', page['slug'])}",
+        "",
+        f"Page: `{page.get('page_path') or 'wiki/pages/' + page['slug'] + '.md'}`",
+        f"Sweep: {sweep_date}",
+        "",
+        "## Claims",
+        "",
+    ]
+    for i, c in enumerate(page["claims"], 1):
+        lines.append(f"### Claim {i}")
+        lines.append("")
+        lines.append(f"- **statement**: {c['statement']}")
+        lines.append(f"- **source_url**: {c['source_url']}")
+        lines.append(f"- **source_title**: {c.get('source_title', '')}")
+        lines.append(f"- **page_line**: {c.get('line', 0)}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def phase_plan(args) -> None:
+    extract = load_json(args.extract_file)
+    if not extract.get("success"):
+        fail(f"extract input not successful: {extract.get('error', 'unknown')}")
+    data = extract.get("data", {})
+    wiki_root = Path(data.get("wiki_root", "")).resolve()
+    if not wiki_root.is_dir():
+        fail(f"extract.wiki_root not a directory: {wiki_root}")
+    if not (wiki_root / ".cogni-wiki" / "config.json").is_file():
+        fail(f"extract.wiki_root is not a cogni-wiki: {wiki_root}")
+
+    pages = data.get("pages", []) or []
+    if not pages:
+        ok({
+            "workspace": "",
+            "workspace_rel": "",
+            "sweep_date": dt.date.today().isoformat(),
+            "plan": [],
+            "stats": {"pages": 0, "total_claims": 0, "total_unique_sources": 0},
+        })
+
+    sweep_date = args.date or dt.date.today().isoformat()
+    workspace = wiki_root / "raw" / f"claims-resweep-{sweep_date}"
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    plan: list[dict] = []
+    unique_sources: set = set()
+    for page in pages:
+        if not page.get("claims"):
+            continue
+        manifest_path = workspace / f"{page['slug']}-claims.md"
+        atomic_write(manifest_path, render_manifest(page, sweep_date))
+        for c in page["claims"]:
+            unique_sources.add(c["source_url"])
+        plan.append({
+            "slug": page["slug"],
+            "manifest": str(manifest_path.relative_to(wiki_root)),
+            "manifest_abs": str(manifest_path),
+            "claim_count": len(page["claims"]),
+            "source_count": len({c["source_url"] for c in page["claims"]}),
+            "page_path": page.get("page_path", f"wiki/pages/{page['slug']}.md"),
+            "age_days": page.get("age_days"),
+        })
+
+    index_path = workspace / "index.json"
+    atomic_write(index_path, json.dumps({
+        "sweep_date": sweep_date,
+        "mode": data.get("mode", "all"),
+        "wiki_root": str(wiki_root),
+        "pages": [
+            {k: v for k, v in entry.items() if k != "manifest_abs"}
+            for entry in plan
+        ],
+        "stats": {
+            "pages": len(plan),
+            "total_claims": sum(p["claim_count"] for p in plan),
+            "total_unique_sources": len(unique_sources),
+        },
+    }, indent=2) + "\n")
+
+    ok({
+        "workspace": str(workspace),
+        "workspace_rel": f"raw/claims-resweep-{sweep_date}",
+        "sweep_date": sweep_date,
+        "plan": plan,
+        "stats": {
+            "pages": len(plan),
+            "total_claims": sum(p["claim_count"] for p in plan),
+            "total_unique_sources": len(unique_sources),
+        },
+    })
+
+
+def render_report(results: dict, plan_index: dict, sweep_date: str) -> str:
+    pages_results = results.get("pages", [])
+    totals = {"verified": 0, "deviated": 0, "source_unavailable": 0, "unverified": 0}
+    for p in pages_results:
+        for c in p.get("claims", []):
+            status = c.get("status", "unverified")
+            totals[status] = totals.get(status, 0) + 1
+
+    deviated_pages = [p["slug"] for p in pages_results
+                      if any(c.get("status") == "deviated" for c in p.get("claims", []))]
+    unavailable_pages = [p["slug"] for p in pages_results
+                         if any(c.get("status") == "source_unavailable" for c in p.get("claims", []))]
+
+    lines = [
+        "---",
+        f"sweep_date: {sweep_date}",
+        f"mode: {plan_index.get('mode', 'all')}",
+        f"total_pages: {len(pages_results)}",
+        f"total_claims: {sum(totals.values())}",
+        f"verified: {totals['verified']}",
+        f"deviated: {totals['deviated']}",
+        f"source_unavailable: {totals['source_unavailable']}",
+        f"unverified: {totals['unverified']}",
+        "---",
+        "",
+        f"# Wiki claims re-verify sweep — {sweep_date}",
+        "",
+        "Pages were not modified. Run `wiki-update` manually for any page where you want to add a `## Stale (date)` marker.",
+        "",
+        "## Summary",
+        "",
+        f"- Pages scanned: {len(pages_results)}",
+        f"- Total claims checked: {sum(totals.values())}",
+        f"- Verified: {totals['verified']}",
+        f"- Deviated: {totals['deviated']} (across {len(deviated_pages)} pages)",
+        f"- Source unavailable: {totals['source_unavailable']} (across {len(unavailable_pages)} pages)",
+        "",
+    ]
+
+    flagged = [p for p in pages_results
+               if any(c.get("status") in ("deviated", "source_unavailable") for c in p.get("claims", []))]
+    if flagged:
+        lines.append("## Pages with findings")
+        lines.append("")
+        for p in flagged:
+            lines.append(f"### {p['slug']}")
+            lines.append("")
+            for c in p.get("claims", []):
+                status = c.get("status", "unverified")
+                if status not in ("deviated", "source_unavailable"):
+                    continue
+                lines.append(f"- **status**: {status}")
+                lines.append(f"  - statement: {c.get('statement', '')}")
+                lines.append(f"  - source: {c.get('source_url', '')}")
+                for d in c.get("deviations", []) or []:
+                    lines.append(f"  - deviation: {d.get('type', '?')} ({d.get('severity', '?')}) — {d.get('explanation', '')}")
+                    excerpt = d.get("source_excerpt", "")
+                    if excerpt:
+                        lines.append(f"    excerpt: {excerpt[:200]}")
+            lines.append("")
+    else:
+        lines.append("No deviated or unavailable claims. Wiki citations are healthy as of this sweep.")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def phase_aggregate(args) -> None:
+    results = load_json(args.results_file)
+    if not results.get("success"):
+        fail(f"results input not successful: {results.get('error', 'unknown')}")
+    rdata = results.get("data", {})
+
+    workspace = Path(args.workspace).resolve()
+    if not workspace.is_dir():
+        fail(f"workspace not a directory: {workspace}")
+    index_path = workspace / "index.json"
+    if not index_path.is_file():
+        fail(f"workspace missing index.json: {index_path}")
+
+    plan_index = json.loads(index_path.read_text(encoding="utf-8"))
+    wiki_root = Path(plan_index.get("wiki_root", "")).resolve()
+    if not (wiki_root / ".cogni-wiki" / "config.json").is_file():
+        fail(f"index.wiki_root no longer a cogni-wiki: {wiki_root}")
+    sweep_date = plan_index.get("sweep_date", dt.date.today().isoformat())
+
+    report_path = workspace / "report.md"
+    atomic_write(report_path, render_report(rdata, plan_index, sweep_date))
+
+    deviated_pages = sorted({
+        p["slug"] for p in rdata.get("pages", [])
+        if any(c.get("status") == "deviated" for c in p.get("claims", []))
+    })
+    unavailable_pages = sorted({
+        p["slug"] for p in rdata.get("pages", [])
+        if any(c.get("status") == "source_unavailable" for c in p.get("claims", []))
+    })
+
+    last_resweep = {
+        "sweep_date": sweep_date,
+        "mode": plan_index.get("mode", "all"),
+        "deviated_pages": deviated_pages,
+        "unavailable_pages": unavailable_pages,
+        "report_path": str(report_path.relative_to(wiki_root)),
+    }
+    last_path = wiki_root / ".cogni-wiki" / "last-resweep.json"
+    with _wiki_lock(wiki_root):
+        atomic_write(last_path, json.dumps(last_resweep, indent=2) + "\n")
+
+    totals = {"verified": 0, "deviated": 0, "source_unavailable": 0, "unverified": 0}
+    for p in rdata.get("pages", []):
+        for c in p.get("claims", []):
+            status = c.get("status", "unverified")
+            totals[status] = totals.get(status, 0) + 1
+
+    ok({
+        "report_path": str(report_path.relative_to(wiki_root)),
+        "last_resweep_path": str(last_path.relative_to(wiki_root)),
+        "sweep_date": sweep_date,
+        "deviated_pages": deviated_pages,
+        "unavailable_pages": unavailable_pages,
+        "stats": {
+            "total_pages": len(rdata.get("pages", [])),
+            "total_claims": sum(totals.values()),
+            **totals,
+        },
+    })
+
+
+def load_json(path_arg: str | None) -> dict:
+    if not path_arg or path_arg == "-":
+        try:
+            return json.loads(sys.stdin.read())
+        except json.JSONDecodeError as e:
+            fail(f"stdin is not valid JSON: {e}")
+    p = Path(path_arg).expanduser()
+    if not p.is_file():
+        fail(f"file not found: {p}")
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        fail(f"{p}: invalid JSON ({e})")
+    return {}  # unreachable
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Materialise sweep workspace and aggregate verification results.")
+    parser.add_argument("--phase", choices=("plan", "aggregate"), required=True)
+    parser.add_argument("--extract-file", help="Path to extract_page_claims.py JSON output (or '-' for stdin). Plan phase.")
+    parser.add_argument("--results-file", help="Path to verification-results JSON (or '-' for stdin). Aggregate phase.")
+    parser.add_argument("--workspace", help="Sweep workspace dir (raw/claims-resweep-<date>). Aggregate phase.")
+    parser.add_argument("--date", help="Override sweep date (YYYY-MM-DD). Plan phase only.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.phase == "plan":
+        if not args.extract_file:
+            args.extract_file = "-"
+        phase_plan(args)
+    else:
+        if not args.workspace:
+            fail("--workspace is required for --phase aggregate")
+        if not args.results_file:
+            args.results_file = "-"
+        phase_aggregate(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes Punkt 4 of the cogni-research ↔ cogni-wiki integration: existing wiki pages now have their inline-cited URLs re-verified against current source content, surfacing deviated and source_unavailable claims **without mutating `wiki/pages/`**.

- New skill `wiki-claims-resweep` — pure orchestrator, pull-mode, report-only
- Two new stdlib-only scripts: `extract_page_claims.py` (deterministic candidate extraction, no network) and `resweep_planner.py` (two-phase: materialise → aggregate)
- Lock-wrapped lint-bridge `<wiki-root>/.cogni-wiki/last-resweep.json` for a future `claim_drift` warning class in `wiki-lint` (deferred to a follow-up PR; the JSON contract exists today)
- Reuses cogni-claims:claims (submit + verify) — no new verification logic

## Design notes

**Variante B** (orthogonal skill, not a wiki-lint extension) — keeps lint mechanical and fast, isolates expensive WebFetch into an opt-in workflow.

**Deterministic claim extraction** — every sentence containing an inline `[text](http(s)://...)` link or bare URL becomes a candidate. No LLM extraction (Wiki prose is synthetic enough that an agent extractor over-yields). Sentences <30 chars are dropped (heading/list-item noise).

**Report-only** — sweep produces a markdown report and a JSON bridge; `wiki/pages/` are never touched. Stale-marker decisions go through `wiki-update` manually, preserving diff-before-write discipline.

Modes: `--all` (default), `--page <slug>`, `--stale-only [--days N]`.

## Patterns reused from #197/#198/#199

- Pure-orchestrator skill dispatching via `Skill(...)`
- Helper-script pattern (`{success, data, error}` JSON contract)
- Materialize-then-enumerate (per-day workspace under `raw/claims-resweep-<date>/`)
- Pull-mode default (no auto-trigger)
- Circular-evidence refusal (URLs pointing back into the wiki tree)
- Pre-flight order (extract before any cogni-claims dispatch)

## Concurrency

`last-resweep.json` is new shared state; `resweep_planner.py::phase_aggregate` participates in the existing `_wiki_lock` advisory contract. Per-page manifests under `raw/claims-resweep-<date>/` are isolated by date+slug, no lock needed. CLAUDE.md's Concurrency Invariant table gets a row for the new file.

## Test plan

- [ ] Smoke-test `--all` against a small test wiki — extract → plan → manifest written deterministically; rerun same day overwrites idempotently
- [ ] Smoke-test `--page <slug>` — single-page sweep
- [ ] Smoke-test `--stale-only` — only flags pages older than `STALE_PAGE_DAYS` (mirrors lint threshold)
- [ ] Smoke-test `--page unknown-slug` — fails fast with clear error
- [ ] No-network audit: `grep -E 'urllib|requests|socket|urlopen' extract_page_claims.py resweep_planner.py` returns empty
- [ ] Aggregate phase with mocked verification results — produces `report.md` + `last-resweep.json` with correct deviated/unavailable page lists
- [ ] `bash cogni-workspace/scripts/check-skill-names.sh` passes (`wiki-claims-resweep` has the required `wiki-` domain prefix)
- [ ] End-to-end against a real wiki + cogni-claims to verify the dispatch chain — to do post-CLA

## Out of scope

- `claim_drift` warning class in `wiki-lint` consuming `last-resweep.json` (follow-up PR)
- Page-body mutation / auto-flag (out by design — wiki-update's territory)
- LLM-based extraction (deterministic is sufficient for cited prose)
- README auto-generation refresh (sections 4/11/12/13 — run `cogni-docs:doc-generate` post-merge if needed)

## CLA reminder

Per the lite CLA-bot pattern, this new PR will need a fresh `I have read the CLA Document and I hereby sign the CLA` comment from the maintainer.

https://claude.ai/code/session_01YUkTLk8wHF2MHYFE3dMeB6

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUkTLk8wHF2MHYFE3dMeB6)_