### PR TITLE
cogni-wiki: regenerate README auto-sections after #198–#201

### DIFF
--- a/cogni-wiki/README.md
+++ b/cogni-wiki/README.md
@@ -66,17 +66,20 @@ sources: [../raw/bai-et-al-2022.pdf]
 1. **Bootstrap** a new wiki with directory layout, SCHEMA.md contract, and seed files → `.cogni-wiki/config.json` + `wiki/index.md` + `wiki/log.md` + `wiki/overview.md` → wiki-ingest, wiki-query, wiki-lint, wiki-update, wiki-resume, wiki-dashboard
 2. **Ingest** source documents into structured wiki pages with YAML frontmatter, backlink audit, and index updates → `wiki/pages/*.md` → wiki-query, wiki-lint, wiki-update, wiki-dashboard
 3. **Query** the wiki to answer questions — reads pages directly, never from model memory, with `[[wikilink]]` citations → `wiki/pages/*.md` → wiki-query, wiki-lint, wiki-update, wiki-dashboard
-4. **Lint** the wiki for health problems — broken wikilinks, orphan pages, stale dates, frontmatter gaps, contradictions → `wiki/pages/lint-*.md` → wiki-update, wiki-query
+4. **Lint** the wiki for health problems — broken wikilinks, orphan pages, stale dates, frontmatter gaps, contradictions, plus `claim_drift` from the latest re-verify sweep → `wiki/pages/lint-*.md` → wiki-update, wiki-query, wiki-claims-resweep
 5. **Update** existing pages with diff-before-write discipline, source citation requirements, and stale-sweep of related pages → `wiki/pages/*.md` → wiki-query, wiki-lint, wiki-dashboard
 6. **Resume** with status, activity summary, and recommended next action
 7. **Dashboard** as a self-contained HTML overview — pages by type, tag cloud, backlink graph, and activity histograms → `wiki-dashboard.html` (self-contained HTML dashboard)
+8. **Cold-start from research** — chains `cogni-research:research-setup` → `research-report` → `wiki-setup` → `wiki-ingest --discover research:<slug>` in one dispatch (Mode A from a topic, Mode B from an existing research slug) → populated wiki seeded with sub-question-sized pages → wiki-query, wiki-lint, wiki-refresh
+9. **Refresh stale pages from research** — matches lint-flagged stale pages to sub-questions of an existing cogni-research project via Jaccard token overlap, materialises one synthesis per match, and dispatches wiki-update sequentially → updated `wiki/pages/*.md` with bumped `updated:` and refreshed sources → wiki-query, wiki-lint
+10. **Re-verify wiki citations** — extracts inline-cited statements from existing pages deterministically, dispatches them through cogni-claims for source re-verification, and writes a sweep report plus a lint-bridge JSON; report-only, never mutates `wiki/pages/` → `<wiki-root>/raw/claims-resweep-<date>/report.md` + `.cogni-wiki/last-resweep.json` → wiki-lint (`claim_drift` warning), wiki-update (manual stale-marker)
 
 ## What it means for you
 
 - **Compound your knowledge, not your effort.** Each ingest aims to leave the wiki denser and more interconnected than before — up to 95% token reduction vs re-loading full documents per query, with every source compiled once rather than re-synthesized on demand.
 - **Ground every answer in curated sources.** `wiki-query` reads the wiki before answering — never from model memory. If the wiki has no page on a topic, the answer says so rather than filling the gap with hallucinated filler.
 - **Keep your knowledge portable across any tool, indefinitely.** `SCHEMA.md` ships inside every wiki directory, so the wiki aims to remain fully readable even if cogni-wiki is uninstalled or replaced — plain markdown, plain backlinks, zero lock-in. Open it in Obsidian, VS Code, or `grep` today; hand it off in 5 years.
-- **Keep every wiki page trustworthy.** `wiki-update` shows the diff before modifying any page and requires a source citation for every new claim — zero silent writes across all 7 skills, so the wiki stays citable.
+- **Keep every wiki page trustworthy.** `wiki-update` shows the diff before modifying any page and requires a source citation for every new claim — zero silent writes across all 10 skills, so the wiki stays citable.
 
 ## Install
 
@@ -101,6 +104,9 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 /cogni-wiki:wiki-update --page <slug>     # Revise a page with new evidence
 /cogni-wiki:wiki-dashboard                # Visual HTML overview
 /cogni-wiki:wiki-resume                   # "Where was I?"
+/cogni-wiki:wiki-from-research            # Cold-start: research → wiki in one dispatch
+/cogni-wiki:wiki-refresh --from-research <slug>   # Refresh stale pages from a research project
+/cogni-wiki:wiki-claims-resweep           # Re-verify cited URLs against current source content
 ```
 
 Or just describe what you want in natural language:
@@ -110,6 +116,9 @@ Or just describe what you want in natural language:
 - "What does my wiki say about constitutional AI?"
 - "Is my wiki healthy?"
 - "Show me the wiki as a dashboard"
+- "Cold-start a wiki from research on agent economy"
+- "Refresh stale pages from the new agent-economy research"
+- "Re-verify wiki citations against current sources"
 
 ## Relationship to Claude Code auto-memory
 
@@ -122,10 +131,13 @@ Claude Code already has an auto-memory system at `~/.claude/projects/.../memory/
 | wiki-setup | Skill | Bootstrap a new Karpathy-style LLM wiki at a user-chosen directory |
 | wiki-ingest | Skill | Ingest a source document into the wiki with summary, frontmatter, and backlink audit |
 | wiki-query | Skill | Answer a question by reading the wiki — never from memory |
-| wiki-lint | Skill | Audit the wiki for broken wikilinks, orphan pages, stale dates, and contradictions |
+| wiki-lint | Skill | Audit the wiki for broken wikilinks, orphan pages, stale dates, contradictions, and `claim_drift` from the latest re-verify sweep |
 | wiki-update | Skill | Revise an existing wiki page with diff-before-write discipline and source citations |
 | wiki-resume | Skill | Show status, activity, and recommended next action for the wiki |
 | wiki-dashboard | Skill | Generate a self-contained HTML dashboard with tag cloud, backlink graph, and histograms |
+| wiki-from-research | Skill | Cold-start orchestrator: chains cogni-research's setup + report into wiki-setup + wiki-ingest in one dispatch (Mode A from a topic, Mode B from an existing research slug) |
+| wiki-refresh | Skill | Refresh stale wiki pages with fresh evidence from a completed cogni-research project; Jaccard match, batch-confirmed, sequential wiki-update dispatch |
+| wiki-claims-resweep | Skill | Re-verify inline-cited URLs in existing wiki pages against current source content via cogni-claims; report-only, writes a sweep report and a lint-bridge JSON |
 | ingest-worker | Agent | Per-source subagent invoked by wiki-ingest batch mode (Steps 1–8); not directly dispatchable |
 
 ## Architecture
@@ -141,24 +153,35 @@ cogni-wiki/
 │   └── claude-research-karparthy.md RAG vs wiki benchmark research
 ├── agents/                          1 fan-out worker agent
 │   └── ingest-worker.md             Per-source subagent for wiki-ingest batch mode
-└── skills/                          7 wiki skills
+└── skills/                          10 wiki skills
     ├── wiki-setup/                  Bootstrap a new wiki
     ├── wiki-ingest/                 Ingest sources into wiki pages
     ├── wiki-query/                  Answer questions from wiki content
-    ├── wiki-lint/                   Health audit with severity tiers
+    ├── wiki-lint/                   Health audit with severity tiers (incl. claim_drift)
     ├── wiki-update/                 Diff-gated page revisions
     ├── wiki-resume/                 Status and next-action dashboard
-    └── wiki-dashboard/              Self-contained HTML overview
+    ├── wiki-dashboard/              Self-contained HTML overview
+    ├── wiki-from-research/          Cold-start: research → wiki orchestrator
+    ├── wiki-refresh/                Stale-page refresh from a research project
+    └── wiki-claims-resweep/         Re-verify inline-cited URLs against current source content
 ```
 
 ## Dependencies
 
-cogni-wiki is standalone — no required or optional cross-plugin dependencies in v0.0.x. Integration contracts with cogni-research, cogni-narrative, cogni-consulting, and cogni-claims are planned for v0.1.x; see [CLAUDE.md](CLAUDE.md) "Future Integration Points".
+cogni-wiki runs standalone for the core ingest/query/lint/update loop. Three skills opt into cross-plugin integrations:
+
+| Skill | Depends on | Used for |
+|-------|-----------|----------|
+| `wiki-from-research`, `wiki-refresh`, `wiki-ingest --discover research:<slug>` | `cogni-research` | Cold-start a wiki, refresh stale pages, or deposit a completed research project as sub-question-sized pages |
+| `wiki-claims-resweep` | `cogni-claims` | Re-verify inline-cited URLs against current source content (`submit` + `verify` modes) |
+| `wiki-lint` (`claim_drift` warning) | none — reads `.cogni-wiki/last-resweep.json` written by `wiki-claims-resweep` | Surface drift findings as warnings during regular health audits |
+
+Integrations with `cogni-narrative` and `cogni-consulting` remain planned for v0.1.x; see [CLAUDE.md](CLAUDE.md) "Cross-Plugin Integration" and "Future Integration Points".
 
 ## Credits
 
 - **Andrej Karpathy** — [LLM Wiki gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). The pattern this plugin implements.
-- **kfchou/wiki-skills** — [reference Claude Code implementation](https://github.com/kfchou/wiki-skills). The five-skill shape (`wiki-init`, `wiki-ingest`, `wiki-query`, `wiki-lint`, `wiki-update`) that inspired this plugin's layout. cogni-wiki adds `wiki-resume` and `wiki-dashboard` to match cogni-* ecosystem conventions.
+- **kfchou/wiki-skills** — [reference Claude Code implementation](https://github.com/kfchou/wiki-skills). The five-skill shape (`wiki-init`, `wiki-ingest`, `wiki-query`, `wiki-lint`, `wiki-update`) that inspired this plugin's layout. cogni-wiki adds `wiki-resume`, `wiki-dashboard`, `wiki-from-research`, `wiki-refresh`, and `wiki-claims-resweep` to match cogni-* ecosystem conventions and to close the research → wiki and citation re-verify loops.
 
 ## License
 


### PR DESCRIPTION
## Summary

The README had drifted to a 7-skill view from before the integration roadmap (PRs #197–#201). Re-aligns the four auto-generated sections plus Quick start and Credits to the current 10-skill state.

This is a manual regeneration since `cogni-docs` is not present in this checkout. The conventions and section boundaries follow `insight-wave/CLAUDE.md` "README Conventions".

## Changes per section

- **§4 What it does**: 7 → 10 numbered items. Adds wiki-from-research, wiki-refresh, wiki-claims-resweep. Notes wiki-lint's new `claim_drift` surface.
- **§7 Quick start**: 3 new command lines + 3 natural-language phrases.
- **§11 Components**: table grows by 3 skill rows.
- **§12 Architecture**: tree shows 10 skills with one-liners.
- **§13 Dependencies**: replaces "v0.1.x deferred" claim with the actual cross-plugin contracts that landed — cogni-research (wiki-from-research, wiki-refresh, wiki-ingest --discover) and cogni-claims (wiki-claims-resweep + lint-bridge for `claim_drift`).
- **Credits**: notes the additional skills cogni-wiki contributes on top of the kfchou/wiki-skills five.
- **Misc**: stale "all 7 skills" → "all 10 skills".

## Why no version bump

CLAUDE.md says: "Bump the patch version after any change to skills, agents, or structure." This PR changes only documentation (no skill, agent, or script state changes); the skill state itself was correctly versioned at each integration PR (0.0.17 → 0.0.21). Adding a 0.0.22 bump for a README-only update would be noise.

## Test plan

- [x] All four auto-sections show consistent count (10 skills) — verified via grep
- [x] Quick start commands match the actual skill names in `skills/`
- [x] Architecture tree skills match Components table skills (1:1)
- [x] No broken links or stale references to "wiki-init" / cogni-narrative integrations

## CLA reminder

Per the lite CLA-bot pattern, this PR will need a fresh `I have read the CLA Document and I hereby sign the CLA` comment.

https://claude.ai/code/session_01YUkTLk8wHF2MHYFE3dMeB6

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUkTLk8wHF2MHYFE3dMeB6)_