### PR TITLE
cogni-wiki: promote `synthesis` to a first-class page type

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -254,7 +254,7 @@
     {
       "name": "cogni-wiki",
       "source": "./cogni-wiki",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "maturity": "incubating",
       "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
       "keywords": [

--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-wiki/CLAUDE.md
+++ b/cogni-wiki/CLAUDE.md
@@ -19,12 +19,12 @@ skills/                         10 wiki skills
       page-frontmatter.md         YAML schema (id, title, tags, type, sources, ...)
       ingest-workflow.md          Step-by-step ingest behavior
       batch-mode.md               --batch-file + --discover schema, execution model, error policy, examples
-  wiki-query/                     Ask questions; answer from wiki, never from memory
+  wiki-query/                     Ask questions; answer from wiki, never from memory; optionally file the answer back as `type: synthesis`
     references/
-      query-patterns.md           Read-before-answer, citation discipline
+      query-patterns.md           Read-before-answer, citation discipline, synthesis file-back walkthrough
   wiki-lint/                      Severity-tiered health audit
     scripts/
-      lint_wiki.py                Orphans, broken links, stale dates, frontmatter check
+      lint_wiki.py                Orphans, broken links, stale dates, frontmatter check, wiki:// source validation
     references/
       severity-tiers.md           Error / warn / info classification
   wiki-update/                    Diff-gated page revisions with stale-sweep
@@ -32,7 +32,7 @@ skills/                         10 wiki skills
       update-discipline.md        Citation-required, diff-before-write rules
   wiki-resume/                    Status dashboard — entry count, last-lint age, next action
     scripts/
-      wiki_status.sh              Emits {success, data, error} JSON
+      wiki_status.sh              Emits {success, data, error} JSON (incl. synthesis_count_30d)
   wiki-dashboard/                 Self-contained HTML overview (pages, tags, backlink graph)
     scripts/
       render_dashboard.py         Reads wiki/ → writes wiki-dashboard.html (stdlib only)
@@ -77,26 +77,31 @@ Created by `wiki-setup` at the user-chosen root (default `cogni-wiki/{slug}/` re
     └── config.json            { "name", "slug", "created", "entries_count", "last_lint" }
 ```
 
+Pages stay flat under `wiki/pages/`; the `type:` frontmatter field carries the semantic distinction (concept / entity / summary / decision / learning / synthesis / note). Per-type directories are explicitly deferred — see the parent tracking issue for the Karpathy-pattern parity work.
+
 ## Page Frontmatter
 
 ```yaml
 ---
 id: <slug>
 title: <human-readable>
-type: concept | entity | summary | decision | learning | note
+type: concept | entity | summary | decision | learning | synthesis | note
 tags: [tag1, tag2]
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
-sources: [../raw/paper-xyz.pdf, https://...]
+sources: [../raw/paper-xyz.pdf, https://..., wiki://other-slug]
 ---
 ```
+
+The `synthesis` type (introduced in v0.0.23) is reserved for LLM-derived answers that `wiki-query --file-back yes` files back into the wiki. Synthesis pages cite their wiki provenance via `wiki://<slug>` entries in `sources:` rather than `../raw/` paths; `wiki-lint` enforces this contract. See `skills/wiki-ingest/references/page-frontmatter.md` for the full schema.
 
 ## Key Conventions
 
 - **Wiki is LLM-maintained, human-curated sources.** The user drops documents in `raw/`; Claude does all the summarising, linking, and bookkeeping.
 - **Always read the wiki for queries — never answer from memory.** Skills enforce this discipline in every SKILL.md.
-- **Append-only log.** Every ingest, query, lint, and update writes a line to `wiki/log.md` with an ISO date prefix.
+- **Append-only log.** Every ingest, query, synthesis, lint, and update writes a line to `wiki/log.md` with an ISO date prefix. The `synthesis` operation prefix (v0.0.23+) distinguishes filed-back query answers from un-filed `query` reads — both are surfaced separately in `wiki-resume` and `wiki-dashboard`.
 - **Bidirectional links.** `[[wikilinks]]` are audited after every ingest; related pages get backlink updates.
+- **Queries can compound.** `wiki-query --file-back yes` writes the answer to `wiki/pages/<slug>.md` as `type: synthesis` with `wiki://<source-slug>` references in `sources:`, so explorations enrich the wiki rather than evaporate. `wiki-lint` validates each `wiki://` target slug exists (`broken_wiki_source` error) and warns when a synthesis page lacks any `wiki://` source (`synthesis_no_wiki_source` warn).
 - **Diff before write.** `wiki-update` shows the planned change before modifying a page and requires a source citation for any new claim.
 - **Stdlib-only scripts.** bash 3.2 + python3 stdlib, no pip or npm dependencies. JSON output format `{success, data, error}`.
 - **No hooks.** All index/log maintenance lives inside the skills for debuggability.
@@ -124,6 +129,8 @@ The advisory lock at `<wiki-root>/.cogni-wiki/.lock` is **retained as defence-in
 2. Wrap every read-modify-write call site in `with _wiki_lock(wiki_root): ...`.
 3. Prefer routing the mutation through an existing locked script (e.g. `config_bump.py`) rather than inlining the write in a new code path — each inlined write is a new place the invariant can be missed.
 4. Never edit any file in the table by hand from a SKILL.md workflow step; always go through the locked script. Hand-edits bypass the lock.
+
+**Note for `wiki-query` file-back (v0.0.23):** the synthesis file-back path writes `wiki/pages/<new-slug>.md` (unique by construction — no lock needed), and routes its `entries_count` bump through `config_bump.py` (locked). It does not need to add a new shared file to the table.
 
 **Known tech debt.** `_wiki_lock` is currently duplicated across three scripts (`backlink_audit.py`, `wiki_index_update.py`, `config_bump.py`). A future consolidation into a shared `cogni-wiki/skills/wiki-ingest/scripts/_wikilock.py` helper would remove the drift risk, but is a non-urgent refactor — the three copies are byte-identical today.
 

--- a/cogni-wiki/README.md
+++ b/cogni-wiki/README.md
@@ -22,7 +22,7 @@ Karpathy's insight: what if knowledge was **compiled once at ingestion** instead
 | Stale claims | Still retrievable, silently | Flagged and reconciled |
 | Debugging wrong answers | Reverse-engineer vector math | Read the markdown file |
 | Token efficiency | 2K–5K chunks re-retrieved per query | Pre-synthesized; up to 95% reduction vs full-doc loading |
-| Compounding over time | No — same effort per query | Yes — wiki gets denser each ingest |
+| Compounding over time | No — same effort per query | Yes — wiki gets denser each ingest, and queries themselves can be filed back as `type: synthesis` pages |
 
 **Where RAG still wins:** Scale beyond ~50K–100K tokens of compiled content; rapidly changing data (daily feeds, inventory); strict source-level attribution for legal/compliance; multi-domain enterprise with role-based access. For those cases, use RAG — or combine both (the hybrid approach [never lost a single round](references/claude-research-karparthy.md) in head-to-head benchmarks).
 
@@ -61,25 +61,27 @@ sources: [../raw/bai-et-al-2022.pdf]
 ---
 ```
 
+Page types: `concept`, `entity`, `summary`, `decision`, `learning`, `synthesis`, `note`. The `synthesis` type (introduced in v0.0.23) is reserved for LLM-derived answers that `wiki-query --file-back yes` files back into the wiki; sources for these pages are `wiki://<slug>` references rather than raw files.
+
 ## What it does
 
 1. **Bootstrap** a new wiki with directory layout, SCHEMA.md contract, and seed files → `.cogni-wiki/config.json` + `wiki/index.md` + `wiki/log.md` + `wiki/overview.md` → wiki-ingest, wiki-query, wiki-lint, wiki-update, wiki-resume, wiki-dashboard
 2. **Ingest** source documents into structured wiki pages with YAML frontmatter, backlink audit, and index updates → `wiki/pages/*.md` → wiki-query, wiki-lint, wiki-update, wiki-dashboard
-3. **Query** the wiki to answer questions — reads pages directly, never from model memory, with `[[wikilink]]` citations → `wiki/pages/*.md` → wiki-query, wiki-lint, wiki-update, wiki-dashboard
-4. **Lint** the wiki for health problems — broken wikilinks, orphan pages, stale dates, frontmatter gaps, contradictions, plus `claim_drift` from the latest re-verify sweep → `wiki/pages/lint-*.md` → wiki-update, wiki-query, wiki-claims-resweep
+3. **Query** the wiki to answer questions — reads pages directly, never from model memory, with `[[wikilink]]` citations; optionally files the answer back as a `type: synthesis` page (introduced in v0.0.23) so explorations compound rather than evaporating into chat history → `wiki/pages/*.md` → wiki-query, wiki-lint, wiki-update, wiki-dashboard
+4. **Lint** the wiki for health problems — broken wikilinks, orphan pages, stale dates, frontmatter gaps, contradictions, broken `wiki://` sources, synthesis pages without wiki provenance, plus `claim_drift` from the latest re-verify sweep → `wiki/pages/lint-*.md` → wiki-update, wiki-query, wiki-claims-resweep
 5. **Update** existing pages with diff-before-write discipline, source citation requirements, and stale-sweep of related pages → `wiki/pages/*.md` → wiki-query, wiki-lint, wiki-dashboard
-6. **Resume** with status, activity summary, and recommended next action
-7. **Dashboard** as a self-contained HTML overview — pages by type, tag cloud, backlink graph, and activity histograms → `wiki-dashboard.html` (self-contained HTML dashboard)
+6. **Resume** with status, activity summary, and recommended next action (now surfaces `synthesis_count_30d` distinctly from `query_count_30d`)
+7. **Dashboard** as a self-contained HTML overview — pages by type (incl. synthesis), tag cloud, backlink graph, and activity histograms → `wiki-dashboard.html` (self-contained HTML dashboard)
 8. **Cold-start from research** — chains `cogni-research:research-setup` → `research-report` → `wiki-setup` → `wiki-ingest --discover research:<slug>` in one dispatch (Mode A from a topic, Mode B from an existing research slug) → populated wiki seeded with sub-question-sized pages → wiki-query, wiki-lint, wiki-refresh
 9. **Refresh stale pages from research** — matches lint-flagged stale pages to sub-questions of an existing cogni-research project via Jaccard token overlap, materialises one synthesis per match, and dispatches wiki-update sequentially → updated `wiki/pages/*.md` with bumped `updated:` and refreshed sources → wiki-query, wiki-lint
 10. **Re-verify wiki citations** — extracts inline-cited statements from existing pages deterministically, dispatches them through cogni-claims for source re-verification, and writes a sweep report plus a lint-bridge JSON; report-only, never mutates `wiki/pages/` → `<wiki-root>/raw/claims-resweep-<date>/report.md` + `.cogni-wiki/last-resweep.json` → wiki-lint (`claim_drift` warning), wiki-update (manual stale-marker)
 
 ## What it means for you
 
-- **Compound your knowledge, not your effort.** Each ingest aims to leave the wiki denser and more interconnected than before — up to 95% token reduction vs re-loading full documents per query, with every source compiled once rather than re-synthesized on demand.
+- **Compound your knowledge, not your effort.** Each ingest aims to leave the wiki denser and more interconnected than before — up to 95% token reduction vs re-loading full documents per query, with every source compiled once rather than re-synthesized on demand. As of v0.0.23, **queries themselves compound** too: `wiki-query --file-back yes` files the answer as a `type: synthesis` page that future queries read directly.
 - **Ground every answer in curated sources.** `wiki-query` reads the wiki before answering — never from model memory. If the wiki has no page on a topic, the answer says so rather than filling the gap with hallucinated filler.
 - **Keep your knowledge portable across any tool, indefinitely.** `SCHEMA.md` ships inside every wiki directory, so the wiki aims to remain fully readable even if cogni-wiki is uninstalled or replaced — plain markdown, plain backlinks, zero lock-in. Open it in Obsidian, VS Code, or `grep` today; hand it off in 5 years.
-- **Keep every wiki page trustworthy.** `wiki-update` shows the diff before modifying any page and requires a source citation for every new claim — zero silent writes across all 10 skills, so the wiki stays citable.
+- **Keep every wiki page trustworthy.** `wiki-update` shows the diff before modifying any page and requires a source citation for every new claim — zero silent writes across all 10 skills, so the wiki stays citable. Synthesis pages additionally cite `wiki://` provenance, validated by `wiki-lint`.
 
 ## Install
 
@@ -96,24 +98,24 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 ## Quick start
 
 ```
-/cogni-wiki:wiki-setup                    # Bootstrap a new wiki
+/cogni-wiki:wiki-setup                                         # Bootstrap a new wiki
 # (drop a paper in cogni-wiki/primary/raw/)
-/cogni-wiki:wiki-ingest                   # Summarise + cross-link
-/cogni-wiki:wiki-query "what did I learn about X?"
-/cogni-wiki:wiki-lint                     # After every 5–10 ingests
-/cogni-wiki:wiki-update --page <slug>     # Revise a page with new evidence
-/cogni-wiki:wiki-dashboard                # Visual HTML overview
-/cogni-wiki:wiki-resume                   # "Where was I?"
-/cogni-wiki:wiki-from-research            # Cold-start: research → wiki in one dispatch
-/cogni-wiki:wiki-refresh --from-research <slug>   # Refresh stale pages from a research project
-/cogni-wiki:wiki-claims-resweep           # Re-verify cited URLs against current source content
+/cogni-wiki:wiki-ingest                                        # Summarise + cross-link
+/cogni-wiki:wiki-query "what did I learn about X?" --file-back yes  # Answer + file as type: synthesis
+/cogni-wiki:wiki-lint                                          # After every 5–10 ingests
+/cogni-wiki:wiki-update --page <slug>                          # Revise a page with new evidence
+/cogni-wiki:wiki-dashboard                                     # Visual HTML overview (incl. synthesis bucket)
+/cogni-wiki:wiki-resume                                        # "Where was I?" (with synthesis_count_30d)
+/cogni-wiki:wiki-from-research                                 # Cold-start: research → wiki in one dispatch
+/cogni-wiki:wiki-refresh --from-research <slug>                # Refresh stale pages from a research project
+/cogni-wiki:wiki-claims-resweep                                # Re-verify cited URLs against current source content
 ```
 
 Or just describe what you want in natural language:
 
 - "Set up a wiki for my AI safety research"
 - "Ingest this paper into the wiki"
-- "What does my wiki say about constitutional AI?"
+- "What does my wiki say about constitutional AI? Save the answer as a synthesis."
 - "Is my wiki healthy?"
 - "Show me the wiki as a dashboard"
 - "Cold-start a wiki from research on agent economy"
@@ -130,11 +132,11 @@ Claude Code already has an auto-memory system at `~/.claude/projects/.../memory/
 |-----------|------|-------------|
 | wiki-setup | Skill | Bootstrap a new Karpathy-style LLM wiki at a user-chosen directory |
 | wiki-ingest | Skill | Ingest a source document into the wiki with summary, frontmatter, and backlink audit |
-| wiki-query | Skill | Answer a question by reading the wiki — never from memory |
-| wiki-lint | Skill | Audit the wiki for broken wikilinks, orphan pages, stale dates, contradictions, and `claim_drift` from the latest re-verify sweep |
+| wiki-query | Skill | Answer a question by reading the wiki — never from memory; optionally files the answer back as a `type: synthesis` page |
+| wiki-lint | Skill | Audit the wiki for broken wikilinks, orphan pages, stale dates, contradictions, broken `wiki://` sources, synthesis pages without wiki provenance, and `claim_drift` from the latest re-verify sweep |
 | wiki-update | Skill | Revise an existing wiki page with diff-before-write discipline and source citations |
-| wiki-resume | Skill | Show status, activity, and recommended next action for the wiki |
-| wiki-dashboard | Skill | Generate a self-contained HTML dashboard with tag cloud, backlink graph, and histograms |
+| wiki-resume | Skill | Show status, activity (incl. synthesis count), and recommended next action for the wiki |
+| wiki-dashboard | Skill | Generate a self-contained HTML dashboard with tag cloud, backlink graph, type bars (incl. synthesis), and histograms |
 | wiki-from-research | Skill | Cold-start orchestrator: chains cogni-research's setup + report into wiki-setup + wiki-ingest in one dispatch (Mode A from a topic, Mode B from an existing research slug) |
 | wiki-refresh | Skill | Refresh stale wiki pages with fresh evidence from a completed cogni-research project; Jaccard match, batch-confirmed, sequential wiki-update dispatch |
 | wiki-claims-resweep | Skill | Re-verify inline-cited URLs in existing wiki pages against current source content via cogni-claims; report-only, writes a sweep report and a lint-bridge JSON |
@@ -153,8 +155,8 @@ cogni-wiki/
 └── skills/                          10 wiki skills
     ├── wiki-setup/                  Bootstrap a new wiki
     ├── wiki-ingest/                 Ingest sources into wiki pages
-    ├── wiki-query/                  Answer questions from wiki content
-    ├── wiki-lint/                   Health audit with severity tiers (incl. claim_drift)
+    ├── wiki-query/                  Answer questions from wiki content; file back as type: synthesis
+    ├── wiki-lint/                   Health audit with severity tiers (incl. claim_drift, broken_wiki_source, synthesis_no_wiki_source)
     ├── wiki-update/                 Diff-gated page revisions
     ├── wiki-resume/                 Status and next-action dashboard
     ├── wiki-dashboard/              Self-contained HTML overview
@@ -179,6 +181,7 @@ Integrations with `cogni-narrative` and `cogni-consulting` remain planned for v0
 
 - **Andrej Karpathy** — [LLM Wiki gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). The pattern this plugin implements.
 - **kfchou/wiki-skills** — [reference Claude Code implementation](https://github.com/kfchou/wiki-skills). The five-skill shape (`wiki-init`, `wiki-ingest`, `wiki-query`, `wiki-lint`, `wiki-update`) that inspired this plugin's layout. cogni-wiki adds `wiki-resume`, `wiki-dashboard`, `wiki-from-research`, `wiki-refresh`, and `wiki-claims-resweep` to match cogni-* ecosystem conventions and to close the research → wiki and citation re-verify loops.
+- **sdh07/llm-wiki-agent** and **sdh07/omegawiki** — reference implementations of the Karpathy pattern that informed the v0.0.23 audit (see tracking issue #212): the synthesis page type, `wiki://` source convention, and split lint/health vocabulary all draw on patterns these projects pioneered.
 
 ## License
 

--- a/cogni-wiki/skills/wiki-dashboard/scripts/render_dashboard.py
+++ b/cogni-wiki/skills/wiki-dashboard/scripts/render_dashboard.py
@@ -33,13 +33,14 @@ from pathlib import Path
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 WIKILINK_RE = re.compile(r"\[\[([a-z0-9][a-z0-9\-]*)\]\]")
 
-VALID_TYPES = ["concept", "entity", "summary", "decision", "learning", "note"]
+VALID_TYPES = ["concept", "entity", "summary", "decision", "learning", "synthesis", "note"]
 TYPE_COLORS = {
     "concept": "#2563eb",
     "entity": "#059669",
     "summary": "#d97706",
     "decision": "#dc2626",
     "learning": "#7c3aed",
+    "synthesis": "#0891b2",
     "note": "#64748b",
 }
 

--- a/cogni-wiki/skills/wiki-ingest/references/page-frontmatter.md
+++ b/cogni-wiki/skills/wiki-ingest/references/page-frontmatter.md
@@ -15,6 +15,7 @@ updated: YYYY-MM-DD                   # REQUIRED. Set at every edit
 sources:                              # Optional but strongly encouraged
   - ../raw/<filename>                 # Relative path from wiki/pages/ to raw/ file
   - https://<url>                     # Or a stable external URL
+  - wiki://<other-page-slug>          # Or a wiki-internal reference (synthesis pages)
 publisher_url: https://<url>          # Optional. Canonical URL at the publisher
 related:                              # Optional. Curated cross-reference list
   - <other-page-slug>
@@ -45,7 +46,8 @@ One of:
 | `entity` | Specific person, organization, product, project, place |
 | `summary` | A condensed version of one raw source, paper, or article |
 | `decision` | A choice made and the reasoning — includes the alternatives considered |
-| `learning` | A generalized takeaway drawn from multiple sources or experience |
+| `learning` | A generalized takeaway drawn from multiple sources or experience (typically authored by hand or filed during ingest) |
+| `synthesis` | An LLM-synthesised answer derived from other wiki pages — filed back by `wiki-query --file-back yes`. Sources are `wiki://<slug>` references to the pages it draws from, not raw files. Distinguishes wiki→wiki derivation from raw-source learnings |
 | `note` | A loose observation that hasn't crystallized — often promoted later to `concept` or `learning` |
 
 Pick the most specific type. `wiki-lint` will warn when a page's body has drifted far from its declared type.
@@ -65,7 +67,8 @@ Pick the most specific type. `wiki-lint` will warn when a page's body has drifte
 
 - Relative paths to files under `<wiki-root>/raw/` — always `../raw/filename` from the page's location in `wiki/pages/`
 - Or stable URLs
-- A page with no sources is flagged `warn` by `wiki-lint` unless its `type` is `decision` or `note`
+- Or `wiki://<slug>` for wiki-internal references — used by `type: synthesis` pages to cite the wiki pages they were derived from. `wiki-lint` validates that each `wiki://<slug>` target page exists (a missing target is a `broken_wiki_source` error).
+- A page with no sources is flagged `warn` by `wiki-lint` unless its `type` is `decision` or `note`. A `type: synthesis` page with no `wiki://` source is flagged `synthesis_no_wiki_source` (warn) — synthesis pages must cite their wiki provenance.
 
 ### `publisher_url` (optional)
 
@@ -103,5 +106,24 @@ related:
   - compounding-knowledge
   - wiki-vs-rag
 status: stable
+---
+```
+
+## Synthesis page example
+
+A `type: synthesis` page filed back by `wiki-query` looks like this — note `wiki://`-prefixed sources rather than `../raw/` paths:
+
+```yaml
+---
+id: rlhf-vs-cai-comparison
+title: RLHF vs Constitutional AI — wiki view
+type: synthesis
+tags: [llms, alignment, comparison]
+created: 2026-05-05
+updated: 2026-05-05
+sources:
+  - wiki://constitutional-ai
+  - wiki://rlhf-overview
+  - wiki://rlhf-limitations
 ---
 ```

--- a/cogni-wiki/skills/wiki-lint/references/severity-tiers.md
+++ b/cogni-wiki/skills/wiki-lint/references/severity-tiers.md
@@ -15,6 +15,7 @@ An error means the wiki's contract is broken and a reader (human or LLM) might m
 | **Missing required frontmatter** | `id`, `title`, `type`, `created`, or `updated` missing | `wiki-update` to add the field |
 | **Invalid type** | `type:` value is not one of the allowed values | `wiki-update` to pick a valid type |
 | **Missing source file** | `sources: [../raw/foo.pdf]` where `raw/foo.pdf` doesn't exist | Either restore the source or remove the reference |
+| **Broken wiki source** | `sources: [wiki://other-slug]` where `wiki/pages/other-slug.md` does not exist | `wiki-update` to fix the slug, or re-run `wiki-query --file-back` to regenerate the synthesis after the missing page is created |
 | **Duplicate slug** | Two pages with the same `id` frontmatter (shouldn't be possible if filenames are unique, but check) | Rename one |
 
 Errors are reported with a file path and line number so the user can jump directly.
@@ -31,6 +32,7 @@ A warning means the wiki works but is accumulating debt. Warnings should be revi
 | **Stale draft** | `status: draft` and `updated` > 180 days ago | `wiki-update` to promote or retire |
 | **Stale page** | `updated` > 365 days ago, regardless of status | Review and refresh or mark `status: stale` |
 | **No sources** | `sources:` empty or missing, and `type` is not `decision` or `note` | `wiki-update` to add citations |
+| **Synthesis without wiki source** | `type: synthesis` but no `wiki://`-prefixed entry in `sources:`. Synthesis pages must cite the wiki pages they derived from. | `wiki-update` to add `wiki://<slug>` references, or re-file via `wiki-query --file-back yes` |
 | **Tag typo** | Tag differs from another tag by edit distance ≤ 2, one used ≥3× more than the other | `wiki-update` to normalize |
 | **Contradiction** | Two pages make opposing claims about the same entity or concept (semantic pass) | `wiki-update` to reconcile, or add explicit contradiction note |
 | **Type drift** | Page body's structure doesn't match declared `type` (e.g. a `concept` page that is actually a `summary`) | `wiki-update` to retype or rewrite |
@@ -48,7 +50,7 @@ Info is not a finding — it's descriptive statistics that help the user underst
 - **Average sources per page**
 - **Most-linked pages** — top 10 pages by inbound `[[wikilink]]` count
 - **Least-linked pages** — pages with exactly 0 or 1 inbound links, excluding orphans (already in warnings)
-- **Log activity** — ingests, queries, lints in the last 30 days
+- **Log activity** — ingests, queries, syntheses, lints in the last 30 days
 - **Age histogram** — buckets for pages by age: <7d, <30d, <90d, <365d, >365d
 - **Last resweep** — date and age (in days) of the most recent `wiki-claims-resweep` run, surfaced when `.cogni-wiki/last-resweep.json` exists
 

--- a/cogni-wiki/skills/wiki-lint/scripts/lint_wiki.py
+++ b/cogni-wiki/skills/wiki-lint/scripts/lint_wiki.py
@@ -18,6 +18,8 @@ Detects:
     - Missing required frontmatter fields
     - Invalid type values
     - Missing source files under raw/
+    - Broken wiki:// sources (target page does not exist)
+    - Synthesis pages missing wiki:// sources
     - Orphan pages (no inbound wikilinks)
     - Stale drafts / stale pages
     - Tag typos (edit distance ≤ TAG_TYPO_MAX_DIST with ≥ TAG_TYPO_RATIO usage ratio)
@@ -44,8 +46,8 @@ STALE_DRAFT_DAYS = 180
 STALE_PAGE_DAYS = 365
 TAG_TYPO_MAX_DIST = 2
 TAG_TYPO_RATIO = 3
-VALID_TYPES = {"concept", "entity", "summary", "decision", "learning", "note"}
-TYPES_REQUIRING_SOURCES = {"concept", "entity", "summary", "learning"}
+VALID_TYPES = {"concept", "entity", "summary", "decision", "learning", "synthesis", "note"}
+TYPES_REQUIRING_SOURCES = {"concept", "entity", "summary", "learning", "synthesis"}
 REQUIRED_FRONTMATTER = {"id", "title", "type", "created", "updated"}
 
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
@@ -215,7 +217,9 @@ def main() -> None:
                         "message": f"type '{ptype}' but no sources field",
                     }
                 )
-            # Missing source files
+            # Validate per-source: missing raw files, broken wiki:// targets,
+            # and remember whether any wiki:// source was seen (for synthesis).
+            has_wiki_source = False
             for src in sources:
                 if isinstance(src, str) and src.startswith("../raw/"):
                     rel = src[len("../raw/") :]
@@ -227,6 +231,34 @@ def main() -> None:
                                 "message": f"source file not found: raw/{rel}",
                             }
                         )
+                elif isinstance(src, str) and src.startswith("wiki://"):
+                    has_wiki_source = True
+                    target = src[len("wiki://") :].strip()
+                    if not target or not (pages_dir / f"{target}.md").is_file():
+                        errors.append(
+                            {
+                                "class": "broken_wiki_source",
+                                "page": slug,
+                                "message": f"wiki:// source not found: wiki://{target}",
+                            }
+                        )
+
+            # Synthesis pages must cite at least one wiki:// source. Empty
+            # sources is already covered by the no_sources warning above; this
+            # catches the case where sources are present but only ../raw/ or URL
+            # entries — a synthesis without wiki provenance is suspicious.
+            if (
+                ptype == "synthesis"
+                and len(sources) > 0
+                and not has_wiki_source
+            ):
+                warnings.append(
+                    {
+                        "class": "synthesis_no_wiki_source",
+                        "page": slug,
+                        "message": "type 'synthesis' but no wiki:// source — synthesis pages must cite the wiki pages they derive from",
+                    }
+                )
 
         # tag counts
         tags = fm.get("tags", [])

--- a/cogni-wiki/skills/wiki-query/SKILL.md
+++ b/cogni-wiki/skills/wiki-query/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: wiki-query
-description: "Answer a question by reading the Karpathy-style wiki — never from memory. Claude consults wiki/index.md first, then reads the relevant wiki/pages/*.md files, synthesizes an answer with [[wikilink]] citations, and optionally files the answer back as a new wiki page so the knowledge compounds. Use this skill whenever the user says 'query the wiki', 'ask the wiki', 'what do I know about X', 'what does my wiki say about Y', 'wiki query', 'search the wiki for Z', or asks any question after setting up a wiki and expects Claude to reason from it. Also trigger when the user asks 'look up X in the wiki', 'check the wiki for X', or asks a question that clearly lives inside their wiki's domain (e.g. they have an AI-safety wiki and ask about CAI) — offer the wiki as the source of truth."
+description: "Answer a question by reading the Karpathy-style wiki — never from memory. Claude consults wiki/index.md first, then reads the relevant wiki/pages/*.md files, synthesizes an answer with [[wikilink]] citations, and optionally files the answer back as a `type: synthesis` page so the knowledge compounds. Use this skill whenever the user says 'query the wiki', 'ask the wiki', 'what do I know about X', 'what does my wiki say about Y', 'wiki query', 'search the wiki for Z', or asks any question after setting up a wiki and expects Claude to reason from it. Also trigger when the user asks 'look up X in the wiki', 'check the wiki for X', or asks a question that clearly lives inside their wiki's domain (e.g. they have an AI-safety wiki and ask about CAI) — offer the wiki as the source of truth."
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion
 ---
 
 # Wiki Query
 
-Answer a question using only what is written in the wiki. Never draw on model memory. Every claim in the answer must trace to a specific wiki page, which in turn traces to a raw source. After answering, optionally persist the synthesis as a new wiki page so the next query benefits.
+Answer a question using only what is written in the wiki. Never draw on model memory. Every claim in the answer must trace to a specific wiki page, which in turn traces to a raw source. After answering, optionally persist the synthesis as a new `type: synthesis` wiki page so the next query benefits.
 
 Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once at the start of the session to re-anchor on the compounding principle.
 
@@ -65,28 +65,29 @@ Rules:
 
 ### 5. Offer to file the answer back
 
-If `--file-back auto`, ask the user: "File this answer as a new wiki page?" If yes, pass control to the file-back step below. If `--file-back yes`, do it without asking. If `no`, stop here after step 4.
+If `--file-back auto`, ask the user: "File this answer as a new `type: synthesis` page?" If yes, pass control to the file-back step below. If `--file-back yes`, do it without asking. If `no`, stop here after step 4.
 
 ### 6. File-back (optional)
 
 If filing the answer back:
 
 1. Choose a slug derived from the question or the synthesized claim
-2. Write a new page at `wiki/pages/{slug}.md` with `type: learning` (or `summary` if the answer is mostly one source)
+2. Write a new page at `wiki/pages/{slug}.md` with `type: synthesis` — the page type for LLM-derived answers built from other wiki pages, introduced in cogni-wiki v0.0.23. (Use `--type learning` only if the user explicitly asks to file the answer as a human-curated takeaway, or `--type summary` if the result is essentially a near-restatement of one source-derived page.)
 3. Frontmatter `sources:` field lists the wiki pages used, prefixed with `wiki://` to distinguish from raw sources:
    ```yaml
    sources:
      - wiki://constitutional-ai
      - wiki://anthropic-safety-team
    ```
-   This is explicit: the learning is a derived synthesis, not a direct restatement of a raw source.
+   This is explicit: the synthesis is a derived wiki→wiki claim, not a new raw assertion. `wiki-lint` validates that each `wiki://<slug>` target exists (broken_wiki_source error) and warns if a `type: synthesis` page has no `wiki://` source (synthesis_no_wiki_source warn).
 4. Body is the synthesized answer with the `[[citations]]` preserved
-5. Update `wiki/index.md` under an appropriate category
+5. Update `wiki/index.md` under an appropriate category (typically a new "Syntheses" section, or under the topic the synthesis covers)
 6. Append to `wiki/log.md`:
    ```
-   ## [YYYY-MM-DD] query | {slug} — {short question}
+   ## [YYYY-MM-DD] synthesis | {slug} — {short question}
    ```
-7. Increment `entries_count` in `.cogni-wiki/config.json`
+   The `synthesis` operation prefix (introduced in v0.0.23) distinguishes filed-back query answers from un-filed queries — Step 7 still uses `query` for the always-on log line. `wiki-resume` and `wiki-dashboard` count the two distinctly via `synthesis_count_30d` and `query_count_30d`.
+7. Increment `entries_count` in `.cogni-wiki/config.json` via `cogni-wiki/skills/wiki-ingest/scripts/config_bump.py --key entries_count --delta 1` (the locked, atomic helper used by `wiki-ingest`)
 8. (Optional) Run `backlink_audit.py` from wiki-ingest on the new page to add bidirectional links
 
 ### 7. Always append to the log (even without filing back)
@@ -97,14 +98,14 @@ Regardless of file-back decision, append a query log line:
 ## [YYYY-MM-DD] query | "{short question}" → read {N} pages
 ```
 
-The log records every query so the user can see what the wiki has been asked.
+The log records every query so the user can see what the wiki has been asked. When the answer was also filed back, both the `query` line (Step 7) and the `synthesis` line (Step 6.6) are present — the first is the question, the second is the page that captures the answer.
 
 ## Output
 
 - An answer with inline `[[citations]]`
-- Optionally: a new `wiki/pages/{slug}.md` learning page
-- An appended line in `wiki/log.md` (always)
-- Optionally: updated index, config, and backlinks (if file-back was yes)
+- Optionally: a new `wiki/pages/{slug}.md` with `type: synthesis`
+- An appended `query` line in `wiki/log.md` (always)
+- Optionally: a `synthesis` line in `wiki/log.md`, updated index, bumped config, and applied backlinks (if file-back was yes)
 
 ## Golden rules
 
@@ -117,4 +118,4 @@ The log records every query so the user can see what the wiki has been asked.
 ## References
 
 - `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` — the pattern
-- `./references/query-patterns.md` — read-before-answer worked example
+- `./references/query-patterns.md` — read-before-answer worked example, including a synthesis file-back walkthrough

--- a/cogni-wiki/skills/wiki-query/references/query-patterns.md
+++ b/cogni-wiki/skills/wiki-query/references/query-patterns.md
@@ -69,7 +69,7 @@ Output structure:
 
 ## File-back heuristics
 
-File the answer back as a new page when:
+File the answer back as a new `type: synthesis` page when:
 
 - The synthesis combined ≥2 pages into a novel claim
 - The user is likely to ask this question again
@@ -80,6 +80,50 @@ Do NOT file back when:
 - The answer is a direct restatement of a single page (already in the wiki)
 - The answer is a one-off navigation question ("which page mentions X?")
 - The answer explicitly reports an absence ("the wiki is silent on Y")
+
+## Worked example: filing a Shape-2 synthesis back
+
+**User:** `/cogni-wiki:wiki-query --question "how do RLHF and Constitutional AI differ?" --file-back yes`
+
+**Step 1–4** — Claude reads `wiki/index.md`, picks `[[rlhf-overview]]`, `[[rlhf-limitations]]`, and `[[constitutional-ai]]`, reads them, and writes the synthesis with `[[citations]]` on every claim.
+
+**Step 6 file-back** — because `--file-back yes` is set, Claude derives the slug `rlhf-vs-cai-comparison` from the question and writes:
+
+```yaml
+---
+id: rlhf-vs-cai-comparison
+title: RLHF vs Constitutional AI — wiki view
+type: synthesis
+tags: [llms, alignment, comparison]
+created: 2026-05-05
+updated: 2026-05-05
+sources:
+  - wiki://rlhf-overview
+  - wiki://rlhf-limitations
+  - wiki://constitutional-ai
+---
+
+## Headline
+
+RLHF uses human-labelled harm preferences as the supervision signal; Constitutional AI replaces those labels with AI-generated critiques against a written constitution [[constitutional-ai]] [[rlhf-overview]].
+
+## Comparison
+
+| Dimension | RLHF | Constitutional AI |
+|-----------|------|-------------------|
+| Supervision source | Human raters [[rlhf-overview]] | Written constitution + critic LLM [[constitutional-ai]] |
+| Scaling pressure | Hires/throughput of human labellers [[rlhf-limitations]] | Critic-model capability [[constitutional-ai]] |
+
+## Sources in the wiki
+
+- [[rlhf-overview]]
+- [[rlhf-limitations]]
+- [[constitutional-ai]]
+```
+
+**Steps 5–7** — the page is added to `wiki/index.md` under a Syntheses section, two log lines are appended (`synthesis | rlhf-vs-cai-comparison — ...` and `query | "how do RLHF and CAI differ?" → read 3 pages`), and `entries_count` is bumped via `config_bump.py`.
+
+Next time the user asks the same question, `wiki-query` will hit `[[rlhf-vs-cai-comparison]]` directly via the index instead of re-reading the three source pages — the exploration has compounded.
 
 ## What the answer must always contain
 

--- a/cogni-wiki/skills/wiki-resume/SKILL.md
+++ b/cogni-wiki/skills/wiki-resume/SKILL.md
@@ -45,7 +45,8 @@ Invoke `${CLAUDE_PLUGIN_ROOT}/skills/wiki-resume/scripts/wiki_status.sh --wiki-r
 - `days_since_lint` — integer or `null`
 - `recent_log` — last 10 lines of `wiki/log.md`
 - `ingest_count_30d` — number of `## [YYYY-MM-DD] ingest` lines in the last 30 days
-- `query_count_30d` — number of query lines in the last 30 days
+- `query_count_30d` — number of `query` lines in the last 30 days (un-filed reads)
+- `synthesis_count_30d` — number of `synthesis` lines (filed-back query answers) in the last 30 days; introduced in v0.0.23
 - `update_count_30d` — same for updates
 - `raw_file_count` — files in `raw/`
 - `orphan_raw_count` — files in `raw/` not referenced by any page frontmatter (quick heuristic)
@@ -61,7 +62,7 @@ _Created_: {created}
 _Description_: {description}
 
 ## Activity (last 30 days)
-- {N} ingests · {N} queries · {N} updates
+- {N} ingests · {N} queries · {N} syntheses · {N} updates
 
 ## Inventory
 - {entries_count} pages
@@ -75,6 +76,8 @@ _Description_: {description}
 {see decision tree below}
 ```
 
+The `syntheses` count surfaces filed-back query answers — a non-zero number is a signal that the wiki is compounding, not just accumulating raw sources. A wiki with high ingest count but zero syntheses suggests the user isn't asking the wiki questions yet; rule 5 below nudges toward `wiki-query` in that case.
+
 ### 4. Recommend next action (decision tree)
 
 Apply the first rule that matches:
@@ -82,10 +85,13 @@ Apply the first rule that matches:
 1. **`entries_count == 0`** → "Drop a source in `raw/` and run `/cogni-wiki:wiki-ingest`."
 2. **`orphan_raw_count > 0`** → "You have {N} raw sources that aren't yet in the wiki. Run `/cogni-wiki:wiki-ingest --discover orphans --discover-dry-run` to review them, then drop `--discover-dry-run` to ingest. No need to hand-craft a batch file — the skill enumerates the orphans for you."
 3. **`days_since_lint == null` OR `days_since_lint > 14`** → "It's been {N} days (or never) since the last lint. Run `/cogni-wiki:wiki-lint`."
-4. **`ingest_count_30d == 0 AND query_count_30d == 0 AND update_count_30d == 0`** → "The wiki hasn't been touched in 30 days. Either ingest something new or run `/cogni-wiki:wiki-query` to reactivate it."
-5. **Else** → "The wiki looks healthy. Continue with whatever you were doing, or run `/cogni-wiki:wiki-dashboard` for a visual overview."
+4. **`ingest_count_30d == 0 AND query_count_30d == 0 AND synthesis_count_30d == 0 AND update_count_30d == 0`** → "The wiki hasn't been touched in 30 days. Either ingest something new or run `/cogni-wiki:wiki-query` to reactivate it."
+5. **`entries_count >= 5 AND query_count_30d == 0 AND synthesis_count_30d == 0`** → "You have {entries_count} pages but haven't asked the wiki anything in 30 days. Run `/cogni-wiki:wiki-query --question '...' --file-back yes` to compound a synthesis page."
+6. **Else** → "The wiki looks healthy. Continue with whatever you were doing, or run `/cogni-wiki:wiki-dashboard` for a visual overview."
 
 Rule 2's concrete `--discover` command is deliberate: the older prose-only recommendation ("run wiki-ingest on them") left Claude (and by extension the user) to figure out how to enumerate the orphans, which in practice meant asking the user to type them out. Emitting the exact command closes that loop — the skill knows it has the `--discover orphans` mode, so `wiki-resume` should hand that over directly.
+
+Rule 5 is new in v0.0.23 — it surfaces the "the wiki is a vault, but you haven't asked it anything" anti-pattern that file-back synthesis pages were built to fix.
 
 ### 5. Do not write anything
 

--- a/cogni-wiki/skills/wiki-resume/scripts/wiki_status.sh
+++ b/cogni-wiki/skills/wiki-resume/scripts/wiki_status.sh
@@ -106,6 +106,7 @@ fi
 ingest_count_30d=0
 query_count_30d=0
 update_count_30d=0
+synthesis_count_30d=0
 if [ -f "$LOG_FILE" ]; then
   # Compute cutoff date (30 days ago) in YYYY-MM-DD.
   if date -d "30 days ago" +%Y-%m-%d >/dev/null 2>&1; then
@@ -128,15 +129,17 @@ if [ -f "$LOG_FILE" ]; then
           if (op == "ingest") ingest++
           else if (op == "query") query++
           else if (op == "update") update++
+          else if (op == "synthesis") synthesis++
         }
       }
       END {
-        printf "%d %d %d", (ingest+0), (query+0), (update+0)
+        printf "%d %d %d %d", (ingest+0), (query+0), (update+0), (synthesis+0)
       }
     ' "$LOG_FILE")
     ingest_count_30d=$(printf '%s' "$counts" | awk '{print $1}')
     query_count_30d=$(printf '%s' "$counts" | awk '{print $2}')
     update_count_30d=$(printf '%s' "$counts" | awk '{print $3}')
+    synthesis_count_30d=$(printf '%s' "$counts" | awk '{print $4}')
   fi
 fi
 
@@ -172,6 +175,7 @@ export WS_DAYS_SINCE_LINT="$days_since_lint"
 export WS_INGEST_30="$ingest_count_30d"
 export WS_QUERY_30="$query_count_30d"
 export WS_UPDATE_30="$update_count_30d"
+export WS_SYNTHESIS_30="$synthesis_count_30d"
 export WS_RECENT_LOG="$recent_log"
 export WS_CONFIG_FILE="$CONFIG_FILE"
 
@@ -214,6 +218,7 @@ data = {
     "ingest_count_30d": int(os.environ.get("WS_INGEST_30", "0") or 0),
     "query_count_30d": int(os.environ.get("WS_QUERY_30", "0") or 0),
     "update_count_30d": int(os.environ.get("WS_UPDATE_30", "0") or 0),
+    "synthesis_count_30d": int(os.environ.get("WS_SYNTHESIS_30", "0") or 0),
     "recent_log": recent_log_lines,
     "schema_version": cfg.get("schema_version"),
 }


### PR DESCRIPTION
Closes #207. Refs #212.

## Summary

Promotes `synthesis` to a first-class page type in cogni-wiki so `wiki-query --file-back yes` answers stop being conflated with hand-curated `learning` pages, and so the wiki distinguishes wiki→wiki derivation from raw-source learnings.

`wiki-query` already filed query answers back as `type: learning` pages with `wiki://`-prefixed sources \(audit finding\); this PR makes that path idiomatic, validated, and visible across lint / dashboard / resume.

## What changes

**Type enum + schema docs**
- `synthesis` added to the type table in `cogni-wiki/skills/wiki-ingest/references/page-frontmatter.md` with a worked example.
- `wiki://<slug>` documented as a valid `sources:` entry, required for `type: synthesis`.

**Lint** \(`lint_wiki.py`, `severity-tiers.md`\)
- `VALID_TYPES` and `TYPES_REQUIRING_SOURCES` gain `synthesis`.
- New error class `broken_wiki_source` — `wiki://<slug>` whose target page does not exist.
- New warn class `synthesis_no_wiki_source` — `type: synthesis` with non-empty `sources:` but no `wiki://` entry.
- Existing `no_sources` warning still fires for empty sources on synthesis pages \(complementary, not redundant\).

**Dashboard** \(`render_dashboard.py`\)
- `synthesis` added to `VALID_TYPES`; assigned cyan `#0891b2` in `TYPE_COLORS` \(distinct from learning's purple\).

**Status / resume** \(`wiki_status.sh`, `wiki-resume/SKILL.md`\)
- awk block counts `synthesis` ops alongside ingest/query/update.
- JSON gains `synthesis_count_30d`.
- New decision-tree rule: nudge users toward `wiki-query --file-back yes` when they have ≥5 pages but haven't queried in 30 days.

**Query** \(`wiki-query/SKILL.md`, `query-patterns.md`\)
- File-back default type changes from `learning` to `synthesis`. `learning` and `summary` remain valid explicit overrides.
- File-back log line uses `## [YYYY-MM-DD] synthesis | …` prefix; the always-on `query` log line in Step 7 is unchanged.
- New end-to-end worked example in `query-patterns.md`.
- Step 6.7 explicitly routes the `entries_count` bump through the locked `config_bump.py` helper \(no inline writes\).

**Plugin docs + version**
- `cogni-wiki/CLAUDE.md`: type enum, "Append-only log" convention, new "Queries can compound" key convention bullet, Concurrency Invariant note that the file-back path needs no new locked surface.
- `cogni-wiki/README.md`: "What it does" item 3, page-type list, Components / Architecture trees, Quick start, Credits.
- `cogni-wiki/.claude-plugin/plugin.json`: `0.0.22 → 0.0.23`.
- `.claude-plugin/marketplace.json`: mirrored cogni-wiki version bump \(top-level `metadata.version` unchanged at `1.0.1` — within-plugin change\).

## Backwards compatibility

- **No migration**: existing `type: learning` pages keep working unchanged. Only new `wiki-query --file-back yes` calls produce `synthesis` pages.
- **No new locked surface**: synthesis file-back writes a unique-by-construction page path and routes its `entries_count` bump through the existing locked `config_bump.py`.
- Wikis that have never had a synthesis page get `synthesis_count_30d: 0` and an empty `synthesis` bar in the dashboard.

## Test plan

Verified locally on a fake wiki containing one `concept` page and one `synthesis` page:

- [x] `python3 lint_wiki.py --wiki-root /tmp/test` → 0 errors, `by_type: {concept: 1, synthesis: 1}`.
- [x] Point `wiki://...` at a missing slug → `broken_wiki_source` error fires.
- [x] Replace synthesis `sources` with only `../raw/...` entries → `synthesis_no_wiki_source` warn fires.
- [x] `python3 render_dashboard.py --wiki-root /tmp/test` → `wiki-dashboard.html` contains a `synthesis` bar and the `#0891b2` cyan colour.
- [x] `bash wiki_status.sh --wiki-root /tmp/test` → JSON has `synthesis_count_30d: 1`, distinct from `query_count_30d: 1` and `ingest_count_30d: 1`.
- [x] `python3 -c "import ast; ast.parse(open('lint_wiki.py').read())"` and `bash -n wiki_status.sh` — all clean.

To exercise end-to-end via the skill commands once the PR is approved:

- [ ] `/cogni-wiki:wiki-setup` → drop two sources in `raw/` → `/cogni-wiki:wiki-ingest` each → `/cogni-wiki:wiki-query --question "compare X and Y" --file-back yes`
- [ ] Confirm `wiki/pages/<slug>.md` has `type: synthesis` and `wiki://<source-slug>` entries; `wiki/log.md` has both `synthesis | …` and `query | …` lines; `entries_count` increments by 1
- [ ] `/cogni-wiki:wiki-resume` shows the new `syntheses` count in the activity line
- [ ] `/cogni-wiki:wiki-dashboard` shows the synthesis bucket on the type bars

## Out of scope \(deferred to tier-2 in #212\)

- Per-type directories \(e.g. `wiki/syntheses/`\). Pages stay flat under `wiki/pages/` for this PR.
- Migration of existing `type: learning` pages.
- Lint `--fix` mode for backfilling `wiki://` references.

https://claude.ai/code/session_01SSRxCFLEH7ycYxpmsfntiL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSRxCFLEH7ycYxpmsfntiL)_