### PR TITLE
cogni-wiki 0.0.24: domain-specific source body templates (closes #211)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -254,7 +254,7 @@
     {
       "name": "cogni-wiki",
       "source": "./cogni-wiki",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "maturity": "incubating",
       "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
       "keywords": [

--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-wiki/CLAUDE.md
+++ b/cogni-wiki/CLAUDE.md
@@ -77,7 +77,7 @@ Created by `wiki-setup` at the user-chosen root (default `cogni-wiki/{slug}/` re
     └── config.json            { "name", "slug", "created", "entries_count", "last_lint" }
 ```
 
-Pages stay flat under `wiki/pages/`; the `type:` frontmatter field carries the semantic distinction (concept / entity / summary / decision / learning / synthesis / note). Per-type directories are explicitly deferred — see the parent tracking issue for the Karpathy-pattern parity work.
+Pages stay flat under `wiki/pages/`; the `type:` frontmatter field carries the semantic distinction (concept / entity / summary / decision / interview / meeting / learning / synthesis / note). Per-type directories are explicitly deferred — see the parent tracking issue for the Karpathy-pattern parity work.
 
 ## Page Frontmatter
 
@@ -85,7 +85,7 @@ Pages stay flat under `wiki/pages/`; the `type:` frontmatter field carries the s
 ---
 id: <slug>
 title: <human-readable>
-type: concept | entity | summary | decision | learning | synthesis | note
+type: concept | entity | summary | decision | interview | meeting | learning | synthesis | note
 tags: [tag1, tag2]
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
@@ -93,7 +93,9 @@ sources: [../raw/paper-xyz.pdf, https://..., wiki://other-slug]
 ---
 ```
 
-The `synthesis` type (introduced in v0.0.23) is reserved for LLM-derived answers that `wiki-query --file-back yes` files back into the wiki. Synthesis pages cite their wiki provenance via `wiki://<slug>` entries in `sources:` rather than `../raw/` paths; `wiki-lint` enforces this contract. See `skills/wiki-ingest/references/page-frontmatter.md` for the full schema.
+The `synthesis` type (introduced in v0.0.23) is reserved for LLM-derived answers that `wiki-query --file-back yes` files back into the wiki. Synthesis pages cite their wiki provenance via `wiki://<slug>` entries in `sources:` rather than `../raw/` paths; `wiki-lint` enforces this contract.
+
+The `interview` and `meeting` types (introduced in v0.0.24) carry the consulting-domain shapes that drive `wiki-ingest`'s body-template dispatch. `customer-call` and `retro` are deliberately **not** distinct types — they are scaffold variants distinguished by the `tags:` field (`tag:customer-call` swaps `interview.md` → `customer-call.md`; `tag:retro` swaps `learning.md` → `retro.md`), so the enum stays small while `wiki-query` can still slice by use case. See `skills/wiki-ingest/references/page-frontmatter.md` for the full schema and `skills/wiki-ingest/references/templates/README.md` for the type→template map.
 
 ## Key Conventions
 

--- a/cogni-wiki/README.md
+++ b/cogni-wiki/README.md
@@ -61,7 +61,7 @@ sources: [../raw/bai-et-al-2022.pdf]
 ---
 ```
 
-Page types: `concept`, `entity`, `summary`, `decision`, `learning`, `synthesis`, `note`. The `synthesis` type (introduced in v0.0.23) is reserved for LLM-derived answers that `wiki-query --file-back yes` files back into the wiki; sources for these pages are `wiki://<slug>` references rather than raw files.
+Page types: `concept`, `entity`, `summary`, `decision`, `interview`, `meeting`, `learning`, `synthesis`, `note`. The `synthesis` type (v0.0.23) is reserved for LLM-derived answers that `wiki-query --file-back yes` files back into the wiki; sources for these pages are `wiki://<slug>` references rather than raw files. The `interview` and `meeting` types (v0.0.24) drive `wiki-ingest`'s body-template dispatch — `customer-call` and `retro` are tag variants of `interview` and `learning`, not new types.
 
 ## What it does
 

--- a/cogni-wiki/skills/wiki-dashboard/scripts/render_dashboard.py
+++ b/cogni-wiki/skills/wiki-dashboard/scripts/render_dashboard.py
@@ -33,12 +33,14 @@ from pathlib import Path
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 WIKILINK_RE = re.compile(r"\[\[([a-z0-9][a-z0-9\-]*)\]\]")
 
-VALID_TYPES = ["concept", "entity", "summary", "decision", "learning", "synthesis", "note"]
+VALID_TYPES = ["concept", "entity", "summary", "decision", "interview", "meeting", "learning", "synthesis", "note"]
 TYPE_COLORS = {
     "concept": "#2563eb",
     "entity": "#059669",
     "summary": "#d97706",
     "decision": "#dc2626",
+    "interview": "#0d9488",
+    "meeting": "#9333ea",
     "learning": "#7c3aed",
     "synthesis": "#0891b2",
     "note": "#64748b",

--- a/cogni-wiki/skills/wiki-ingest/SKILL.md
+++ b/cogni-wiki/skills/wiki-ingest/SKILL.md
@@ -36,7 +36,7 @@ Exactly one of `--source`, `--batch-file`, or `--discover` must be provided.
 | `--older-than-days` | No (discovery mode) | For `--discover stubs`: restrict to drafts whose `updated:` date is older than N days |
 | `--exclude-ingested` | No (discovery mode) | Drop any discovered source whose derived slug already exists as a wiki page. Use this to run `--discover` repeatedly and only ever ingest the deltas. |
 | `--title` | No | Override the page title; otherwise derive from the source (first heading, URL title, filename). Single-source mode only — in batch/discovery mode, titles are per-entry |
-| `--type` | No | Page type: `concept | entity | summary | decision | learning | note`. Defaults to `summary` for full-source ingests, `note` for short pastes. In discovery mode, applied as a default to every discovered entry |
+| `--type` | No | Page type: `concept | entity | summary | decision | interview | meeting | learning | note`. Defaults to `summary` for full-source ingests, `note` for short pastes. Also selects the body template Step 4 uses — see Step 4 for the type→template map. In discovery mode, applied as a default to every discovered entry |
 | `--tags` | No | Comma-separated tags. In discovery mode, applied as a default to every discovered entry |
 | `--auto-backlinks <K>` | No | Skip Step 6 hand-curation: auto-apply the top-K `confidence != low` candidates from `backlink_audit.py`. Mutually exclusive with `--review`. Default for batch/discover mode is `--auto-backlinks 5`; default for single-source mode is hand-curation. Pass explicitly (e.g. `--auto-backlinks 3` or `--auto-backlinks 8`) to tune the cap. |
 | `--review` | No | Force Step 6 hand-curation, even in batch/discover mode. Mutually exclusive with `--auto-backlinks`. Default (and no-op) in single-source mode; the opt-out against the new batch/discover default. |
@@ -126,6 +126,40 @@ Show this synthesis to the user before proceeding to write. For autonomous runs 
 
 Path: `<wiki-root>/wiki/pages/{slug}.md` where `slug` is derived from the title.
 
+#### 4a. Select the body template
+
+Domain-specific scaffolds live under `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/templates/` — one markdown file per `type` (plus two tag-driven variants). Pick the template **before** drafting the body so the page conforms to the per-type heading shape and required `[[wikilinks]]`. The map (also documented in `references/page-frontmatter.md`):
+
+| Resolved type | Template |
+|---|---|
+| `summary`, `concept`, `entity` | `default.md` |
+| `interview` (default) | `interview.md` |
+| `interview` + tag `customer-call` | `customer-call.md` |
+| `meeting` | `meeting.md` |
+| `decision` | `decision.md` |
+| `learning` (default) | `learning.md` |
+| `learning` + tag `retro` | `retro.md` |
+| `synthesis`, `note` | no template — write the body directly |
+
+Resolution order:
+
+1. **Explicit `--type T`.** Use `T`. If the user also passed `--tags` containing `customer-call` (with `--type interview`) or `retro` (with `--type learning`), pick the matching variant. Otherwise pick the default for `T`.
+2. **No `--type` was passed.** Infer from the source using these heuristics, in order — first hit wins:
+   - Source is a transcript with named speakers → `type: interview`. If the speakers include a customer / account context (the source is in a `customer-calls/` folder, or the user prompt mentions an account name), pick the `customer-call` variant via tag.
+   - Source has agenda + attendees + action items → `type: meeting`.
+   - Source is an ADR-shaped document (Context / Options / Decision / Consequences) → `type: decision`.
+   - Source is a retrospective board / "what went well, what didn't, actions" → `type: learning` with the `retro` tag.
+   - Source is a generalised lesson distilled across multiple inputs (no one-source anchor) → `type: learning`.
+   - Source is a paper, article, blog post, or report → `type: summary`.
+   - Source is a freeform paste under ~500 chars → `type: note`.
+   - Otherwise → `type: summary` with `default.md`.
+3. **Re-ingest mode.** Read the existing page's `type` (and any variant-defining tag like `customer-call` or `retro`) from frontmatter and pick the matching template. Do **not** silently switch templates on re-ingest — if the source has shifted shape, surface it in Step 3's takeaway synthesis and ask the user to confirm a type change before writing.
+4. **Surface the choice.** Step 3's takeaway block already names "Proposed page type and title"; extend that line to include the resolved template (e.g. `Proposed: type=interview, template=customer-call.md`). Autonomous runs proceed without confirmation; otherwise wait for the user.
+
+If a required `[[wikilink]]` declared in the template's header comment is unresolvable (the entity / concept / engagement page does not exist yet), file a stub at `wiki/pages/{stub-slug}.md` (frontmatter only, body is the one-line summary) before linking — never link to a page that doesn't exist (`SKILL.md` Failure modes: "Never invent backlinks").
+
+#### 4b. Compose the page
+
 Frontmatter (see `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/page-frontmatter.md` for the full schema):
 
 ```yaml
@@ -144,12 +178,14 @@ publisher_url: https://{publisher canonical URL, only if observable}
 
 **On `publisher_url`**: populate it only when the canonical URL is observable — do not fabricate. URL ingest → set it to the source URL (same one passed to WebFetch). File ingest with a URL printed on the PDF cover / in PDF metadata / in source text → use that URL. File ingest with no observable URL → omit the `publisher_url` key entirely (the field is optional). A guessed URL that 404s costs more credibility than an unlinked citation downstream; cogni-research will fall back to the wiki's `publisher_base_url` if set.
 
-Body structure:
+Body structure (the template selected in Step 4a sets the per-type heading shape inside `Details`; the four top-level sections below are constant):
 
 1. **One-sentence summary** (the line that will appear in `index.md`)
 2. **Key takeaways** — bulleted, each with a `[[wikilink]]` or source citation where applicable
-3. **Details** — the actual distilled content, organized with `##` subheadings
+3. **Details** — the actual distilled content. Use the headings the template prescribes (e.g. `Interviewee / Context / Topics covered / Notable quotes / Open questions raised` for `interview.md`). Drop sections the source genuinely doesn't support — empty scaffolds are noise. Add type-specific sections only when the template invites them.
 4. **Sources** — markdown-linked list of raw files and URLs
+
+Verify the body contains every required `[[wikilink]]` listed in the template's header comment before writing. A template-required link that points at a non-existent page is the trigger to file a stub per Step 4a — write the stub first, then write this page.
 
 Write the page file. Do not write anything else yet.
 
@@ -268,7 +304,8 @@ If `config_bump.py` exits non-zero or returns malformed JSON, report the error b
 ## References
 
 - `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` — the pattern
-- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/page-frontmatter.md` — full frontmatter schema
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/page-frontmatter.md` — full frontmatter schema, type enum, type→template map
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/templates/` — body scaffolds per type (`default`, `interview`, `customer-call`, `meeting`, `decision`, `retro`, `learning`); see `templates/README.md` for selection rules
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/ingest-workflow.md` — worked example
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/batch-mode.md` — `--batch-file` input schema, per-source mode rules, error policy, and worked example
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/backlink_audit.py` — candidate backlink finder

--- a/cogni-wiki/skills/wiki-ingest/references/batch-mode.md
+++ b/cogni-wiki/skills/wiki-ingest/references/batch-mode.md
@@ -191,7 +191,7 @@ Per-entry fields mirror the single-source CLI parameters exactly:
 |-------|----------|-----------|
 | `source` | Yes | Path (relative to the wiki root) or URL; matches today's `--source` parameter |
 | `title` | No | Override; matches `--title` |
-| `type` | No | `concept \| entity \| summary \| decision \| learning \| note`; matches `--type` |
+| `type` | No | `concept \| entity \| summary \| decision \| interview \| meeting \| learning \| note`; matches `--type`. See `./page-frontmatter.md` §"Type → body template mapping" for which template each type dispatches to |
 | `tags` | No | List of strings; matches `--tags` (no comma splitting needed) |
 
 Unknown top-level keys (siblings of `sources`) and unknown per-entry fields both cause the batch to abort before Step 1 of the first entry — malformed input never half-writes the wiki.

--- a/cogni-wiki/skills/wiki-ingest/references/ingest-workflow.md
+++ b/cogni-wiki/skills/wiki-ingest/references/ingest-workflow.md
@@ -247,3 +247,124 @@ entries_count: 42 → 44 (2 fresh, 1 re-ingest unchanged)
 - On error, the fail-fast policy halts the loop and reports partial progress. Every completed source is already safely in the wiki because all per-source writes are atomic — see `./batch-mode.md` §"Error policy" for the full resume procedure.
 
 For the full schema, error policy, and the Phase 2 follow-ups deferred from this iteration (continue-on-error, parallel dispatch), read `./batch-mode.md`.
+
+## Worked examples by template
+
+The two preceding examples (`many-shot-jailbreaking.md`, `constitutional-ai.md`) illustrate the `default.md` scaffold — `type: summary`, generic key-takeaways/details/sources shape. The remaining body templates each cover a domain-specific shape; one short example per template follows so Step 4a's selection rules can be checked against a concrete page.
+
+Each example assumes Step 1 found the wiki and Step 3's takeaway synthesis cleared duplication risk; we focus on Step 4 (template pick + frontmatter + body shape) and call out the per-template required `[[wikilinks]]`.
+
+### `interview.md` — captured conversation
+
+Source: `raw/interview-pm-onboarding-2026-04-22.md` (a 40-minute call with the PM of a customer-success org about onboarding pain).
+
+Invocation: `wiki-ingest --source raw/interview-pm-onboarding-2026-04-22.md --type interview --title "Interview: PM onboarding pain (Acme CS)"`
+
+Step 4a resolves: `type=interview`, no `customer-call` tag → `template=interview.md`. Required links: an interviewee entity page, at least one topic concept page.
+
+```markdown
+---
+id: interview-pm-onboarding-acme
+title: "Interview: PM onboarding pain (Acme CS)"
+type: interview
+tags: [onboarding, customer-success, acme]
+created: 2026-04-22
+updated: 2026-04-22
+sources:
+  - ../raw/interview-pm-onboarding-2026-04-22.md
+---
+
+40-minute interview with `[[priya-rao]]` on `[[customer-onboarding]]` friction in Acme's CS org; surfaced three repeatable failure modes.
+
+## Key takeaways
+
+- Day-1 setup time is the single biggest predictor of 90-day retention, not feature depth `[[customer-onboarding]]`.
+- Self-serve flows hide the moments where humans should intervene — three of the lost accounts had a clear "stuck" signal in week 2 that nobody saw.
+- Re-onboarding (after a champion leaves) is treated as a special case but happens for ~30% of accounts annually.
+
+## Details
+
+### Interviewee
+
+- **Name / role**: `[[priya-rao]]` — PM of Onboarding, Acme CS
+- **Affiliation**: Acme Inc.
+- **Date interviewed**: 2026-04-22
+- **Format**: recorded call, transcript in `raw/`
+
+### Context
+
+Follow-up to the Q1 churn analysis. We picked Priya because her team owns the day-1 → day-30 window and she had visibility into the three accounts that churned in March.
+
+### Topics covered
+
+#### Day-1 setup time
+…
+
+#### Stuck-signal detection
+…
+
+#### Re-onboarding mechanics
+…
+
+### Notable quotes
+
+> The accounts that survived the first 14 days at all weren't the ones who used more features — they were the ones who got the first integration live before the kickoff call ended.
+>
+> — Priya Rao, on what predicts retention
+
+### Open questions raised
+
+- Could the stuck-signal detection generalise across CS orgs, or is it Acme-specific?
+- What does "first integration live" mean operationally for a non-API product?
+
+## Sources
+
+- [Interview transcript — Acme PM onboarding](../raw/interview-pm-onboarding-2026-04-22.md)
+```
+
+The interviewee link to `[[priya-rao]]` is required per the template; if the page doesn't exist, Step 4a's stub-first rule files `wiki/pages/priya-rao.md` (frontmatter only, one-line summary) before writing this page.
+
+### `customer-call.md` — sales / CS variant
+
+Source: `raw/call-acme-q2-renewal.md`. Invocation: `wiki-ingest --source raw/call-acme-q2-renewal.md --type interview --tags customer-call,renewal --title "Acme Q2 renewal call"`.
+
+Step 4a sees `type: interview` + tag `customer-call` → `template=customer-call.md`. Required links: customer entity, engagement / opportunity. The body uses the customer-call scaffold (call meta / pains / signals / objections / asks-and-commitments / next steps) instead of the generic interview shape — the table-driven asks-and-commitments structure is the load-bearing difference.
+
+### `meeting.md` — meeting notes
+
+Source: `raw/q2-planning-2026-04-15.md`. Invocation: `wiki-ingest --source raw/q2-planning-2026-04-15.md --type meeting --title "Q2 planning — leadership"`.
+
+Step 4a resolves: `type=meeting` → `template=meeting.md`. Required links: at least one attendee or team, plus the project/topic the meeting concerns. Body shape: meeting meta → goal → key discussions → decisions made → action items table → parking lot.
+
+If a decision recorded in the meeting deserves an ADR, file a separate `type: decision` page and link to it from the meeting's "Decisions made" section. The meeting page records that the decision happened; the decision page records the rationale.
+
+### `decision.md` — ADR-shaped record
+
+Source: `raw/decision-replatform-2026-03-10.md`. Invocation: `wiki-ingest --source raw/decision-replatform-2026-03-10.md --type decision --title "Decision: replatform onto stack X"`.
+
+Step 4a resolves: `type=decision` → `template=decision.md`. Required links: the engagement / project / scope; any prior decision this one supersedes. Body shape: context → options considered (table) → decision → rationale → consequences (positive / negative / open risks) → revisit conditions.
+
+The `revisit conditions` section is the highest-leverage discipline for `decision` pages — without it, decisions ossify silently. A page that lacks them should be flagged in lint once the per-type required-section rule lands (deferred to issue #210's lint contract).
+
+### `retro.md` — retrospective variant
+
+Source: `raw/retro-engagement-acme-q1-2026.md`. Invocation: `wiki-ingest --source raw/retro-engagement-acme-q1-2026.md --type learning --tags retro --title "Retro: Acme Q1 engagement"`.
+
+Step 4a sees `type: learning` + tag `retro` → `template=retro.md`. Required links: the engagement / sprint / initiative; the team / participants. Body shape: retro meta → what worked → what didn't → what we'll change (table with owner + checkpoint) → patterns worth promoting.
+
+The "patterns worth promoting" section is what turns retros from journaling into anti-repetition memory: when a learning recurs across two retros, promote it to a `type: learning` page in its own right and link both retros to it.
+
+### `learning.md` — generalised lesson
+
+Invocation: `wiki-ingest --source raw/learning-three-engagement-shape.md --type learning --title "Learning: three-engagement-shape pattern"`.
+
+Step 4a resolves: `type=learning`, no `retro` tag → `template=learning.md`. Required links: at least one source page or entity the learning generalises from. Body shape: where this came from (cited sources with `[[wikilinks]]`) → when it applies → when it doesn't → implications → open questions.
+
+A learning anchored to zero `[[wikilink]]` source pages is a hunch, not a learning — the template's "Where this came from" section is mandatory to keep this distinction visible.
+
+## Template-selection edge cases
+
+- **Mixed-shape source.** A meeting that contains a major decision: file the meeting under `meeting.md`, then file the decision separately under `decision.md` and cross-link. Do not stretch one template to cover both — `wiki-query` reliability comes from uniform per-type structure.
+- **Source doesn't fit any template.** Fall back to `default.md`. The scaffolds are guidance, not a gate; an honest freeform page is better than a forced ADR.
+- **`--type note`.** No template; pastes are typically too short to benefit from a scaffold. Promote to a typed page later via `wiki-update` if it crystallises.
+- **`--type synthesis`.** No template; `wiki-query --file-back yes` writes the body directly per its own discipline (see `wiki-query/references/query-patterns.md`).

--- a/cogni-wiki/skills/wiki-ingest/references/page-frontmatter.md
+++ b/cogni-wiki/skills/wiki-ingest/references/page-frontmatter.md
@@ -46,11 +46,31 @@ One of:
 | `entity` | Specific person, organization, product, project, place |
 | `summary` | A condensed version of one raw source, paper, or article |
 | `decision` | A choice made and the reasoning — includes the alternatives considered |
-| `learning` | A generalized takeaway drawn from multiple sources or experience (typically authored by hand or filed during ingest) |
+| `interview` | A captured conversation: customer / expert / user / stakeholder. Use the `customer-call` tag to mark sales / customer-success calls, the most common variant |
+| `meeting` | Internal or external meeting notes — agenda, discussion, decisions made, action items |
+| `learning` | A generalized takeaway drawn from multiple sources or experience (typically authored by hand or filed during ingest). Use the `retro` tag for retrospectives |
 | `synthesis` | An LLM-synthesised answer derived from other wiki pages — filed back by `wiki-query --file-back yes`. Sources are `wiki://<slug>` references to the pages it draws from, not raw files. Distinguishes wiki→wiki derivation from raw-source learnings |
 | `note` | A loose observation that hasn't crystallized — often promoted later to `concept` or `learning` |
 
 Pick the most specific type. `wiki-lint` will warn when a page's body has drifted far from its declared type.
+
+`customer-call` and `retro` are deliberately **not** distinct types — they are scaffold variants distinguished by tag. This keeps the enum small while still giving `wiki-query` and the dashboard a way to slice by use case (`tag:customer-call`, `tag:retro`).
+
+### Type → body template mapping
+
+`wiki-ingest` Step 4 dispatches each `type` to a body scaffold under `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/templates/`:
+
+| Type | Template file |
+|------|---------------|
+| `summary`, `concept`, `entity` | `default.md` |
+| `interview` | `interview.md` (or `customer-call.md` when tagged `customer-call`) |
+| `meeting` | `meeting.md` |
+| `decision` | `decision.md` |
+| `learning` | `learning.md` (or `retro.md` when tagged `retro`) |
+| `synthesis` | n/a — `wiki-query --file-back yes` writes the body directly |
+| `note` | n/a — pastes are short by design; default scaffold optional |
+
+See `./templates/README.md` for authoring conventions and per-template required `[[wikilinks]]`.
 
 ### `tags` (optional)
 

--- a/cogni-wiki/skills/wiki-ingest/references/templates/README.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/README.md
@@ -1,0 +1,36 @@
+# Body Templates
+
+Each `.md` file in this directory is a body scaffold for one `type` of page. `wiki-ingest` Step 4 picks the matching template (by `--type`, or by inferring the type from source content) and uses it to generate the page body. The LLM still writes the content; the template fixes the heading shape and the prompted-fields list so downstream queries can rely on uniform structure.
+
+A scaffold is **structure, not content**. It does not pre-fill claims, takeaways, or examples — those must trace back to the source per the "never summarise from memory" rule (`SKILL.md` Failure modes).
+
+## Available templates
+
+| File | Maps to `type` | When to use |
+|---|---|---|
+| `default.md` | `summary`, `concept`, `entity` | Generic source ingest. The current freeform shape, made explicit. |
+| `interview.md` | `interview` | Customer/expert/user interview transcripts. |
+| `customer-call.md` | `interview` (variant) | Sales / customer-success / discovery calls. Same `type` as interview, different scaffold and required links. |
+| `meeting.md` | `meeting` | Internal or external meeting notes. |
+| `decision.md` | `decision` | ADR-style records: context, options, decision, consequences. |
+| `retro.md` | `learning` (variant) | Retrospectives: what worked, what didn't, actions. Filed as `type: learning` so it surfaces in lessons-learned queries. |
+| `learning.md` | `learning` | Generalised takeaway drawn from one or more sources. |
+
+`customer-call.md` and `retro.md` are scaffold variants, not new types — to keep the `type` enum in `page-frontmatter.md` small. Distinguish them with a tag (`customer-call`, `retro`) so `wiki-query` can still slice by use case.
+
+## Per-template required wikilinks
+
+Each scaffold documents a "Required `[[wikilinks]]`" block at its top. These are the links the body MUST contain for the page to be considered well-formed for that type. They become per-type lint rules once the forward→reverse link contract (issue #210) lands. Until then, treat them as authoring guidance — `wiki-ingest` should surface a warning when a required link is missing.
+
+## Selection rules (Step 4)
+
+1. **Explicit `--type T` was passed.** Use the template that maps to `T`. If the user wants a variant scaffold (e.g. `--type interview` for a customer call), pass `--tags customer-call` so the page is recognisable downstream and pick `customer-call.md`.
+2. **No `--type` was passed.** Infer from source heuristics — see `wiki-ingest/SKILL.md` Step 4 for the matrix. Fall back to `default.md` when no signal dominates.
+3. **Re-ingest mode.** Preserve the existing page's `type` from frontmatter and pick the matching template; do not switch templates silently.
+
+## Authoring conventions
+
+- Use `{{placeholder}}` syntax for fields the LLM must fill in.
+- Use `_(prompt to author)_` lines to explain what content belongs in a section without demanding a specific phrasing.
+- Required `[[wikilinks]]` are listed at the top; suggested ones are noted inline.
+- Scaffolds keep to the standard ingest body shape: one-sentence summary → key takeaways → details → sources. The type-specific structure lives **inside** the Details section.

--- a/cogni-wiki/skills/wiki-ingest/references/templates/customer-call.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/customer-call.md
@@ -1,0 +1,60 @@
+<!--
+template: customer-call
+type: interview  (with tag `customer-call`)
+required_wikilinks:
+  - the customer / account — `[[<customer-slug>]]` (entity page)
+  - the engagement, opportunity, or product line — `[[<engagement-or-product-slug>]]`
+suggested_wikilinks:
+  - any prior call with the same customer (chronological thread)
+  - relevant pain-point or jobs-to-be-done concept pages
+-->
+
+# {{title}}
+
+{{one-sentence summary capturing the customer, the call's purpose, and the headline outcome.}}
+
+## Key takeaways
+
+- {{takeaway 1 — pain, signal, ask, objection — anchored to a quote and `[[wikilink]]` where applicable}}
+- {{takeaway 2}}
+- {{takeaway 3}}
+- {{add 0–4 more}}
+
+## Details
+
+### Call meta
+
+- **Customer / account**: `[[{{customer-slug}}]]`
+- **Attendees (us)**: {{names / roles}}
+- **Attendees (them)**: {{names / roles, with seniority noted}}
+- **Engagement / opportunity**: `[[{{engagement-or-product-slug}}]]`
+- **Date**: {{YYYY-MM-DD}}
+- **Stage**: {{discovery / demo / negotiation / renewal / support / win-back}}
+
+### Pains and jobs-to-be-done
+
+_(What hurts? What are they trying to get done? Quote the customer where the phrasing matters; otherwise paraphrase tightly.)_
+
+### Signals
+
+_(Buying signals, churn signals, expansion signals, competitive mentions. Tag each with the type of signal so it's queryable.)_
+
+### Objections / risks
+
+_(What stands in the way of a yes / a renewal / an expansion? Be specific — "price" is not enough; "wants TCO comparison vs incumbent before Q3 board" is.)_
+
+### Asks and commitments
+
+| Direction | What | Owner | Due |
+|---|---|---|---|
+| Customer → us | {{ask}} | {{name}} | {{date}} |
+| Us → customer | {{commitment}} | {{name}} | {{date}} |
+
+### Next steps
+
+- {{action 1}}
+- {{action 2}}
+
+## Sources
+
+- [{{call notes / transcript / recording}}](../raw/{{source-filename}})

--- a/cogni-wiki/skills/wiki-ingest/references/templates/decision.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/decision.md
@@ -1,0 +1,57 @@
+<!--
+template: decision (ADR-shaped)
+type: decision
+required_wikilinks:
+  - the engagement, project, or scope the decision belongs to — `[[<context-slug>]]`
+  - any prior decision this one supersedes or revises — `[[<prior-decision-slug>]]` (omit if first of its kind)
+suggested_wikilinks:
+  - inputs that informed the decision (interviews, learnings, prior summaries)
+  - downstream pages that should now be updated to reflect the decision
+-->
+
+# {{title}}
+
+{{one-sentence summary stating the decision in plain prose: "We chose X over Y, because Z."}}
+
+## Key takeaways
+
+- **Decision**: {{decided option, restated for grep-ability}}
+- **Owner**: `[[{{decision-owner-slug}}]]`
+- **Status**: {{proposed | accepted | superseded | deprecated}}
+- {{additional takeaway capturing the most consequential trade-off}}
+
+## Details
+
+### Context
+
+_(What problem prompted this decision? What forces — technical, organisational, customer-driven — pushed it onto the agenda? Pull from the source; do not narrate from memory.)_
+
+### Options considered
+
+| Option | Pros | Cons | Notes |
+|---|---|---|---|
+| {{option A}} | {{pros}} | {{cons}} | {{notes / who advocated}} |
+| {{option B}} | {{pros}} | {{cons}} | {{notes}} |
+| {{option C — including "do nothing" if it was a real option}} | {{pros}} | {{cons}} | {{notes}} |
+
+### Decision
+
+_(State the chosen option in one paragraph. Make the choice unambiguous — a future reader landing here without context should know exactly what was decided.)_
+
+### Rationale
+
+_(Why this option over the alternatives? What evidence, principles, or constraints drove the choice? Cite inputs with `[[wikilinks]]` to interviews, learnings, prior decisions.)_
+
+### Consequences
+
+- **Expected positive**: {{what we believe will improve}}
+- **Expected negative / accepted cost**: {{what we are knowingly trading away}}
+- **Open risks**: {{what could invalidate this decision later}}
+
+### Revisit conditions
+
+_(What signal would trigger reopening this decision? E.g. "if customer churn on tier-2 exceeds 8% in any quarter", "after the next engagement of this shape ships". Without this, decisions ossify.)_
+
+## Sources
+
+- [{{deciding meeting or doc}}](../raw/{{source-filename}})

--- a/cogni-wiki/skills/wiki-ingest/references/templates/default.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/default.md
@@ -1,0 +1,27 @@
+<!--
+template: default
+type: summary | concept | entity
+required_wikilinks:
+  - none (depends on source content)
+suggested_wikilinks:
+  - any existing concept / entity pages mentioned in the source
+-->
+
+# {{title}}
+
+{{one-sentence summary — the line that will appear in `index.md`.}}
+
+## Key takeaways
+
+- {{takeaway 1, with `[[wikilink]]` or source citation where applicable}}
+- {{takeaway 2}}
+- {{takeaway 3}}
+- {{add 0–4 more}}
+
+## Details
+
+_(Distil the source under `##` subheadings the source itself suggests — e.g. method, results, argument, context. Do not invent structure the source does not support. If the source is silent on a topic, the page is silent on it.)_
+
+## Sources
+
+- [{{source title}}](../raw/{{source-filename}})

--- a/cogni-wiki/skills/wiki-ingest/references/templates/interview.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/interview.md
@@ -1,0 +1,53 @@
+<!--
+template: interview
+type: interview
+required_wikilinks:
+  - the interviewee — `[[<person-or-role-slug>]]` (an entity page; create one as a stub if missing)
+  - at least one topic concept — `[[<concept-slug>]]`
+suggested_wikilinks:
+  - related interviews on the same topic
+  - any decision page that cites this interview as input
+-->
+
+# {{title}}
+
+{{one-sentence summary capturing who was interviewed, on what topic, what mattered most.}}
+
+## Key takeaways
+
+- {{takeaway 1 — quote-anchored, with `[[wikilink]]` to the relevant concept or entity}}
+- {{takeaway 2}}
+- {{takeaway 3}}
+- {{add 0–4 more}}
+
+## Details
+
+### Interviewee
+
+- **Name / role**: `[[{{interviewee-slug}}]]`
+- **Affiliation**: {{org / team / capacity}}
+- **Date interviewed**: {{YYYY-MM-DD}}
+- **Format**: {{recorded call / live notes / written exchange}}
+
+### Context
+
+_(Why this conversation happened. What was the prompt — a discovery loop, a follow-up, a referral? What did we hope to learn going in? Pull from the transcript / your notes; do not narrate from memory.)_
+
+### Topics covered
+
+_(Group the interview by the questions or themes the source surfaces. One `###` heading per topic. Quote sparingly — synthesise.)_
+
+### Notable quotes
+
+> {{verbatim quote that anchors a key takeaway above}}
+>
+> — {{interviewee}}, {{context}}
+
+### Open questions raised
+
+- {{question 1 — what we still don't know after this interview}}
+- {{question 2}}
+
+## Sources
+
+- [{{transcript or notes}}](../raw/{{source-filename}})

--- a/cogni-wiki/skills/wiki-ingest/references/templates/learning.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/learning.md
@@ -1,0 +1,50 @@
+<!--
+template: learning
+type: learning
+required_wikilinks:
+  - at least one source page or entity the learning generalises from — `[[<source-slug>]]`
+suggested_wikilinks:
+  - related concept pages the learning connects
+  - any decision that depends on this learning
+-->
+
+# {{title}}
+
+{{one-sentence summary stating the lesson in plain prose, the way you would tell a teammate.}}
+
+## Key takeaways
+
+- **Lesson**: {{the lesson, restated for grep-ability}}
+- **Generality**: {{how broadly does this apply? a domain, a team, a class of problem?}}
+- **Confidence**: {{anecdotal | recurring | well-evidenced}} — based on `{{N}}` distinct observations
+- {{additional takeaway capturing the trigger or canonical example}}
+
+## Details
+
+### Where this came from
+
+_(The observations or sources this learning generalises from. Cite each with a `[[wikilink]]` to the wiki page that captures it. A learning anchored to zero source pages is a hunch, not a learning — link or downgrade.)_
+
+- `[[{{source-1-slug}}]]` — {{what this case contributed}}
+- `[[{{source-2-slug}}]]` — {{what this case contributed}}
+
+### When it applies
+
+_(The conditions under which this learning is load-bearing. "Always" is rarely right — be specific about scope so future readers can recognise when it does and doesn't apply.)_
+
+### When it doesn't
+
+_(Counter-examples, edge cases, or contexts where the lesson would mislead. Without this section, learnings ossify into folklore.)_
+
+### Implications
+
+- {{what this changes about how we plan / build / decide}}
+- {{what we would now do differently in the next instance of this situation}}
+
+### Open questions
+
+- {{what we still don't know that would sharpen the lesson}}
+
+## Sources
+
+- [{{primary source if any}}](../raw/{{source-filename}})

--- a/cogni-wiki/skills/wiki-ingest/references/templates/meeting.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/meeting.md
@@ -1,0 +1,58 @@
+<!--
+template: meeting
+type: meeting
+required_wikilinks:
+  - at least one attendee or team — `[[<person-or-team-slug>]]`
+  - the project, engagement, or topic the meeting concerns — `[[<context-slug>]]`
+suggested_wikilinks:
+  - any decision recorded in the meeting (cross-link to a `type: decision` page once filed)
+  - prior meeting in the same recurring series
+-->
+
+# {{title}}
+
+{{one-sentence summary capturing the meeting's purpose and headline outcome.}}
+
+## Key takeaways
+
+- {{takeaway 1 — what was actually decided / shifted / blocked}}
+- {{takeaway 2}}
+- {{takeaway 3}}
+- {{add 0–4 more}}
+
+## Details
+
+### Meeting meta
+
+- **Date**: {{YYYY-MM-DD}}
+- **Attendees**: `[[{{person-1}}]]`, `[[{{person-2}}]]`, …
+- **Project / context**: `[[{{context-slug}}]]`
+- **Format**: {{standup / planning / review / 1:1 / external}}
+
+### Goal
+
+_(Why the meeting happened. The original prompt or agenda item, in one to three sentences. If the meeting drifted from the goal, note that — drift is a signal.)_
+
+### Key discussions
+
+_(One `###` heading per topic. Capture the substance, not the chronology. Quote sparingly.)_
+
+### Decisions made
+
+- {{decision 1}} — promote to a `type: decision` page if it warrants its own ADR
+- {{decision 2}}
+
+### Action items
+
+| What | Owner | Due |
+|---|---|---|
+| {{action 1}} | `[[{{owner-slug}}]]` | {{date}} |
+| {{action 2}} | `[[{{owner-slug}}]]` | {{date}} |
+
+### Parking lot
+
+- {{open question or topic deferred to a later meeting}}
+
+## Sources
+
+- [{{meeting notes / recording / chat log}}](../raw/{{source-filename}})

--- a/cogni-wiki/skills/wiki-ingest/references/templates/retro.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/retro.md
@@ -1,0 +1,61 @@
+<!--
+template: retro
+type: learning  (with tag `retro`)
+required_wikilinks:
+  - the engagement, sprint, or initiative being reflected on — `[[<context-slug>]]`
+  - the team or participants — `[[<team-slug>]]` (or individual entity pages)
+suggested_wikilinks:
+  - prior retros for the same team / cadence (chronological thread)
+  - any decision page that emerged from the retro
+-->
+
+# {{title}}
+
+{{one-sentence summary capturing what was reflected on, the period covered, and the headline learning.}}
+
+## Key takeaways
+
+- {{takeaway 1 — a generalised lesson, not a one-off detail}}
+- {{takeaway 2}}
+- {{takeaway 3}}
+- {{add 0–3 more}}
+
+## Details
+
+### Retro meta
+
+- **Period**: {{start date — end date, or sprint label}}
+- **Context**: `[[{{context-slug}}]]`
+- **Participants**: `[[{{team-or-person-slug}}]]`, …
+- **Format**: {{start-stop-continue / 4Ls / mad-sad-glad / custom}}
+
+### What worked
+
+_(Practices, decisions, or conditions that produced outcomes the team wants to keep. One bullet per item; each anchored to a specific observation, not a vibe.)_
+
+- {{worked 1}}
+- {{worked 2}}
+
+### What didn't
+
+_(Friction, surprises, misses. Be specific — "communication broke down" is a smell; "we shipped before stakeholder X had reviewed the brief" is actionable.)_
+
+- {{didn't 1}}
+- {{didn't 2}}
+
+### What we'll change
+
+_(Concrete actions for the next cycle. Each one needs an owner and a checkpoint, otherwise it's a wish, not a change.)_
+
+| Change | Owner | Checkpoint |
+|---|---|---|
+| {{change 1}} | `[[{{owner-slug}}]]` | {{when we'll check}} |
+| {{change 2}} | `[[{{owner-slug}}]]` | {{when we'll check}} |
+
+### Patterns worth promoting
+
+_(If a learning here repeats a pattern from prior retros, cite the prior `[[retro-<slug>]]` and consider promoting the pattern to a `type: learning` page in its own right. Anti-repetition memory is the whole point of writing retros down.)_
+
+## Sources
+
+- [{{retro notes / board snapshot}}](../raw/{{source-filename}})

--- a/cogni-wiki/skills/wiki-ingest/scripts/batch_builder.py
+++ b/cogni-wiki/skills/wiki-ingest/scripts/batch_builder.py
@@ -62,7 +62,8 @@ Filters (compose freely with any discovery mode):
                         safe to rerun after partial progress.
 
     --type TYPE         Apply as the per-entry `type` default (one of:
-                        concept, entity, summary, decision, learning, note).
+                        concept, entity, summary, decision, interview,
+                        meeting, learning, note).
     --tags a,b,c        Apply as the per-entry `tags` default.
     --research-root P   Override the auto-located cogni-research project root.
                         Default lookup tries `<workspace>/cogni-research-<SLUG>/`
@@ -127,7 +128,7 @@ from pathlib import Path
 from typing import Iterable
 
 
-VALID_TYPES = {"concept", "entity", "summary", "decision", "learning", "note"}
+VALID_TYPES = {"concept", "entity", "summary", "decision", "interview", "meeting", "learning", "note"}
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 SLUG_CLEAN_RE = re.compile(r"[^a-z0-9]+")
 

--- a/cogni-wiki/skills/wiki-setup/SKILL.md
+++ b/cogni-wiki/skills/wiki-setup/SKILL.md
@@ -114,6 +114,16 @@ Use the current date via `date +%Y-%m-%d`. Omit `publisher_base_url` (do not emi
 Report in plain prose:
 - Where the wiki was created (absolute path)
 - Next recommended action — usually `drop a source document in raw/ and run /cogni-wiki:wiki-ingest`
+- Available body templates so the user knows which `--type` values trigger a domain-specific scaffold. Source of truth: `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/templates/`. Surface as a single short list:
+  - `default` — generic source ingest (`--type summary | concept | entity`)
+  - `interview` — captured conversation (`--type interview`)
+  - `customer-call` — sales / customer-success variant (`--type interview --tags customer-call`)
+  - `meeting` — meeting notes (`--type meeting`)
+  - `decision` — ADR-shaped record (`--type decision`)
+  - `retro` — retrospective variant (`--type learning --tags retro`)
+  - `learning` — generalised lesson (`--type learning`)
+
+  Point the user at `references/templates/README.md` for the per-template required `[[wikilinks]]` and authoring conventions when they want to dig deeper.
 - Gentle reminder that Claude will never answer `wiki-query` calls from memory — only from the wiki
 
 Do not create example pages or sample sources. An empty wiki is the correct starting state.


### PR DESCRIPTION
## Summary

Resolves #211 (the smallest tier-1 sub-issue under tracking issue #212). Adds seven body scaffolds for `wiki-ingest` so transcripts, ADRs, retros, and meeting notes follow consistent per-type structure — making downstream `wiki-query` slicing reliable (e.g., "what decisions have we made about X" can trust every decision page has a Decision section).

- New: `cogni-wiki/skills/wiki-ingest/references/templates/{README,default,interview,customer-call,meeting,decision,retro,learning}.md`. Each template documents required `[[wikilinks]]` and prompted fields in a header comment.
- `wiki-ingest/SKILL.md` Step 4 split into 4a (template selection: explicit `--type`, source heuristics, re-ingest preserves type) and 4b (compose). Required template links must resolve; missing targets trigger a stub-first write.
- `page-frontmatter.md`: `type` enum gains `interview` and `meeting`. `customer-call` and `retro` are deliberately tag-driven scaffold variants — keeps the enum small while still giving `wiki-query` a way to slice by use case.
- `wiki-setup` Step 5 now lists available templates in the bootstrap output.
- `ingest-workflow.md` adds one worked example per template plus an edge-cases section (mixed-shape sources, falling back to default, `--type note` / `synthesis`).
- Version bump 0.0.23 → 0.0.24 in `plugin.json` and `marketplace.json`.

The follow-up commit `a49b6fa` closes five drift points the audit surfaced — places that hard-coded the type allowlist and would otherwise reject or mis-bin pages of the new types:

- `batch_builder.py` — `VALID_TYPES` set + `--help` docstring add `interview`, `meeting`.
- `render_dashboard.py` — `VALID_TYPES` and `TYPE_COLORS` extended (interview = teal, meeting = purple).
- `batch-mode.md` schema table — full enum + cross-link to the template map.
- `cogni-wiki/CLAUDE.md` and `cogni-wiki/README.md` — frontmatter enum lines updated; new paragraph notes the v0.0.24 additions and the `customer-call` / `retro` tag-variant pattern.

`lint_wiki.py:49` `VALID_TYPES` is left unchanged on purpose — it drives a soft "unknown type" warning that's tolerable to lag enum additions; tightening it is a separate small change.

Per-type required-link enforcement in lint waits for #210 (forward→reverse link contract); for now the templates are authoring guidance.

## Acceptance criteria (#211)

- [x] At least 5 templates exist under `wiki-ingest/references/templates/` — 7 shipped.
- [x] `wiki-ingest/SKILL.md` Step 4 documents the template-selection branch.
- [x] `--type interview path/to/transcript.md` produces a page using the interview template (verified by static map + worked example).
- [x] One worked example per template in `ingest-workflow.md`.
- [x] Per-template required-link rules documented (header comment in each template + `templates/README.md`).

## Test plan

- [x] `python3 batch_builder.py --type interview ...` → `success: true`, entry has `type: interview` (verified locally on a temp wiki).
- [x] `python3 batch_builder.py --type bogus ...` → argparse rejects (existing behaviour preserved).
- [x] `python3 render_dashboard.py` on a temp wiki containing `type: meeting` and `type: interview` pages → HTML contains both type sections with the new colors (`#9333ea`, `#0d9488`).
- [x] `grep -rn "concept.*entity.*summary.*decision.*learning" cogni-wiki/` returns only `lint_wiki.py:49` (the intentional skip).
- [ ] Smoke-test: run `wiki-setup` end-to-end and confirm Step 5 surfaces the template list as expected.
- [ ] Smoke-test: run `wiki-ingest --type decision` against a sample ADR-shaped source and confirm Step 4a picks `decision.md`.

Tracked under #212.

https://claude.ai/code/session_017obYArxUFQmk8A3otACtUi

---
_Generated by [Claude Code](https://claude.ai/code/session_017obYArxUFQmk8A3otACtUi)_