### PR TITLE
cogni-wiki 0.0.25: multi-format auto-conversion at ingest (closes #208)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -254,7 +254,7 @@
     {
       "name": "cogni-wiki",
       "source": "./cogni-wiki",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "maturity": "incubating",
       "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
       "keywords": [

--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-wiki/CLAUDE.md
+++ b/cogni-wiki/CLAUDE.md
@@ -57,7 +57,7 @@ references/
 | Agents | 0 | — (wiki-ingest batch mode runs sequentially in the orchestrator's own context as of v0.0.22; the previous `ingest-worker` per-source subagent was removed because parallel fan-out broke the Karpathy-pattern invariant that source N+1 must see source N's page) |
 | Commands | 0 | — (skills serve as slash commands per plugin-dev guidance) |
 | Hooks | 0 | — (all bookkeeping lives inside skills) |
-| Scripts | 9 | backlink_audit.py, wiki_index_update.py, batch_builder.py, lint_wiki.py, wiki_status.sh, render_dashboard.py, refresh_planner.py, extract_page_claims.py, resweep_planner.py |
+| Scripts | 10 | backlink_audit.py, wiki_index_update.py, batch_builder.py, lint_wiki.py, wiki_status.sh, render_dashboard.py, refresh_planner.py, extract_page_claims.py, resweep_planner.py, convert_to_md.py |
 
 ## Wiki Data Layout (outside the plugin)
 

--- a/cogni-wiki/README.md
+++ b/cogni-wiki/README.md
@@ -177,6 +177,16 @@ cogni-wiki runs standalone for the core ingest/query/lint/update loop. Three ski
 
 Integrations with `cogni-narrative` and `cogni-consulting` remain planned for v0.1.x; see [CLAUDE.md](CLAUDE.md) "Cross-Plugin Integration" and "Future Integration Points".
 
+## Optional dependencies
+
+cogni-wiki is stdlib-only by default. One skill step lights up additional capabilities when an optional CLI is present; absence is never a hard error for the formats stdlib already covers.
+
+| Tool | Skill / step | What it enables | Install |
+|---|---|---|---|
+| `markitdown` | `wiki-ingest` Step 2a (`scripts/convert_to_md.py`) | Auto-conversion of binary office formats (`.docx`, `.pptx`, `.xlsx`, `.epub`) and richer extraction for `.html` / `.txt` / `.csv` / `.json` / `.ipynb` so consulting sources (interviews, decks, financial models) ingest without manual pre-conversion | `pip install markitdown` (or `pipx install markitdown` for a sandboxed install) |
+
+When `markitdown` is not installed, `wiki-ingest` still handles `.md`, `.pdf` (via the Read tool's `pages` parameter), `.html` (stdlib `html.parser` fallback), `.txt` (verbatim), URL ingest (via WebFetch), and pasted text. Binary office formats short-circuit with a clear error pointing back at this section, so the failure mode is never silent half-extraction. See `skills/wiki-ingest/SKILL.md` §2a for the full backend table and the `--no-convert` opt-out.
+
 ## Credits
 
 - **Andrej Karpathy** — [LLM Wiki gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). The pattern this plugin implements.

--- a/cogni-wiki/skills/wiki-ingest/SKILL.md
+++ b/cogni-wiki/skills/wiki-ingest/SKILL.md
@@ -38,6 +38,7 @@ Exactly one of `--source`, `--batch-file`, or `--discover` must be provided.
 | `--title` | No | Override the page title; otherwise derive from the source (first heading, URL title, filename). Single-source mode only — in batch/discovery mode, titles are per-entry |
 | `--type` | No | Page type: `concept | entity | summary | decision | interview | meeting | learning | note`. Defaults to `summary` for full-source ingests, `note` for short pastes. Also selects the body template Step 4 uses — see Step 4 for the type→template map. In discovery mode, applied as a default to every discovered entry |
 | `--tags` | No | Comma-separated tags. In discovery mode, applied as a default to every discovered entry |
+| `--no-convert` | No | Skip Step 2's auto-conversion branch even if the source is a non-markdown format (`.docx`, `.pptx`, `.html`, …). Use this when you have already pre-converted the source to markdown and want the existing path to be read verbatim. Single-source mode and per-entry in batch/discovery mode (set `no_convert: true` on the entry); ignored when the source is `.md`, `.pdf`, or a URL because Step 2 already short-circuits those. |
 | `--auto-backlinks <K>` | No | Skip Step 6 hand-curation: auto-apply the top-K `confidence != low` candidates from `backlink_audit.py`. Mutually exclusive with `--review`. Default for batch/discover mode is `--auto-backlinks 5`; default for single-source mode is hand-curation. Pass explicitly (e.g. `--auto-backlinks 3` or `--auto-backlinks 8`) to tune the cap. |
 | `--review` | No | Force Step 6 hand-curation, even in batch/discover mode. Mutually exclusive with `--auto-backlinks`. Default (and no-op) in single-source mode; the opt-out against the new batch/discover default. |
 
@@ -105,11 +106,46 @@ See `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/ingest-workflow.md` §"
 
 ### 2. Read the source
 
-- **File in `raw/`**: Read it directly. For PDFs, extract text with the Read tool's pages parameter.
-- **URL**: Fetch via WebFetch, then write a local copy under `raw/` with a slug-named filename so the source is preserved even if the URL rots.
-- **Pasted text**: Write the paste to `raw/paste-{YYYYMMDD-HHMMSS}.md` first, then proceed as a file ingest. Never ingest pasted content without persisting the raw.
+The source-reading branch picks one of four paths and, for non-markdown files, can chain through an auto-conversion sub-step before the rest of the pipeline runs. The original under `raw/` always remains the ground-truth artefact — frontmatter `sources:` points at it, never at the converted markdown — so re-ingest can re-convert if a future tooling release improves extraction.
+
+- **File in `raw/`**:
+  - `.md` / `.markdown` → read directly.
+  - `.pdf` → extract text with the Read tool's `pages` parameter, exactly as before.
+  - **Any other extension** (`.docx`, `.pptx`, `.xlsx`, `.html`, `.epub`, `.txt`, …) → run the auto-conversion sub-step below, then read the converted markdown the script returned. Skip the sub-step entirely when the user passed `--no-convert` (or set `no_convert: true` on the batch entry); in that case, treat the source as opaque and only the orchestrator's own reading discipline applies.
+- **URL**: Fetch via WebFetch, then write a local copy under `raw/` with a slug-named filename so the source is preserved even if the URL rots. WebFetch already returns markdown-ish content, so there is no auto-conversion sub-step here; `--no-convert` is a no-op.
+- **Pasted text**: Write the paste to `raw/paste-{YYYYMMDD-HHMMSS}.md` first, then proceed as a markdown file ingest. Never ingest pasted content without persisting the raw.
 
 Every wiki page must cite a file in `raw/` or a stable URL. This link to raw/ is what makes the wiki trustworthy — every claim traces through a page to its original source, and that chain breaks if any page floats without a raw anchor.
+
+#### 2a. Auto-conversion sub-step (non-markdown `raw/` files only)
+
+Invoke the helper, parse the JSON, branch on `data.backend`:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/convert_to_md.py --source <source-path>
+```
+
+The script preserves the original under `raw/` and writes converted markdown alongside as `<source>.converted.md`. Conversion is idempotent: a `.converted.md` whose mtime is newer than (or equal to) the source's mtime is re-used unchanged (`backend: cache-hit`); pass `--force` to override when deliberately re-converting.
+
+| `data.backend` | What it means | What to do |
+|---|---|---|
+| `noop-markdown` | Source was `.md` / `.markdown` | Read `data.converted_path` (== source); no surfacing needed |
+| `noop-pdf` | Source was `.pdf` | Use the existing Read-tool pages flow; ignore `data.converted_path` |
+| `stdlib-passthrough` | `.txt` copied verbatim by stdlib | Read `data.converted_path`; surface `[backend: stdlib-passthrough]` |
+| `stdlib-html` | `.html` / `.htm` stripped via stdlib `html.parser` | Read `data.converted_path`; surface `[backend: stdlib-html]` |
+| `markitdown` | Shelled out to the optional `markitdown` CLI | Read `data.converted_path`; surface `[backend: markitdown]` |
+| `cache-hit` | `<source>.converted.md` was up-to-date and re-used | Read `data.converted_path`; surface `[backend: cache-hit]` |
+
+Surface the backend in the user transcript next to the source line so the operator can see which conversion path ran (e.g. `Source: raw/q1-customer-call.docx [backend: markitdown]`). This makes pre-conversion failures and quality drift visible without forcing a separate diagnostic.
+
+If the script returns `success: false`, surface the error verbatim and offer two paths to the user:
+
+- For `backend: unsupported` (a binary office format with no markitdown installed): point them at the README's "Optional dependencies" section so they can install `markitdown`, or ask them to convert to `.md` manually and re-invoke. Do not invent a fallback — half-extracted text from a `.docx` is worse than no ingest.
+- For `backend: markitdown-error` (markitdown is installed but failed on this file): surface the stderr and ask whether to retry with `--no-convert` (skip the helper entirely and pass the binary path through unchanged) or hand-convert.
+
+In batch / discovery mode, treat a non-zero `convert_to_md.py` exit as the entry's Step 2 failure and let the fail-fast policy in §0 halt the loop. Sources processed before the failure are already consistent on disk; nothing about the converted-file caching changes that — `.converted.md` writes go through `tempfile + os.replace` so a crash mid-script cannot leave a half-written cache.
+
+`--no-convert` (or `no_convert: true` on a batch entry) skips this entire sub-step. Use it when the user has already pre-converted the source and dropped both the original and the markdown copy in `raw/`, or when investigating a markitdown extraction bug and you want the orchestrator to read the binary path directly. The script is idempotent enough that re-enabling auto-conversion on a later run still produces the right state.
 
 ### 3. Surface key takeaways BEFORE writing the page
 
@@ -177,6 +213,8 @@ publisher_url: https://{publisher canonical URL, only if observable}
 ```
 
 **On `publisher_url`**: populate it only when the canonical URL is observable — do not fabricate. URL ingest → set it to the source URL (same one passed to WebFetch). File ingest with a URL printed on the PDF cover / in PDF metadata / in source text → use that URL. File ingest with no observable URL → omit the `publisher_url` key entirely (the field is optional). A guessed URL that 404s costs more credibility than an unlinked citation downstream; cogni-research will fall back to the wiki's `publisher_base_url` if set.
+
+**On `sources:` after auto-conversion.** When Step 2a converted the source, point `sources:` at the **original** (`../raw/{source-filename.docx}`), not the `.converted.md` cache file. The cache is a derived artefact — re-ingest can rebuild it from the original if a markitdown release improves extraction, and a pinned cache path would silently rot the citation chain.
 
 Body structure (the template selected in Step 4a sets the per-type heading shape inside `Details`; the four top-level sections below are constant):
 
@@ -293,6 +331,7 @@ If `config_bump.py` exits non-zero or returns malformed JSON, report the error b
 - N existing pages in `wiki/pages/` edited with new backlinks (where N ≥ 0)
 - One appended line in `wiki/log.md`
 - Updated `config.json`
+- Optionally, one `<source>.converted.md` cache file in `raw/` next to a non-markdown source (Step 2a). Re-used on idempotent re-ingest; safe to delete to force re-conversion.
 
 ## Failure modes and rules
 
@@ -300,14 +339,16 @@ If `config_bump.py` exits non-zero or returns malformed JSON, report the error b
 - **Never invent backlinks.** Only link to pages that actually exist in `wiki/pages/`.
 - **Never overwrite a page silently.** Overwrites are only allowed through the explicit re-ingest path: Step 1 must detect the existing slug, set `mode: re-ingest`, and emit the re-ingest warning before any page write. Silent overwrites (writing to an existing slug without surfacing `mode: re-ingest` to the user) remain forbidden. For content-only edits that preserve the existing synthesis, use `wiki-update` rather than a re-ingest.
 - **Raw first, page second.** Pasted content is persisted to `raw/` before any page work begins.
+- **Original source is the citation, not the cache.** When Step 2a writes a `.converted.md`, frontmatter `sources:` still points at the original. The cache is a derived artefact — re-ingest may rebuild it; nothing in the wiki should depend on its path.
 
 ## References
 
 - `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` — the pattern
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/page-frontmatter.md` — full frontmatter schema, type enum, type→template map
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/templates/` — body scaffolds per type (`default`, `interview`, `customer-call`, `meeting`, `decision`, `retro`, `learning`); see `templates/README.md` for selection rules
-- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/ingest-workflow.md` — worked example
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/ingest-workflow.md` — worked example, including a `.docx` ingest end-to-end (Step 2a auto-conversion)
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/batch-mode.md` — `--batch-file` input schema, per-source mode rules, error policy, and worked example
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/backlink_audit.py` — candidate backlink finder
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/wiki_index_update.py` — deterministic `wiki/index.md` insert/update helper
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/batch_builder.py` — discovery helper; enumerates candidates for `--discover` and emits the batch-mode payload on stdout
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/convert_to_md.py` — multi-format auto-conversion helper used by Step 2a (`.docx`, `.pptx`, `.xlsx`, `.html`, `.epub`, …); stdlib-first with optional `markitdown` shell-out

--- a/cogni-wiki/skills/wiki-ingest/references/ingest-workflow.md
+++ b/cogni-wiki/skills/wiki-ingest/references/ingest-workflow.md
@@ -368,3 +368,112 @@ A learning anchored to zero `[[wikilink]]` source pages is a hunch, not a learni
 - **Source doesn't fit any template.** Fall back to `default.md`. The scaffolds are guidance, not a gate; an honest freeform page is better than a forced ADR.
 - **`--type note`.** No template; pastes are typically too short to benefit from a scaffold. Promote to a typed page later via `wiki-update` if it crystallises.
 - **`--type synthesis`.** No template; `wiki-query --file-back yes` writes the body directly per its own discipline (see `wiki-query/references/query-patterns.md`).
+
+## Worked example: `.docx` ingest end-to-end (Step 2a auto-conversion)
+
+The preceding examples all assumed a markdown or PDF source — those bypass Step 2a entirely. This section shows the full path for a non-markdown source so the auto-conversion branch is concrete.
+
+### Scenario
+
+A consulting team has a discovery call recording transcribed by their notetaker into Word format and dropped at `raw/discovery-acme-q2-2026-04-22.docx`. They invoke:
+
+```
+wiki-ingest --source raw/discovery-acme-q2-2026-04-22.docx \
+            --type interview --tags customer-call,acme,q2 \
+            --title "Discovery call: Acme CS pain (Q2 2026)"
+```
+
+### Step 1: locate the wiki, detect mode
+
+`config.json` is found three levels up. Slug `discovery-acme-cs-pain-q2-2026` is derived from the title; no page at that slug yet, so `mode: fresh`.
+
+### Step 2: read the source
+
+Extension is `.docx` — neither `.md` nor `.pdf`, so the Step 2a auto-conversion sub-step fires.
+
+### Step 2a: auto-convert
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/convert_to_md.py \
+    --source raw/discovery-acme-q2-2026-04-22.docx
+```
+
+`markitdown` is on `$PATH`; the script shells out and writes the converted markdown to `raw/discovery-acme-q2-2026-04-22.docx.converted.md`. Output:
+
+```json
+{
+  "success": true,
+  "data": {
+    "source_path": "raw/discovery-acme-q2-2026-04-22.docx",
+    "converted_path": "raw/discovery-acme-q2-2026-04-22.docx.converted.md",
+    "backend": "markitdown",
+    "cached": false
+  },
+  "error": ""
+}
+```
+
+Surface the backend in the response transcript:
+
+```
+Source: raw/discovery-acme-q2-2026-04-22.docx [backend: markitdown]
+        → raw/discovery-acme-q2-2026-04-22.docx.converted.md
+```
+
+The orchestrator now reads the converted markdown for the rest of Steps 3 and 4. The original `.docx` is untouched and remains the citation anchor.
+
+### Step 2a fallback paths (one of these is what you hit, not all of them)
+
+- **`markitdown` not installed but the source is `.html` / `.txt`.** Backend is `stdlib-html` or `stdlib-passthrough`; no install needed; surface the backend tag and proceed.
+- **`markitdown` not installed and the source is a binary office format.** Script returns `success: false`, `backend: unsupported`. Stop and tell the user: "`.docx` requires markitdown — `pip install markitdown` (see `README.md` §Optional dependencies) or convert the file to `.md` manually and re-invoke. Aborting before any wiki write." No partial state to clean up — Step 2a runs before Step 4.
+- **`markitdown` installed but errors on this file.** Script returns `success: false`, `backend: markitdown-error`, with stderr in `error`. Surface verbatim and offer two paths: re-invoke with `--no-convert` (the orchestrator reads the binary path directly — useful for inspecting metadata when the file is text-shaped despite the extension) or hand-convert. Do not invent a fallback that silently half-extracts.
+- **Re-ingest of the same `.docx`.** Backend returns `cache-hit` because `<source>.converted.md` is newer than the source; the conversion is skipped, the cached markdown is read, and Step 2a finishes in milliseconds. To force re-conversion (e.g., after a markitdown upgrade), pass `--force` to `convert_to_md.py` directly or delete the cache file before invoking.
+
+### Step 3: takeaways before writing
+
+Surface in plain prose, e.g.:
+
+> **Source**: 38-minute discovery call with Priya Rao (PM Onboarding, Acme CS), 2026-04-22. Converted from `.docx` via markitdown; original retained at `raw/discovery-acme-q2-2026-04-22.docx`.
+>
+> **Key takeaways:**
+> 1. Day-1 setup time predicts 90-day retention more than feature depth — three of last quarter's churned accounts had multi-day setup gaps.
+> 2. Acme has no signal-detection on stuck onboarding flows; "stuck" only surfaces when the AE notices low usage on a check-in.
+> 3. Re-onboarding (champion turnover) hits ~30% of accounts annually and is treated as ad-hoc rather than a flow.
+>
+> **Existing pages this touches:**
+> - `[[priya-rao]]` — does not yet exist; will file a stub per the `interview.md` template's required-link rule.
+> - `[[customer-onboarding]]` — exists; will gain a backlink.
+> - `[[acme-engagement-q2-2026]]` — does not yet exist; will file a stub for the engagement.
+>
+> **Proposed**: type=interview, template=customer-call.md (because of the `customer-call` tag), title=Discovery call: Acme CS pain (Q2 2026).
+
+### Step 4: write the page
+
+Step 4a resolves to `customer-call.md` (type `interview` + tag `customer-call`). Stubs are filed for `priya-rao` and `acme-engagement-q2-2026` first per the "never invent backlinks" rule. Then the page itself:
+
+```markdown
+---
+id: discovery-acme-cs-pain-q2-2026
+title: "Discovery call: Acme CS pain (Q2 2026)"
+type: interview
+tags: [customer-call, acme, q2]
+created: 2026-04-22
+updated: 2026-04-22
+sources:
+  - ../raw/discovery-acme-q2-2026-04-22.docx
+---
+
+…body filled per customer-call.md scaffold…
+```
+
+The `sources:` line points at the **`.docx` original**, not the `.converted.md` cache — see `SKILL.md` §"Failure modes" ("Original source is the citation, not the cache"). A future re-ingest can rebuild the cache from the original if a markitdown release improves extraction; nothing in the wiki should depend on the cache path.
+
+### Steps 5–9
+
+Identical to the markdown / PDF examples earlier in this document. The auto-conversion sub-step is invisible to everything downstream of Step 2; the `.converted.md` cache file lives quietly next to the original under `raw/` and is only re-touched on a deliberate `--force` or cache-mtime-older-than-source.
+
+### Anti-patterns specific to multi-format ingest
+
+- **Pointing `sources:` at the `.converted.md` file.** The cache is derived; the citation chain must trace to the original artefact the user actually has on disk. A page citing a `.converted.md` will silently rot the next time markitdown improves and the cache is regenerated with different formatting.
+- **Deleting the original `.docx` after conversion succeeded.** The wiki's portability promise rests on every page tracing to a `raw/` artefact. The cache is **not** a substitute — it's a derived view.
+- **Using `--no-convert` to silence a `markitdown-error`.** That just kicks the problem downstream — the orchestrator will read a binary blob and write a noise-filled page. Either fix the markitdown failure (or upgrade) or hand-convert the source to `.md`.

--- a/cogni-wiki/skills/wiki-ingest/scripts/convert_to_md.py
+++ b/cogni-wiki/skills/wiki-ingest/scripts/convert_to_md.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""
+convert_to_md.py — convert a non-markdown source file to markdown for ingest.
+
+Issue #208: wiki-ingest's Step 2 today only handles `.md` files in `raw/`,
+PDFs (via the Read tool's pages parameter), URLs (via WebFetch), and pasted
+text. Multi-format consulting sources (`.docx` interviews, `.pptx` decks,
+`.xlsx` models, `.html` web archives, `.epub` training material) require
+manual pre-conversion before the user can ingest them.
+
+This helper closes that gap with stdlib-first detection plus an optional
+shell-out to `markitdown` when available. The original under `raw/` is
+preserved verbatim — the converted markdown is written alongside as
+`<source-stem>.converted.md` so the ground-truth source remains the file
+referenced by `sources:` frontmatter; re-ingest can re-convert if a future
+markitdown release improves extraction.
+
+cogni-wiki stays stdlib-only by default. markitdown is an optional
+dependency that enables richer extraction for binary office formats; its
+absence is not an error for the formats stdlib can handle (`.md`, `.pdf`,
+`.html`, `.txt`).
+
+Usage:
+    convert_to_md.py --source raw/report.docx
+    convert_to_md.py --source raw/page.html --no-markitdown
+    convert_to_md.py --source raw/notes.md            # no-op, returns source path
+    convert_to_md.py --source raw/report.docx --force # ignore the cache
+
+Output contract (stdout, single-line JSON):
+    {
+      "success": true,
+      "data": {
+        "source_path": "raw/report.docx",
+        "converted_path": "raw/report.converted.md",
+        "backend": "markitdown",
+        "cached": false
+      },
+      "error": ""
+    }
+
+Backends:
+  - noop-markdown          source is already `.md` / `.markdown` — `converted_path` == `source_path`
+  - noop-pdf               source is `.pdf` — wiki-ingest Step 2 handles PDFs via the Read tool
+  - stdlib-passthrough     source is `.txt` — copied verbatim into the converted file
+  - stdlib-html            source is `.html` / `.htm` — tags stripped via `html.parser`
+  - markitdown             shelled out to the `markitdown` CLI when installed
+  - cache-hit              `<source>.converted.md` is newer than the source — re-used unchanged
+
+Idempotency: a converted file whose mtime is newer than (or equal to) the
+source's mtime is treated as up-to-date and re-used without invoking the
+backend. `--force` overrides. The PDF and markdown no-ops are always
+idempotent because they never write a converted file.
+
+stdlib-only (Python 3.8+, macOS / Linux). markitdown is optional.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import List
+
+
+MARKDOWN_EXTS = {".md", ".markdown"}
+PDF_EXTS = {".pdf"}
+TEXT_EXTS = {".txt"}
+HTML_EXTS = {".html", ".htm"}
+# Formats markitdown handles when available; stdlib has no fallback for these.
+MARKITDOWN_ONLY_EXTS = {
+    ".docx", ".doc",
+    ".pptx", ".ppt",
+    ".xlsx", ".xls",
+    ".epub",
+    ".rst",
+    ".csv", ".tsv",
+    ".json", ".xml",
+    ".yaml", ".yml",
+    ".ipynb",
+}
+
+
+def fail(msg: str, **extra) -> None:
+    print(json.dumps({"success": False, "data": dict(extra), "error": msg}))
+    sys.exit(1)
+
+
+def ok(**data) -> None:
+    print(json.dumps({"success": True, "data": data, "error": ""}))
+    sys.exit(0)
+
+
+class _HTMLToText(HTMLParser):
+    """Stdlib-only HTML→text fallback. Coarse — preserves heading levels and
+    paragraph breaks; drops attributes, scripts, and styles. Good enough for
+    web-archive ingest when markitdown isn't installed."""
+
+    _SKIP_TAGS = {"script", "style", "noscript", "head"}
+    _BLOCK_TAGS = {"p", "li", "tr", "div", "section", "article", "blockquote"}
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._chunks: List[str] = []
+        self._skip_depth = 0
+        self._heading: int = 0  # active heading level, 0 if none
+
+    def handle_starttag(self, tag, attrs):
+        if tag in self._SKIP_TAGS:
+            self._skip_depth += 1
+            return
+        if len(tag) == 2 and tag[0] == "h" and tag[1].isdigit():
+            self._heading = int(tag[1])
+            self._chunks.append("\n\n" + "#" * self._heading + " ")
+            return
+        if tag == "br":
+            self._chunks.append("\n")
+            return
+        if tag in self._BLOCK_TAGS:
+            self._chunks.append("\n\n")
+            return
+
+    def handle_endtag(self, tag):
+        if tag in self._SKIP_TAGS:
+            if self._skip_depth > 0:
+                self._skip_depth -= 1
+            return
+        if len(tag) == 2 and tag[0] == "h" and tag[1].isdigit():
+            self._heading = 0
+            self._chunks.append("\n\n")
+            return
+        if tag in self._BLOCK_TAGS:
+            self._chunks.append("\n\n")
+
+    def handle_data(self, data):
+        if self._skip_depth == 0:
+            self._chunks.append(data)
+
+    def text(self) -> str:
+        raw = "".join(self._chunks)
+        # Collapse runs of >2 newlines to exactly 2 (paragraph break).
+        out_lines: List[str] = []
+        blank_run = 0
+        for line in raw.splitlines():
+            stripped = line.strip()
+            if stripped:
+                out_lines.append(stripped)
+                blank_run = 0
+            else:
+                blank_run += 1
+                if blank_run == 1:
+                    out_lines.append("")
+        return "\n".join(out_lines).strip() + "\n"
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".convert-to-md-", dir=str(parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _converted_path_for(source: Path) -> Path:
+    # Sit alongside the source so frontmatter-relative paths still resolve.
+    # `<stem>.converted.md` keeps the original extension visible in the name.
+    return source.with_suffix(source.suffix + ".converted.md")
+
+
+def _is_cache_fresh(source: Path, converted: Path) -> bool:
+    if not converted.is_file():
+        return False
+    try:
+        return converted.stat().st_mtime >= source.stat().st_mtime
+    except OSError:
+        return False
+
+
+def _convert_html_stdlib(source: Path) -> str:
+    raw = source.read_text(encoding="utf-8", errors="replace")
+    parser = _HTMLToText()
+    parser.feed(raw)
+    parser.close()
+    return parser.text()
+
+
+def _convert_via_markitdown(source: Path) -> str:
+    # markitdown's CLI prints the converted markdown to stdout.
+    # We pass the input as a positional argument so it works for binary formats.
+    proc = subprocess.run(
+        ["markitdown", str(source)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"markitdown exited {proc.returncode}: {proc.stderr.strip() or '<no stderr>'}"
+        )
+    return proc.stdout
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert a non-markdown source to markdown for wiki-ingest"
+    )
+    parser.add_argument("--source", required=True, help="Path to the source file under raw/")
+    parser.add_argument(
+        "--no-markitdown",
+        action="store_true",
+        help="Skip the markitdown CLI even if installed (use stdlib backends only)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-run conversion even if the cached .converted.md is newer than the source",
+    )
+    args = parser.parse_args()
+
+    source = Path(args.source).expanduser()
+    if not source.is_file():
+        fail(f"source not found: {source}", source_path=str(source))
+
+    ext = source.suffix.lower()
+
+    if ext in MARKDOWN_EXTS:
+        ok(
+            source_path=str(source),
+            converted_path=str(source),
+            backend="noop-markdown",
+            cached=False,
+        )
+        return
+
+    if ext in PDF_EXTS:
+        # PDFs are read by wiki-ingest Step 2 via the Read tool's pages param.
+        # We deliberately do not invoke markitdown here — the existing pipeline
+        # is fine for consulting workloads (per issue #208 non-goals).
+        ok(
+            source_path=str(source),
+            converted_path=str(source),
+            backend="noop-pdf",
+            cached=False,
+        )
+        return
+
+    converted = _converted_path_for(source)
+
+    if not args.force and _is_cache_fresh(source, converted):
+        ok(
+            source_path=str(source),
+            converted_path=str(converted),
+            backend="cache-hit",
+            cached=True,
+        )
+        return
+
+    have_markitdown = (not args.no_markitdown) and bool(shutil.which("markitdown"))
+
+    backend: str
+    content: str
+
+    try:
+        if ext in TEXT_EXTS and not have_markitdown:
+            content = source.read_text(encoding="utf-8", errors="replace")
+            backend = "stdlib-passthrough"
+        elif ext in HTML_EXTS and not have_markitdown:
+            content = _convert_html_stdlib(source)
+            backend = "stdlib-html"
+        elif have_markitdown and ext in (TEXT_EXTS | HTML_EXTS | MARKITDOWN_ONLY_EXTS):
+            content = _convert_via_markitdown(source)
+            backend = "markitdown"
+        elif ext in MARKITDOWN_ONLY_EXTS:
+            fail(
+                f"format {ext!r} requires markitdown — install with `pip install markitdown` "
+                f"or convert {source.name} to markdown manually",
+                source_path=str(source),
+                backend="unsupported",
+            )
+            return
+        else:
+            fail(
+                f"unsupported source extension {ext!r}",
+                source_path=str(source),
+                backend="unsupported",
+            )
+            return
+    except RuntimeError as e:
+        fail(str(e), source_path=str(source), backend="markitdown-error")
+        return
+    except OSError as e:
+        fail(f"could not read source: {e}", source_path=str(source))
+        return
+
+    _atomic_write_text(converted, content)
+
+    ok(
+        source_path=str(source),
+        converted_path=str(converted),
+        backend=backend,
+        cached=False,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `convert_to_md.py` Step 2a helper for `wiki-ingest`: stdlib-first multi-format auto-conversion with optional `markitdown` shell-out for binary office formats (`.docx`, `.pptx`, `.xlsx`, `.epub`).
- Six backends: `noop-markdown`, `noop-pdf`, `stdlib-passthrough` (`.txt`), `stdlib-html` (`.html` via `html.parser`), `markitdown`, `cache-hit` (mtime-idempotent; `--force` to override).
- Original under `raw/` stays the citation anchor; converted markdown lives alongside as `<source>.converted.md` (atomic `tempfile + os.replace`). Frontmatter `sources:` always points at the original — the cache is a derived artefact.
- Wires the helper into `wiki-ingest/SKILL.md` §2 / new §2a, with a `--no-convert` opt-out (single-source) / `no_convert: true` (per batch entry), a backend table, error handling for `unsupported` + `markitdown-error`, and a new failure-mode rule "Original source is the citation, not the cache".
- README gains an "Optional dependencies" section listing `markitdown` and what stdlib still covers without it.
- New worked `.docx` ingest end-to-end example in `references/ingest-workflow.md`, including all four Step 2a fallback paths and three multi-format-specific anti-patterns.
- Bumps `cogni-wiki/.claude-plugin/plugin.json` and the matching `.claude-plugin/marketplace.json` entry to **0.0.25**, and updates `cogni-wiki/CLAUDE.md` Component Inventory (Scripts row 9 → 10).

Closes #208. Tracked under #212.

## Test plan

- [x] `convert_to_md.py` returns the documented `{success, data, error}` JSON contract on `.md` (`noop-markdown`), `.pdf` (`noop-pdf`), `.txt` (`stdlib-passthrough`), `.html` (`stdlib-html`), and a missing source path (`success: false`).
- [x] Re-running on the same `.html` source returns `backend: cache-hit, cached: true`; passing `--force` re-runs the backend.
- [x] `.docx` without `markitdown` installed returns `success: false, backend: unsupported` with an instructive message pointing at the README "Optional dependencies" section — no half-extracted page is written.
- [ ] On a wiki with `markitdown` installed: `wiki-ingest --source raw/sample.docx --type interview --tags customer-call …` ingests the source end-to-end, surfaces `[backend: markitdown]` in the transcript, and writes `sources: ../raw/sample.docx` (NOT the `.converted.md` cache path).
- [ ] `wiki-ingest --source raw/sample.docx --no-convert` skips Step 2a entirely and treats the binary path as opaque (used as the `markitdown-error` escape hatch).
- [ ] `wiki-resume` after the upgrade reads `version: 0.0.25` from `plugin.json` and Claude Desktop picks the bump up via `marketplace.json`.

## Notes

- Local commit signing was non-functional in the implementation environment (signing server returned `400 missing source`), so all commits on this branch were authored via the GitHub MCP `create_or_update_file` / `push_files` API rather than `git commit`. Functionally identical; flagged here in case the unusual commit cadence (5 small commits instead of one squash candidate) is surprising on review.
- The `convert_to_md.py` helper is stdlib-only — installation of `markitdown` is strictly opt-in per the README "Optional dependencies" entry.
- Per-type directory promotion (deferred Tier-2 in #212) and a `batch-mode.md` schema entry for `no_convert: true` are intentionally out of scope; SKILL.md documents the batch field directly.

https://claude.ai/code/session_01XB42WZwBbdZQ6VAiv7Utgf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XB42WZwBbdZQ6VAiv7Utgf)_