### PR TITLE
cogni-wiki: split wiki-health (zero-LLM) from wiki-lint (semantic) (#209)

### DIFF
--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",
@@ -17,6 +17,7 @@
     "ingest",
     "query",
     "lint",
+    "health",
     "backlinks",
     "agent"
   ]

--- a/cogni-wiki/CLAUDE.md
+++ b/cogni-wiki/CLAUDE.md
@@ -5,7 +5,7 @@ Compile-time knowledge engine for personal and small-team knowledge work — a b
 ## Plugin Architecture
 
 ```
-skills/                         10 wiki skills
+skills/                         11 wiki skills
   wiki-setup/                     Bootstrap a new wiki at a user-chosen root
     references/
       SCHEMA.md.template          Copied into the wiki at setup time
@@ -22,17 +22,22 @@ skills/                         10 wiki skills
   wiki-query/                     Ask questions; answer from wiki, never from memory; optionally file the answer back as `type: synthesis`
     references/
       query-patterns.md           Read-before-answer, citation discipline, synthesis file-back walkthrough
-  wiki-lint/                      Severity-tiered health audit
+  wiki-health/                    Zero-LLM structural integrity preflight; runs every session via wiki-resume (v0.0.27)
     scripts/
-      lint_wiki.py                Orphans, broken links, stale dates, frontmatter check, wiki:// source validation
+      health.py                   Broken wikilinks, missing frontmatter, broken raw/wiki:// sources, id mismatch, invalid type, stub pages, entries_count drift, index/filesystem drift, claim_drift count
     references/
-      severity-tiers.md           Error / warn / info classification
+      checks.md                   Canonical list of structural checks with detection logic and the lint boundary
+  wiki-lint/                      Semantic, LLM-powered audit; runs wiki-health first as preflight (v0.0.27)
+    scripts/
+      lint_wiki.py                Deterministic warnings (orphans, stale, tag typos, reverse links, claim_drift narrative); the LLM-powered semantic checks (contradictions, type drift, undercited claims, missing concept pages) run from the SKILL.md workflow
+    references/
+      severity-tiers.md           Health vs Lint coverage matrix + error/warn/info classification
   wiki-update/                    Diff-gated page revisions with stale-sweep
     references/
       update-discipline.md        Citation-required, diff-before-write rules
-  wiki-resume/                    Status dashboard — entry count, last-lint age, next action
+  wiki-resume/                    Status dashboard — entry count, last-lint age, health snapshot, next action; runs wiki-health automatically (v0.0.27)
     scripts/
-      wiki_status.sh              Emits {success, data, error} JSON (incl. synthesis_count_30d)
+      wiki_status.sh              Emits {success, data, error} JSON (incl. synthesis_count_30d, health_count_30d, embedded health.errors/warnings/drifts)
   wiki-dashboard/                 Self-contained HTML overview (pages, tags, backlink graph)
     scripts/
       render_dashboard.py         Reads wiki/ → writes wiki-dashboard.html (stdlib only)
@@ -53,11 +58,11 @@ references/
 
 | Type | Count | Items |
 |------|-------|-------|
-| Skills | 10 | wiki-setup, wiki-ingest, wiki-query, wiki-lint, wiki-update, wiki-resume, wiki-dashboard, wiki-from-research, wiki-refresh, wiki-claims-resweep |
+| Skills | 11 | wiki-setup, wiki-ingest, wiki-query, wiki-health, wiki-lint, wiki-update, wiki-resume, wiki-dashboard, wiki-from-research, wiki-refresh, wiki-claims-resweep |
 | Agents | 0 | — (wiki-ingest batch mode runs sequentially in the orchestrator's own context as of v0.0.22; the previous `ingest-worker` per-source subagent was removed because parallel fan-out broke the Karpathy-pattern invariant that source N+1 must see source N's page) |
 | Commands | 0 | — (skills serve as slash commands per plugin-dev guidance) |
 | Hooks | 0 | — (all bookkeeping lives inside skills) |
-| Scripts | 10 | backlink_audit.py, wiki_index_update.py, batch_builder.py, lint_wiki.py, wiki_status.sh, render_dashboard.py, refresh_planner.py, extract_page_claims.py, resweep_planner.py, convert_to_md.py |
+| Scripts | 11 | backlink_audit.py, wiki_index_update.py, batch_builder.py, health.py, lint_wiki.py, wiki_status.sh, render_dashboard.py, refresh_planner.py, extract_page_claims.py, resweep_planner.py, convert_to_md.py |
 
 ## Wiki Data Layout (outside the plugin)
 
@@ -101,9 +106,10 @@ The `interview` and `meeting` types (introduced in v0.0.24) carry the consulting
 
 - **Wiki is LLM-maintained, human-curated sources.** The user drops documents in `raw/`; Claude does all the summarising, linking, and bookkeeping.
 - **Always read the wiki for queries — never answer from memory.** Skills enforce this discipline in every SKILL.md.
-- **Append-only log.** Every ingest, query, synthesis, lint, and update writes a line to `wiki/log.md` with an ISO date prefix. The `synthesis` operation prefix (v0.0.23+) distinguishes filed-back query answers from un-filed `query` reads — both are surfaced separately in `wiki-resume` and `wiki-dashboard`.
+- **Append-only log.** Every ingest, query, synthesis, lint, update, and (as of v0.0.27) health run writes a line to `wiki/log.md` with an ISO date prefix. The `synthesis` operation prefix (v0.0.23+) distinguishes filed-back query answers from un-filed `query` reads; the `health` operation prefix (v0.0.27+) distinguishes free zero-LLM preflights from tokenful `lint` runs. All five are surfaced separately in `wiki-resume` and `wiki-dashboard`.
 - **Bidirectional links.** `[[wikilinks]]` are audited after every ingest; related pages get backlink updates. The forward → reverse contract is codified in each wiki's `SCHEMA.md` (added in v0.0.26) under "Forward → reverse link contract" — every audit candidate carries a stable `rule_id` (today: `R1_bidirectional_wikilink`), and `wiki-lint`'s `reverse_link_missing` warning enforces it for hand-edited or imported pages. Existing wikis with `schema_version < "0.0.3"` get a migration nudge from `wiki-resume`'s status block; the lint check works either way, so the migration is offline-safe.
-- **Queries can compound.** `wiki-query --file-back yes` writes the answer to `wiki/pages/<slug>.md` as `type: synthesis` with `wiki://<source-slug>` references in `sources:`, so explorations enrich the wiki rather than evaporate. `wiki-lint` validates each `wiki://` target slug exists (`broken_wiki_source` error) and warns when a synthesis page lacks any `wiki://` source (`synthesis_no_wiki_source` warn).
+- **Queries can compound.** `wiki-query --file-back yes` writes the answer to `wiki/pages/<slug>.md` as `type: synthesis` with `wiki://<source-slug>` references in `sources:`, so explorations enrich the wiki rather than evaporate. `wiki-health` validates each `wiki://` target slug exists (`broken_wiki_source` error) and `wiki-lint` warns when a synthesis page lacks any `wiki://` source (`synthesis_no_wiki_source` warn).
+- **Health vs lint split.** `wiki-health` (v0.0.27+) is the zero-LLM, every-session structural preflight (broken links, missing frontmatter, broken sources, stub pages, drift counts). `wiki-lint` is the periodic, tokenful semantic pass (contradictions, type drift, undercited claims, missing concept pages, plus the deterministic warnings that need narrative — orphans, stale dates, tag typos, reverse-link gaps, claim-drift severity). `wiki-resume` runs health automatically; lint refuses to run while health reports errors > 0 (override with `--ignore-health`). The full per-check ownership matrix lives in `skills/wiki-lint/references/severity-tiers.md`.
 - **Diff before write.** `wiki-update` shows the planned change before modifying a page and requires a source citation for any new claim.
 - **Stdlib-only scripts.** bash 3.2 + python3 stdlib, no pip or npm dependencies. JSON output format `{success, data, error}`.
 - **No hooks.** All index/log maintenance lives inside the skills for debuggability.
@@ -134,6 +140,8 @@ The advisory lock at `<wiki-root>/.cogni-wiki/.lock` is **retained as defence-in
 
 **Note for `wiki-query` file-back (v0.0.23):** the synthesis file-back path writes `wiki/pages/<new-slug>.md` (unique by construction — no lock needed), and routes its `entries_count` bump through `config_bump.py` (locked). It does not need to add a new shared file to the table.
 
+**Note for `wiki-health` (v0.0.27):** `health.py` is read-only against `wiki/pages/`, `wiki/index.md`, and `.cogni-wiki/`. It writes nothing directly — the `## [YYYY-MM-DD] health | ...` log line is appended by the SKILL workflow via the same path every other operation log line uses, and `wiki/log.md` is treated as append-only (no read-modify-write), so it does not need a lock entry.
+
 **Known tech debt.** `_wiki_lock` is currently duplicated across three scripts (`backlink_audit.py`, `wiki_index_update.py`, `config_bump.py`). A future consolidation into a shared `cogni-wiki/skills/wiki-ingest/scripts/_wikilock.py` helper would remove the drift risk, but is a non-urgent refactor — the three copies are byte-identical today.
 
 **Do NOT rely on:** `os.replace` atomicity alone (it guarantees atomic file replacement, not correctness of the read-modify-write), or Python's GIL (cross-process invocations from separate sessions are not protected by it). The `batch_size` config key referenced in `wiki-ingest` versions ≤0.0.21 is no longer read; legacy wikis with the key are harmless.
@@ -147,7 +155,8 @@ insight-wave already uses Claude Code's auto-memory system at `~/.claude/project
 - **cogni-research → cogni-wiki** (v0.0.17, sub-question-centric — Option B). `wiki-ingest --discover research:<project-slug>` enumerates one batch entry per sub-question of a completed cogni-research project, materialises per-sub-question synthesis files under `<wiki-root>/raw/research-<slug>/sq-NN-<short>.md`, and feeds them through the standard batch-mode pipeline (Steps 1–8 per source). The synthesis bundles findings (from contexts), verified claims (filtered to `verification_status: verified`), and source URLs. Materialisation is the one deviation from the discovery-is-read-only rule and is unavoidable: cogni-research spreads each sub-question's evidence across four entity types, and the per-source ingest-worker reads one file. Materialisation is deterministic and idempotent. See `skills/wiki-ingest/references/batch-mode.md` §"Discovery → research" for the full contract. The reverse path (`wiki-researcher` agent reading a wiki as a RAG source for a research project) is owned by cogni-research and pre-dates this integration.
 - **wiki-from-research cold-start** (v0.0.18). The `wiki-from-research` skill chains `cogni-research:research-setup` → `cogni-research:research-report` (auto-chained internally) → `cogni-wiki:wiki-setup` → `cogni-wiki:wiki-ingest --discover research:<slug>` in one dispatch. Mode A starts from a free-text `--topic`; Mode B starts from an existing `--research-slug`. The skill is a pure orchestrator — it writes nothing directly; every artefact comes from its sub-skills' contracts. Pre-flight is fail-fast: wiki-target collisions are detected before any cogni-research dispatch (so an unusable target never burns research budget). Mode B verifies `output/report.md` exists, refuses `report_source ∈ {wiki, hybrid}` projects (circular-evidence risk), and nudges the user to run `verify-report` first if zero claims are verified.
 - **wiki-refresh stale-page loop** (v0.0.19, pull-mode only). The `wiki-refresh` skill closes the *update* loop — stale wiki pages get fresh evidence from a completed cogni-research project. Calls `lint_wiki.py` directly to enumerate `stale_page` (>365d) and `stale_draft` (>180d) findings, runs `refresh_planner.py` to match each stale page to the highest-scoring sub-question via Jaccard token overlap on `(title + tags + type)` vs `(query + parent_topic)`, prints a batch plan for one user confirmation, then materialises one synthesis file per match under `<wiki-root>/raw/refresh-<research-slug>-<YYYY-MM-DD>/<page-slug>.md` and dispatches `wiki-update` sequentially per page. Default match threshold `0.30`, tunable via `--match-threshold` or interactively via the `refine` action in the plan-review prompt. Push-mode auto-research per stale page is deferred (cost-prohibitive at scale). The entity-loading helpers in `refresh_planner.py` mirror those in `batch_builder.py` — known tech debt, parallel to the `_wiki_lock` duplication noted in §"Concurrency Invariant".
-- **wiki-claims-resweep citation re-verify** (v0.0.20, pull-mode only). The `wiki-claims-resweep` skill closes the *citation-drift* loop — existing wiki pages have their cited source URLs re-checked against current content. `extract_page_claims.py` walks `wiki/pages/` and yields one claim candidate per sentence containing an inline `[text](http(s)://...)` link or bare URL (deterministic, no LLM, no network). The orchestrator runs `resweep_planner.py --phase plan` to materialise per-page claim manifests under `<wiki-root>/raw/claims-resweep-<YYYY-MM-DD>/`, batch-confirms with the user, then dispatches `cogni-claims:claims` (`submit` then `verify`) sequentially per page. The cogni-claims source-cache (`cogni-claims/sources/{url-hash}.json`) keeps repeat WebFetches free across pages within one sweep. After verification, `resweep_planner.py --phase aggregate` writes `report.md` to the workspace and `last-resweep.json` (lock-wrapped) to `.cogni-wiki/`. **Report-only**: this skill never modifies `wiki/pages/`. Stale-marker decisions go through `wiki-update` manually. Circular sources (URLs pointing back into the wiki tree) are skipped per claim and counted, mirroring the `report_source ∈ {wiki, hybrid}` refusal pattern from `wiki-from-research`/`wiki-refresh`. As of v0.0.21, `wiki-lint` reads `last-resweep.json` and surfaces flagged pages via the `claim_drift` warning class plus a `last_resweep` info line — the bridge is closed without making lint network-dependent (all WebFetch stays in the opt-in sweep skill).
+- **wiki-claims-resweep citation re-verify** (v0.0.20, pull-mode only). The `wiki-claims-resweep` skill closes the *citation-drift* loop — existing wiki pages have their cited source URLs re-checked against current content. `extract_page_claims.py` walks `wiki/pages/` and yields one claim candidate per sentence containing an inline `[text](http(s)://...)` link or bare URL (deterministic, no LLM, no network). The orchestrator runs `resweep_planner.py --phase plan` to materialise per-page claim manifests under `<wiki-root>/raw/claims-resweep-<YYYY-MM-DD>/`, batch-confirms with the user, then dispatches `cogni-claims:claims` (`submit` then `verify`) sequentially per page. The cogni-claims source-cache (`cogni-claims/sources/{url-hash}.json`) keeps repeat WebFetches free across pages within one sweep. After verification, `resweep_planner.py --phase aggregate` writes `report.md` to the workspace and `last-resweep.json` (lock-wrapped) to `.cogni-wiki/`. **Report-only**: this skill never modifies `wiki/pages/`. Stale-marker decisions go through `wiki-update` manually. Circular sources (URLs pointing back into the wiki tree) are skipped per claim and counted, mirroring the `report_source ∈ {wiki, hybrid}` refusal pattern from `wiki-from-research`/`wiki-refresh`. As of v0.0.21, `wiki-lint` reads `last-resweep.json` and surfaces flagged pages via the `claim_drift` warning class plus a `last_resweep` info line; as of v0.0.27, `wiki-health` additionally exposes the *count* of flagged pages so it surfaces in `wiki-resume`'s status block without needing a tokenful lint run.
+- **wiki-health ↔ wiki-lint boundary** (v0.0.27, intra-plugin). The split formalises the llm-wiki-agent "Health vs Lint Boundary": `wiki-health` owns deterministic structural integrity (zero LLM, every session, sub-second on 100-page wikis); `wiki-lint` owns semantic content quality (LLM-powered, periodic, refuses to run while health is broken). `wiki-resume` invokes `health.py` automatically as part of its session-start status, so the user gets a structural preflight without thinking about it. The full per-check ownership matrix is in `skills/wiki-lint/references/severity-tiers.md`. The two skills share the `{success, data, error}` JSON contract and the same severity vocabulary so the lint report can include health's findings verbatim. **No new shared-state files** — `health.py` is read-only against `wiki/pages/`, `wiki/index.md`, and `.cogni-wiki/`; the only side effect is the `## [YYYY-MM-DD] health | ...` log line, which is append-only and needs no lock.
 
 ## Future Integration Points
 

--- a/cogni-wiki/README.md
+++ b/cogni-wiki/README.md
@@ -28,7 +28,7 @@ Karpathy's insight: what if knowledge was **compiled once at ingestion** instead
 
 ## What it is
 
-**IS:** A compile-time knowledge engine based on [Andrej Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). Where other insight-wave plugins *generate* knowledge artifacts (research reports, trend analyses, portfolio propositions), cogni-wiki *preserves* them — compiling sources into interlinked markdown pages that Claude reads directly instead of re-deriving from scratch. Seven skills cover the full lifecycle: setup, ingest, query, lint, update, resume, and dashboard.
+**IS:** A compile-time knowledge engine based on [Andrej Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). Where other insight-wave plugins *generate* knowledge artifacts (research reports, trend analyses, portfolio propositions), cogni-wiki *preserves* them — compiling sources into interlinked markdown pages that Claude reads directly instead of re-deriving from scratch. Eleven skills cover the full lifecycle: setup, ingest, query, health, lint, update, resume, dashboard, plus three integration skills (cold-start from research, refresh stale pages, re-verify cited URLs).
 
 ## Data model
 
@@ -65,23 +65,25 @@ Page types: `concept`, `entity`, `summary`, `decision`, `interview`, `meeting`, 
 
 ## What it does
 
-1. **Bootstrap** a new wiki with directory layout, SCHEMA.md contract, and seed files → `.cogni-wiki/config.json` + `wiki/index.md` + `wiki/log.md` + `wiki/overview.md` → wiki-ingest, wiki-query, wiki-lint, wiki-update, wiki-resume, wiki-dashboard
-2. **Ingest** source documents into structured wiki pages with YAML frontmatter, backlink audit, and index updates → `wiki/pages/*.md` → wiki-query, wiki-lint, wiki-update, wiki-dashboard
-3. **Query** the wiki to answer questions — reads pages directly, never from model memory, with `[[wikilink]]` citations; optionally files the answer back as a `type: synthesis` page (introduced in v0.0.23) so explorations compound rather than evaporating into chat history → `wiki/pages/*.md` → wiki-query, wiki-lint, wiki-update, wiki-dashboard
-4. **Lint** the wiki for health problems — broken wikilinks, orphan pages, stale dates, frontmatter gaps, contradictions, broken `wiki://` sources, synthesis pages without wiki provenance, plus `claim_drift` from the latest re-verify sweep → `wiki/pages/lint-*.md` → wiki-update, wiki-query, wiki-claims-resweep
-5. **Update** existing pages with diff-before-write discipline, source citation requirements, and stale-sweep of related pages → `wiki/pages/*.md` → wiki-query, wiki-lint, wiki-dashboard
-6. **Resume** with status, activity summary, and recommended next action (now surfaces `synthesis_count_30d` distinctly from `query_count_30d`)
-7. **Dashboard** as a self-contained HTML overview — pages by type (incl. synthesis), tag cloud, backlink graph, and activity histograms → `wiki-dashboard.html` (self-contained HTML dashboard)
-8. **Cold-start from research** — chains `cogni-research:research-setup` → `research-report` → `wiki-setup` → `wiki-ingest --discover research:<slug>` in one dispatch (Mode A from a topic, Mode B from an existing research slug) → populated wiki seeded with sub-question-sized pages → wiki-query, wiki-lint, wiki-refresh
-9. **Refresh stale pages from research** — matches lint-flagged stale pages to sub-questions of an existing cogni-research project via Jaccard token overlap, materialises one synthesis per match, and dispatches wiki-update sequentially → updated `wiki/pages/*.md` with bumped `updated:` and refreshed sources → wiki-query, wiki-lint
-10. **Re-verify wiki citations** — extracts inline-cited statements from existing pages deterministically, dispatches them through cogni-claims for source re-verification, and writes a sweep report plus a lint-bridge JSON; report-only, never mutates `wiki/pages/` → `<wiki-root>/raw/claims-resweep-<date>/report.md` + `.cogni-wiki/last-resweep.json` → wiki-lint (`claim_drift` warning), wiki-update (manual stale-marker)
+1. **Bootstrap** a new wiki with directory layout, SCHEMA.md contract, and seed files → `.cogni-wiki/config.json` + `wiki/index.md` + `wiki/log.md` + `wiki/overview.md` → wiki-ingest, wiki-query, wiki-health, wiki-lint, wiki-update, wiki-resume, wiki-dashboard
+2. **Ingest** source documents into structured wiki pages with YAML frontmatter, backlink audit, and index updates → `wiki/pages/*.md` → wiki-query, wiki-health, wiki-lint, wiki-update, wiki-dashboard
+3. **Query** the wiki to answer questions — reads pages directly, never from model memory, with `[[wikilink]]` citations; optionally files the answer back as a `type: synthesis` page (introduced in v0.0.23) so explorations compound rather than evaporating into chat history → `wiki/pages/*.md` → wiki-query, wiki-health, wiki-lint, wiki-update, wiki-dashboard
+4. **Health-check** structural integrity in seconds — broken wikilinks, missing frontmatter, broken raw/`wiki://` sources, id mismatches, invalid types, stub pages, `entries_count` drift between config and filesystem, index/filesystem drift; zero LLM calls; runs automatically every session via `wiki-resume` (introduced in v0.0.27)  → prose summary + `## [YYYY-MM-DD] health | ...` log line
+5. **Lint** the wiki with a tokenful semantic pass — contradictions, type drift, undercited claims, missing concept pages, plus the deterministic warnings that need narrative (orphans, stale dates, tag typos, reverse-link gaps, claim-drift severity from the latest re-verify sweep). Calls `wiki-health` first as a free preflight; refuses to run while structural errors are pending  → `wiki/pages/lint-*.md` → wiki-update, wiki-query, wiki-claims-resweep
+6. **Update** existing pages with diff-before-write discipline, source citation requirements, and stale-sweep of related pages → `wiki/pages/*.md` → wiki-query, wiki-health, wiki-lint, wiki-dashboard
+7. **Resume** with status, activity summary, health snapshot, and recommended next action; runs `wiki-health` automatically and surfaces structural-integrity counts before any other recommendation (v0.0.27)
+8. **Dashboard** as a self-contained HTML overview — pages by type (incl. synthesis), tag cloud, backlink graph, and activity histograms → `wiki-dashboard.html` (self-contained HTML dashboard)
+9. **Cold-start from research** — chains `cogni-research:research-setup` → `research-report` → `wiki-setup` → `wiki-ingest --discover research:<slug>` in one dispatch (Mode A from a topic, Mode B from an existing research slug) → populated wiki seeded with sub-question-sized pages → wiki-query, wiki-health, wiki-lint, wiki-refresh
+10. **Refresh stale pages from research** — matches lint-flagged stale pages to sub-questions of an existing cogni-research project via Jaccard token overlap, materialises one synthesis per match, and dispatches wiki-update sequentially → updated `wiki/pages/*.md` with bumped `updated:` and refreshed sources → wiki-query, wiki-lint
+11. **Re-verify wiki citations** — extracts inline-cited statements from existing pages deterministically, dispatches them through cogni-claims for source re-verification, and writes a sweep report plus a lint-bridge JSON; report-only, never mutates `wiki/pages/` → `<wiki-root>/raw/claims-resweep-<date>/report.md` + `.cogni-wiki/last-resweep.json` → wiki-health (claim_drift count), wiki-lint (`claim_drift` warning), wiki-update (manual stale-marker)
 
 ## What it means for you
 
 - **Compound your knowledge, not your effort.** Each ingest aims to leave the wiki denser and more interconnected than before — up to 95% token reduction vs re-loading full documents per query, with every source compiled once rather than re-synthesized on demand. As of v0.0.23, **queries themselves compound** too: `wiki-query --file-back yes` files the answer as a `type: synthesis` page that future queries read directly.
+- **Catch broken structure for free, every session.** As of v0.0.27, `wiki-resume` runs a zero-LLM `wiki-health` preflight on every status call — broken wikilinks, missing frontmatter, broken sources, id mismatches, and `entries_count` drift surface immediately, with no token cost. The tokenful semantic `wiki-lint` pass refuses to run while structural errors are pending, so you never burn lint tokens reasoning about a broken graph.
 - **Ground every answer in curated sources.** `wiki-query` reads the wiki before answering — never from model memory. If the wiki has no page on a topic, the answer says so rather than filling the gap with hallucinated filler.
 - **Keep your knowledge portable across any tool, indefinitely.** `SCHEMA.md` ships inside every wiki directory, so the wiki aims to remain fully readable even if cogni-wiki is uninstalled or replaced — plain markdown, plain backlinks, zero lock-in. Open it in Obsidian, VS Code, or `grep` today; hand it off in 5 years.
-- **Keep every wiki page trustworthy.** `wiki-update` shows the diff before modifying any page and requires a source citation for every new claim — zero silent writes across all 10 skills, so the wiki stays citable. Synthesis pages additionally cite `wiki://` provenance, validated by `wiki-lint`.
+- **Keep every wiki page trustworthy.** `wiki-update` shows the diff before modifying any page and requires a source citation for every new claim — zero silent writes across all eleven skills, so the wiki stays citable. Synthesis pages additionally cite `wiki://` provenance, validated by `wiki-health` (existence) and `wiki-lint` (file-back discipline).
 
 ## Install
 
@@ -102,10 +104,11 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 # (drop a paper in cogni-wiki/primary/raw/)
 /cogni-wiki:wiki-ingest                                        # Summarise + cross-link
 /cogni-wiki:wiki-query "what did I learn about X?" --file-back yes  # Answer + file as type: synthesis
-/cogni-wiki:wiki-lint                                          # After every 5–10 ingests
+/cogni-wiki:wiki-health                                        # Free zero-LLM structural preflight (also auto-run by wiki-resume)
+/cogni-wiki:wiki-lint                                          # Tokenful semantic pass after every 5–10 ingests
 /cogni-wiki:wiki-update --page <slug>                          # Revise a page with new evidence
 /cogni-wiki:wiki-dashboard                                     # Visual HTML overview (incl. synthesis bucket)
-/cogni-wiki:wiki-resume                                        # "Where was I?" (with synthesis_count_30d)
+/cogni-wiki:wiki-resume                                        # "Where was I?" (with health snapshot + synthesis_count_30d)
 /cogni-wiki:wiki-from-research                                 # Cold-start: research → wiki in one dispatch
 /cogni-wiki:wiki-refresh --from-research <slug>                # Refresh stale pages from a research project
 /cogni-wiki:wiki-claims-resweep                                # Re-verify cited URLs against current source content
@@ -116,7 +119,8 @@ Or just describe what you want in natural language:
 - "Set up a wiki for my AI safety research"
 - "Ingest this paper into the wiki"
 - "What does my wiki say about constitutional AI? Save the answer as a synthesis."
-- "Is my wiki healthy?"
+- "Is my wiki broken?" (→ wiki-health, free)
+- "Audit my wiki for contradictions" (→ wiki-lint, tokenful)
 - "Show me the wiki as a dashboard"
 - "Cold-start a wiki from research on agent economy"
 - "Refresh stale pages from the new agent-economy research"
@@ -133,9 +137,10 @@ Claude Code already has an auto-memory system at `~/.claude/projects/.../memory/
 | wiki-setup | Skill | Bootstrap a new Karpathy-style LLM wiki at a user-chosen directory |
 | wiki-ingest | Skill | Ingest a source document into the wiki with summary, frontmatter, and backlink audit |
 | wiki-query | Skill | Answer a question by reading the wiki — never from memory; optionally files the answer back as a `type: synthesis` page |
-| wiki-lint | Skill | Audit the wiki for broken wikilinks, orphan pages, stale dates, contradictions, broken `wiki://` sources, synthesis pages without wiki provenance, and `claim_drift` from the latest re-verify sweep |
+| wiki-health | Skill | Zero-LLM structural integrity preflight — broken wikilinks, missing frontmatter, broken raw/`wiki://` sources, id mismatch, invalid type, stub pages, `entries_count` drift, index/filesystem drift, claim_drift count. Runs automatically every session via wiki-resume (v0.0.27) |
+| wiki-lint | Skill | Tokenful semantic audit — contradictions, type drift, undercited claims, missing concept pages, plus deterministic warnings that need narrative (orphans, stale, tag typos, reverse links, claim_drift severity). Refuses to run while wiki-health reports errors |
 | wiki-update | Skill | Revise an existing wiki page with diff-before-write discipline and source citations |
-| wiki-resume | Skill | Show status, activity (incl. synthesis count), and recommended next action for the wiki |
+| wiki-resume | Skill | Show status, activity (incl. synthesis count + health snapshot), and recommended next action for the wiki |
 | wiki-dashboard | Skill | Generate a self-contained HTML dashboard with tag cloud, backlink graph, type bars (incl. synthesis), and histograms |
 | wiki-from-research | Skill | Cold-start orchestrator: chains cogni-research's setup + report into wiki-setup + wiki-ingest in one dispatch (Mode A from a topic, Mode B from an existing research slug) |
 | wiki-refresh | Skill | Refresh stale wiki pages with fresh evidence from a completed cogni-research project; Jaccard match, batch-confirmed, sequential wiki-update dispatch |
@@ -152,13 +157,14 @@ cogni-wiki/
 ├── references/                      Shared reference material
 │   ├── karpathy-pattern.md          Karpathy LLM Wiki pattern
 │   └── claude-research-karparthy.md RAG vs wiki benchmark research
-└── skills/                          10 wiki skills
+└── skills/                          11 wiki skills
     ├── wiki-setup/                  Bootstrap a new wiki
     ├── wiki-ingest/                 Ingest sources into wiki pages
     ├── wiki-query/                  Answer questions from wiki content; file back as type: synthesis
-    ├── wiki-lint/                   Health audit with severity tiers (incl. claim_drift, broken_wiki_source, synthesis_no_wiki_source)
+    ├── wiki-health/                 Zero-LLM structural preflight (broken links, frontmatter, sources, drift)
+    ├── wiki-lint/                   Tokenful semantic audit (contradictions, type drift, undercited, missing concepts) + deterministic narrative warnings
     ├── wiki-update/                 Diff-gated page revisions
-    ├── wiki-resume/                 Status and next-action dashboard
+    ├── wiki-resume/                 Status and next-action dashboard (auto-runs wiki-health)
     ├── wiki-dashboard/              Self-contained HTML overview
     ├── wiki-from-research/          Cold-start: research → wiki orchestrator
     ├── wiki-refresh/                Stale-page refresh from a research project
@@ -167,13 +173,13 @@ cogni-wiki/
 
 ## Dependencies
 
-cogni-wiki runs standalone for the core ingest/query/lint/update loop. Three skills opt into cross-plugin integrations:
+cogni-wiki runs standalone for the core ingest/query/health/lint/update loop. Three skills opt into cross-plugin integrations:
 
 | Skill | Depends on | Used for |
 |-------|-----------|----------|
 | `wiki-from-research`, `wiki-refresh`, `wiki-ingest --discover research:<slug>` | `cogni-research` | Cold-start a wiki, refresh stale pages, or deposit a completed research project as sub-question-sized pages |
 | `wiki-claims-resweep` | `cogni-claims` | Re-verify inline-cited URLs against current source content (`submit` + `verify` modes) |
-| `wiki-lint` (`claim_drift` warning) | none — reads `.cogni-wiki/last-resweep.json` written by `wiki-claims-resweep` | Surface drift findings as warnings during regular health audits |
+| `wiki-lint` (`claim_drift` warning), `wiki-health` (`claim_drift_count`) | none — read `.cogni-wiki/last-resweep.json` written by `wiki-claims-resweep` | Surface drift findings as warnings during regular health/lint audits |
 
 Integrations with `cogni-narrative` and `cogni-consulting` remain planned for v0.1.x; see [CLAUDE.md](CLAUDE.md) "Cross-Plugin Integration" and "Future Integration Points".
 
@@ -190,8 +196,8 @@ When `markitdown` is not installed, `wiki-ingest` still handles `.md`, `.pdf` (v
 ## Credits
 
 - **Andrej Karpathy** — [LLM Wiki gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). The pattern this plugin implements.
-- **kfchou/wiki-skills** — [reference Claude Code implementation](https://github.com/kfchou/wiki-skills). The five-skill shape (`wiki-init`, `wiki-ingest`, `wiki-query`, `wiki-lint`, `wiki-update`) that inspired this plugin's layout. cogni-wiki adds `wiki-resume`, `wiki-dashboard`, `wiki-from-research`, `wiki-refresh`, and `wiki-claims-resweep` to match cogni-* ecosystem conventions and to close the research → wiki and citation re-verify loops.
-- **sdh07/llm-wiki-agent** and **sdh07/omegawiki** — reference implementations of the Karpathy pattern that informed the v0.0.23 audit (see tracking issue #212): the synthesis page type, `wiki://` source convention, and split lint/health vocabulary all draw on patterns these projects pioneered.
+- **kfchou/wiki-skills** — [reference Claude Code implementation](https://github.com/kfchou/wiki-skills). The five-skill shape (`wiki-init`, `wiki-ingest`, `wiki-query`, `wiki-lint`, `wiki-update`) that inspired this plugin's layout. cogni-wiki adds `wiki-health`, `wiki-resume`, `wiki-dashboard`, `wiki-from-research`, `wiki-refresh`, and `wiki-claims-resweep` to match cogni-* ecosystem conventions and to close the structural-preflight, research → wiki, and citation re-verify loops.
+- **sdh07/llm-wiki-agent** and **sdh07/omegawiki** — reference implementations of the Karpathy pattern that informed the v0.0.23 / v0.0.27 audits (see tracking issue #212): the synthesis page type, `wiki://` source convention, the `health` vs `lint` boundary, and the structural-integrity-as-pre-flight discipline all draw on patterns these projects pioneered.
 
 ## License
 

--- a/cogni-wiki/skills/wiki-health/SKILL.md
+++ b/cogni-wiki/skills/wiki-health/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: wiki-health
+description: "Run a fast, zero-LLM structural integrity check on a Karpathy-style wiki — broken [[wikilinks]], missing frontmatter fields, broken raw/wiki:// sources, id mismatches, invalid type values, stub pages, and entries_count drift between config.json and the filesystem. Use this skill whenever the user says 'health check the wiki', 'is the wiki broken', 'wiki health', 'preflight the wiki', 'check wiki structure', or as the first step before any tokenful audit. wiki-resume runs this skill automatically at session start. Cheap, deterministic, every-session."
+allowed-tools: Read, Bash, Glob
+---
+
+# Wiki Health
+
+A zero-LLM, deterministic structural integrity check. Health is to lint what `git status` is to `git log` — a free pre-flight you can run any time without thinking about token cost. Health surfaces only what's mechanically broken; the semantic interpretation belongs to `wiki-lint`.
+
+Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once for new sessions.
+
+## When to run
+
+- Automatically by `wiki-resume` at session start (no user action needed)
+- User asks "is the wiki broken", "health check the wiki", "wiki health", "preflight the wiki"
+- Before every `wiki-lint` invocation as a free preflight (lint refuses to run a tokenful semantic pass while structural errors are pending)
+- Before publishing or sharing the wiki
+
+## Never run when
+
+- There is no wiki in the working directory — offer `wiki-setup`
+- The wiki is empty (`entries_count: 0`) — there is nothing structural to check
+
+## Why this skill exists separately from `wiki-lint`
+
+llm-wiki-agent draws a sharp boundary that cogni-wiki was missing:
+
+| Dimension | `wiki-health` | `wiki-lint` |
+|---|---|---|
+| **Scope** | Structural integrity | Content quality (semantic) |
+| **LLM calls** | Zero | Yes — contradictions, type drift, missing concepts |
+| **Cost** | Free | Tokens |
+| **Frequency** | Every session | Every 10–15 ingests |
+| **Run order** | First (pre-flight) | After health passes |
+
+> Run `health` first — linting an empty file wastes tokens.
+
+The two payoffs:
+
+1. A free, every-session pre-flight the user can run without thinking. Today the user has to mentally pre-commit to a tokenful `wiki-lint` to learn that an `index.md` line points to a nonexistent file.
+2. Headroom for a semantic lint (contradictions, stale claims, missing concept pages) that's always tokenful — and that we no longer pay for just to find broken wikilinks.
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--wiki-root` | No | Override the auto-detected wiki root |
+| `--quiet` | No | Suppress the prose summary; emit only the script JSON. Used by `wiki-resume`. |
+
+## Workflow
+
+### 1. Locate the wiki
+
+Walk upward to find `.cogni-wiki/config.json`. If none, stop and offer `wiki-setup`.
+
+### 2. Run the health script
+
+Invoke `${CLAUDE_PLUGIN_ROOT}/skills/wiki-health/scripts/health.py --wiki-root <path>`. The script emits JSON with the `{success, data, error}` contract. On `success: false`, surface the raw error and stop — do not attempt a partial summary.
+
+The script's `data` payload contains:
+
+```
+{
+  "errors":   [{"class": "...", "page": "...", "message": "..."}, ...],
+  "warnings": [{"class": "...", "page": "...", "message": "..."}, ...],
+  "stats": {
+    "pages_audited":         <int>,
+    "errors":                <int>,
+    "warnings":              <int>,
+    "entries_count_config":  <int>,    // value from .cogni-wiki/config.json
+    "entries_count_actual":  <int>,    // file count under wiki/pages/ excl. lint-*
+    "entries_count_drift":   <int>,    // actual - config
+    "claim_drift_count":     <int>,    // 0 when no last-resweep.json present
+    "claim_drift_date":      <ISO>     // null when no last-resweep.json present
+  }
+}
+```
+
+Error classes: `broken_wikilink`, `missing_frontmatter`, `id_mismatch`, `invalid_type`, `missing_source`, `broken_wiki_source`, `read_error`.
+
+Warning classes (structural debt only — semantic warnings live in `wiki-lint`): `stub_page`, `entries_count_drift`, `index_filesystem_drift`.
+
+### 3. Append to `wiki/log.md`
+
+Unconditionally — even on a clean run — append:
+
+```
+## [{YYYY-MM-DD}] health | {N} errors, {N} warnings
+```
+
+The log line has a dedicated `health` operation prefix so `wiki-resume` and `wiki-dashboard` can count health runs separately from lint runs. Health runs are expected to be frequent (every session); their log entries are the cheapest possible record that the pre-flight happened.
+
+### 4. Report to the user
+
+Unless `--quiet`, print a ≤5-line summary:
+
+```
+Health: {N} errors, {N} warnings ({pages_audited} pages audited)
+{If errors > 0: list the first 3 errors with page slugs}
+{If entries_count_drift != 0: "⚠ entries_count says {config} but filesystem has {actual}"}
+{If claim_drift_count > 0: "⚠ {N} pages flagged by last resweep ({date})"}
+Next: {recommendation — see decision tree below}
+```
+
+#### Recommendation decision tree
+
+Apply the first rule that matches:
+
+1. **`errors > 0`** → "Fix the {N} structural errors via `/cogni-wiki:wiki-update` before running anything else. Errors block reliable reads."
+2. **`entries_count_drift != 0`** → "`entries_count` is out of sync with the filesystem. Run `/cogni-wiki:wiki-ingest` to bump the counter, or hand-edit `.cogni-wiki/config.json` to match (it should be {actual})."
+3. **`warnings > 0` AND `claim_drift_count > 0`** → "{N} structural warnings + {M} claim drifts from the last resweep. Run `/cogni-wiki:wiki-lint` for a semantic pass that narrates the drifts."
+4. **`warnings > 0`** → "{N} structural warnings (stubs / drift). Address via `/cogni-wiki:wiki-update`, or run `/cogni-wiki:wiki-lint` for a full semantic pass."
+5. **Else** → "Clean health. The wiki is structurally sound — proceed with whatever you were doing."
+
+### 5. Do not write anything to wiki pages
+
+This skill is **report-only**. It writes the log line and nothing else. Auto-fixes are explicitly not in scope — the same Karpathy-pattern discipline that keeps `wiki-lint` from auto-fixing applies to health: fixes happen via `wiki-update`, with diff-before-write review.
+
+## Output
+
+- Stdout: prose summary (omitted if `--quiet`)
+- `wiki/log.md` appended with the `health` line
+- Nothing written to `wiki/pages/` or `.cogni-wiki/config.json`
+
+## Golden rules
+
+1. **Zero LLM calls.** Health is structural integrity only. Any check that needs reasoning belongs in `wiki-lint`.
+2. **Always log, even on clean runs.** The log is the audit trail; absence of health runs is itself a smell.
+3. **Never auto-fix.** Findings are reported; fixes go through `wiki-update`.
+4. **Cheap enough to run every session.** If a check would push the script past ~1 second on a 100-page wiki, it belongs in `wiki-lint`, not here.
+5. **Same `{success, data, error}` JSON contract** as every other cogni-wiki script.
+
+## Boundary with `wiki-lint`
+
+| Check | Owner | Why |
+|-------|-------|-----|
+| Broken `[[wikilink]]` | `wiki-health` | Structural — file either exists or doesn't |
+| Missing required frontmatter | `wiki-health` | Schema check — deterministic |
+| Invalid `type:` value | `wiki-health` | Schema check — deterministic |
+| Filename / `id:` mismatch | `wiki-health` | Schema check — deterministic |
+| Missing `../raw/` source file | `wiki-health` | Filesystem check — deterministic |
+| Broken `wiki://` source | `wiki-health` | Structural — target page either exists or doesn't |
+| Stub page (body < 50 chars) | `wiki-health` | Length check — deterministic |
+| `entries_count` drift | `wiki-health` | Counter vs filesystem — deterministic |
+| `index.md` ↔ filesystem drift | `wiki-health` | Set difference — deterministic |
+| Claim-drift **count** from last resweep | `wiki-health` | Counter — deterministic |
+| Orphan page | `wiki-lint` | Reportable but rarely urgent — debt, not breakage |
+| Stale draft / stale page | `wiki-lint` | Date math + judgement on what "stale" means in context |
+| Tag typo | `wiki-lint` | Edit-distance + ratio heuristic, often false-positive |
+| Reverse-link missing | `wiki-lint` | SCHEMA contract violation — needs narrative + fix path |
+| Synthesis page without `wiki://` source | `wiki-lint` | Bridge to file-back discipline; better narrated |
+| Claim-drift **narrative** (per page) | `wiki-lint` | Reading the resweep report and explaining severity |
+| **Contradictions across pages** | `wiki-lint` (LLM) | Semantic — needs reading |
+| **Type drift** (concept page that's actually a summary) | `wiki-lint` (LLM) | Semantic — needs reading |
+| **Undercited claims** | `wiki-lint` (LLM) | Semantic — needs reading |
+| **Missing concept pages** (entity in 3+ pages, no own page) | `wiki-lint` (LLM) | Semantic — needs reading |
+
+Rule of thumb: if a check needs `Read` on more than its own targets to decide, it goes to lint.
+
+## References
+
+- `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` — the pattern
+- `./references/checks.md` — the full list of structural checks with detection logic
+- `./scripts/health.py` — the deterministic check engine
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-lint/SKILL.md` — the semantic counterpart
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-lint/references/severity-tiers.md` — the full health-vs-lint boundary table

--- a/cogni-wiki/skills/wiki-health/references/checks.md
+++ b/cogni-wiki/skills/wiki-health/references/checks.md
@@ -1,0 +1,59 @@
+# Health Checks
+
+This file is the canonical list of what `health.py` checks. Every check here is deterministic, requires zero LLM calls, and runs on every wiki-resume invocation. If a check needs reasoning or judgement, it belongs in `wiki-lint` (semantic pass), not here.
+
+## Errors — block reliable reads
+
+| Class | Detection | Fix path |
+|-------|-----------|----------|
+| `broken_wikilink` | `[[slug]]` in any page where `wiki/pages/{slug}.md` does not exist | `wiki-update` the referring page — remove the link or create the target |
+| `missing_frontmatter` | One of `id`, `title`, `type`, `created`, `updated` is missing or empty | `wiki-update` to add the field |
+| `id_mismatch` | Frontmatter `id: x` but filename is `y.md` | Rename the file or fix the frontmatter |
+| `invalid_type` | Frontmatter `type:` value not in `{concept, entity, summary, decision, interview, meeting, learning, synthesis, note}` | `wiki-update` to pick a valid type |
+| `missing_source` | `sources: [../raw/foo.pdf]` where `raw/foo.pdf` does not exist | Restore the source or remove the reference |
+| `broken_wiki_source` | `sources: [wiki://other-slug]` where `wiki/pages/other-slug.md` does not exist | `wiki-update` to fix the slug, or re-run `wiki-query --file-back` to regenerate the synthesis after the missing page is created |
+| `read_error` | Page file unreadable (permission, encoding, IO) | OS-level — investigate filesystem |
+
+## Warnings — structural debt that is still mechanical
+
+These are warnings, not errors, because they don't block reads — but they are still purely deterministic, so they belong in health rather than lint.
+
+| Class | Detection | Fix path |
+|-------|-----------|----------|
+| `stub_page` | Page body (after frontmatter) is shorter than `STUB_PAGE_MIN_CHARS` (50) | `wiki-update` to expand, or delete if abandoned |
+| `entries_count_drift` | `.cogni-wiki/config.json` `entries_count` differs from actual file count under `wiki/pages/` (excluding `lint-*` and `health-*`) | Run `wiki-ingest` to bump the counter, or hand-edit `config.json` to match |
+| `index_filesystem_drift` | A slug appears in `wiki/index.md` as a `[[wikilink]]` but no `wiki/pages/{slug}.md` exists, or vice versa | `wiki-update` to add the missing entry, or delete the stale index line |
+
+## Stats — descriptive only
+
+| Stat | Meaning |
+|------|---------|
+| `pages_audited` | Count of `*.md` under `wiki/pages/` excluding `lint-*` and `health-*` |
+| `errors` / `warnings` | Total count of each tier |
+| `entries_count_config` | Value from `.cogni-wiki/config.json` |
+| `entries_count_actual` | Filesystem count |
+| `entries_count_drift` | `actual - config` (signed) |
+| `claim_drift_count` | Number of pages flagged by the most recent `wiki-claims-resweep` (read from `.cogni-wiki/last-resweep.json`); `0` when no resweep has run |
+| `claim_drift_date` | ISO date of the most recent resweep, or `null` |
+
+## What is deliberately **not** here (lives in `wiki-lint`)
+
+- `orphan_page` — judgemental: top-level entries are intentionally orphans
+- `stale_draft` / `stale_page` — date-based but the threshold is editorial
+- `tag_typo` — heuristic; often false-positive on intentional variants
+- `reverse_link_missing` — needs narrative around the SCHEMA `R1_bidirectional_wikilink` contract
+- `synthesis_no_wiki_source` — needs narrative around file-back discipline
+- `claim_drift` per-page narrative — health surfaces the count; lint narrates severity
+- `contradiction`, `type_drift`, `undercited_claim`, `missing_concept_page` — semantic, LLM-powered
+
+## Thresholds
+
+| Knob | Default | Rationale |
+|------|---------|-----------|
+| `STUB_PAGE_MIN_CHARS` | 50 | A page shorter than this is not yet useful; flagging it nudges either expansion or deletion. Lower than this and we'd flag every just-created page mid-ingest. |
+
+All thresholds are constants at the top of `health.py` so they can be tuned without restructuring the script.
+
+## Performance contract
+
+`health.py` is expected to complete in under 1 second on a 100-page wiki. The checks are O(pages) with one filesystem walk and one `index.md` read. If a future check would break this contract, it belongs in `wiki-lint`, not here. The whole point of the split is that health is cheap enough to run on every `wiki-resume`.

--- a/cogni-wiki/skills/wiki-health/scripts/health.py
+++ b/cogni-wiki/skills/wiki-health/scripts/health.py
@@ -255,7 +255,7 @@ def main() -> None:
             )
 
         for target in WIKILINK_RE.findall(text):
-                inbound_links.setdefault(target, set()).add(slug)
+            inbound_links.setdefault(target, set()).add(slug)
 
     existing_slugs = set(all_pages.keys())
     for slug, sources in sorted(inbound_links.items()):

--- a/cogni-wiki/skills/wiki-health/scripts/health.py
+++ b/cogni-wiki/skills/wiki-health/scripts/health.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""
+health.py — zero-LLM structural integrity check for a Karpathy-style wiki.
+
+Emits JSON on stdout with the {success, data, error} contract:
+    {"success": true,
+     "data": {
+       "errors":   [{"class": "...", "page": "...", "message": "..."}, ...],
+       "warnings": [{"class": "...", "page": "...", "message": "..."}, ...],
+       "stats":    { ... }
+     },
+     "error": ""}
+
+Detects:
+    Errors:
+        - Broken [[wikilinks]]
+        - Missing required frontmatter fields
+        - Filename / id mismatches
+        - Invalid type values
+        - Missing ../raw/ source files
+        - Broken wiki:// sources (target page does not exist)
+        - Read errors
+    Warnings (structural debt only — semantic warnings live in wiki-lint):
+        - Stub pages (body shorter than STUB_PAGE_MIN_CHARS)
+        - entries_count drift between config.json and filesystem
+        - index.md <-> filesystem drift (entries on one side missing on the other)
+    Stats:
+        - pages_audited, errors, warnings
+        - entries_count_config / _actual / _drift
+        - claim_drift_count + date (read from .cogni-wiki/last-resweep.json)
+
+Non-goals:
+    - Orphan pages, stale dates, tag typos, reverse-link audit — those belong
+      to wiki-lint where they can be narrated alongside semantic findings.
+    - Auto-fix — health reports only; fixes go through wiki-update.
+    - LLM calls — health is deterministic by design.
+
+stdlib-only. Python 3.8+. Performance contract: under 1 second on a 100-page
+wiki.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+from pathlib import Path
+
+
+STUB_PAGE_MIN_CHARS = 50
+VALID_TYPES = {
+    "concept",
+    "entity",
+    "summary",
+    "decision",
+    "interview",
+    "meeting",
+    "learning",
+    "synthesis",
+    "note",
+}
+REQUIRED_FRONTMATTER = {"id", "title", "type", "created", "updated"}
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+WIKILINK_RE = re.compile(r"\[\[([a-z0-9][a-z0-9\-]*)\]\]")
+
+
+def fail(msg: str) -> None:
+    print(json.dumps({"success": False, "data": {}, "error": msg}))
+    sys.exit(1)
+
+
+def ok(data: dict) -> None:
+    print(json.dumps({"success": True, "data": data, "error": ""}))
+    sys.exit(0)
+
+
+def parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Return (frontmatter_dict, body_text).
+
+    body_text is the page content after the closing `---`. When no frontmatter
+    is found, returns ({}, text).
+    """
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return {}, text
+    body = text[m.end() :]
+    out: dict = {}
+    current_key = None
+    for line in m.group(1).splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if line.startswith("  - ") and current_key:
+            out.setdefault(current_key, []).append(line[4:].strip())
+            continue
+        if ":" in line:
+            k, _, v = line.partition(":")
+            k = k.strip()
+            v = v.strip()
+            current_key = k
+            if v.startswith("[") and v.endswith("]"):
+                inside = v[1:-1].strip()
+                if not inside:
+                    out[k] = []
+                else:
+                    out[k] = [x.strip() for x in inside.split(",") if x.strip()]
+            elif v:
+                out[k] = v
+            else:
+                out[k] = []
+    return out, body
+
+
+def _load_last_resweep(wiki_root: Path) -> dict | None:
+    p = wiki_root / ".cogni-wiki" / "last-resweep.json"
+    if not p.is_file():
+        return None
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _load_config(wiki_root: Path) -> dict:
+    p = wiki_root / ".cogni-wiki" / "config.json"
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _index_slugs(wiki_root: Path) -> set[str]:
+    """Return slugs referenced as [[wikilinks]] in wiki/index.md.
+
+    Returns an empty set when index.md is missing or unreadable — the caller
+    can decide whether that's worth flagging (it isn't, today; missing index
+    is a wiki-setup problem caught elsewhere).
+    """
+    p = wiki_root / "wiki" / "index.md"
+    if not p.is_file():
+        return set()
+    try:
+        text = p.read_text(encoding="utf-8")
+    except OSError:
+        return set()
+    return set(WIKILINK_RE.findall(text))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Zero-LLM structural integrity check for a cogni-wiki"
+    )
+    parser.add_argument("--wiki-root", required=True)
+    args = parser.parse_args()
+
+    wiki_root = Path(args.wiki_root).expanduser().resolve()
+    pages_dir = wiki_root / "wiki" / "pages"
+    raw_dir = wiki_root / "raw"
+
+    if not (wiki_root / ".cogni-wiki" / "config.json").is_file():
+        fail(f"not a cogni-wiki (no .cogni-wiki/config.json under {wiki_root})")
+    if not pages_dir.is_dir():
+        fail(f"wiki/pages/ not found under {wiki_root}")
+
+    errors: list = []
+    warnings: list = []
+
+    all_pages: dict = {}
+    inbound_links: dict = {}
+
+    for page in sorted(pages_dir.glob("*.md")):
+        slug = page.stem
+        try:
+            text = page.read_text(encoding="utf-8")
+        except OSError as e:
+            errors.append(
+                {"class": "read_error", "page": slug, "message": str(e)}
+            )
+            continue
+        fm, body = parse_frontmatter(text)
+        all_pages[slug] = {"fm": fm, "body": body}
+
+        # Lint reports and prior health reports are exempt from frontmatter
+        # and source schema; they're audit artefacts, not knowledge pages.
+        if slug.startswith("lint-") or slug.startswith("health-"):
+            for target in WIKILINK_RE.findall(text):
+                inbound_links.setdefault(target, set()).add(slug)
+            continue
+
+        for field in REQUIRED_FRONTMATTER:
+            if field not in fm or fm[field] in (None, "", []):
+                errors.append(
+                    {
+                        "class": "missing_frontmatter",
+                        "page": slug,
+                        "message": f"missing required field '{field}'",
+                    }
+                )
+
+        if fm.get("id") and fm["id"] != slug:
+            errors.append(
+                {
+                    "class": "id_mismatch",
+                    "page": slug,
+                    "message": f"frontmatter id '{fm['id']}' != filename '{slug}'",
+                }
+            )
+
+        ptype = fm.get("type")
+        if ptype and ptype not in VALID_TYPES:
+            errors.append(
+                {
+                    "class": "invalid_type",
+                    "page": slug,
+                    "message": f"type '{ptype}' not in {sorted(VALID_TYPES)}",
+                }
+            )
+
+        sources = fm.get("sources", [])
+        if isinstance(sources, list):
+            for src in sources:
+                if isinstance(src, str) and src.startswith("../raw/"):
+                    rel = src[len("../raw/") :]
+                    if not (raw_dir / rel).exists():
+                        errors.append(
+                            {
+                                "class": "missing_source",
+                                "page": slug,
+                                "message": f"source file not found: raw/{rel}",
+                            }
+                        )
+                elif isinstance(src, str) and src.startswith("wiki://"):
+                    target = src[len("wiki://") :].strip()
+                    if not target or not (pages_dir / f"{target}.md").is_file():
+                        errors.append(
+                            {
+                                "class": "broken_wiki_source",
+                                "page": slug,
+                                "message": f"wiki:// source not found: wiki://{target}",
+                            }
+                        )
+
+        if len(body.strip()) < STUB_PAGE_MIN_CHARS:
+            warnings.append(
+                {
+                    "class": "stub_page",
+                    "page": slug,
+                    "message": (
+                        f"body is {len(body.strip())} chars (< {STUB_PAGE_MIN_CHARS}); "
+                        f"expand or delete"
+                    ),
+                }
+            )
+
+        for target in WIKILINK_RE.findall(text):
+                inbound_links.setdefault(target, set()).add(slug)
+
+    existing_slugs = set(all_pages.keys())
+    for slug, sources in sorted(inbound_links.items()):
+        if slug not in existing_slugs:
+            for source_slug in sorted(sources):
+                errors.append(
+                    {
+                        "class": "broken_wikilink",
+                        "page": source_slug,
+                        "message": f"[[{slug}]] target does not exist",
+                    }
+                )
+
+    non_audit_pages = {
+        s for s in all_pages
+        if not s.startswith("lint-") and not s.startswith("health-")
+    }
+    cfg = _load_config(wiki_root)
+    entries_count_config = (
+        int(cfg["entries_count"])
+        if isinstance(cfg.get("entries_count"), int)
+        else 0
+    )
+    entries_count_actual = len(non_audit_pages)
+    entries_count_drift = entries_count_actual - entries_count_config
+    if entries_count_drift != 0:
+        warnings.append(
+            {
+                "class": "entries_count_drift",
+                "page": "*",
+                "message": (
+                    f".cogni-wiki/config.json entries_count={entries_count_config} "
+                    f"but filesystem has {entries_count_actual} "
+                    f"(drift={entries_count_drift:+d})"
+                ),
+            }
+        )
+
+    index_slugs = _index_slugs(wiki_root)
+    if index_slugs:
+        in_index_not_fs = sorted(index_slugs - existing_slugs)
+        in_fs_not_index = sorted(non_audit_pages - index_slugs)
+        for slug in in_index_not_fs:
+            warnings.append(
+                {
+                    "class": "index_filesystem_drift",
+                    "page": slug,
+                    "message": f"appears in wiki/index.md but no page file exists",
+                }
+            )
+        for slug in in_fs_not_index:
+            warnings.append(
+                {
+                    "class": "index_filesystem_drift",
+                    "page": slug,
+                    "message": f"page exists but is not referenced in wiki/index.md",
+                }
+            )
+
+    resweep = _load_last_resweep(wiki_root)
+    claim_drift_count = 0
+    claim_drift_date = None
+    if resweep:
+        claim_drift_date = resweep.get("sweep_date")
+        deviated = resweep.get("deviated_pages") or []
+        unavailable = resweep.get("unavailable_pages") or []
+        flagged = {s for s in (list(deviated) + list(unavailable)) if s in existing_slugs}
+        claim_drift_count = len(flagged)
+
+    ok(
+        {
+            "errors": errors,
+            "warnings": warnings,
+            "stats": {
+                "pages_audited": entries_count_actual,
+                "errors": len(errors),
+                "warnings": len(warnings),
+                "entries_count_config": entries_count_config,
+                "entries_count_actual": entries_count_actual,
+                "entries_count_drift": entries_count_drift,
+                "claim_drift_count": claim_drift_count,
+                "claim_drift_date": claim_drift_date,
+                "checked_at": dt.date.today().isoformat(),
+            },
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cogni-wiki/skills/wiki-lint/SKILL.md
+++ b/cogni-wiki/skills/wiki-lint/SKILL.md
@@ -1,25 +1,29 @@
 ---
 name: wiki-lint
-description: "Audit a Karpathy-style wiki for health problems — broken [[wikilinks]], orphan pages with no inbound links, stale dates, missing frontmatter fields, contradictions between pages, tag typos, and sources that no longer exist in raw/. Writes a severity-tiered report to wiki/pages/lint-YYYY-MM-DD.md and always appends to wiki/log.md. Use this skill whenever the user says 'lint the wiki', 'check the wiki', 'audit my wiki', 'health check the wiki', 'wiki lint', 'find broken links in the wiki', 'is my wiki healthy', 'anything broken in the wiki', or after every ~5–10 ingests as a maintenance pass. Also trigger when `wiki-resume` reports the wiki has not been linted in a while."
+description: "Run a semantic, LLM-powered audit of a Karpathy-style wiki — contradictions across pages, type drift (a 'concept' page that's actually a 'summary'), undercited claims, missing concept pages (entities mentioned in 3+ pages but lacking their own page), plus the deterministic-but-narrative warnings (orphans, stale drafts, tag typos, reverse-link gaps, claim-drift severity from the latest resweep). Calls wiki-health first as a free preflight; refuses to run while structural errors are pending. Writes a severity-tiered report to wiki/pages/lint-YYYY-MM-DD.md and always appends to wiki/log.md. Use this skill whenever the user says 'lint the wiki', 'audit my wiki', 'check the wiki for contradictions', 'wiki lint', 'find stale claims', or as a periodic maintenance pass after every ~10–15 ingests. For a fast structural-only check, use wiki-health instead."
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 
 # Wiki Lint
 
-Run a severity-tiered health audit over the wiki. Mechanical issues (broken links, missing frontmatter, orphan pages, stale dates, missing sources) are found by the `lint_wiki.py` script. Semantic issues (contradictions between pages, type drift, weak writing) are found by Claude reading the wiki with the script's output as a starting point.
+Run a semantic, LLM-powered audit. Lint is what `wiki-health` is **not** — it's the tokenful pass that reads pages and reasons about them: contradictions, type drift, undercited claims, missing concept pages, and the narrative interpretation of `claim_drift` from the latest resweep.
+
+The deterministic structural checks (broken wikilinks, missing frontmatter, broken sources, id mismatches, invalid types, stub pages, entries_count drift, index↔filesystem drift) live in `wiki-health`. Lint **always runs health first** as a free preflight — and refuses to run the tokenful semantic pass while structural errors are pending, because reasoning about a wiki with broken links wastes tokens and confuses the model.
 
 Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once at the start of any lint session.
 
 ## When to run
 
-- User explicitly asks to lint, audit, or health-check the wiki
+- User asks to lint, audit, contradiction-check, or content-quality-check the wiki
 - `wiki-resume` reports `last_lint` is null or >14 days old
-- After every ~5–10 ingests as a maintenance cadence
+- After every ~10–15 ingests as a maintenance cadence
 - Before exporting or sharing the wiki with someone else
+- After a `wiki-claims-resweep` run, to narrate the drift findings
 
 ## Never run when
 
 - The wiki is empty (`entries_count: 0`) — there is nothing to lint
+- `wiki-health` reports structural errors > 0 (refuse and direct the user to fix structure first; semantic reasoning about a broken wiki wastes tokens). Override with `--ignore-health` if the user explicitly wants the semantic pass anyway, but warn loudly.
 - Another `wiki-lint` is already in progress (check for a `lint-YYYY-MM-DD.md` being written in the current session)
 
 ## Parameters
@@ -27,7 +31,9 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once at the start of
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `--wiki-root` | No | Override the auto-detected wiki root |
-| `--skip-semantic` | No | Skip the Claude-driven contradiction and type-drift pass. Fast mechanical-only mode. |
+| `--skip-semantic` | No | Skip the LLM-driven contradiction/type-drift/missing-concept pass. Equivalent to running `wiki-health` plus the deterministic warnings (orphans, stale, tag typos, reverse links). Use when you want a tokenless full deterministic pass. |
+| `--ignore-health` | No | Run the semantic pass even when `wiki-health` reports errors. Discouraged — fix structural errors first. |
+| `--semantic-page-cap` | No | Maximum number of pages sampled for the semantic pass. Default: 20. |
 
 ## Workflow
 
@@ -35,25 +41,48 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once at the start of
 
 Walk upward to find `.cogni-wiki/config.json`. Set `wiki-root`.
 
-### 2. Run the mechanical lint script
+### 2. Run wiki-health as preflight
 
-Invoke `${CLAUDE_PLUGIN_ROOT}/skills/wiki-lint/scripts/lint_wiki.py --wiki-root <path>`. The script emits JSON with three severity tiers: `errors`, `warnings`, `info`. If the script exits non-zero or returns malformed JSON, report the raw error to the user and stop — do not write a partial lint report.
+Invoke `${CLAUDE_PLUGIN_ROOT}/skills/wiki-health/scripts/health.py --wiki-root <path>`. This is the same script `wiki-health` runs — by sharing the engine, lint and health stay consistent on what counts as a structural error.
 
-### 3. Read the script output
+If `data.stats.errors > 0` and `--ignore-health` was not passed, refuse to continue:
 
-The script categorizes findings into three severity tiers — see `./references/severity-tiers.md` for the full classification. In brief: **Errors** (broken structural contracts like dead wikilinks or missing frontmatter), **Warnings** (accumulating debt like orphan pages, stale drafts, tag typos, missing reverse links per the SCHEMA forward→reverse contract), **Info** (descriptive statistics like page counts and tag distribution).
+> wiki-health reports {N} structural errors. Fix them via /cogni-wiki:wiki-update before running a semantic lint, or pass --ignore-health to override (not recommended; reasoning about a broken wiki wastes tokens).
 
-The `reverse_link_missing` warning class enforces the wiki's SCHEMA `R1_bidirectional_wikilink` rule (page A contains `[[B]]` ⇒ page B should contain `[[A]]`). Surface these grouped by target page so the user can address them via a single `wiki-update` per page.
+Log a `lint | refused (health failed)` line to `wiki/log.md` and stop. Otherwise carry the health summary forward — it goes into the lint report.
 
-### 4. Read contradicted pages (semantic pass)
+### 3. Run the deterministic warning pass (lint_wiki.py)
 
-Unless `--skip-semantic`, sample up to 20 pages (or all of them if `entries_count < 20`) and look for:
+Invoke `${CLAUDE_PLUGIN_ROOT}/skills/wiki-lint/scripts/lint_wiki.py --wiki-root <path>`. The script emits JSON with the warnings/info that need narrative — orphans, stale drafts, tag typos, reverse-link gaps, synthesis-without-wiki-source, claim_drift per page. The structural errors that lint_wiki.py also emits are redundant with health (same engine semantics) and should be deduplicated against the health output when composing the report.
 
-- **Contradictions**: two pages making opposing claims about the same entity or concept
-- **Type drift**: a page tagged `concept` whose body is actually a `summary` (or vice versa)
-- **Undercited claims**: strong claims in page bodies that have no source citation
+### 4. Run the LLM-powered semantic pass
 
-The semantic pass is best-effort. It never rewrites pages — it only records findings in the report.
+Unless `--skip-semantic`, sample up to `--semantic-page-cap` pages (or all of them if `entries_count < cap`) and apply each of the four semantic checks below. Track token cost and surface it in the report.
+
+#### 4a. Contradictions across pages
+
+Group pages by overlap of `tags:` + frontmatter `type:` + most-linked targets. For each group, ask: "Do any of these pages make opposing claims about the same entity, concept, or decision?" Record findings as `contradiction` warnings with the two page slugs and a one-sentence reconciliation hint.
+
+#### 4b. Type drift
+
+For each sampled page, compare the declared `type:` against the body shape:
+
+- `concept` should be a definitional/explanatory page about an idea
+- `entity` should describe a person, organization, product, or thing
+- `summary` should compress a single source
+- `decision` should record what was chosen and why
+- `learning` should distil a takeaway from experience
+- `synthesis` should weave findings across multiple wiki pages
+
+Flag mismatches as `type_drift` warnings with the suggested correct type.
+
+#### 4c. Undercited claims
+
+Scan page bodies for strong factual claims (numbers, named entities, dated events) that lack a citation in the surrounding sentence or in `sources:`. Flag as `undercited_claim` warnings with the sentence quoted.
+
+#### 4d. Missing concept pages
+
+Scan all pages for entity/concept names that recur across **3 or more** pages but have no page of their own under `wiki/pages/`. Flag as `missing_concept_page` info items with the recurring name and the pages that mention it.
 
 ### 5. Write the lint report
 
@@ -79,48 +108,61 @@ Body structure:
 
 ## Summary
 
-- 🔴 Errors: {N}
-- 🟡 Warnings: {N}
-- 🔵 Info points: {N}
+- Health: 🔴 {N} errors · 🟡 {N} warnings (from wiki-health preflight)
+- Lint:   🟡 {N} warnings · 🔵 {N} info (deterministic + semantic)
 - Pages audited: {N}
-- Semantic pass: {yes/skipped}
+- Semantic pass: {yes / skipped / N pages sampled}
+- Token cost (semantic pass): ~{N} input + {N} output tokens
 
-## 🔴 Errors
+## 🔴 Errors (from wiki-health)
 
-### Broken wikilinks
-- `[[non-existent-page]]` in `[[page-a]]`, line 12
-- ...
+{Listed verbatim from health.data.errors. If empty, say "None — health is clean."}
 
-### Missing frontmatter fields
-- `[[page-b]]` — missing `type`
-- ...
-
-## 🟡 Warnings
+## 🟡 Warnings — deterministic
 
 ### Orphan pages
 - `[[page-c]]` — no inbound links
 - ...
 
-### Stale drafts
+### Stale drafts / pages
 - `[[page-d]]` — `updated: 2025-08-01`, 255 days old, status: draft
 
 ### Probable tag typos
 - `mashine-learning` (3 uses) vs `machine-learning` (17 uses)
 
-### Contradictions (semantic)
-- `[[page-e]]` claims X. `[[page-f]]` claims ¬X. Reconcile via `wiki-update`.
+### Reverse-link gaps (SCHEMA R1)
+- `[[page-e]]` is linked from `[[page-f]]` but does not link back
+
+### Synthesis pages without wiki:// source
+- `[[synthesis-x]]` — `type: synthesis` but no `wiki://` entry in sources
+
+### Claim drift (from last resweep, {date})
+- `[[page-g]]` — 2 claims deviated, 1 source unavailable; see `raw/claims-resweep-{date}/report.md`
+
+## 🟡 Warnings — semantic (LLM)
+
+### Contradictions
+- `[[page-h]]` claims X. `[[page-i]]` claims ¬X. Reconcile via `wiki-update`.
+
+### Type drift
+- `[[page-j]]` declared `concept` but body is a `summary` of one source. Suggest retype.
+
+### Undercited claims
+- `[[page-k]]`: "Revenue grew 47% YoY in 2025" — no citation in sources or sentence.
 
 ## 🔵 Info
 
 - Total pages: 47
 - By type: 18 concept, 12 summary, 8 learning, 5 entity, 3 decision, 1 note
 - Average sources per page: 1.8
-- Log entries in last 30 days: 12 ingests, 24 queries, 1 lint (previous)
+- Log entries in last 30 days: 12 ingests, 24 queries, 1 lint (previous), 7 health
 - Most-linked pages: [[llm-wiki-pattern]] (8), [[compounding-knowledge]] (6), ...
+- Missing concept pages (mentioned in ≥3 pages, no own page):
+  - "Constitutional AI" — mentioned in [[bai-2022]], [[anthropic-overview]], [[rlhf-survey]]
 
 ## Next actions
 
-{A short prose section recommending what to fix first — errors always first, then stale drafts, then contradictions.}
+{A short prose section recommending what to fix first — health errors always first, then contradictions, then stale drafts, then deterministic warnings.}
 ```
 
 ### 6. Update the index
@@ -128,16 +170,16 @@ Body structure:
 Add the lint report to `wiki/index.md` under a `## Maintenance` category (create the heading if it doesn't exist). Entry format:
 
 ```
-- [[lint-2026-04-12]] — Lint report: 2 errors, 5 warnings
+- [[lint-2026-04-12]] — Lint report: {N} health errors, {N} lint warnings
 ```
 
 ### 7. Append to the log — unconditionally
 
 ```
-## [{YYYY-MM-DD}] lint | {N} errors, {N} warnings
+## [{YYYY-MM-DD}] lint | {N} health errors, {N} lint warnings, ~{N} tokens
 ```
 
-Even when the wiki is clean (zero findings), log the lint run. The log is the audit trail.
+Even when the wiki is clean (zero findings), log the lint run. The log is the audit trail. The token-cost annotation is what makes lint visibly different from `health` in the log — health is free and runs every session; lint is paid and runs periodically.
 
 ### 8. Update `.cogni-wiki/config.json`
 
@@ -146,10 +188,11 @@ Set `last_lint` to today's ISO date. Leave `entries_count` untouched (the lint r
 ### 9. Report to the user
 
 Print a ≤5-line summary:
-- Severity counts
+- Health snapshot from preflight (N errors, N warnings)
+- Lint counts (deterministic + semantic)
 - Top 3 findings across all tiers
+- Token cost
 - Path to the full report
-- Recommended next action
 
 ## Output
 
@@ -163,10 +206,14 @@ Print a ≤5-line summary:
 1. **Never auto-fix findings.** Lint only reports because auto-fixing bypasses the diff-before-write review that catches unintended changes. Fixes happen via `wiki-update`.
 2. **Log even on clean runs.** The absence of findings is itself useful signal.
 3. **Contradictions are surfaced, not resolved.** Only `wiki-update` reconciles them.
-4. **Report date is the invocation date** — if the lint runs at 23:59 and writes past midnight, the filename uses the invocation date.
+4. **Health gates lint.** A wiki with structural errors does not get a tokenful semantic pass unless the user explicitly overrides — otherwise the LLM reasons over a broken graph and produces noisy findings.
+5. **Surface token cost.** Every lint run reports approximately how many tokens the semantic pass consumed. Health is free; lint is paid; the user should always know which they ran.
+6. **Report date is the invocation date** — if the lint runs at 23:59 and writes past midnight, the filename uses the invocation date.
 
 ## References
 
 - `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` — the pattern
-- `./references/severity-tiers.md` — tier definitions
-- `./scripts/lint_wiki.py` — mechanical lint pass
+- `./references/severity-tiers.md` — tier definitions and the full health-vs-lint coverage matrix
+- `./scripts/lint_wiki.py` — deterministic warning pass (orphans, stale, tag typos, reverse links, claim_drift narrative)
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-health/SKILL.md` — the structural counterpart, run as preflight
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-health/scripts/health.py` — the structural integrity engine

--- a/cogni-wiki/skills/wiki-lint/references/severity-tiers.md
+++ b/cogni-wiki/skills/wiki-lint/references/severity-tiers.md
@@ -2,9 +2,45 @@
 
 The lint report uses three tiers. Each finding belongs to exactly one tier. The tier determines urgency, not necessarily truth — a tier-1 finding might be intentional; it still gets flagged so the user sees it.
 
+## Health vs Lint coverage matrix
+
+As of v0.0.27, structural integrity checks live in `wiki-health` (zero LLM, every session) and content-quality checks live in `wiki-lint` (LLM-powered, periodic). The two skills share the same severity vocabulary; they differ in what they own.
+
+| Class | Tier | Owner | LLM? |
+|-------|------|-------|------|
+| `broken_wikilink` | Error | `wiki-health` | no |
+| `missing_frontmatter` | Error | `wiki-health` | no |
+| `id_mismatch` | Error | `wiki-health` | no |
+| `invalid_type` | Error | `wiki-health` | no |
+| `missing_source` | Error | `wiki-health` | no |
+| `broken_wiki_source` | Error | `wiki-health` | no |
+| `read_error` | Error | `wiki-health` | no |
+| `stub_page` | Warning | `wiki-health` | no |
+| `entries_count_drift` | Warning | `wiki-health` | no |
+| `index_filesystem_drift` | Warning | `wiki-health` | no |
+| Claim-drift **count** (from last resweep) | Stat | `wiki-health` | no |
+| `orphan_page` | Warning | `wiki-lint` | no |
+| `stale_draft` | Warning | `wiki-lint` | no |
+| `stale_page` | Warning | `wiki-lint` | no |
+| `no_sources` | Warning | `wiki-lint` | no |
+| `synthesis_no_wiki_source` | Warning | `wiki-lint` | no |
+| `reverse_link_missing` | Warning | `wiki-lint` | no |
+| `tag_typo` | Warning | `wiki-lint` | no |
+| `claim_drift` (per-page narrative) | Warning | `wiki-lint` | no |
+| `contradiction` | Warning | `wiki-lint` | **yes** |
+| `type_drift` | Warning | `wiki-lint` | **yes** |
+| `undercited_claim` | Warning | `wiki-lint` | **yes** |
+| `missing_concept_page` | Info | `wiki-lint` | **yes** |
+| Total pages, by type, top tags, most-linked | Info | `wiki-lint` | no |
+| `last_resweep` (date narrative) | Info | `wiki-lint` | no |
+
+**Rule of thumb:** if a check is a pure filesystem or schema test, it lives in `wiki-health`. If it needs date math with editorial judgement, a heuristic, narrative, or actual reading of page bodies, it lives in `wiki-lint`. Health is what runs on every session; lint is what runs every 10–15 ingests.
+
+**Why lint still does deterministic warnings.** Orphans, stale drafts, tag typos, and reverse-link gaps are all mechanically detectable but require narrative around the fix path — e.g. an orphan might be intentional (a top-level entry), a stale draft might be a deliberate parking spot, a reverse-link gap encodes the SCHEMA `R1_bidirectional_wikilink` contract. Surfacing them in the same report as the semantic findings keeps the "tokenful pass" coherent: when the user runs lint, they see everything that needs human judgement in one place.
+
 ## 🔴 Error — structural integrity
 
-An error means the wiki's contract is broken and a reader (human or LLM) might make a wrong inference. Errors must be fixed.
+An error means the wiki's contract is broken and a reader (human or LLM) might make a wrong inference. Errors must be fixed. **Errors are owned by `wiki-health`** — they're cheap to detect deterministically and they should fail fast on every session, not wait for a tokenful lint.
 
 ### Error classes
 
@@ -18,51 +54,57 @@ An error means the wiki's contract is broken and a reader (human or LLM) might m
 | **Broken wiki source** | `sources: [wiki://other-slug]` where `wiki/pages/other-slug.md` does not exist | `wiki-update` to fix the slug, or re-run `wiki-query --file-back` to regenerate the synthesis after the missing page is created |
 | **Duplicate slug** | Two pages with the same `id` frontmatter (shouldn't be possible if filenames are unique, but check) | Rename one |
 
-Errors are reported with a file path and line number so the user can jump directly.
+Errors are reported with a file path and line number so the user can jump directly. `wiki-lint` refuses to run its semantic pass when `wiki-health` reports errors > 0 (override with `--ignore-health`) — reasoning over a broken graph wastes tokens and produces noisy findings.
 
 ## 🟡 Warning — maintenance debt
 
-A warning means the wiki works but is accumulating debt. Warnings should be reviewed periodically — not urgent, but don't let them pile up.
+A warning means the wiki works but is accumulating debt. Warnings should be reviewed periodically — not urgent, but don't let them pile up. Warnings split between health (mechanical-only structural debt) and lint (everything that needs narrative or reading).
 
 ### Warning classes
 
-| Class | Detection | Fix path |
-|-------|-----------|----------|
-| **Orphan page** | No other page in `wiki/pages/` contains a `[[slug]]` link to this page, AND the page is not listed in `wiki/index.md` as a top-level entry | Add inbound links via `wiki-ingest` backlink audit or `wiki-update`; or confirm top-level status |
-| **Stale draft** | `status: draft` and `updated` > 180 days ago | `wiki-update` to promote or retire |
-| **Stale page** | `updated` > 365 days ago, regardless of status | Review and refresh or mark `status: stale` |
-| **No sources** | `sources:` empty or missing, and `type` is not `decision` or `note` | `wiki-update` to add citations |
-| **Synthesis without wiki source** | `type: synthesis` but no `wiki://`-prefixed entry in `sources:`. Synthesis pages must cite the wiki pages they derived from. | `wiki-update` to add `wiki://<slug>` references, or re-file via `wiki-query --file-back yes` |
-| **Reverse link missing** | Page A contains `[[B]]` but page B does not contain `[[A]]` — violates SCHEMA.md `R1_bidirectional_wikilink`. Lint reports (filename `lint-*`) are exempt on both ends per `R3`. | `wiki-update` page B to add a natural-language sentence containing `[[A]]`, or re-run `wiki-ingest` against B to refresh the backlink-audit pass. Auto-fix via `--fix` is not available today; the discipline is "lint reports, never auto-fixes" |
-| **Tag typo** | Tag differs from another tag by edit distance ≤ 2, one used ≥3× more than the other | `wiki-update` to normalize |
-| **Contradiction** | Two pages make opposing claims about the same entity or concept (semantic pass) | `wiki-update` to reconcile, or add explicit contradiction note |
-| **Type drift** | Page body's structure doesn't match declared `type` (e.g. a `concept` page that is actually a `summary`) | `wiki-update` to retype or rewrite |
-| **Claim drift** | A `wiki-claims-resweep` finding (`deviated` or `source_unavailable`) is recorded for the page in `.cogni-wiki/last-resweep.json` | Consult the sweep report; consider `wiki-update` to mark the affected claims stale, or re-run `wiki-claims-resweep` after sources are recovered |
+| Class | Detection | Owner | Fix path |
+|-------|-----------|-------|----------|
+| **Stub page** | Body shorter than 50 chars after frontmatter | `wiki-health` | `wiki-update` to expand, or delete |
+| **entries_count drift** | `.cogni-wiki/config.json` `entries_count` ≠ actual file count under `wiki/pages/` (excluding `lint-*` and `health-*`) | `wiki-health` | Run `wiki-ingest` to bump the counter, or hand-edit `config.json` |
+| **Index/filesystem drift** | A slug appears in `wiki/index.md` as a `[[wikilink]]` but no page file exists, or a page exists but is not in the index | `wiki-health` | `wiki-update` to add the missing entry, or delete the stale index line |
+| **Orphan page** | No other page in `wiki/pages/` contains a `[[slug]]` link to this page, AND the page is not listed in `wiki/index.md` as a top-level entry | `wiki-lint` | Add inbound links via `wiki-ingest` backlink audit or `wiki-update`; or confirm top-level status |
+| **Stale draft** | `status: draft` and `updated` > 180 days ago | `wiki-lint` | `wiki-update` to promote or retire |
+| **Stale page** | `updated` > 365 days ago, regardless of status | `wiki-lint` | Review and refresh or mark `status: stale` |
+| **No sources** | `sources:` empty or missing, and `type` is not `decision` or `note` | `wiki-lint` | `wiki-update` to add citations |
+| **Synthesis without wiki source** | `type: synthesis` but no `wiki://`-prefixed entry in `sources:`. Synthesis pages must cite the wiki pages they derived from. | `wiki-lint` | `wiki-update` to add `wiki://<slug>` references, or re-file via `wiki-query --file-back yes` |
+| **Reverse link missing** | Page A contains `[[B]]` but page B does not contain `[[A]]` — violates SCHEMA.md `R1_bidirectional_wikilink`. Lint reports (filename `lint-*`) and health reports (`health-*`) are exempt on both ends per `R3`. | `wiki-lint` | `wiki-update` page B to add a natural-language sentence containing `[[A]]`, or re-run `wiki-ingest` against B to refresh the backlink-audit pass. Auto-fix via `--fix` is not available today; the discipline is "lint reports, never auto-fixes" |
+| **Tag typo** | Tag differs from another tag by edit distance ≤ 2, one used ≥3× more than the other | `wiki-lint` | `wiki-update` to normalize |
+| **Contradiction** | Two pages make opposing claims about the same entity or concept (semantic pass) | `wiki-lint` (LLM) | `wiki-update` to reconcile, or add explicit contradiction note |
+| **Type drift** | Page body's structure doesn't match declared `type` (e.g. a `concept` page that is actually a `summary`) | `wiki-lint` (LLM) | `wiki-update` to retype or rewrite |
+| **Undercited claim** | Strong factual claim (number, named entity, dated event) with no citation in the surrounding sentence or `sources:` | `wiki-lint` (LLM) | `wiki-update` to add a citation or soften the claim |
+| **Claim drift** | A `wiki-claims-resweep` finding (`deviated` or `source_unavailable`) is recorded for the page in `.cogni-wiki/last-resweep.json` | `wiki-lint` (narrative); `wiki-health` (count) | Consult the sweep report; consider `wiki-update` to mark the affected claims stale, or re-run `wiki-claims-resweep` after sources are recovered |
 
 ## 🔵 Info — observations
 
-Info is not a finding — it's descriptive statistics that help the user understand the wiki's shape. Info never requires action, but it often reveals opportunities.
+Info is not a finding — it's descriptive statistics that help the user understand the wiki's shape. Info never requires action, but it often reveals opportunities. Info is owned by `wiki-lint` (the periodic, fully-detailed audit); `wiki-health` exposes only the few counts it cheaply computes (`pages_audited`, `entries_count_*`, `claim_drift_count`).
 
 ### Info classes
 
-- **Total pages**, excluding lint reports
+- **Total pages**, excluding lint and health reports
 - **Pages by type** distribution
 - **Tag distribution** — top 20 tags with counts
 - **Average sources per page**
 - **Most-linked pages** — top 10 pages by inbound `[[wikilink]]` count
 - **Least-linked pages** — pages with exactly 0 or 1 inbound links, excluding orphans (already in warnings)
-- **Log activity** — ingests, queries, syntheses, lints in the last 30 days
+- **Log activity** — ingests, queries, syntheses, lints, health runs in the last 30 days
 - **Age histogram** — buckets for pages by age: <7d, <30d, <90d, <365d, >365d
 - **Last resweep** — date and age (in days) of the most recent `wiki-claims-resweep` run, surfaced when `.cogni-wiki/last-resweep.json` exists
+- **Missing concept pages** (LLM) — entity/concept names that recur across ≥3 pages but lack a page of their own
 
 ## Thresholds
 
-| Knob | Default | Rationale |
-|------|---------|-----------|
-| Stale draft cutoff | 180 days | Drafts that sit this long usually need retirement or promotion |
-| Stale page cutoff | 365 days | A year is generous — shorter cutoffs cause warning fatigue |
-| Tag-typo max edit distance | 2 | Catches `mashine`/`machine` without flagging `nlp`/`llm` |
-| Tag-typo usage ratio | 3:1 | Only flag when one spelling dominates — below that it's just two variant tags |
-| Semantic pass page cap | 20 | Limit cost on large wikis; rotate which pages are sampled on repeat runs |
+| Knob | Default | Owner | Rationale |
+|------|---------|-------|-----------|
+| Stub page minimum body length | 50 chars | `wiki-health` | Below this, the page isn't yet useful; flagging nudges expansion or deletion |
+| Stale draft cutoff | 180 days | `wiki-lint` | Drafts that sit this long usually need retirement or promotion |
+| Stale page cutoff | 365 days | `wiki-lint` | A year is generous — shorter cutoffs cause warning fatigue |
+| Tag-typo max edit distance | 2 | `wiki-lint` | Catches `mashine`/`machine` without flagging `nlp`/`llm` |
+| Tag-typo usage ratio | 3:1 | `wiki-lint` | Only flag when one spelling dominates — below that it's just two variant tags |
+| Semantic pass page cap | 20 | `wiki-lint` | Limit cost on large wikis; rotate which pages are sampled on repeat runs |
 
-All thresholds live in constants at the top of `lint_wiki.py` so they can be tuned without restructuring the script.
+All thresholds live in constants at the top of the relevant script (`health.py` or `lint_wiki.py`) so they can be tuned without restructuring the script.

--- a/cogni-wiki/skills/wiki-resume/SKILL.md
+++ b/cogni-wiki/skills/wiki-resume/SKILL.md
@@ -54,7 +54,7 @@ The script emits JSON with:
 - `health_count_30d` — number of `health` lines (introduced in v0.0.27); a healthy session-start cadence puts this at one or more per active day
 - `raw_file_count` — files in `raw/`
 - `orphan_raw_count` — files in `raw/` not referenced by any page frontmatter (quick heuristic)
-- `schema_version` — value of `schema_version` in `.cogni-wiki/config.json`, or `null` if absent. Used by Step 3's Schema section to surface a migration nudge when the wiki predates a SCHEMA.md addition.
+- `schema_version` — value of `schema_version` in `.cogni-wiki/config.json`, or `null` if absent. Used by Step 3's Schema section to surface a migration nudge when the wiki predates the most recent SCHEMA.md additions.
 - `health` — a sub-object with `available`, `errors`, `warnings`, `entries_count_drift`, `claim_drift_count`, `claim_drift_date`. `available: false` when the health.py invocation failed; the rest of the status block still works.
 
 ### 3. Compose the status view
@@ -86,8 +86,10 @@ else:
 
 ## Schema
 - schema_version: {schema_version}
-{if schema_version is null OR schema_version < "0.0.3":
-- "Older than v0.0.3 — the SCHEMA.md "Forward → reverse link contract" section is missing. To migrate, append the contract section from `${CLAUDE_PLUGIN_ROOT}/skills/wiki-setup/references/SCHEMA.md.template` to your `<wiki-root>/SCHEMA.md`, then bump `schema_version` to `"0.0.3"` in `.cogni-wiki/config.json`. `wiki-lint`'s `reverse_link_missing` check works either way; the migration only ensures the contract is auditable when reading the wiki on its own."
+{if schema_version is null OR schema_version < "0.0.4":
+- "Older than v0.0.4 — the SCHEMA.md shipped with this wiki is missing one or both of the following sections, depending on how old the wiki is. Apply the missing pieces from `${CLAUDE_PLUGIN_ROOT}/skills/wiki-setup/references/SCHEMA.md.template`, then bump `schema_version` to `"0.0.4"` in `.cogni-wiki/config.json`. The migration is offline-safe and idempotent — lint and health work either way; the SCHEMA changes only ensure the contract is auditable when reading the wiki on its own.
+  - If schema_version < 0.0.3: append the `## Forward → reverse link contract` section between the existing `## Linking` and `## Log format` sections.
+  - If schema_version < 0.0.4: broaden the `## Log format` operation enum to `{ingest|query|synthesis|lint|health|update|setup}`, and rename the `R3_lint_report` row in the forward→reverse contract table to `R3_audit_report` covering both `[[lint-YYYY-MM-DD]]` and `[[health-YYYY-MM-DD]]` filenames. See `${CLAUDE_PLUGIN_ROOT}/skills/wiki-setup/SKILL.md` §"Migration for existing wikis" for the full step-by-step."
 }
 
 ## Recent log (last 10 lines)

--- a/cogni-wiki/skills/wiki-resume/SKILL.md
+++ b/cogni-wiki/skills/wiki-resume/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: wiki-resume
-description: "Show status, activity, and recommended next action for a Karpathy-style wiki — entry count, days since last lint, recent log activity, stale drafts, and what the user should do next. Use this skill whenever the user says 'resume the wiki', 'wiki status', 'what's in my wiki', 'where was I with the wiki', 'wiki resume', 'show me the wiki overview', or asks 'what should I do next with my wiki'. Also trigger proactively after a wiki-setup or a long gap between invocations to orient the user."
+description: "Show status, activity, health snapshot, and recommended next action for a Karpathy-style wiki — entry count, days since last lint, recent log activity, stale drafts, structural-integrity errors from wiki-health (run automatically every session), and what the user should do next. Use this skill whenever the user says 'resume the wiki', 'wiki status', 'what's in my wiki', 'where was I with the wiki', 'wiki resume', 'show me the wiki overview', or asks 'what should I do next with my wiki'. Also trigger proactively after a wiki-setup or a long gap between invocations to orient the user."
 allowed-tools: Read, Bash, Glob
 ---
 
 # Wiki Resume
 
-Give the user a fast, grounded status view of their wiki so they know what's inside and what the right next action is. No writing — this skill only reads.
+Give the user a fast, grounded status view of their wiki so they know what's inside and what the right next action is. As of v0.0.27, resume also runs `wiki-health` automatically as part of every status call — a free, zero-LLM structural pre-flight that surfaces broken wikilinks, missing frontmatter, and other mechanical issues without the user having to think about it. No writing to wiki pages — this skill is read-only against the wiki itself; it only logs the health invocation it dispatches.
 
-Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once for new sessions. Resume is a read-only skill — it never edits the wiki.
+Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once for new sessions.
 
 ## When to run
 
@@ -27,6 +27,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once for new session
 |-----------|----------|-------------|
 | `--wiki-root` | No | Override the auto-detected wiki root |
 | `--verbose` | No | Include the last 10 log entries verbatim, not just counts |
+| `--skip-health` | No | Skip the automatic `wiki-health` preflight. Use only when health.py is broken or you want a literal no-side-effect read. |
 
 ## Workflow
 
@@ -34,12 +35,14 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once for new session
 
 Walk upward to find `.cogni-wiki/config.json`. If none, stop and offer `wiki-setup`.
 
-### 2. Run the status script
+### 2. Run the status script (which now also runs wiki-health)
 
-Invoke `${CLAUDE_PLUGIN_ROOT}/skills/wiki-resume/scripts/wiki_status.sh --wiki-root <path>`. If the script exits non-zero or returns malformed JSON, fall back to reading `config.json` and `wiki/log.md` directly — report what you can, note that the full status script failed, and suggest the user check `wiki_status.sh` manually. The script emits JSON with:
+Invoke `${CLAUDE_PLUGIN_ROOT}/skills/wiki-resume/scripts/wiki_status.sh --wiki-root <path>`. Unless `--skip-health` is passed, the script shells out to `${CLAUDE_PLUGIN_ROOT}/skills/wiki-health/scripts/health.py` once and folds the result into its JSON output. If the script exits non-zero or returns malformed JSON, fall back to reading `config.json` and `wiki/log.md` directly — report what you can, note that the full status script failed, and suggest the user check `wiki_status.sh` manually.
+
+The script emits JSON with:
 
 - `name`, `slug`, `created`, `description` — from `config.json`
-- `entries_count` — actual file count in `wiki/pages/` excluding `lint-*.md`
+- `entries_count` — actual file count in `wiki/pages/` excluding `lint-*.md` and `health-*.md`
 - `lint_count` — number of `lint-*.md` reports
 - `last_lint` — ISO date of most recent lint report file
 - `days_since_lint` — integer or `null`
@@ -48,9 +51,11 @@ Invoke `${CLAUDE_PLUGIN_ROOT}/skills/wiki-resume/scripts/wiki_status.sh --wiki-r
 - `query_count_30d` — number of `query` lines in the last 30 days (un-filed reads)
 - `synthesis_count_30d` — number of `synthesis` lines (filed-back query answers) in the last 30 days; introduced in v0.0.23
 - `update_count_30d` — same for updates
+- `health_count_30d` — number of `health` lines (introduced in v0.0.27); a healthy session-start cadence puts this at one or more per active day
 - `raw_file_count` — files in `raw/`
 - `orphan_raw_count` — files in `raw/` not referenced by any page frontmatter (quick heuristic)
 - `schema_version` — value of `schema_version` in `.cogni-wiki/config.json`, or `null` if absent. Used by Step 3's Schema section to surface a migration nudge when the wiki predates a SCHEMA.md addition.
+- `health` — a sub-object with `available`, `errors`, `warnings`, `entries_count_drift`, `claim_drift_count`, `claim_drift_date`. `available: false` when the health.py invocation failed; the rest of the status block still works.
 
 ### 3. Compose the status view
 
@@ -62,8 +67,17 @@ _Slug_: {slug}
 _Created_: {created}
 _Description_: {description}
 
+## Health (preflight, every session)
+{if health.available is false:
+- "⚠ wiki-health did not run cleanly — see wiki_status.sh logs. Status below uses cached counts only."
+else:
+- {N} errors, {N} warnings
+- {if health.entries_count_drift != 0: "entries_count drift: {drift:+d} (config vs filesystem)"}
+- {if health.claim_drift_count > 0: "{N} pages flagged by last resweep ({date})"}
+}
+
 ## Activity (last 30 days)
-- {N} ingests · {N} queries · {N} syntheses · {N} updates
+- {N} ingests · {N} queries · {N} syntheses · {N} updates · {N} health
 
 ## Inventory
 - {entries_count} pages
@@ -83,39 +97,43 @@ _Description_: {description}
 {see decision tree below}
 ```
 
-The `syntheses` count surfaces filed-back query answers — a non-zero number is a signal that the wiki is compounding, not just accumulating raw sources. A wiki with high ingest count but zero syntheses suggests the user isn't asking the wiki questions yet; rule 5 below nudges toward `wiki-query` in that case.
+The `syntheses` count surfaces filed-back query answers — a non-zero number is a signal that the wiki is compounding, not just accumulating raw sources. A wiki with high ingest count but zero syntheses suggests the user isn't asking the wiki questions yet; rule 5 below nudges toward `wiki-query` in that case. The `health` count is the new v0.0.27 signal: zero in the last 30 days means session-start preflight isn't happening, and the user should be encouraged to invoke `wiki-resume` (which runs health) more often.
 
 ### 4. Recommend next action (decision tree)
 
 Apply the first rule that matches:
 
-1. **`entries_count == 0`** → "Drop a source in `raw/` and run `/cogni-wiki:wiki-ingest`."
-2. **`orphan_raw_count > 0`** → "You have {N} raw sources that aren't yet in the wiki. Run `/cogni-wiki:wiki-ingest --discover orphans --discover-dry-run` to review them, then drop `--discover-dry-run` to ingest. No need to hand-craft a batch file — the skill enumerates the orphans for you."
-3. **`days_since_lint == null` OR `days_since_lint > 14`** → "It's been {N} days (or never) since the last lint. Run `/cogni-wiki:wiki-lint`."
-4. **`ingest_count_30d == 0 AND query_count_30d == 0 AND synthesis_count_30d == 0 AND update_count_30d == 0`** → "The wiki hasn't been touched in 30 days. Either ingest something new or run `/cogni-wiki:wiki-query` to reactivate it."
-5. **`entries_count >= 5 AND query_count_30d == 0 AND synthesis_count_30d == 0`** → "You have {entries_count} pages but haven't asked the wiki anything in 30 days. Run `/cogni-wiki:wiki-query --question '...' --file-back yes` to compound a synthesis page."
-6. **Else** → "The wiki looks healthy. Continue with whatever you were doing, or run `/cogni-wiki:wiki-dashboard` for a visual overview."
+1. **`health.available AND health.errors > 0`** → "wiki-health flagged {N} structural errors. Fix them via `/cogni-wiki:wiki-update` before anything else — errors block reliable reads. The errors are listed above."
+2. **`health.available AND health.entries_count_drift != 0`** → "`entries_count` is out of sync with the filesystem (drift={drift:+d}). Run `/cogni-wiki:wiki-ingest` to bump the counter, or hand-edit `.cogni-wiki/config.json` to match."
+3. **`health.available AND health.claim_drift_count > 0 AND days_since_lint > 14`** → "{N} pages flagged by the last resweep ({date}) and lint hasn't run in {days} days. Run `/cogni-wiki:wiki-lint` for the semantic narrative."
+4. **`entries_count == 0`** → "Drop a source in `raw/` and run `/cogni-wiki:wiki-ingest`."
+5. **`orphan_raw_count > 0`** → "You have {N} raw sources that aren't yet in the wiki. Run `/cogni-wiki:wiki-ingest --discover orphans --discover-dry-run` to review them, then drop `--discover-dry-run` to ingest. No need to hand-craft a batch file — the skill enumerates the orphans for you."
+6. **`days_since_lint == null` OR `days_since_lint > 14`** → "It's been {N} days (or never) since the last lint. Run `/cogni-wiki:wiki-lint`."
+7. **`ingest_count_30d == 0 AND query_count_30d == 0 AND synthesis_count_30d == 0 AND update_count_30d == 0`** → "The wiki hasn't been touched in 30 days. Either ingest something new or run `/cogni-wiki:wiki-query` to reactivate it."
+8. **`entries_count >= 5 AND query_count_30d == 0 AND synthesis_count_30d == 0`** → "You have {entries_count} pages but haven't asked the wiki anything in 30 days. Run `/cogni-wiki:wiki-query --question '...' --file-back yes` to compound a synthesis page."
+9. **Else** → "The wiki looks healthy. Continue with whatever you were doing, or run `/cogni-wiki:wiki-dashboard` for a visual overview."
 
-Rule 2's concrete `--discover` command is deliberate: the older prose-only recommendation ("run wiki-ingest on them") left Claude (and by extension the user) to figure out how to enumerate the orphans, which in practice meant asking the user to type them out. Emitting the exact command closes that loop — the skill knows it has the `--discover orphans` mode, so `wiki-resume` should hand that over directly.
+Rules 1–3 are new in v0.0.27 — they fire on the freshly-collected health snapshot so structural problems surface before any other recommendation. The deterministic split lets resume make a confident statement about what is broken without burning lint tokens. Rule 5's concrete `--discover` command is deliberate: the older prose-only recommendation ("run wiki-ingest on them") left Claude (and by extension the user) to figure out how to enumerate the orphans, which in practice meant asking the user to type them out. Rule 8 surfaces the "the wiki is a vault, but you haven't asked it anything" anti-pattern that file-back synthesis pages were built to fix.
 
-Rule 5 is new in v0.0.23 — it surfaces the "the wiki is a vault, but you haven't asked it anything" anti-pattern that file-back synthesis pages were built to fix.
+### 5. Side effects
 
-### 5. Do not write anything
-
-This skill is strictly read-only. Do not append to the log. Do not touch `config.json`. Do not create files. The only side effect is the status printed to the user.
+This skill is read-only against `wiki/pages/` and `.cogni-wiki/config.json` — it never edits them. The one side effect introduced in v0.0.27 is that the dispatched `wiki-health` invocation appends a `## [YYYY-MM-DD] health | N errors, N warnings` line to `wiki/log.md`. That's intentional: every health pre-flight should be on the audit trail, and resume is the canonical session-start trigger. Use `--skip-health` if you genuinely want zero side effects.
 
 ## Output
 
-- A prose status block printed to the user
-- Nothing written to disk
+- A prose status block printed to the user (with a Health section)
+- One `health` line appended to `wiki/log.md` (skip with `--skip-health`)
 
 ## Golden rules
 
-1. **Read-only.** Resume never writes.
-2. **Always recommend an action.** The user should leave this skill knowing what to do next.
-3. **Ground the numbers in the filesystem**, not in cached config values — the script counts files directly so a stale `entries_count` in `config.json` doesn't mislead.
+1. **Read-only against wiki pages.** Resume never modifies `wiki/pages/`, `wiki/index.md`, or `.cogni-wiki/config.json`.
+2. **Health is automatic.** The user shouldn't have to remember to preflight — resume does it for them.
+3. **Always recommend an action.** The user should leave this skill knowing what to do next.
+4. **Ground the numbers in the filesystem**, not in cached config values — the script counts files directly so a stale `entries_count` in `config.json` doesn't mislead.
 
 ## References
 
 - `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` — the pattern
-- `./scripts/wiki_status.sh` — the status collector
+- `./scripts/wiki_status.sh` — the status collector (now also dispatches health.py)
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-health/SKILL.md` — the structural pre-flight skill
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-health/scripts/health.py` — the deterministic check engine

--- a/cogni-wiki/skills/wiki-resume/scripts/wiki_status.sh
+++ b/cogni-wiki/skills/wiki-resume/scripts/wiki_status.sh
@@ -2,7 +2,7 @@
 # wiki_status.sh — collect status facts for a cogni-wiki and emit JSON.
 #
 # Usage:
-#   wiki_status.sh --wiki-root <path>
+#   wiki_status.sh --wiki-root <path> [--skip-health]
 #
 # Output contract:
 #   {"success": true|false, "data": { ... }, "error": "string"}
@@ -12,6 +12,12 @@
 # Rationale: a shell script is the right tool here because everything we need
 # is file counting, date arithmetic, and grep over log.md. Delegating to python3
 # only for JSON assembly keeps the shell portion trivial and portable.
+#
+# v0.0.27: also dispatches wiki-health/scripts/health.py once and folds the
+# resulting errors / warnings / entries_count_drift / claim_drift_count into
+# the JSON output under the `health` sub-object. Failures are non-fatal —
+# `health.available` flips to false and the rest of the status block still
+# works.
 
 set -u
 
@@ -21,7 +27,7 @@ usage() {
 wiki_status.sh — collect status facts for a cogni-wiki and emit JSON.
 
 Usage:
-  wiki_status.sh --wiki-root <path>
+  wiki_status.sh --wiki-root <path> [--skip-health]
   wiki_status.sh -h | --help
 
 Output contract:
@@ -30,6 +36,7 @@ USAGE
 }
 
 WIKI_ROOT=""
+SKIP_HEALTH=0
 while [ $# -gt 0 ]; do
   case "$1" in
     -h|--help)
@@ -39,6 +46,10 @@ while [ $# -gt 0 ]; do
     --wiki-root)
       WIKI_ROOT="${2:-}"
       shift 2
+      ;;
+    --skip-health)
+      SKIP_HEALTH=1
+      shift
       ;;
     *)
       printf '{"success": false, "data": {}, "error": "unknown arg: %s"}\n' "$1"
@@ -68,11 +79,15 @@ LOG_FILE="$WIKI_ROOT/wiki/log.md"
 RAW_DIR="$WIKI_ROOT/raw"
 CONFIG_FILE="$WIKI_ROOT/.cogni-wiki/config.json"
 
+# Resolve script dir so we can find ../../wiki-health/scripts/health.py.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HEALTH_SCRIPT="$SCRIPT_DIR/../../wiki-health/scripts/health.py"
+
 # ---------- counts ----------
 entries_count=0
 lint_count=0
 if [ -d "$PAGES_DIR" ]; then
-  entries_count=$(find "$PAGES_DIR" -maxdepth 1 -type f -name '*.md' ! -name 'lint-*.md' 2>/dev/null | wc -l | tr -d ' ')
+  entries_count=$(find "$PAGES_DIR" -maxdepth 1 -type f -name '*.md' ! -name 'lint-*.md' ! -name 'health-*.md' 2>/dev/null | wc -l | tr -d ' ')
   lint_count=$(find "$PAGES_DIR" -maxdepth 1 -type f -name 'lint-*.md' 2>/dev/null | wc -l | tr -d ' ')
 fi
 
@@ -107,6 +122,7 @@ ingest_count_30d=0
 query_count_30d=0
 update_count_30d=0
 synthesis_count_30d=0
+health_count_30d=0
 if [ -f "$LOG_FILE" ]; then
   # Compute cutoff date (30 days ago) in YYYY-MM-DD.
   if date -d "30 days ago" +%Y-%m-%d >/dev/null 2>&1; then
@@ -130,16 +146,18 @@ if [ -f "$LOG_FILE" ]; then
           else if (op == "query") query++
           else if (op == "update") update++
           else if (op == "synthesis") synthesis++
+          else if (op == "health") health++
         }
       }
       END {
-        printf "%d %d %d %d", (ingest+0), (query+0), (update+0), (synthesis+0)
+        printf "%d %d %d %d %d", (ingest+0), (query+0), (update+0), (synthesis+0), (health+0)
       }
     ' "$LOG_FILE")
     ingest_count_30d=$(printf '%s' "$counts" | awk '{print $1}')
     query_count_30d=$(printf '%s' "$counts" | awk '{print $2}')
     update_count_30d=$(printf '%s' "$counts" | awk '{print $3}')
     synthesis_count_30d=$(printf '%s' "$counts" | awk '{print $4}')
+    health_count_30d=$(printf '%s' "$counts" | awk '{print $5}')
   fi
 fi
 
@@ -164,6 +182,15 @@ $(find "$RAW_DIR" -maxdepth 1 -type f 2>/dev/null)
 EOF
 fi
 
+# ---------- health preflight (v0.0.27) ----------
+health_json=""
+if [ "$SKIP_HEALTH" -eq 0 ] && [ -f "$HEALTH_SCRIPT" ]; then
+  # health.py is stdlib-only and fast; capture its stdout. Failures are
+  # non-fatal — we just leave health_json empty and the python assembler
+  # below will set health.available=false.
+  health_json=$(python3 "$HEALTH_SCRIPT" --wiki-root "$WIKI_ROOT" 2>/dev/null || true)
+fi
+
 # ---------- assemble JSON via python3 ----------
 # Pass values via env to avoid shell-escape hell.
 export WS_ENTRIES_COUNT="$entries_count"
@@ -176,8 +203,10 @@ export WS_INGEST_30="$ingest_count_30d"
 export WS_QUERY_30="$query_count_30d"
 export WS_UPDATE_30="$update_count_30d"
 export WS_SYNTHESIS_30="$synthesis_count_30d"
+export WS_HEALTH_30="$health_count_30d"
 export WS_RECENT_LOG="$recent_log"
 export WS_CONFIG_FILE="$CONFIG_FILE"
+export WS_HEALTH_JSON="$health_json"
 
 python3 - <<'PY'
 import json
@@ -204,6 +233,33 @@ recent_log_lines = [line for line in recent_log_raw.splitlines() if line.strip()
 
 last_lint = os.environ.get("WS_LAST_LINT", "").strip() or None
 
+# Parse the embedded health.py JSON if present.
+health_block = {
+    "available": False,
+    "errors": None,
+    "warnings": None,
+    "entries_count_drift": None,
+    "claim_drift_count": None,
+    "claim_drift_date": None,
+}
+health_raw = os.environ.get("WS_HEALTH_JSON", "").strip()
+if health_raw:
+    try:
+        parsed = json.loads(health_raw)
+        if parsed.get("success"):
+            stats = (parsed.get("data") or {}).get("stats") or {}
+            health_block = {
+                "available": True,
+                "errors": int(stats.get("errors", 0) or 0),
+                "warnings": int(stats.get("warnings", 0) or 0),
+                "entries_count_drift": int(stats.get("entries_count_drift", 0) or 0),
+                "claim_drift_count": int(stats.get("claim_drift_count", 0) or 0),
+                "claim_drift_date": stats.get("claim_drift_date"),
+            }
+    except (json.JSONDecodeError, ValueError, TypeError):
+        # Leave health_block in its "unavailable" state.
+        pass
+
 data = {
     "name": cfg.get("name"),
     "slug": cfg.get("slug"),
@@ -219,8 +275,10 @@ data = {
     "query_count_30d": int(os.environ.get("WS_QUERY_30", "0") or 0),
     "update_count_30d": int(os.environ.get("WS_UPDATE_30", "0") or 0),
     "synthesis_count_30d": int(os.environ.get("WS_SYNTHESIS_30", "0") or 0),
+    "health_count_30d": int(os.environ.get("WS_HEALTH_30", "0") or 0),
     "recent_log": recent_log_lines,
     "schema_version": cfg.get("schema_version"),
+    "health": health_block,
 }
 
 print(json.dumps({"success": True, "data": data, "error": ""}))

--- a/cogni-wiki/skills/wiki-setup/SKILL.md
+++ b/cogni-wiki/skills/wiki-setup/SKILL.md
@@ -102,14 +102,19 @@ Write `<wiki-root>/.cogni-wiki/config.json` with JSON:
   "created": "{{YYYY-MM-DD}}",
   "entries_count": 0,
   "last_lint": null,
-  "schema_version": "0.0.3",
+  "schema_version": "0.0.4",
   "publisher_base_url": "{{publisher_base_url_or_empty}}"
 }
 ```
 
-Use the current date via `date +%Y-%m-%d`. Omit `publisher_base_url` (do not emit the key at all) when `--publisher-base-url` was not provided — an empty string is acceptable but a missing key reads more cleanly in single-publisher wikis where the field is unused. `schema_version` `"0.0.3"` marks the addition of the SCHEMA "Forward → reverse link contract" table; `"0.0.2"` (which added `publisher_base_url`) and `"0.0.1"` configs remain valid on read.
+Use the current date via `date +%Y-%m-%d`. Omit `publisher_base_url` (do not emit the key at all) when `--publisher-base-url` was not provided — an empty string is acceptable but a missing key reads more cleanly in single-publisher wikis where the field is unused. `schema_version` `"0.0.4"` marks the addition of the `synthesis` and `health` log prefixes plus the `R3_audit_report` exemption broadening; `"0.0.3"` (which added the SCHEMA "Forward → reverse link contract" table), `"0.0.2"` (which added `publisher_base_url`), and `"0.0.1"` configs remain valid on read.
 
-**Migration for existing wikis (schema_version < 0.0.3).** When `wiki-resume` or any wiki-* skill encounters a wiki at `schema_version < 0.0.3`, append the `## Forward → reverse link contract` section from `${CLAUDE_PLUGIN_ROOT}/skills/wiki-setup/references/SCHEMA.md.template` to the wiki's existing `SCHEMA.md` (between the existing `## Linking` and `## Log format` sections), then bump `.cogni-wiki/config.json` `schema_version` to `"0.0.3"`. The migration is idempotent — `wiki-lint` `reverse_link_missing` reports the same findings whether or not the SCHEMA section is present, so the user is never blocked on the migration; it only ensures the contract is auditable when reading the wiki on its own.
+**Migration for existing wikis (schema_version < 0.0.4).** When `wiki-resume` or any wiki-* skill encounters a wiki at `schema_version < 0.0.4`, the `SCHEMA.md` shipped inside that wiki is missing one or both of the following sections — apply the missing pieces by reading the differences against `${CLAUDE_PLUGIN_ROOT}/skills/wiki-setup/references/SCHEMA.md.template`, then bump `.cogni-wiki/config.json` `schema_version` to `"0.0.4"`:
+
+- **`< 0.0.3`:** append the `## Forward → reverse link contract` section between the existing `## Linking` and `## Log format` sections.
+- **`< 0.0.4`:** in the `## Log format` block, broaden the operation enum to `{ingest|query|synthesis|lint|health|update|setup}`. In the forward→reverse contract table, rename row `R3_lint_report` to `R3_audit_report` and broaden its exemption text to cover both `[[lint-YYYY-MM-DD]]` and `[[health-YYYY-MM-DD]]` filenames (the `wiki-health` skill, added in v0.0.27, only writes a log line today; the `health-*` filename exemption is forward-compatible plumbing for a future health-report-as-page feature).
+
+The migration is idempotent and offline-safe. `wiki-lint`'s `reverse_link_missing` check works whether or not the SCHEMA section is present, and the new `health` log prefix is parsed by `wiki_status.sh` regardless of what SCHEMA.md says — the migration only ensures the contract is auditable when reading the wiki on its own.
 
 ### 5. Confirm to the user
 

--- a/cogni-wiki/skills/wiki-setup/references/SCHEMA.md.template
+++ b/cogni-wiki/skills/wiki-setup/references/SCHEMA.md.template
@@ -61,13 +61,13 @@ Wikilinks are bidirectional. Every forward `[[link]]` from page A to page B impl
 |---------|------------------------|---------------------------------|------------|
 | `R1_bidirectional_wikilink` | A's body contains `[[B]]` | B's body should contain `[[A]]` somewhere — typically as a one-line natural-language reference, not a dump | `backlink_audit.py` proposes; `wiki-lint reverse_link_missing` validates |
 | `R2_synthesis_wiki_source` | A is `type: synthesis` and lists `wiki://B` in `sources:` | **No reverse link required** — synthesis pages are leaves on the citation graph; forcing every cited page to link back would flood high-traffic concepts with synthesis backlinks | `wiki-lint synthesis_no_wiki_source` (forward direction only) |
-| `R3_lint_report` | Any page contains `[[lint-YYYY-MM-DD]]` | **No reverse link required** — lint reports are terminal, append-only, and never edited | n/a (lint reports are exempt from `reverse_link_missing`) |
+| `R3_audit_report` | Any page contains `[[lint-YYYY-MM-DD]]` or `[[health-YYYY-MM-DD]]` | **No reverse link required** — lint and health reports are terminal, append-only, and never edited | n/a (audit reports are exempt from `reverse_link_missing` on both ends) |
 
 Notes:
 
 - All current `type:` values (concept, entity, summary, decision, interview, meeting, learning, note) participate in `R1` symmetrically. There are no per-type asymmetries today; if per-type page directories land later (see the cogni-wiki Karpathy-pattern parity tracking issue), this table will gain per-relationship rows.
 - A backlink should read like prose, not a dumped list. The reverse `[[A]]` typically lives next to a sentence that earns its presence on B — see `wiki-update`'s diff-before-write discipline.
-- `R1` exempts pages whose filename starts with `lint-` (terminal lint reports) on both ends.
+- `R3` exempts pages whose filename starts with `lint-` or `health-` on both ends. As of v0.0.27, `wiki-health` only writes a log line and does not yet create `health-*.md` page files; the exemption is forward-compatible plumbing for a future health-report-as-page feature.
 - `wiki-lint reverse_link_missing` is a warning, not an error: it surfaces missing reverses but never auto-fixes them, mirroring the "lint reports, never auto-fixes" rule. Apply via `wiki-update` or, for fresh ingests, via `wiki-ingest`'s backlink-audit step.
 
 ## Log format
@@ -75,10 +75,10 @@ Notes:
 Append only. Format:
 
 ```
-## [YYYY-MM-DD] {ingest|query|lint|update|setup} | one-line note
+## [YYYY-MM-DD] {ingest|query|synthesis|lint|health|update|setup} | one-line note
 ```
 
-Never rewrite or reorder log entries.
+The `synthesis` prefix (v0.0.23+) marks filed-back query answers — distinct from un-filed `query` reads. The `health` prefix (v0.0.27+) marks zero-LLM structural pre-flights — distinct from tokenful `lint` runs. Both are surfaced separately by `wiki-resume` and `wiki-dashboard`. Never rewrite or reorder log entries.
 
 ## Index format
 


### PR DESCRIPTION
## Summary

Splits the cogni-wiki audit surface in two, mirroring the llm-wiki-agent "Health vs Lint Boundary" pattern. Closes #209 (Tier-1 sub-issue under tracking #212).

- **New `wiki-health` skill** — zero-LLM, every-session structural integrity preflight. `health.py` checks broken `[[wikilinks]]`, missing frontmatter, broken `../raw/` and `wiki://` sources, id mismatch, invalid type, stub pages (<50 chars), `entries_count` drift, `index.md` ↔ filesystem drift, and surfaces `claim_drift_count` from the latest resweep. Outputs `{success, data, error}` JSON. Logs `## [date] health | N errors, N warnings`.
- **Refocused `wiki-lint`** — now an LLM-powered semantic audit (contradictions, type drift, undercited claims, missing concept pages) plus the deterministic warnings that need narrative (orphans, stale dates, tag typos, reverse-link gaps, `claim_drift` severity). Calls `wiki-health` first as a free preflight; refuses to run while structural errors are pending (override `--ignore-health`). Token cost surfaced in the report.
- **`wiki-resume` runs health automatically** — `wiki_status.sh` now shells out to `health.py` and folds the result into a new `health` sub-object plus `health_count_30d` activity counter. Three new decision-tree rules fire on health findings ahead of any other recommendation; degrades gracefully if `health.py` fails.
- **SCHEMA contract caught up** — log-format enum broadens to `{ingest|query|synthesis|lint|health|update|setup}`; `R3_lint_report` → `R3_audit_report` exempting both `lint-*` and `health-*` filenames. `schema_version` bumps `"0.0.3"` → `"0.0.4"`; `wiki-resume` migration nudge updated with branched prose so wikis at any older schema get the right step-by-step.
- **Docs & manifest** — `severity-tiers.md` adds canonical Health vs Lint coverage matrix (23 checks with owner + LLM flag). `CLAUDE.md` and `README.md` reflect Skills 10 → 11 / Scripts 10 → 11. `plugin.json` 0.0.26 → 0.0.27 with `health` keyword.

Backward-compat preserved: `lint_wiki.py` was deliberately not modified, so `wiki-refresh` (which calls it directly for `stale_page` / `stale_draft` warnings) continues to work unchanged.

## Acceptance criteria from #209

- [x] New `cogni-wiki/skills/wiki-health/` with `SKILL.md`, `scripts/health.py`, `references/checks.md`
- [x] `wiki-lint/SKILL.md` updated: docstring, scope, when-to-run, refers to health for structural checks
- [x] `wiki-resume` runs health automatically and surfaces errors in the dashboard line
- [x] `wiki-health` adds `## [YYYY-MM-DD] health | ...` operation prefix to `log.md`
- [x] At least one semantic check in `wiki-lint` actually fires an LLM (contradiction scan, type drift, undercited claims, missing concept pages), with token cost surfaced in the report
- [x] `references/severity-tiers.md` documents which tiers belong to which skill (Health vs Lint coverage matrix at top)
- [x] `wiki-claims-resweep` integration: lint surfaces drift narrative; health surfaces drift count

## Test plan

- [ ] In a scratch wiki: `python3 cogni-wiki/skills/wiki-health/scripts/health.py --wiki-root <wiki-root>` returns `{success: true}` with `stats.errors / .warnings / .entries_count_drift / .claim_drift_count` populated; runs in under 1 s on a 100-page wiki
- [ ] `bash cogni-wiki/skills/wiki-resume/scripts/wiki_status.sh --wiki-root <wiki-root>` returns JSON containing the new `health: { available, errors, warnings, ... }` sub-object and `health_count_30d`
- [ ] `wiki-resume --skip-health` skips the dispatch and reports `health.available: false` without failing
- [ ] On a wiki with intentional broken `[[wikilink]]`: health flags it as `broken_wikilink` error; `wiki-lint` refuses to run the semantic pass without `--ignore-health`
- [ ] Set `schema_version: "0.0.3"` in `.cogni-wiki/config.json` and run `wiki-resume` — migration nudge fires for the v0.0.4 SCHEMA delta only (log-format + R3 broadening); set `null` and the nudge fires for both v0.0.3 and v0.0.4 deltas
- [ ] `wiki-refresh` smoke check: still parses `lint_wiki.py` output and finds `stale_page` / `stale_draft` warnings (constants in `refresh_planner.py` lines 68–70 unchanged)
- [ ] On a fresh `wiki-setup`: `.cogni-wiki/config.json` has `schema_version: "0.0.4"`; the copied `SCHEMA.md` includes `health` in the log enum and the `R3_audit_report` row

## Commits

- `1de0ce4` — wiki-health skill + lint SKILL.md refactor
- `46eb04c` — severity-tiers + wiki-resume SKILL + wiki_status.sh wiring
- `e4e86b8` — CLAUDE.md + plugin.json bump
- `116230f` — README.md
- `bf87e30` — SCHEMA contract caught up to v0.0.27 (post-audit completion)

Tracked under #212 (Karpathy-pattern parity scoreboard).

---
_Generated by [Claude Code](https://claude.ai/code/session_018jDapFxFRknUvvZ14XaiFQ)_