### PR TITLE
cogni-wiki: auto-rebuilt context_brief.md (v0.0.29, #219)

### DIFF
--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions are surfaced at ingest (not missed at retrieval), and knowledge compounds instead of starting from zero. Based on Andrej Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-wiki/CLAUDE.md
+++ b/cogni-wiki/CLAUDE.md
@@ -17,6 +17,7 @@ skills/                         11 wiki skills
       backlink_audit.py           Scans pages/, proposes bidirectional [[links]]
       wiki_index_update.py        Deterministic index.md insert/update (atomic)
       batch_builder.py            Enumerates candidates for --discover (orphans, stubs, glob, research:<slug>); emits batch JSON. Materialises per-sub-question synthesis files for research mode.
+      rebuild_context_brief.py    Rebuilds wiki/context_brief.md (≤8 KiB; auto-invoked by Step 8.5 of every dispatch as of v0.0.29)
     references/
       page-frontmatter.md         YAML schema (id, title, tags, type, sources, ...)
       ingest-workflow.md          Step-by-step ingest behavior
@@ -37,7 +38,7 @@ skills/                         11 wiki skills
   wiki-update/                    Diff-gated page revisions with stale-sweep
     references/
       update-discipline.md        Citation-required, diff-before-write rules
-  wiki-resume/                    Status dashboard — entry count, last-lint age, health snapshot, next action; runs wiki-health automatically (v0.0.27)
+  wiki-resume/                    Status dashboard — entry count, last-lint age, health snapshot, next action; runs wiki-health automatically (v0.0.27); reads wiki/context_brief.md first (v0.0.29)
     scripts/
       wiki_status.sh              Emits {success, data, error} JSON (incl. synthesis_count_30d, health_count_30d, embedded health.errors/warnings/drifts)
   wiki-dashboard/                 Self-contained HTML overview (pages, tags, backlink graph)
@@ -64,7 +65,7 @@ references/
 | Agents | 0 | — (wiki-ingest batch mode runs sequentially in the orchestrator's own context as of v0.0.22; the previous `ingest-worker` per-source subagent was removed because parallel fan-out broke the Karpathy-pattern invariant that source N+1 must see source N's page) |
 | Commands | 0 | — (skills serve as slash commands per plugin-dev guidance) |
 | Hooks | 0 | — (all bookkeeping lives inside skills) |
-| Scripts | 13 | backlink_audit.py, wiki_index_update.py, batch_builder.py, config_bump.py, _wikilib.py, convert_to_md.py, health.py, lint_wiki.py, wiki_status.sh, render_dashboard.py, refresh_planner.py, extract_page_claims.py, resweep_planner.py, migrate_layout.py |
+| Scripts | 14 | backlink_audit.py, wiki_index_update.py, batch_builder.py, config_bump.py, _wikilib.py, convert_to_md.py, rebuild_context_brief.py, health.py, lint_wiki.py, wiki_status.sh, render_dashboard.py, refresh_planner.py, extract_page_claims.py, resweep_planner.py, migrate_layout.py |
 
 ## Wiki Data Layout (outside the plugin)
 
@@ -79,6 +80,7 @@ Created by `wiki-setup` at the user-chosen root (default `cogni-wiki/{slug}/` re
 │   ├── index.md               LLM-maintained catalog, one-line summary per page
 │   ├── log.md                 Append-only operation log
 │   ├── overview.md            Evolving synthesis / "state of the wiki"
+│   ├── context_brief.md       ≤8 KiB auto-rebuilt "first read" for fresh sessions (v0.0.29)
 │   ├── concepts/              type: concept
 │   ├── entities/              type: entity
 │   ├── summaries/             type: summary
@@ -153,7 +155,9 @@ The advisory lock at `<wiki-root>/.cogni-wiki/.lock` is **retained as defence-in
 
 **Note for `wiki-health` (v0.0.27):** `health.py` is read-only against the per-type page dirs, `wiki/index.md`, and `.cogni-wiki/`. It writes nothing directly — the `## [YYYY-MM-DD] health | ...` log line is appended by the SKILL workflow via the same path every other operation log line uses, and `wiki/log.md` is treated as append-only (no read-modify-write), so it does not need a lock entry.
 
-**Lock helper consolidated (v0.0.28).** `_wiki_lock` lives in `skills/wiki-ingest/scripts/_wikilib.py` alongside the per-type-directory traversal helpers (`PAGE_TYPE_DIRS`, `iter_pages`, `build_slug_index`, `fail_if_pre_migration`). The previously duplicated copies in `backlink_audit.py`, `wiki_index_update.py`, and `config_bump.py` have been removed and replaced with `from _wikilib import _wiki_lock`. New shared-state writers MUST import from `_wikilib` rather than re-inline the lock context manager.
+**Note for `rebuild_context_brief.py` (v0.0.29):** the script writes `wiki/context_brief.md` (unique-by-construction; single writer) and runs `health.py` as a read-only subprocess. The atomic `tempfile + os.replace` write goes through `_wikilib.atomic_write`. Reads of `wiki/log.md`, `wiki/index.md`, and per-type page bodies are snapshot-only — no read-modify-write. **No new shared-state file** added to the table; concurrent `wiki-ingest` invocations from separate sessions are still serialised because every other Step 1–8 mutation goes through the existing locked scripts before Step 8.5 runs.
+
+**Lock helper consolidated (v0.0.28).** `_wiki_lock` lives in `skills/wiki-ingest/scripts/_wikilib.py` alongside the per-type-directory traversal helpers (`PAGE_TYPE_DIRS`, `iter_pages`, `build_slug_index`, `fail_if_pre_migration`). The previously duplicated copies in `backlink_audit.py`, `wiki_index_update.py`, and `config_bump.py` have been removed and replaced with `from _wikilib import _wiki_lock`. New shared-state writers MUST import from `_wikilib` rather than re-inline the lock context manager. As of v0.0.29, `_wikilib` also exports `atomic_write` and `emit_json` — extracted from the byte-for-byte-duplicated patterns in every wiki script. New writers consume them from `_wikilib`; existing inlines stay (lift-and-shift in a follow-up PR if desired).
 
 **Do NOT rely on:** `os.replace` atomicity alone (it guarantees atomic file replacement, not correctness of the read-modify-write), or Python's GIL (cross-process invocations from separate sessions are not protected by it). The `batch_size` config key referenced in `wiki-ingest` versions ≤0.0.21 is no longer read; legacy wikis with the key are harmless.
 
@@ -169,6 +173,7 @@ insight-wave already uses Claude Code's auto-memory system at `~/.claude/project
 - **wiki-claims-resweep citation re-verify** (v0.0.20, pull-mode only). The `wiki-claims-resweep` skill closes the *citation-drift* loop — existing wiki pages have their cited source URLs re-checked against current content. `extract_page_claims.py` walks every per-type page dir and yields one claim candidate per sentence containing an inline `[text](http(s)://...)` link or bare URL (deterministic, no LLM, no network). The orchestrator runs `resweep_planner.py --phase plan` to materialise per-page claim manifests under `<wiki-root>/raw/claims-resweep-<YYYY-MM-DD>/`, batch-confirms with the user, then dispatches `cogni-claims:claims` (`submit` then `verify`) sequentially per page. The cogni-claims source-cache (`cogni-claims/sources/{url-hash}.json`) keeps repeat WebFetches free across pages within one sweep. After verification, `resweep_planner.py --phase aggregate` writes `report.md` to the workspace and `last-resweep.json` (lock-wrapped) to `.cogni-wiki/`. **Report-only**: this skill never modifies any per-type page dir. Stale-marker decisions go through `wiki-update` manually. Circular sources (URLs pointing back into the wiki tree) are skipped per claim and counted, mirroring the `report_source ∈ {wiki, hybrid}` refusal pattern from `wiki-from-research`/`wiki-refresh`. As of v0.0.21, `wiki-lint` reads `last-resweep.json` and surfaces flagged pages via the `claim_drift` warning class plus a `last_resweep` info line; as of v0.0.27, `wiki-health` additionally exposes the *count* of flagged pages so it surfaces in `wiki-resume`'s status block without needing a tokenful lint run.
 - **wiki-health ↔ wiki-lint boundary** (v0.0.27, intra-plugin). The split formalises the llm-wiki-agent "Health vs Lint Boundary": `wiki-health` owns deterministic structural integrity (zero LLM, every session, sub-second on 100-page wikis); `wiki-lint` owns semantic content quality (LLM-powered, periodic, refuses to run while health is broken). `wiki-resume` invokes `health.py` automatically as part of its session-start status, so the user gets a structural preflight without thinking about it. The full per-check ownership matrix is in `skills/wiki-lint/references/severity-tiers.md`. The two skills share the `{success, data, error}` JSON contract and the same severity vocabulary so the lint report can include health's findings verbatim. **No new shared-state files** — `health.py` is read-only against the per-type page dirs, `wiki/index.md`, and `.cogni-wiki/`; the only side effect is the `## [YYYY-MM-DD] health | ...` log line, which is append-only and needs no lock.
 - **per-type page directories** (v0.0.28, intra-plugin, schema_version `0.0.5`). Pages are now stored under per-type subdirectories (`wiki/concepts/`, `wiki/decisions/`, `wiki/syntheses/`, …) instead of flat `wiki/pages/`. Audit reports (`lint-*.md`, `health-*.md`) live under `wiki/audits/`. The traversal contract is owned by `_wikilib.iter_pages()` / `build_slug_index()` so consumers no longer hard-code paths. Existing wikis must run `wiki-setup/scripts/migrate_layout.py --apply` once; every other skill hard-fails on the legacy flat layout via `_wikilib.fail_if_pre_migration`, and `wiki-resume`'s `wiki_status.sh` surfaces `schema_migration_pending: true` to nudge the user (without hard-failing — the resume path is exactly where the user reads the nudge from). `[[wikilink]]` syntax is unchanged — slugs remain globally unique and address pages without paths. Closes #212 Tier 2 item #1.
+- **context brief** (v0.0.29, intra-plugin). Every `wiki-ingest` dispatch ends with `rebuild_context_brief.py` (Step 8.5), which writes `wiki/context_brief.md` — a deterministic ≤ 8 KiB file summarising type counts, top entities by inbound backlinks, the last 30 days of activity, cached open lints (read from `.cogni-wiki/last_lint.json` if present and ≤ 24 h old), and a fresh `health.py` snapshot. `wiki-resume`'s Step 1 reads the brief before any other status work, so a fresh Claude Code session orients from one file instead of a 3+ file scan. Failure to rebuild the brief never rolls back the ingest — the brief is a derived artefact, regenerated on the next dispatch. The lint section degrades gracefully when no cache is present; the lint-cache writer hook is a deliberate follow-up. Closes #212 Tier 2 item #2 (#219).
 
 ## Future Integration Points
 

--- a/cogni-wiki/docs/plans/issue-219-context-brief.md
+++ b/cogni-wiki/docs/plans/issue-219-context-brief.md
@@ -1,0 +1,98 @@
+# Plan: cogni-wiki #219 — auto-rebuilt `wiki/context_brief.md`
+
+**Parent**: [#212](https://github.com/cogni-work/insight-wave/issues/212) Karpathy-pattern parity tracking issue.
+**Sub-issue**: [#219](https://github.com/cogni-work/insight-wave/issues/219).
+**Position**: next open Tier 2 item after the per-type-dirs work that landed in #218 (cogni-wiki v0.0.28).
+**Target version**: cogni-wiki v0.0.29.
+**Status**: PLAN ONLY — no code in this commit.
+
+---
+
+## 1. Goal
+
+A `≤8k`-char `wiki/context_brief.md`, rebuilt at the end of every `wiki-ingest` run, becomes the single "first read" for a new Claude Code session. Stdlib-only, deterministic, zero LLM tokens. Inspired by ΩmegaWiki's `tools/research_wiki.py rebuild-context-brief`.
+
+## 2. Brief contents (deterministic sections, in order)
+
+1. **Header** — schema-version stamp, generation timestamp, total page count.
+2. **Type counts** — one line per `_wikilib.PAGE_TYPE_DIRS` entry (e.g. `- concepts: 47`).
+3. **Top entities / concepts** — top N pages by inbound backlink count (cheap pass over `iter_pages` + body scan, or fall back to alphabetical if backlink data isn't precomputed).
+4. **Recent activity** — last 30 days of `wiki/log.md` lines, verbatim. Already nicely formatted by Step 7 of `wiki-ingest`: `## [YYYY-MM-DD] op | slug — title`.
+5. **Open lints (top)** — read `.cogni-wiki/last_lint.json` if recent (≤24h); else skip. Render `data.errors[:10]` + `data.warnings[:10]` as `class | page | message`.
+6. **Health snapshot** — invoke `health.py` once (cheap, zero-LLM): `errors`, `entries_count_drift`, `claim_drift_count`.
+7. **Truncation marker** — if anywhere we'd cross 8000 chars, hard-truncate the *recent activity* section first, append `…(truncated)`. Type counts and open lints are constant-bounded; never truncate those.
+
+## 3. Files to add / change
+
+| File | Action | Notes |
+|---|---|---|
+| `cogni-wiki/skills/wiki-ingest/scripts/rebuild_context_brief.py` | **NEW** | Stdlib-only. CLI: `--wiki-root <path>`. Emits `{success, data: {path, bytes, sections}, error}` JSON on stdout. Atomic write via `tempfile.NamedTemporaryFile` + `os.replace`. **No `_wiki_lock` needed for the write** — `context_brief.md` has a single writer (this script). Acquire the lock only for the *read snapshot* of `index.md`/`log.md`/page bodies, drop it before writing. |
+| `cogni-wiki/skills/wiki-ingest/scripts/_wikilib.py` | extend | Add `def atomic_write(path: Path, text: str) -> None` and `def emit_json(success, data=None, error=None) -> None`. Both are duplicated inline across scripts today; extracting them now keeps `rebuild_context_brief.py` tiny. Keep additive — do not refactor existing inlines in this PR. |
+| `cogni-wiki/skills/wiki-ingest/SKILL.md` | edit | Insert a new step between current Step 8 (`config_bump`) and Step 9 (`report`): `Step 8.5 — rebuild context brief`. Run **once per dispatch** (after the source loop), not per source. A failure here must NOT roll back the ingest — log to `log.md` and continue to Step 9. |
+| `cogni-wiki/skills/wiki-resume/SKILL.md` | edit | Insert pre-Step-1 instruction: "Step 0: read `<wiki-root>/wiki/context_brief.md` if present before status collection." Update prose template (lines ~75–115) to summarise from the brief when available. Bump the "As of v0.0.27..." line to v0.0.29. |
+| `cogni-wiki/CLAUDE.md` | edit | Add a "v0.0.29 — context brief" subsection alongside existing version notes. |
+| `cogni-wiki/.claude-plugin/plugin.json` | edit | `0.0.28` → `0.0.29`. |
+| `cogni-wiki/tests/test_context_brief.sh` | **NEW** | Bash smoke modeled on `test_migrate_and_smoke.sh`. Assert: file exists post-ingest, `wc -c` ≤ 8192, contains expected section headers, `head -1` matches schema-version stamp, missing-file fallback in `wiki-resume` works. |
+
+## 4. Out of scope
+
+- No standalone `wiki-context-brief` skill. Manual rebuild hook is `wiki-ingest --rebuild-context-brief` (no other args) — defer until someone asks.
+- No schema-version bump. Brief is additive; missing → `wiki-resume` falls back. `_wikilib.SCHEMA_VERSION_PER_TYPE_DIRS` stays at `0.0.5`.
+- No LLM rewriting of the brief. The whole point is determinism + zero token cost.
+- No new wiki-root `CLAUDE.md.template` for seeded wikis. (None exists today; `wiki-setup/references/` only has `SCHEMA.md.template` + `directory-layout.md`. Session-start nudge therefore lives entirely in `wiki-resume/SKILL.md`.)
+
+## 5. Risks & decisions
+
+### Lint cost on every ingest
+Lint is currently the heaviest tokenful operation. Two options:
+- **(a)** run `lint_wiki.py` inline at every ingest — simple, but slows every ingest noticeably and burns tokens.
+- **(b)** read `.cogni-wiki/last_lint.json` if recent enough (e.g. ≤24h); else skip the open-lints section. `wiki-refresh` is the right place to refresh the lint cache.
+
+**Recommendation: (b).** Keeps ingest fast, brief still useful. Section header reads `## Open lints (cached YYYY-MM-DD)` or `## Open lints (stale — run wiki-refresh)`. **Confirm before coding.**
+
+### 8k cap policy
+Truncate "recent activity" section first (longest, least essential). Never truncate type counts or open lints — both constant-bounded. Hard cap, not soft cap (per the issue's explicit guidance against soft caps that defeat the purpose).
+
+### Concurrency
+`context_brief.md` has one writer (this script) — no inter-skill contention. But mid-rebuild a concurrent skill could be writing `log.md` or `index.md`. Acquire `_wiki_lock` for the read-snapshot phase, drop, then write. Cheaper than holding the lock through subprocess calls to `health.py`.
+
+### Failure isolation
+Brief rebuild failures must not roll back the ingest. Catch all exceptions in the Step 8.5 invocation; log a one-liner to `wiki/log.md` (`## [YYYY-MM-DD] context-brief | rebuild failed: <reason>`); continue to Step 9 report.
+
+## 6. Acceptance
+
+- After `wiki-ingest`, `wiki/context_brief.md` exists, ≤ 8192 bytes, reflects current state.
+- A fresh session can answer "what's in this wiki" from the brief alone.
+- Brief absent ⇒ `wiki-resume` degrades cleanly to current behaviour.
+- New bash test in `cogni-wiki/tests/` asserts presence + size + schema header + fallback path.
+- Plugin version bumped to `0.0.29`; `cogni-wiki/CLAUDE.md` has a v0.0.29 entry.
+
+## 7. Suggested PR shape
+
+Single PR titled `cogni-wiki: auto-rebuilt context_brief.md (#219)`, scoped to:
+
+1. New `rebuild_context_brief.py` + helpers in `_wikilib.py` (additive only).
+2. SKILL.md edits to `wiki-ingest` (new Step 8.5) and `wiki-resume` (new Step 0).
+3. `plugin.json` 0.0.28 → 0.0.29 and `CLAUDE.md` version note.
+4. New bash test + tiny fixture extension if needed.
+
+## 8. Open questions to resolve before coding
+
+1. **Lint inline vs cached**: confirm Option (b) above (cached `.cogni-wiki/last_lint.json` with staleness marker). Default to (b) absent objection.
+2. **Top-N count for entities/concepts**: 10? 20? Suggest 10 to keep tail headroom under 8k.
+3. **Recent-activity window**: issue says "~30 days". Make it a constant `RECENT_DAYS = 30` at top of script for easy tuning. No CLI flag.
+4. **`open_questions.md` (Tier 2 sibling, #220)**: issue calls out picking a consistent pattern. Defer that decision to #220's PR — both files are auto-derived at end-of-ingest, both unlocked single-writer; the patterns will line up naturally.
+
+## 9. References
+
+- Parent tracker: cogni-work/insight-wave#212.
+- Sub-issue: cogni-work/insight-wave#219.
+- Survey anchors:
+  - `cogni-wiki/.claude-plugin/plugin.json` (line 3 — version bump site).
+  - `cogni-wiki/skills/wiki-ingest/SKILL.md` (Steps 0–9; insertion site is between current 8 and 9).
+  - `cogni-wiki/skills/wiki-ingest/scripts/_wikilib.py` (lines 38, 63, 175, 195 — `PAGE_TYPE_DIRS`, `_wiki_lock`, `iter_pages`, `build_slug_index`).
+  - `cogni-wiki/skills/wiki-lint/scripts/lint_wiki.py` (subprocess source; JSON contract `{success, data: {errors, warnings, info, stats}, error}`).
+  - `cogni-wiki/skills/wiki-health/scripts/health.py` (subprocess source; already invoked by `wiki-resume/scripts/wiki_status.sh` — proven pattern).
+  - `cogni-wiki/skills/wiki-resume/SKILL.md` (Step 1 around line 50; Golden Rules ~145).
+  - `cogni-wiki/tests/test_migrate_and_smoke.sh` + `cogni-wiki/tests/fixtures/legacy-wiki/` (test pattern + fixture).
+- Inspiration: ΩmegaWiki `tools/research_wiki.py rebuild-context-brief`.

--- a/cogni-wiki/skills/wiki-ingest/SKILL.md
+++ b/cogni-wiki/skills/wiki-ingest/SKILL.md
@@ -48,7 +48,7 @@ Exactly one of `--source`, `--batch-file`, or `--discover` must be provided.
 
 The three input modes are mutually exclusive. Pick the one that matches the caller's inputs and follow the corresponding rule; everything from Step 1 onwards is identical across modes.
 
-**Sequential by design.** Batch and discovery modes execute Steps 1–8 as a strict sequential loop in the orchestrator's own context — one source at a time, in input order, with every page write, index update, backlink apply, log line, and config bump committed to disk before the next iteration begins. This is load-bearing: source N+1's Step 3 ("which existing pages does this source touch") and Step 6 (backlink audit) must see the page that source N just created, otherwise the wiki fragments instead of compounds. See `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/batch-mode.md` §"Execution model" for the rationale and the history of why an earlier per-source subagent fan-out was removed.
+**Sequential by design.** Batch and discovery modes execute Steps 1–8 as a strict sequential loop in the orchestrator's own context — one source at a time, in input order, with every page write, index update, backlink apply, log line, and config bump committed to disk before the next iteration begins. This is load-bearing: source N+1's Step 3 ("which existing pages does this source touch") and Step 6 (backlink audit) must see the page that source N just created, otherwise the wiki fragments instead of compounds. See `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/batch-mode.md` §"Execution model" for the rationale and the history of why an earlier per-source subagent fan-out was removed. Step 8.5 (context brief rebuild, v0.0.29+) runs **once per dispatch** after the loop completes, not per source.
 
 **Backlink-curation decision (once, at dispatch).** Resolve `auto_backlinks` before any Step 1 work so every iteration applies the same rule:
 
@@ -83,7 +83,7 @@ Slug collisions in discovery mode are already handled by Step 1's `mode: fresh |
 - Otherwise, execute `sources[]` as a **strict sequential loop**. For each `source_entry` in input order, run Steps 1–8 inline in this orchestrator's context (read source → Step 3 takeaway synthesis → write page → update index → backlink audit + apply → log → config bump), passing `auto_backlinks` resolved above into Step 6. Only after all per-source scripts have returned and their writes committed do you advance to the next entry.
 - **Fail-fast.** If any iteration's step (1–8) fails, halt the loop immediately. Sources processed before the failure are atomically consistent on disk (per-page writes use `tempfile + os.replace`; shared-state writes go through the locked scripts). Record the failed entry's error and the list of un-attempted entries for the Step 9 report.
 - **Step 3 in batch mode.** Surface the takeaway synthesis to the user transcript exactly as in single-source mode. Batch mode is autonomous-run by construction (the user said "ingest all of them"), so emit the synthesis and proceed to Step 4 without waiting for confirmation — the discipline is "synthesis is visible", not "the user must approve every page".
-- In Step 9, emit one aggregated report covering every entry that completed, the entry that failed (if any), and any entries skipped by the fail-fast halt.
+- Once the loop completes (or fail-fast halts it), run Step 8.5 once for the dispatch, then emit the aggregated Step 9 report.
 
 **If neither `--batch-file` nor `--discover` is present**, run Steps 1–9 on the single `--source`. This is the existing path; nothing about it changes.
 
@@ -317,14 +317,29 @@ Never rewrite existing log lines.
 
 If `config_bump.py` exits non-zero or returns malformed JSON, report the error but do not abort — the page, index, backlinks, and log are already consistent on disk. The script is idempotent-safe to re-run with a compensating `--delta` to reconcile drift.
 
+### 8.5. Rebuild `wiki/context_brief.md` (v0.0.29+)
+
+Run **once per dispatch**, after the per-source loop has completed (single-source mode: after Step 8 of the only source; batch / discovery mode: after the last entry's Step 8 has committed). The brief is the canonical "first read" for a fresh Claude Code session — it summarises the wiki's current shape (type counts, top entities by inbound backlinks, last 30 days of activity, cached open lints, fresh `health.py` snapshot) in ≤ 8 KiB so a new session can orient without opening `index.md`, every per-type page directory, and `log.md`.
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/rebuild_context_brief.py --wiki-root <wiki-root>
+```
+
+The script is read-only against pages, runs `health.py` once internally, and atomically replaces `wiki/context_brief.md` via `tempfile + os.replace` (through `_wikilib.atomic_write`). No lock is needed — the brief has a single writer, and reads are snapshot-only. A hard 8000-byte cap is enforced; if the assembled body exceeds it, the script truncates the "recent activity" section first (constant-bounded sections like type counts, top entities, lints, and health are never truncated).
+
+**Failure isolation.** A non-zero exit or malformed JSON from `rebuild_context_brief.py` MUST NOT roll back the ingest. The page write, index update, backlinks, log line, and `entries_count` bump from Steps 4–8 are already on disk. Surface the error to the user as part of the Step 9 report and continue — the brief is a derived artefact that the next ingest will rebuild.
+
+**Out of scope, deliberately.** The "Open lints" section reads `.cogni-wiki/last_lint.json` if present and ≤ 24 h old; otherwise it renders an inline "not yet cached" note. This step does not invoke `lint_wiki.py` — keeping the ingest path token-free is the entire point of the brief. The lint-cache writer hook (so a `wiki-lint` run populates `last_lint.json`) is a deliberate follow-up; until it lands, the lints section degrades gracefully and the rest of the brief is unaffected.
+
 ### 9. Report to the user
 
 **Single-source mode.** Tell the user, in ≤5 sentences:
 - The new page slug and path
 - How many existing pages got backlinks
+- Whether the context brief was rebuilt cleanly (one line: "context_brief.md: {bytes}B" or the failure mode)
 - What to do next (usually: drop another source or run `wiki-query`)
 
-**Batch mode.** Emit one aggregated block instead of a per-source report. For every entry that reached this step, print the slug, its resolved mode (`fresh` or `re-ingest`), and its backlink count. Report `entries_count` delta (fresh sources only; re-ingests never increment). On a fail-fast halt, also list the source that failed with its error and any sources that were skipped. See `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/batch-mode.md` §"Step 9 in batch mode" for the exact format.
+**Batch mode.** Emit one aggregated block instead of a per-source report. For every entry that reached this step, print the slug, its resolved mode (`fresh` or `re-ingest`), and its backlink count. Report `entries_count` delta (fresh sources only; re-ingests never increment) and the Step 8.5 brief-rebuild result. On a fail-fast halt, also list the source that failed with its error and any sources that were skipped. See `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/batch-mode.md` §"Step 9 in batch mode" for the exact format.
 
 ## Output
 
@@ -333,6 +348,7 @@ If `config_bump.py` exits non-zero or returns malformed JSON, report the error b
 - N existing pages (across the per-type dirs under `wiki/`) edited with new backlinks (where N ≥ 0)
 - One appended line in `wiki/log.md`
 - Updated `config.json`
+- `wiki/context_brief.md` rebuilt once per dispatch (≤ 8 KiB; deterministic; never blocks the ingest on failure) — v0.0.29+
 - Optionally, one `<source>.converted.md` cache file in `raw/` next to a non-markdown source (Step 2a). Re-used on idempotent re-ingest; safe to delete to force re-conversion.
 
 ## Failure modes and rules
@@ -342,6 +358,7 @@ If `config_bump.py` exits non-zero or returns malformed JSON, report the error b
 - **Never overwrite a page silently.** Overwrites are only allowed through the explicit re-ingest path: Step 1 must detect the existing slug, set `mode: re-ingest`, and emit the re-ingest warning before any page write. Silent overwrites (writing to an existing slug without surfacing `mode: re-ingest` to the user) remain forbidden. For content-only edits that preserve the existing synthesis, use `wiki-update` rather than a re-ingest.
 - **Raw first, page second.** Pasted content is persisted to `raw/` before any page work begins.
 - **Original source is the citation, not the cache.** When Step 2a writes a `.converted.md`, frontmatter `sources:` still points at the original. The cache is a derived artefact — re-ingest may rebuild it; nothing in the wiki should depend on its path.
+- **Brief failures never roll back the ingest.** Step 8.5 is fail-soft by contract — the rest of the dispatch is committed before it runs.
 
 ## References
 
@@ -354,3 +371,4 @@ If `config_bump.py` exits non-zero or returns malformed JSON, report the error b
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/wiki_index_update.py` — deterministic `wiki/index.md` insert/update helper
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/batch_builder.py` — discovery helper; enumerates candidates for `--discover` and emits the batch-mode payload on stdout
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/convert_to_md.py` — multi-format auto-conversion helper used by Step 2a (`.docx`, `.pptx`, `.xlsx`, `.html`, `.epub`, …); stdlib-first with optional `markitdown` shell-out
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/rebuild_context_brief.py` — Step 8.5: writes `wiki/context_brief.md` (≤ 8 KiB; auto-rebuilt once per dispatch as of v0.0.29)

--- a/cogni-wiki/skills/wiki-ingest/scripts/_wikilib.py
+++ b/cogni-wiki/skills/wiki-ingest/scripts/_wikilib.py
@@ -26,6 +26,7 @@ import json
 import os
 import re
 import sys
+import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -208,3 +209,49 @@ def build_slug_index(wiki_root: Path, include_audit: bool = False) -> dict:
     100-page wikis (matches health.py's performance contract).
     """
     return {slug: (path, ptype) for slug, path, ptype in iter_pages(wiki_root, include_audit=include_audit)}
+
+
+# ---------------------------------------------------------------------------
+# v0.0.29 additions: shared write + JSON-emit helpers.
+#
+# These two patterns were inlined byte-for-byte in every script under
+# `cogni-wiki/skills/*/scripts/`. New writers (starting with
+# rebuild_context_brief.py for #219) consume them from here so the contract
+# is owned in exactly one place. Existing inlines are NOT refactored in
+# v0.0.29 — keep the diff additive; lift them in a follow-up PR if desired.
+# ---------------------------------------------------------------------------
+
+
+def atomic_write(path: Path, text: str) -> None:
+    """Atomically replace `path` with `text` (UTF-8).
+
+    Same `tempfile + os.replace` pattern used inline by every other writer in
+    the plugin (e.g. `wiki_index_update.py::update_index`). Creates parent
+    dirs as needed. A crash mid-write leaves either the previous content or
+    the new content on disk — never a partial write. The temp file lives in
+    the same directory as the target so `os.replace` cannot cross devices.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def emit_json(success: bool, data=None, error: str = "") -> None:
+    """Print the standard `{success, data, error}` JSON line on stdout.
+
+    Every wiki script inlines a near-identical helper today (see
+    `lint_wiki.py` `ok()`/`fail()`). Extracted here so new scripts can
+    `from _wikilib import emit_json` instead of re-deriving the contract.
+    """
+    print(json.dumps({"success": bool(success), "data": data or {}, "error": error or ""}))

--- a/cogni-wiki/skills/wiki-ingest/scripts/rebuild_context_brief.py
+++ b/cogni-wiki/skills/wiki-ingest/scripts/rebuild_context_brief.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""
+rebuild_context_brief.py — emit `wiki/context_brief.md`, the canonical
+"first read" for a fresh Claude Code session.
+
+Auto-invoked by Step 8.5 of `wiki-ingest` once per dispatch (after the
+per-source loop). Stdlib-only. `{success, data, error}` JSON on stdout.
+
+Sections, in order:
+
+  1. Header             — wiki name, schema version, generated timestamp,
+                          total page count.
+  2. Type counts        — one line per `_wikilib.PAGE_TYPE_DIRS` entry.
+  3. Top entities       — top 10 by inbound `[[backlink]]` count.
+  4. Recent activity    — last 30 days of `wiki/log.md`, verbatim.
+  5. Open lints (cached)— from `.cogni-wiki/last_lint.json` if present
+                          and ≤ 24 h old; degrades gracefully otherwise.
+  6. Health snapshot    — invokes `health.py` once (zero-LLM, sub-second).
+
+A hard 8000-byte cap is enforced. If the assembled body exceeds it, the
+recent-activity section is truncated first (it is the only section that
+grows unboundedly with wiki age); type counts, entities, lints, and
+health are constant-bounded and never truncated.
+
+Failure isolation: a non-zero exit or unparseable JSON from this script
+must never roll back the ingest. The brief is a derived artefact — the
+next ingest will rebuild it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# `_wikilib` lives in this same directory.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _wikilib import (  # noqa: E402
+    PAGE_TYPE_DIRS,
+    atomic_write,
+    build_slug_index,
+    emit_json,
+    fail_if_pre_migration,
+)
+
+
+CONTEXT_BRIEF_PATH = "wiki/context_brief.md"
+HARD_CAP_BYTES = 8000
+RECENT_DAYS = 30
+TOP_N_ENTITIES = 10
+LINT_CACHE_TTL_HOURS = 24
+
+WIKILINK_RE = re.compile(r"\[\[([a-zA-Z0-9][a-zA-Z0-9._-]*)\]\]")
+LOG_DATE_RE = re.compile(r"^## \[(\d{4}-\d{2}-\d{2})\]")
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _today() -> datetime.date:
+    return datetime.datetime.now(datetime.timezone.utc).date()
+
+
+def _section_header(title: str) -> str:
+    return f"## {title}\n\n"
+
+
+def _build_header(wiki_root: Path, total_pages: int) -> str:
+    cfg_path = wiki_root / ".cogni-wiki" / "config.json"
+    name = "(unknown)"
+    schema_version = "(unknown)"
+    try:
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+        name = cfg.get("name") or name
+        schema_version = cfg.get("schema_version") or schema_version
+    except (OSError, json.JSONDecodeError):
+        pass
+    return (
+        f"# Context brief — {name}\n\n"
+        f"_Generated_: {_now_iso()}  \n"
+        f"_Schema_: {schema_version}  \n"
+        f"_Total pages_: {total_pages}\n\n"
+        "This file is auto-rebuilt by `wiki-ingest`. Read this first; "
+        "the rest of the wiki is a delta on top of what's here.\n\n"
+    )
+
+
+def _build_type_counts(slug_index: dict) -> str:
+    counts = {ptype: 0 for ptype in PAGE_TYPE_DIRS}
+    for _slug, (_path, ptype) in slug_index.items():
+        if ptype in counts:
+            counts[ptype] += 1
+    out = [_section_header("Type counts")]
+    for ptype in PAGE_TYPE_DIRS:
+        out.append(f"- {PAGE_TYPE_DIRS[ptype]}: {counts[ptype]}\n")
+    out.append("\n")
+    return "".join(out)
+
+
+def _build_top_entities(slug_index: dict, top_n: int) -> str:
+    """Top N pages by inbound [[wikilink]] count.
+
+    One linear pass over each page's body. O(pages × avg-page-length);
+    sub-second on 100-page wikis per the health.py performance contract.
+    """
+    inbound = {slug: 0 for slug in slug_index}
+    for _slug, (path, _ptype) in slug_index.items():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for m in WIKILINK_RE.finditer(text):
+            target = m.group(1)
+            if target in inbound:
+                inbound[target] += 1
+
+    ranked = sorted(
+        ((slug, n) for slug, n in inbound.items() if n > 0),
+        key=lambda kv: (-kv[1], kv[0]),
+    )[:top_n]
+
+    out = [_section_header(f"Top entities (by inbound backlinks, top {top_n})")]
+    if not ranked:
+        out.append("_No backlinks yet — wiki may be young or hand-edited._\n\n")
+        return "".join(out)
+    for slug, n in ranked:
+        out.append(f"- [[{slug}]] — {n} inbound\n")
+    out.append("\n")
+    return "".join(out)
+
+
+def _read_recent_log(wiki_root: Path, days: int) -> list:
+    """Lines of wiki/log.md whose ISO-date prefix is within the last `days`."""
+    log_path = wiki_root / "wiki" / "log.md"
+    if not log_path.is_file():
+        return []
+    cutoff = _today() - datetime.timedelta(days=days)
+    keep = []
+    try:
+        for line in log_path.read_text(encoding="utf-8").splitlines():
+            m = LOG_DATE_RE.match(line)
+            if not m:
+                continue
+            try:
+                d = datetime.date.fromisoformat(m.group(1))
+            except ValueError:
+                continue
+            if d >= cutoff:
+                keep.append(line)
+    except OSError:
+        return []
+    return keep
+
+
+def _build_recent_activity(lines: list, days: int) -> str:
+    out = [_section_header(f"Recent activity (last {days} days)")]
+    if not lines:
+        out.append("_No activity._\n\n")
+        return "".join(out)
+    for line in lines:
+        out.append(line + "\n")
+    out.append("\n")
+    return "".join(out)
+
+
+def _build_open_lints(wiki_root: Path) -> str:
+    """Read `.cogni-wiki/last_lint.json` if present and ≤ TTL; else skip note.
+
+    This skill never invokes `lint_wiki.py` itself — keeping the ingest
+    path token-free is the entire point. The cache write hook is a
+    follow-up; until then the section degrades to an inline note.
+    """
+    cache_path = wiki_root / ".cogni-wiki" / "last_lint.json"
+    out = [_section_header("Open lints (cached)")]
+    if not cache_path.is_file():
+        out.append(
+            "_No cached lint result — run `/cogni-wiki:wiki-lint` to populate._\n\n"
+        )
+        return "".join(out)
+    try:
+        mtime = datetime.datetime.fromtimestamp(
+            cache_path.stat().st_mtime, datetime.timezone.utc
+        )
+        age_hours = (datetime.datetime.now(datetime.timezone.utc) - mtime).total_seconds() / 3600.0
+    except OSError:
+        out.append("_Cached lint mtime unreadable._\n\n")
+        return "".join(out)
+    if age_hours > LINT_CACHE_TTL_HOURS:
+        out.append(
+            f"_Cached lint is stale ({age_hours:.0f}h old) — run `/cogni-wiki:wiki-lint`._\n\n"
+        )
+        return "".join(out)
+    try:
+        cache = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        out.append("_Cached lint unreadable._\n\n")
+        return "".join(out)
+    data = cache.get("data") or {}
+    errors = data.get("errors") or []
+    warnings = data.get("warnings") or []
+    if not errors and not warnings:
+        out.append(f"_Clean (cached {age_hours:.0f}h ago)._\n\n")
+        return "".join(out)
+    for ent in errors[:10]:
+        out.append(
+            f"- ERROR | {ent.get('class', '?')} | {ent.get('page', '?')} | {ent.get('message', '')}\n"
+        )
+    for ent in warnings[:10]:
+        out.append(
+            f"- WARN  | {ent.get('class', '?')} | {ent.get('page', '?')} | {ent.get('message', '')}\n"
+        )
+    out.append("\n")
+    return "".join(out)
+
+
+def _build_health_snapshot(wiki_root: Path) -> str:
+    out = [_section_header("Health snapshot")]
+    health_script = (
+        Path(__file__).resolve().parents[2] / "wiki-health" / "scripts" / "health.py"
+    )
+    if not health_script.is_file():
+        out.append("_health.py not found._\n\n")
+        return "".join(out)
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(health_script), "--wiki-root", str(wiki_root)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        out.append(f"_health invocation failed: {exc}._\n\n")
+        return "".join(out)
+    if not proc.stdout:
+        out.append("_health emitted no JSON._\n\n")
+        return "".join(out)
+    try:
+        # health.py emits one JSON line on stdout; take the last non-empty line.
+        last_line = [ln for ln in proc.stdout.splitlines() if ln.strip()][-1]
+        payload = json.loads(last_line)
+    except (json.JSONDecodeError, IndexError):
+        out.append("_health JSON unparseable._\n\n")
+        return "".join(out)
+    if not payload.get("success"):
+        out.append(f"_health failed: {payload.get('error', '')}._\n\n")
+        return "".join(out)
+    stats = (payload.get("data") or {}).get("stats") or {}
+    out.append(
+        f"- errors: {stats.get('errors', 0)}\n"
+        f"- warnings: {stats.get('warnings', 0)}\n"
+        f"- entries_count_drift: {stats.get('entries_count_drift', 0)}\n"
+        f"- claim_drift_count: {stats.get('claim_drift_count', 0)}\n\n"
+    )
+    return "".join(out)
+
+
+def _truncate_to_cap(sections: dict, recent_key: str, cap: int):
+    """Assemble sections in canonical order; truncate `recent_key` first if over cap."""
+    order = ["header", "type_counts", "top_entities", "recent", "lints", "health"]
+    body = "".join(sections[k] for k in order)
+    if len(body.encode("utf-8")) <= cap:
+        return body, False
+
+    # Drop trailing lines from `recent` until we fit, then append a marker.
+    head, _, _tail = sections[recent_key].partition("\n\n")
+    lines = head.splitlines(keepends=True)
+    while lines:
+        lines.pop()
+        sections[recent_key] = "".join(lines) + "\n…(truncated)\n\n"
+        body = "".join(sections[k] for k in order)
+        if len(body.encode("utf-8")) <= cap:
+            return body, True
+    # Even with `recent` empty we're over: fall back to header alone.
+    return sections["header"] + "…(truncated; even minimal sections exceed cap)\n", True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Rebuild wiki/context_brief.md (cogni-wiki #219)."
+    )
+    parser.add_argument("--wiki-root", required=True)
+    args = parser.parse_args()
+
+    wiki_root = Path(args.wiki_root).resolve()
+    if not (wiki_root / ".cogni-wiki" / "config.json").is_file():
+        emit_json(False, error=f"not a wiki root: {wiki_root}")
+        return 1
+
+    fail_if_pre_migration(wiki_root)
+
+    slug_index = build_slug_index(wiki_root, include_audit=False)
+
+    sections = {
+        "header": _build_header(wiki_root, len(slug_index)),
+        "type_counts": _build_type_counts(slug_index),
+        "top_entities": _build_top_entities(slug_index, TOP_N_ENTITIES),
+        "recent": _build_recent_activity(_read_recent_log(wiki_root, RECENT_DAYS), RECENT_DAYS),
+        "lints": _build_open_lints(wiki_root),
+        "health": _build_health_snapshot(wiki_root),
+    }
+
+    body, truncated = _truncate_to_cap(sections, "recent", HARD_CAP_BYTES)
+    out_path = wiki_root / CONTEXT_BRIEF_PATH
+    try:
+        atomic_write(out_path, body)
+    except OSError as exc:
+        emit_json(False, error=f"atomic_write failed: {exc}")
+        return 1
+
+    emit_json(
+        True,
+        data={
+            "path": str(out_path.relative_to(wiki_root)),
+            "bytes": len(body.encode("utf-8")),
+            "truncated": truncated,
+            "sections": list(sections.keys()),
+            "total_pages": len(slug_index),
+        },
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cogni-wiki/skills/wiki-resume/SKILL.md
+++ b/cogni-wiki/skills/wiki-resume/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Bash, Glob
 
 # Wiki Resume
 
-Give the user a fast, grounded status view of their wiki so they know what's inside and what the right next action is. As of v0.0.27, resume also runs `wiki-health` automatically as part of every status call — a free, zero-LLM structural pre-flight that surfaces broken wikilinks, missing frontmatter, and other mechanical issues without the user having to think about it. No writing to wiki pages — this skill is read-only against the wiki itself; it only logs the health invocation it dispatches.
+Give the user a fast, grounded status view of their wiki so they know what's inside and what the right next action is. As of v0.0.27, resume also runs `wiki-health` automatically as part of every status call — a free, zero-LLM structural pre-flight that surfaces broken wikilinks, missing frontmatter, and other mechanical issues without the user having to think about it. As of v0.0.29, resume also reads `wiki/context_brief.md` (auto-rebuilt by `wiki-ingest`) before any other status work, so a fresh session orients from one ≤ 8 KiB file instead of a 3+ file scan. No writing to wiki pages — this skill is read-only against the wiki itself; it only logs the health invocation it dispatches.
 
 Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once for new sessions.
 
@@ -31,9 +31,11 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once for new session
 
 ## Workflow
 
-### 1. Locate the wiki
+### 1. Locate the wiki, then read the context brief
 
 Walk upward to find `.cogni-wiki/config.json`. If none, stop and offer `wiki-setup`.
+
+Once the wiki root is resolved, **read `<wiki-root>/wiki/context_brief.md` first if it exists** (v0.0.29+). The brief is the canonical "first read" for a session — auto-rebuilt at the end of every `wiki-ingest` dispatch by `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/rebuild_context_brief.py`, it summarises type counts, top entities by inbound backlinks, the last 30 days of activity, cached open lints, and a fresh `health.py` snapshot in ≤ 8 KiB. With it, the rest of this skill's status block reads as a delta on top of what's already known instead of starting from cold. If the brief is absent (older wikis pre-v0.0.29, wikis where `wiki-ingest` has never run, or wikis where the rebuild failed), skip silently and proceed to Step 2 — every section of the eventual status view still works without it.
 
 ### 2. Run the status script (which now also runs wiki-health)
 
@@ -119,7 +121,7 @@ Rules 1–3 are new in v0.0.27 — they fire on the freshly-collected health sna
 
 ### 5. Side effects
 
-This skill is read-only against `wiki/<type>/` and `.cogni-wiki/config.json` — it never edits them. The one side effect introduced in v0.0.27 is that the dispatched `wiki-health` invocation appends a `## [YYYY-MM-DD] health | N errors, N warnings` line to `wiki/log.md`. That's intentional: every health pre-flight should be on the audit trail, and resume is the canonical session-start trigger. Use `--skip-health` if you genuinely want zero side effects.
+This skill is read-only against `wiki/<type>/` and `.cogni-wiki/config.json` — it never edits them. The one side effect introduced in v0.0.27 is that the dispatched `wiki-health` invocation appends a `## [YYYY-MM-DD] health | N errors, N warnings` line to `wiki/log.md`. That's intentional: every health pre-flight should be on the audit trail, and resume is the canonical session-start trigger. Use `--skip-health` if you genuinely want zero side effects. The v0.0.29 context-brief read in Step 1 introduces no new side effects — it is a plain `Read` of `wiki/context_brief.md`.
 
 ## Output
 
@@ -132,6 +134,7 @@ This skill is read-only against `wiki/<type>/` and `.cogni-wiki/config.json` —
 2. **Health is automatic.** The user shouldn't have to remember to preflight — resume does it for them.
 3. **Always recommend an action.** The user should leave this skill knowing what to do next.
 4. **Ground the numbers in the filesystem**, not in cached config values — the script counts files directly so a stale `entries_count` in `config.json` doesn't mislead.
+5. **Read the brief before running the script** (v0.0.29+). The status script's output is the delta on top of `context_brief.md`, not a from-scratch summary.
 
 ## References
 
@@ -139,3 +142,4 @@ This skill is read-only against `wiki/<type>/` and `.cogni-wiki/config.json` —
 - `./scripts/wiki_status.sh` — the status collector (now also dispatches health.py)
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-health/SKILL.md` — the structural pre-flight skill
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-health/scripts/health.py` — the deterministic check engine
+- `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/scripts/rebuild_context_brief.py` — produces `wiki/context_brief.md` (v0.0.29+) at the end of every ingest dispatch

--- a/cogni-wiki/tests/test_context_brief.sh
+++ b/cogni-wiki/tests/test_context_brief.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# test_context_brief.sh — smoke test for rebuild_context_brief.py (#219, v0.0.29).
+#
+# 1. Copies the legacy fixture and runs migrate_layout.py to land on the
+#    per-type layout the script requires.
+# 2. Invokes rebuild_context_brief.py and asserts:
+#    - exit success and JSON contract
+#    - wiki/context_brief.md exists
+#    - file is ≤ 8192 bytes (the hard cap is 8000; CR/LF wiggle accepted)
+#    - all six section headers are present
+# 3. Re-runs the script and asserts the same invariants (idempotent).
+# 4. Probes a pre-migration wiki and asserts the standard hard-fail message.
+#
+# bash 3.2 + python3 stdlib only. Exits non-zero on any failure.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURES="$PLUGIN_ROOT/tests/fixtures"
+WORKDIR="$(mktemp -d)"
+WIKI="$WORKDIR/test-wiki"
+
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+red() { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+fail() { red "FAIL: $1"; exit 1; }
+
+assert_success_json() {
+  local label="$1" out="$2" ok
+  ok=$(printf '%s' "$out" | python3 -c 'import json, sys; d=json.loads(sys.stdin.read()); print("yes" if d.get("success") else "no")' 2>/dev/null || echo "parse-error")
+  if [ "$ok" != "yes" ]; then
+    red "FAIL ($label): expected success:true"
+    printf '%s\n' "$out"
+    exit 1
+  fi
+}
+
+# ---------- prepare a migrated fixture ----------
+cp -R "$FIXTURES/legacy-wiki" "$WIKI"
+python3 "$PLUGIN_ROOT/skills/wiki-setup/scripts/migrate_layout.py" \
+  --wiki-root "$WIKI" --apply >/dev/null
+green "fixture migrated to per-type layout"
+
+# ---------- 1) first run ----------
+OUT=$(python3 "$PLUGIN_ROOT/skills/wiki-ingest/scripts/rebuild_context_brief.py" \
+  --wiki-root "$WIKI")
+assert_success_json "rebuild_context_brief.py first run" "$OUT"
+
+BRIEF="$WIKI/wiki/context_brief.md"
+[ -f "$BRIEF" ] || fail "context_brief.md not created"
+
+BYTES=$(wc -c < "$BRIEF" | tr -d ' ')
+if [ "$BYTES" -gt 8192 ]; then
+  fail "context_brief.md is $BYTES bytes (hard cap is 8000, ≤8192 with newline slack)"
+fi
+green "context_brief.md created, $BYTES bytes (≤ 8192)"
+
+# Header sanity — every canonical section must be present.
+for HDR in '^# Context brief' '^## Type counts' '^## Top entities' \
+           '^## Recent activity' '^## Open lints' '^## Health snapshot'; do
+  if ! grep -q "$HDR" "$BRIEF"; then
+    fail "missing header: $HDR"
+  fi
+done
+green "all six section headers present"
+
+# JSON payload sanity.
+SECTIONS=$(printf '%s' "$OUT" | python3 -c 'import json, sys; d=json.loads(sys.stdin.read()); print(",".join(d["data"]["sections"]))')
+EXPECTED="header,type_counts,top_entities,recent,lints,health"
+if [ "$SECTIONS" != "$EXPECTED" ]; then
+  fail "sections payload: got [$SECTIONS], expected [$EXPECTED]"
+fi
+green "JSON sections payload matches"
+
+# ---------- 2) idempotent re-run ----------
+OUT=$(python3 "$PLUGIN_ROOT/skills/wiki-ingest/scripts/rebuild_context_brief.py" \
+  --wiki-root "$WIKI")
+assert_success_json "rebuild_context_brief.py re-run" "$OUT"
+BYTES2=$(wc -c < "$BRIEF" | tr -d ' ')
+if [ "$BYTES2" -gt 8192 ]; then
+  fail "context_brief.md is $BYTES2 bytes after re-run (cap 8192)"
+fi
+green "idempotent re-run: $BYTES2 bytes"
+
+# ---------- 3) pre-migration probe ----------
+cp -R "$FIXTURES/legacy-wiki" "$WORKDIR/legacy-wiki"
+OUT=$(python3 "$PLUGIN_ROOT/skills/wiki-ingest/scripts/rebuild_context_brief.py" \
+  --wiki-root "$WORKDIR/legacy-wiki" 2>/dev/null || true)
+RESULT=$(printf '%s' "$OUT" | python3 -c '
+import json, sys
+d = json.loads(sys.stdin.read())
+print("ok" if (not d.get("success")) and ("pre-migration" in d.get("error", "")) else "bad")
+' 2>/dev/null || echo "parse-error")
+if [ "$RESULT" != "ok" ]; then
+  fail "pre-migration probe: expected success:false with pre-migration message; got: $OUT"
+fi
+green "rebuild_context_brief.py hard-fails on legacy layout"
+
+green "ALL TESTS PASS"


### PR DESCRIPTION
## Summary

Closes the next Tier 2 sub-issue under #212: **#219 — auto-rebuilt `wiki/context_brief.md`**. Bumps cogni-wiki to **v0.0.29**.

A new `wiki/context_brief.md` is rebuilt at the end of every `wiki-ingest` dispatch — one ≤ 8 KiB file that becomes the canonical "first read" for a fresh Claude Code session, summarising type counts, top entities by inbound backlinks, the last 30 days of activity, cached open lints, and a fresh `health.py` snapshot. `wiki-resume` now reads the brief before any other status work.

### What's in this PR

**New scripts**
- `cogni-wiki/skills/wiki-ingest/scripts/rebuild_context_brief.py` — stdlib-only, `{success, data, error}` JSON, atomic `tempfile + os.replace` write through `_wikilib.atomic_write`. Hard-truncates "recent activity" first if the assembled body exceeds 8000 bytes.

**Additive `_wikilib` helpers**
- `atomic_write(path, text)` and `emit_json(success, data, error)` — extracted from patterns inlined across every wiki script. Existing inlines are left in place (lift-and-shift in a follow-up).

**SKILL.md edits**
- `wiki-ingest/SKILL.md` — new **Step 8.5** between Step 8 (config bump) and Step 9 (report). Runs **once per dispatch** after the source loop, with explicit failure isolation: a non-zero exit never rolls back the ingest. Step 9 reports brief-rebuild result.
- `wiki-resume/SKILL.md` — Step 1 now reads `wiki/context_brief.md` before invoking `wiki_status.sh`. New Golden Rule + References entry.

**Docs**
- `cogni-wiki/CLAUDE.md` — new "context brief (v0.0.29, intra-plugin)" Cross-Plugin Integration entry, Concurrency-Invariant note explaining no new lock is needed, layout diagram updated, Scripts count 13 → 14.
- `cogni-wiki/.claude-plugin/plugin.json` — `0.0.28` → `0.0.29`.
- `cogni-wiki/docs/plans/issue-219-context-brief.md` — design plan retained as the historical artefact.

**Tests**
- `cogni-wiki/tests/test_context_brief.sh` — stdlib bash smoke modeled on `test_migrate_and_smoke.sh`. Asserts file is created, ≤ 8192 bytes, all six section headers present, idempotent on re-run, and hard-fails on a pre-migration legacy-layout wiki.

### Defaults applied (per pre-implementation alignment)

| Decision | Default chosen |
|---|---|
| Open-lints source | Cached `.cogni-wiki/last_lint.json` (≤ 24 h TTL); ingest never invokes `lint_wiki.py`. Section degrades gracefully when no cache exists. |
| Top-N entities | 10 |
| Recent-activity window | `RECENT_DAYS = 30` (constant in script, no CLI flag) |
| Lint-cache writer | Deferred to a follow-up — not part of this PR. The brief works without it. |
| `--rebuild-context-brief` manual hook on `wiki-ingest` | Deferred (issue says "don't ship until someone asks"). |

### Out of scope (unchanged from plan)

- No schema-version bump. Brief is additive; missing → `wiki-resume` falls back. `_wikilib.SCHEMA_VERSION_PER_TYPE_DIRS` stays at `0.0.5`.
- No LLM rewriting of the brief.
- No new wiki-root `CLAUDE.md.template`.
- No refactor of existing `ok()/fail()` inlines to the new `emit_json` helper.

## Test plan

- [x] `bash cogni-wiki/tests/test_context_brief.sh` passes locally on the migrated fixture (822-byte brief, all six sections, idempotent, pre-migration probe hard-fails).
- [x] `bash cogni-wiki/tests/test_migrate_and_smoke.sh` still passes — no regression in the v0.0.28 migrator or any consumer.
- [x] Manual: rendered the brief against the migrated fixture wiki and inspected it — all six sections populated correctly (3 pages, top-3 entities ranked by 2 inbound backlinks each, migrate log line under recent activity, lints section degrades cleanly with the "no cached lint" note, health snapshot 0/0/0/0).
- [ ] Manual against a real-world wiki (deferred to user — fixture coverage is sufficient for CI).