### PR TITLE
cogni-workspace 0.6.29: detect theme drift between standard and workspace copies (closes #244)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,7 +62,7 @@
     {
       "name": "cogni-workspace",
       "source": "./cogni-workspace",
-      "version": "0.6.28",
+      "version": "0.6.29",
       "maturity": "preview",
       "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
       "keywords": [

--- a/cogni-workspace/.claude-plugin/plugin.json
+++ b/cogni-workspace/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-workspace",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-workspace/scripts/check-theme-drift.py
+++ b/cogni-workspace/scripts/check-theme-drift.py
@@ -36,8 +36,6 @@ def sha256_file(path):
 
 def parse_design_source(path):
     """Parse a .claude-design-source sidecar. Returns {url, sha256} or None."""
-    if not os.path.isfile(path):
-        return None
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
@@ -55,22 +53,17 @@ def signature(theme_dir):
 
     Returns ``None`` if ``theme.md`` is missing (the theme is ineligible).
     """
-    theme_md = os.path.join(theme_dir, "theme.md")
-    if not os.path.isfile(theme_md):
+    theme_md_sha = sha256_file(os.path.join(theme_dir, "theme.md"))
+    if theme_md_sha is None:
         return None
-    manifest_path = os.path.join(theme_dir, "manifest.json")
-    tokens_css_path = os.path.join(theme_dir, "tokens", "tokens.css")
-    sidecar_path = os.path.join(theme_dir, ".claude-design-source")
-
-    manifest_sha = sha256_file(manifest_path) if os.path.isfile(manifest_path) else None
-    tokens_css_sha = sha256_file(tokens_css_path) if os.path.isfile(tokens_css_path) else None
-
+    manifest_sha = sha256_file(os.path.join(theme_dir, "manifest.json"))
+    tokens_css_sha = sha256_file(os.path.join(theme_dir, "tokens", "tokens.css"))
     return {
         "tier": "tiered" if manifest_sha else "tier-0",
-        "theme_md_sha256": sha256_file(theme_md),
+        "theme_md_sha256": theme_md_sha,
         "manifest_sha256": manifest_sha,
         "tokens_css_sha256": tokens_css_sha,
-        "design_source": parse_design_source(sidecar_path),
+        "design_source": parse_design_source(os.path.join(theme_dir, ".claude-design-source")),
     }
 
 
@@ -181,9 +174,10 @@ def classify(std, ws):
     return ("identical", "identical")
 
 
-def emit(success, data=None, error=""):
-    print(json.dumps({"success": success, "data": data or {}, "error": error}))
-    return 0 if success else 1
+def emit(data, pretty=False):
+    indent = 2 if pretty else None
+    print(json.dumps({"success": True, "data": data, "error": ""}, indent=indent, ensure_ascii=False))
+    return 0
 
 
 def main():
@@ -209,24 +203,19 @@ def main():
 
     if not standard_dir or not os.path.isdir(standard_dir):
         data["note"] = "standard themes dir not found; no drift to report"
-        output = json.dumps({"success": True, "data": data, "error": ""}, indent=2 if args.pretty else None, ensure_ascii=False)
-        print(output)
-        return 0
+        return emit(data, args.pretty)
 
     if is_stale_path(workspace_root) or not workspace_dir or not os.path.isdir(workspace_dir):
         data["note"] = "workspace themes dir not found; no drift to report"
-        output = json.dumps({"success": True, "data": data, "error": ""}, indent=2 if args.pretty else None, ensure_ascii=False)
-        print(output)
-        return 0
+        return emit(data, args.pretty)
 
     standard = scan_dir(standard_dir)
     workspace = scan_dir(workspace_dir)
 
-    shadowed = sorted(set(standard.keys()) & set(workspace.keys()))
     rows = []
     drift_count = 0
     identical_count = 0
-    for slug in shadowed:
+    for slug in sorted(set(standard.keys()) & set(workspace.keys())):
         std = standard[slug]
         ws = workspace[slug]
         status, advisory = classify(std, ws)
@@ -245,10 +234,7 @@ def main():
     data["shadowed_slugs"] = rows
     data["drift_count"] = drift_count
     data["identical_count"] = identical_count
-
-    output = json.dumps({"success": True, "data": data, "error": ""}, indent=2 if args.pretty else None, ensure_ascii=False)
-    print(output)
-    return 0
+    return emit(data, args.pretty)
 
 
 if __name__ == "__main__":

--- a/cogni-workspace/scripts/check-theme-drift.py
+++ b/cogni-workspace/scripts/check-theme-drift.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""check-theme-drift.py — Detect drift between standard and workspace theme copies.
+
+Compares ``${CLAUDE_PLUGIN_ROOT}/themes/`` (standard, ships with the plugin) and
+``${COGNI_WORKSPACE_ROOT}/themes/`` (user-owned). For each slug that exists on
+both sides, computes a shallow signature and classifies the drift. Slugs that
+exist on only one side are not reported — that is the normal case, not drift.
+
+Read-only. stdlib only (``hashlib``, ``json``, ``os``, ``argparse``). At most
+four file opens per theme directory: ``theme.md``, ``manifest.json``,
+``tokens/tokens.css``, and ``.claude-design-source``.
+
+Output envelope matches the cogni-workspace convention:
+    {"success": bool, "data": {...}, "error": "..."}
+
+When the workspace dir is missing or stale (no ``COGNI_WORKSPACE_ROOT``, stale
+Cowork session, etc.), returns ``success: true`` with ``shadowed_slugs: []``
+and a ``note`` — workspace-status treats this as "no drift to report".
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+
+
+def sha256_file(path):
+    """Return the hex sha256 of a file, or None on any error."""
+    try:
+        with open(path, "rb") as f:
+            return hashlib.sha256(f.read()).hexdigest()
+    except (OSError, IOError):
+        return None
+
+
+def parse_design_source(path):
+    """Parse a .claude-design-source sidecar. Returns {url, sha256} or None."""
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    url = data.get("url")
+    sha = data.get("sha256")
+    if not url and not sha:
+        return None
+    return {"url": url, "sha256": sha}
+
+
+def signature(theme_dir):
+    """Compute a shallow drift signature for one theme directory.
+
+    Returns ``None`` if ``theme.md`` is missing (the theme is ineligible).
+    """
+    theme_md = os.path.join(theme_dir, "theme.md")
+    if not os.path.isfile(theme_md):
+        return None
+    manifest_path = os.path.join(theme_dir, "manifest.json")
+    tokens_css_path = os.path.join(theme_dir, "tokens", "tokens.css")
+    sidecar_path = os.path.join(theme_dir, ".claude-design-source")
+
+    manifest_sha = sha256_file(manifest_path) if os.path.isfile(manifest_path) else None
+    tokens_css_sha = sha256_file(tokens_css_path) if os.path.isfile(tokens_css_path) else None
+
+    return {
+        "tier": "tiered" if manifest_sha else "tier-0",
+        "theme_md_sha256": sha256_file(theme_md),
+        "manifest_sha256": manifest_sha,
+        "tokens_css_sha256": tokens_css_sha,
+        "design_source": parse_design_source(sidecar_path),
+    }
+
+
+def scan_dir(themes_dir):
+    """Return {slug: signature} for eligible immediate subdirs.
+
+    Skips entries starting with ``_`` or ``.`` and any dir without ``theme.md``
+    (mirrors the filter in pick-theme/scripts/discover-themes.py).
+    """
+    result = {}
+    if not themes_dir or not os.path.isdir(themes_dir):
+        return result
+    for entry in sorted(os.listdir(themes_dir)):
+        if entry.startswith("_") or entry.startswith("."):
+            continue
+        theme_dir = os.path.join(themes_dir, entry)
+        if not os.path.isdir(theme_dir):
+            continue
+        sig = signature(theme_dir)
+        if sig is None:
+            continue
+        result[entry] = sig
+    return result
+
+
+def is_stale_path(path):
+    """Mirror of discover-themes.py:is_stale_path — never crash on missing dirs."""
+    if not path:
+        return True
+    if path.startswith("/sessions/"):
+        return True
+    return not os.path.isdir(path)
+
+
+def sidecar_diff(std_src, ws_src):
+    """Return advisory suffix describing sidecar mismatch, or empty string.
+
+    Three cases:
+      - both present, url or sha256 differs → ``standard imported from bundle X;
+        workspace imported from bundle Y``
+      - exactly one present → ``(one side imported from a Claude Design bundle,
+        the other did not)``
+      - both absent, or both present and equal → empty string
+    """
+    if std_src is None and ws_src is None:
+        return ""
+    if std_src is None or ws_src is None:
+        return "; (one side imported from a Claude Design bundle, the other did not)"
+    if std_src.get("url") != ws_src.get("url") or std_src.get("sha256") != ws_src.get("sha256"):
+        std_id = std_src.get("url") or std_src.get("sha256") or "?"
+        ws_id = ws_src.get("url") or ws_src.get("sha256") or "?"
+        return "; standard imported from bundle {}; workspace imported from bundle {}".format(
+            std_id, ws_id
+        )
+    return ""
+
+
+def classify(std, ws):
+    """Compare two signatures and return (status, advisory).
+
+    Sidecar mismatch promotes an otherwise ``identical`` row to
+    ``workspace_customised`` so it surfaces; on already-drifting rows the
+    sidecar text is appended to the advisory.
+    """
+    sidecar_suffix = sidecar_diff(std["design_source"], ws["design_source"])
+
+    std_tier = std["tier"]
+    ws_tier = ws["tier"]
+
+    if std_tier == "tier-0" and ws_tier == "tier-0":
+        if std["theme_md_sha256"] == ws["theme_md_sha256"] and not sidecar_suffix:
+            return ("identical", "identical")
+        return ("workspace_customised", "workspace customised" + sidecar_suffix)
+
+    if std_tier == "tiered" and ws_tier == "tier-0":
+        return (
+            "upgrade_available",
+            "upgrade available — workspace copy is tier-0, standard is tiered" + sidecar_suffix,
+        )
+
+    if std_tier == "tier-0" and ws_tier == "tiered":
+        return ("workspace_ahead", "workspace ahead" + sidecar_suffix)
+
+    # both tiered
+    manifest_differs = std["manifest_sha256"] != ws["manifest_sha256"]
+    tokens_differs = std["tokens_css_sha256"] != ws["tokens_css_sha256"]
+    if manifest_differs or tokens_differs:
+        parts = []
+        if manifest_differs:
+            parts.append(
+                "standard manifest sha {}, workspace sha {}".format(
+                    (std["manifest_sha256"] or "none")[:8],
+                    (ws["manifest_sha256"] or "none")[:8],
+                )
+            )
+        if tokens_differs:
+            parts.append(
+                "tokens.css differs (standard {} vs workspace {})".format(
+                    (std["tokens_css_sha256"] or "none")[:8],
+                    (ws["tokens_css_sha256"] or "none")[:8],
+                )
+            )
+        return ("tier_drift", "tier drift — " + "; ".join(parts) + sidecar_suffix)
+
+    if std["theme_md_sha256"] != ws["theme_md_sha256"] or sidecar_suffix:
+        return ("workspace_customised", "workspace customised" + sidecar_suffix)
+
+    return ("identical", "identical")
+
+
+def emit(success, data=None, error=""):
+    print(json.dumps({"success": success, "data": data or {}, "error": error}))
+    return 0 if success else 1
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Detect drift between standard and workspace theme copies.")
+    parser.add_argument("--plugin-root", default="", help="Override CLAUDE_PLUGIN_ROOT")
+    parser.add_argument("--workspace-root", default="", help="Override COGNI_WORKSPACE_ROOT")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output")
+    args = parser.parse_args()
+
+    plugin_root = args.plugin_root or os.environ.get("CLAUDE_PLUGIN_ROOT", "")
+    workspace_root = args.workspace_root or os.environ.get("COGNI_WORKSPACE_ROOT", "")
+
+    standard_dir = os.path.join(plugin_root, "themes") if plugin_root else ""
+    workspace_dir = os.path.join(workspace_root, "themes") if workspace_root else ""
+
+    data = {
+        "standard_dir": standard_dir,
+        "workspace_dir": workspace_dir,
+        "shadowed_slugs": [],
+        "drift_count": 0,
+        "identical_count": 0,
+    }
+
+    if not standard_dir or not os.path.isdir(standard_dir):
+        data["note"] = "standard themes dir not found; no drift to report"
+        output = json.dumps({"success": True, "data": data, "error": ""}, indent=2 if args.pretty else None, ensure_ascii=False)
+        print(output)
+        return 0
+
+    if is_stale_path(workspace_root) or not workspace_dir or not os.path.isdir(workspace_dir):
+        data["note"] = "workspace themes dir not found; no drift to report"
+        output = json.dumps({"success": True, "data": data, "error": ""}, indent=2 if args.pretty else None, ensure_ascii=False)
+        print(output)
+        return 0
+
+    standard = scan_dir(standard_dir)
+    workspace = scan_dir(workspace_dir)
+
+    shadowed = sorted(set(standard.keys()) & set(workspace.keys()))
+    rows = []
+    drift_count = 0
+    identical_count = 0
+    for slug in shadowed:
+        std = standard[slug]
+        ws = workspace[slug]
+        status, advisory = classify(std, ws)
+        rows.append({
+            "slug": slug,
+            "status": status,
+            "advisory": advisory,
+            "standard": std,
+            "workspace": ws,
+        })
+        if status == "identical":
+            identical_count += 1
+        else:
+            drift_count += 1
+
+    data["shadowed_slugs"] = rows
+    data["drift_count"] = drift_count
+    data["identical_count"] = identical_count
+
+    output = json.dumps({"success": True, "data": data, "error": ""}, indent=2 if args.pretty else None, ensure_ascii=False)
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cogni-workspace/skills/workspace-status/SKILL.md
+++ b/cogni-workspace/skills/workspace-status/SKILL.md
@@ -80,6 +80,32 @@ Scan `${COGNI_WORKSPACE_ROOT}/themes/` (skip `_template`):
 - For each theme, check that `theme.md` contains "Color Palette" and "Typography" sections (these are the minimum viable sections visual plugins look for)
 - Check that `_template/` exists (needed to create new themes)
 
+#### Theme drift (shadowed slugs)
+
+The picker merges `${CLAUDE_PLUGIN_ROOT}/themes/` (standard, ships with the plugin) with `${COGNI_WORKSPACE_ROOT}/themes/` (user-owned), and workspace copies shadow standard copies when slugs collide. This shadowing is **intentional** — it enables user customisation. The drift advisories below are **informational, not errors**: the picker still resolves a valid theme either way.
+
+The motivating example is `cogni-work`: after the Phase 3 upgrade (RFC #132), the standard copy ships a tiered layout (manifest.json, tokens/, components/, `.claude-design-source` sidecar). A pre-Phase 3 workspace copy silently downgrades the experience because the picker resolves the workspace copy first.
+
+Run:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/check-theme-drift.py
+```
+
+The script compares the two locations and emits one row per shadowed slug. Slugs that exist on only one side are not reported (that's the normal case, not drift). Statuses:
+
+| Standard | Workspace | Status | Surface text |
+|---|---|---|---|
+| tier-0 | tier-0, theme.md equal | `identical` | `identical` |
+| tier-0 | tier-0, theme.md differs | `workspace_customised` | `workspace customised` |
+| tiered | tier-0 | `upgrade_available` | `upgrade available — workspace copy is tier-0, standard is tiered` |
+| tiered | tiered, manifest or tokens.css differs | `tier_drift` | `tier drift — standard manifest sha X, workspace sha Y` |
+| tier-0 | tiered | `workspace_ahead` | `workspace ahead` |
+
+When `.claude-design-source` sidecars differ in URL or sha256, the advisory appends `standard imported from bundle X; workspace imported from bundle Y`. A sidecar mismatch on otherwise-identical files promotes the row to `workspace_customised` so the divergence surfaces.
+
+`identical` rows are not surfaced in the default report (they're not a problem). Detailed mode shows them.
+
 ### 5. Dependencies
 
 External tools that scripts rely on. Required dependencies block core functionality; optional ones limit specific features.
@@ -158,6 +184,11 @@ Environment:  WARNING  | 12 vars set, 2 broken
   Broken: COGNI_NARRATIVE_ROOT -> /path/does/not/exist
   Broken: COGNI_NARRATIVE_PLUGIN -> /path/does/not/exist
   -> Run manage-workspace to refresh environment variables
+
+Themes:       WARNING  | 3 themes available, 1 drift advisory
+  cogni-work: upgrade available — workspace copy is tier-0, standard is tiered
+    standard imported from bundle https://api.anthropic.com/v1/design/h/X9LG…
+  -> Run `manage-themes` to refresh the workspace copy (overwrites local edits)
 ```
 
 Every issue should end with a concrete next step — either a skill to run (`manage-workspace`, `manage-themes`) or a command to execute.


### PR DESCRIPTION
## Summary

- New `cogni-workspace/scripts/check-theme-drift.py` — read-only diagnostic that compares `${CLAUDE_PLUGIN_ROOT}/themes/` (standard) and `${COGNI_WORKSPACE_ROOT}/themes/` (user-owned). For each slug present in both locations it computes a shallow signature (`theme.md`, `manifest.json`, `tokens/tokens.css`, `.claude-design-source`) and classifies the drift into one of five status enums: `identical`, `workspace_customised`, `upgrade_available`, `tier_drift`, `workspace_ahead`. Slugs that exist on only one side are not reported (that's the normal case, not drift).
- `workspace-status` Check 4 now documents the new sub-check, the five-row status table, and a WARNING report-format example.
- Picker contract is untouched — `discover-themes.py` output is byte-identical.

## Why

The picker merges standard with workspace and workspace shadows standard when slugs collide. The shadowing is intentional, but `workspace-status` Check 4 only saw the merged view — so when the standard copy ships a Phase 3 tier upgrade (PR #239 + #240) and the user's workspace copy is still tier-0 `theme.md`-only, the picker silently resolves the older copy with no diagnostic signal. The new sub-check surfaces the drift as an advisory; the user decides whether to overwrite, merge, or accept.

Sibling issue #243 (Themes check is tier-unaware) can reuse the helpers added here.

## Test plan

- [x] `python3 cogni-workspace/scripts/check-theme-drift.py --pretty` against a synthetic fixture covers each status: `upgrade_available`, `identical`, `tier_drift`, sidecar-mismatch (promoted to `workspace_customised`), pure `workspace_customised`, and one-sided slug (no row emitted).
- [x] `python3 cogni-workspace/scripts/check-theme-drift.py --workspace-root /tmp/nonexistent --pretty` returns `success: true`, `shadowed_slugs: []`, `note` set — never crashes on stale paths.
- [x] `bash cogni-workspace/scripts/verify-theme-backcompat.sh` still passes (discover-themes.py untouched).
- [x] `python3 cogni-workspace/scripts/validate-theme-manifest.py cogni-workspace/themes/cogni-work` unchanged.
- [x] `python3 cogni-workspace/skills/pick-theme/scripts/discover-themes.py --plugin-root cogni-workspace` output unchanged.
- [ ] `Skill("cogni-workspace:workspace-status")` against a live workspace with a pre-Phase 3 `cogni-work/` copy shows the new advisory in the Themes row.

## Notes

- Version bump 0.6.28 → 0.6.29 mirrored across `cogni-workspace/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` per CLAUDE.md.
- The second commit applies `/simplify` review: removes the previously-unused `emit()` helper's dead-code status, routes all JSON output through it, and drops redundant `os.path.isfile()` pre-checks (the open + try/except already handles missing files).

Closes #244. Sibling: #243. Worked example: #240.

---
_Generated by [Claude Code](https://claude.ai/code/session_012j6efpDdPA6c56SMAnhRDc)_