### PR TITLE
cogni-portfolio 0.9.48: validate-entities handles shared_solution overlays (closes #246)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -96,7 +96,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.47",
+      "version": "0.9.48",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
       "keywords": [

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/agents/solution-planner.md
+++ b/cogni-portfolio/agents/solution-planner.md
@@ -476,7 +476,7 @@ In overlay mode:
    - `professional_services.description`: How optional services relate to THIS feature
    - `professional_services.options[].name`: Feature-specific service names (e.g., "Pitch-Review & Optimierung" vs. "Trend-Analyse-Workshop")
    - `professional_services.options[].scope`: What each service delivers for THIS feature
-6. Write `"shared_solution_ref": "{relative-path-to-shared-ref}"` and `"messaging_overlay": true`
+6. Write `"shared_solution_ref": "{project-root-relative path, e.g. solutions/_shared/<product>--<market>}"` and `"messaging_overlay": true`
 7. Write the complete solution JSON to the specified output path
 
 **Content language**: Follow the same language rules as normal mode — check `portfolio.json` for `language` field.

--- a/cogni-portfolio/agents/solution-review-assessor.md
+++ b/cogni-portfolio/agents/solution-review-assessor.md
@@ -387,7 +387,7 @@ Return a simplified assessment JSON for overlay solutions:
 {
   "slug": "cogni-sales--b2b-sales-dach",
   "review_mode": "overlay",
-  "shared_solution_ref": "_shared/insight-wave-plugins--b2b-sales-dach",
+  "shared_solution_ref": "solutions/_shared/insight-wave-plugins--b2b-sales-dach",
   "criteria": {
     "does_traceability": {"score": "pass", "note": ""},
     "scope_clarity": {"score": "pass", "note": ""},

--- a/cogni-portfolio/references/data-model.md
+++ b/cogni-portfolio/references/data-model.md
@@ -594,7 +594,7 @@ The reference solution defines all commercial fields — pricing, cost model, ti
 
 **Overlay solutions** are the per-Feature×Market files. They inherit commercial structure from the reference and carry feature-specific messaging:
 
-`shared_solution_ref` (string, optional): Relative path to the shared reference solution (e.g., `"_shared/insight-wave-plugins--b2b-sales-dach"`). When present, this solution was derived from a shared reference — its commercial fields (pricing, cost model, tiers, durations) are inherited, and only messaging fields (descriptions, scope text, service names) are feature-specific.
+`shared_solution_ref` (string, optional): Path to the shared reference solution, relative to the project root (the directory containing `portfolio.json`) — e.g., `"solutions/_shared/insight-wave-plugins--b2b-sales-dach"`. When present, this solution was derived from a shared reference — its commercial fields (pricing, cost model, tiers, durations) are inherited, and only messaging fields (descriptions, scope text, service names) are feature-specific.
 
 `messaging_overlay` (boolean, optional): When `true`, indicates this solution was generated in overlay mode. Commercial fields must match the referenced shared solution. Editing commercial fields on an overlay creates drift — update the shared reference and regenerate overlays instead.
 

--- a/cogni-portfolio/scripts/project-status.sh
+++ b/cogni-portfolio/scripts/project-status.sh
@@ -977,7 +977,7 @@ for sf in glob.glob(os.path.join(proj, 'solutions', '*.json')):
             overlay_solutions += 1
             ref = d.get('shared_solution_ref')
             if ref:
-                ref_path = os.path.join(proj, 'solutions', ref + '.json')
+                ref_path = os.path.join(proj, ref + '.json')
                 if os.path.isfile(ref_path):
                     shared = json.load(open(ref_path))
                     sol_type = d.get('solution_type', 'project')

--- a/cogni-portfolio/scripts/validate-entities.sh
+++ b/cogni-portfolio/scripts/validate-entities.sh
@@ -683,18 +683,21 @@ if sol_type != ref_type:
     sys.exit(5)  # solution_type mismatch
 if sol_type in ('subscription', 'hybrid'):
     s_tiers = d.get('subscription', {}).get('tiers', {})
-    r_tiers = shared.get('subscription', {}).get('tiers', {})
-    for tier_name in r_tiers:
-        st = s_tiers.get(tier_name, {})
-        rt = r_tiers[tier_name]
-        if st.get('price_monthly') != rt.get('price_monthly') or st.get('price_annual') != rt.get('price_annual'):
-            sys.exit(4)  # pricing drift
+    # Strict overlays carry no inline pricing — nothing to drift.
+    if s_tiers:
+        r_tiers = shared.get('subscription', {}).get('tiers', {})
+        for tier_name in r_tiers:
+            st = s_tiers.get(tier_name, {})
+            rt = r_tiers[tier_name]
+            if st.get('price_monthly') != rt.get('price_monthly') or st.get('price_annual') != rt.get('price_annual'):
+                sys.exit(4)  # pricing drift
 elif sol_type == 'project':
     s_pricing = d.get('pricing', {})
-    r_pricing = shared.get('pricing', {})
-    for tier_name in r_pricing:
-        if s_pricing.get(tier_name, {}).get('price') != r_pricing[tier_name].get('price'):
-            sys.exit(4)  # pricing drift
+    if s_pricing:
+        r_pricing = shared.get('pricing', {})
+        for tier_name in r_pricing:
+            if s_pricing.get(tier_name, {}).get('price') != r_pricing[tier_name].get('price'):
+                sys.exit(4)  # pricing drift
 " 2>/dev/null && shared_rc=0 || shared_rc=$?
     case $shared_rc in
       0) ;; # valid or not a shared solution
@@ -754,6 +757,9 @@ if sol_type in ('project', ''):
     if not isinstance(impl, list) or len(impl) == 0: sys.exit(5)
     for phase in impl:
         if 'phase' not in phase or 'duration_weeks' not in phase: sys.exit(5)
+        dw = phase.get('duration_weeks')
+        if not isinstance(dw, (int, float)) and not (isinstance(dw, str) and dw.isdigit()):
+            sys.exit(10)  # non-numeric duration — warning, mirrors exit 6 above
     pricing = d.get('pricing')
     if not isinstance(pricing, dict): sys.exit(6)
     for tier in ['proof_of_value', 'small', 'medium', 'large']:
@@ -781,6 +787,7 @@ else:
       7) add_error "solution" "$slug" "Shared reference (subscription/hybrid) missing required subscription object (needs tiers, currency)" ;;
       8) add_error "solution" "$slug" "Shared reference (partnership) missing required program object (needs stages, revenue_share)" ;;
       9) add_error "solution" "$slug" "Shared reference has invalid solution_type — must be project, subscription, partnership, or hybrid" ;;
+      10) add_warning "solution" "$slug" "Shared reference has non-numeric duration_weeks value (e.g. 'ongoing') — accepted but may affect duration totals" ;;
     esac
   done
 fi

--- a/cogni-portfolio/scripts/validate-entities.sh
+++ b/cogni-portfolio/scripts/validate-entities.sh
@@ -579,6 +579,12 @@ with open('$s') as fh:
     if 'proposition_slug' not in d: sys.exit(1)
     sol_type = d.get('solution_type', 'project')
 
+    # Overlay short-circuit: when messaging_overlay is true, commercial fields
+    # live on the shared reference, not on the overlay. Envelope checks
+    # (ref resolves, type matches) run in the shared_solution_ref block below.
+    if d.get('messaging_overlay'):
+        sys.exit(0)
+
     if sol_type in ('project', ''):
         # Project solutions require implementation + pricing
         impl = d.get('implementation')
@@ -663,15 +669,19 @@ if overlay and ref is None:
     sys.exit(1)  # messaging_overlay=true but no shared_solution_ref
 if ref is not None and not overlay:
     sys.exit(2)  # shared_solution_ref present but messaging_overlay not set
-# Check referenced shared solution exists
-shared_path = os.path.join('$PROJECT_DIR', 'solutions', ref + '.json')
+# Check referenced shared solution exists. Ref is project-root-relative
+# (e.g. solutions/_shared/<product>--<market>).
+shared_path = os.path.join('$PROJECT_DIR', ref + '.json')
 if not os.path.isfile(shared_path):
     sys.exit(3)  # shared reference not found
 # Verify commercial fields match the reference
 with open(shared_path) as sfh:
     shared = json.load(sfh)
-# Compare pricing fields based on solution type
+# solution_type must match the referenced shared solution
 sol_type = d.get('solution_type', 'project')
+ref_type = shared.get('solution_type', 'project')
+if sol_type != ref_type:
+    sys.exit(5)  # solution_type mismatch
 if sol_type in ('subscription', 'hybrid'):
     s_tiers = d.get('subscription', {}).get('tiers', {})
     r_tiers = shared.get('subscription', {}).get('tiers', {})
@@ -691,8 +701,24 @@ elif sol_type == 'project':
       0) ;; # valid or not a shared solution
       1) add_warning "solution" "$slug" "messaging_overlay is true but shared_solution_ref is missing" ;;
       2) add_warning "solution" "$slug" "shared_solution_ref present but messaging_overlay not set to true" ;;
-      3) add_error "solution" "$slug" "shared_solution_ref references non-existent file" ;;
+      3)
+        ref_path=$(python3 -c "import json; print(json.load(open('$s')).get('shared_solution_ref',''))" 2>/dev/null)
+        add_error "solution" "$slug" "shared_solution_ref references non-existent file: $ref_path"
+        ;;
       4) add_warning "solution" "$slug" "Pricing drift detected — commercial fields differ from shared reference" ;;
+      5)
+        types=$(python3 -c "
+import json, os
+d = json.load(open('$s'))
+ref = d.get('shared_solution_ref', '')
+sp = os.path.join('$PROJECT_DIR', ref + '.json')
+s = json.load(open(sp)) if os.path.isfile(sp) else {}
+print(d.get('solution_type','project') + '|' + s.get('solution_type','project'))
+" 2>/dev/null)
+        sol_t="${types%%|*}"
+        ref_t="${types##*|}"
+        add_error "solution" "$slug" "solution_type ($sol_t) does not match shared reference type ($ref_t)"
+        ;;
     esac
   done
 fi
@@ -719,6 +745,31 @@ with open(prod_path) as pfh:
     prod = json.load(pfh)
 if not prod.get('shared_solution'):
     sys.exit(4)  # product not marked as shared_solution
+
+# Per-solution_type field checks. Mirrors the non-overlay branches of the
+# main solutions structural check (lines 582-610) — reference files must
+# carry the commercial structure that overlays inherit.
+sol_type = d.get('solution_type', 'project')
+if sol_type in ('project', ''):
+    impl = d.get('implementation')
+    if not isinstance(impl, list) or len(impl) == 0: sys.exit(5)
+    for phase in impl:
+        if 'phase' not in phase or 'duration_weeks' not in phase: sys.exit(5)
+    pricing = d.get('pricing')
+    if not isinstance(pricing, dict): sys.exit(6)
+    for tier in ['proof_of_value', 'small', 'medium', 'large']:
+        t = pricing.get(tier)
+        if not isinstance(t, dict) or 'price' not in t or 'currency' not in t: sys.exit(6)
+elif sol_type in ('subscription', 'hybrid'):
+    sub = d.get('subscription')
+    if not isinstance(sub, dict): sys.exit(7)
+    if 'tiers' not in sub or 'currency' not in sub: sys.exit(7)
+elif sol_type == 'partnership':
+    prog = d.get('program')
+    if not isinstance(prog, dict): sys.exit(8)
+    if 'stages' not in prog or 'revenue_share' not in prog: sys.exit(8)
+else:
+    sys.exit(9)
 " 2>/dev/null && shared_ref_rc=0 || shared_ref_rc=$?
     case $shared_ref_rc in
       0) ;; # valid
@@ -726,6 +777,11 @@ if not prod.get('shared_solution'):
       2) add_error "solution" "$slug" "Shared reference missing product_slug or market_slug" ;;
       3) add_error "solution" "$slug" "Shared reference product_slug references non-existent product" ;;
       4) add_warning "solution" "$slug" "Shared reference product not marked with shared_solution: true" ;;
+      5) add_error "solution" "$slug" "Shared reference (project) missing implementation phases or phase fields" ;;
+      6) add_error "solution" "$slug" "Shared reference (project) missing pricing tiers (proof_of_value, small, medium, large with price + currency)" ;;
+      7) add_error "solution" "$slug" "Shared reference (subscription/hybrid) missing required subscription object (needs tiers, currency)" ;;
+      8) add_error "solution" "$slug" "Shared reference (partnership) missing required program object (needs stages, revenue_share)" ;;
+      9) add_error "solution" "$slug" "Shared reference has invalid solution_type — must be project, subscription, partnership, or hybrid" ;;
     esac
   done
 fi

--- a/cogni-portfolio/scripts/validate-entities.sh
+++ b/cogni-portfolio/scripts/validate-entities.sh
@@ -677,7 +677,6 @@ if not os.path.isfile(shared_path):
 # Verify commercial fields match the reference
 with open(shared_path) as sfh:
     shared = json.load(sfh)
-# solution_type must match the referenced shared solution
 sol_type = d.get('solution_type', 'project')
 ref_type = shared.get('solution_type', 'project')
 if sol_type != ref_type:
@@ -746,9 +745,9 @@ with open(prod_path) as pfh:
 if not prod.get('shared_solution'):
     sys.exit(4)  # product not marked as shared_solution
 
-# Per-solution_type field checks. Mirrors the non-overlay branches of the
-# main solutions structural check (lines 582-610) — reference files must
-# carry the commercial structure that overlays inherit.
+# Per-solution_type field checks: reference files must carry the
+# commercial structure that overlays inherit. Mirrors the non-overlay
+# branches of the main solutions structural check above.
 sol_type = d.get('solution_type', 'project')
 if sol_type in ('project', ''):
     impl = d.get('implementation')

--- a/cogni-portfolio/skills/solutions/SKILL.md
+++ b/cogni-portfolio/skills/solutions/SKILL.md
@@ -373,8 +373,8 @@ When the user asks to review or improve existing solutions (or when you notice i
 
    | Solution | Shared Ref | Commercial Sync | Messaging |
    |----------|-----------|----------------|-----------|
-   | cogni-sales--b2b-sales-dach | _shared/iwp--b2b-sales-dach | in sync | DOES traceable |
-   | cogni-trends--b2b-sales-dach | _shared/iwp--b2b-sales-dach | DRIFTED (pricing) | DOES traceable |
+   | cogni-sales--b2b-sales-dach | solutions/_shared/iwp--b2b-sales-dach | in sync | DOES traceable |
+   | cogni-trends--b2b-sales-dach | solutions/_shared/iwp--b2b-sales-dach | DRIFTED (pricing) | DOES traceable |
 
    When reviewing overlay solutions, focus on messaging quality and DOES traceability — skip commercial evaluation (it belongs on the shared reference). When commercial changes are needed, recommend updating the shared reference and regenerating overlays rather than fixing individual solutions.
 

--- a/cogni-portfolio/tests/test-validate-entities.sh
+++ b/cogni-portfolio/tests/test-validate-entities.sh
@@ -9,6 +9,8 @@
 # Usage: bash cogni-portfolio/tests/test-validate-entities.sh
 # Exits non-zero on any assertion failure.
 
+# `set -u` only — `set -e` would abort on the first failing assertion and
+# defeat the per-fixture failure counter below.
 set -u
 
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -144,74 +146,90 @@ write_overlay() {
 EOF
 }
 
-# Count solution-entity errors matching a substring. Other entity errors are
-# ignored so each fixture stays focused on the contract under test.
-count_solution_errors() {
-  local pdir="$1"
+# Run the validator on $pdir once, stashing exit code (RC) and stdout
+# (VALIDATOR_OUTPUT) in globals so each fixture invokes the script exactly
+# once and downstream counters operate on the same result.
+run_validator() {
+  VALIDATOR_OUTPUT=$(bash "$SCRIPT" "$1" 2>/dev/null)
+  RC=$?
+}
+
+# Count solution-entity entries of $kind (errors|warnings) matching $substring.
+# Other entities are ignored so each fixture stays focused on the contract
+# under test.
+count_solution_entries() {
+  local kind="$1"
   local substring="${2:-}"
-  bash "$SCRIPT" "$pdir" 2>/dev/null | python3 -c "
+  printf '%s' "$VALIDATOR_OUTPUT" | python3 -c "
 import json, sys
-substring = sys.argv[1] if len(sys.argv) > 1 else ''
+kind = sys.argv[1]
+substring = sys.argv[2] if len(sys.argv) > 2 else ''
 doc = json.load(sys.stdin)
 n = 0
-for e in doc.get('errors', []):
+for e in doc.get(kind, []):
     if e.get('entity') != 'solution':
         continue
     if substring and substring not in e.get('message', ''):
         continue
     n += 1
 print(n)
-" "$substring"
+" "$kind" "$substring"
 }
 
-# Print solution errors (for diagnostic output on failure).
-dump_solution_errors() {
-  local pdir="$1"
-  bash "$SCRIPT" "$pdir" 2>/dev/null | python3 -c "
+# Print solution errors and warnings (for diagnostic output on failure).
+dump_solution_entries() {
+  printf '%s' "$VALIDATOR_OUTPUT" | python3 -c "
 import json, sys
 doc = json.load(sys.stdin)
-for e in doc.get('errors', []):
-    if e.get('entity') == 'solution':
-        print('  ' + e.get('file','') + ': ' + e.get('message',''))
+for kind in ('errors', 'warnings'):
+    for e in doc.get(kind, []):
+        if e.get('entity') == 'solution':
+            print('  ' + kind[0].upper() + ' ' + e.get('file','') + ': ' + e.get('message',''))
 "
 }
 
 # ─── Fixture 1: overlay-valid ───────────────────────────────────────────────
+# Asserts the contract surface: clean overlay over a well-formed reference
+# must produce 0 solution errors, 0 solution warnings, and validator rc 0.
 pdir="$(seed_project overlay-valid subscription)"
 write_subscription_ref "$pdir"
 write_overlay "$pdir" subscription "solutions/_shared/acme-suite--dach"
-n=$(count_solution_errors "$pdir")
-if [ "$n" = "0" ]; then
-  pass "overlay-valid: 0 solution errors"
+run_validator "$pdir"
+n_err=$(count_solution_entries errors)
+n_warn=$(count_solution_entries warnings)
+if [ "$RC" = "0" ] && [ "$n_err" = "0" ] && [ "$n_warn" = "0" ]; then
+  pass "overlay-valid: rc=0, 0 solution errors, 0 solution warnings"
 else
-  fail "overlay-valid" "expected 0 solution errors, got $n"
-  dump_solution_errors "$pdir" >&2
+  fail "overlay-valid" "expected rc=0/0/0, got rc=$RC errors=$n_err warnings=$n_warn"
+  dump_solution_entries >&2
 fi
 
 # ─── Fixture 2: overlay-missing-ref ─────────────────────────────────────────
 pdir="$(seed_project overlay-missing-ref subscription)"
 write_subscription_ref "$pdir"
 write_overlay "$pdir" subscription "solutions/_shared/does-not-exist"
-n_total=$(count_solution_errors "$pdir")
-n_match=$(count_solution_errors "$pdir" "references non-existent file")
-if [ "$n_total" = "1" ] && [ "$n_match" = "1" ]; then
-  pass "overlay-missing-ref: 1 error naming the missing path"
+run_validator "$pdir"
+n_total=$(count_solution_entries errors)
+n_match=$(count_solution_entries errors "references non-existent file")
+if [ "$RC" != "0" ] && [ "$n_total" = "1" ] && [ "$n_match" = "1" ]; then
+  pass "overlay-missing-ref: rc!=0, 1 error naming the missing path"
 else
-  fail "overlay-missing-ref" "expected 1 error matching 'references non-existent file', got total=$n_total match=$n_match"
-  dump_solution_errors "$pdir" >&2
+  fail "overlay-missing-ref" "expected rc!=0 and 1 error matching 'references non-existent file', got rc=$RC total=$n_total match=$n_match"
+  dump_solution_entries >&2
 fi
 
 # ─── Fixture 3: overlay-type-mismatch ───────────────────────────────────────
 pdir="$(seed_project overlay-type-mismatch subscription)"
 write_subscription_ref "$pdir"
 write_overlay "$pdir" project "solutions/_shared/acme-suite--dach"
-n_total=$(count_solution_errors "$pdir")
-n_match=$(count_solution_errors "$pdir" "does not match shared reference type")
-if [ "$n_total" = "1" ] && [ "$n_match" = "1" ]; then
-  pass "overlay-type-mismatch: 1 error naming the mismatch"
+run_validator "$pdir"
+n_total=$(count_solution_entries errors)
+n_match=$(count_solution_entries errors "does not match shared reference type")
+if [ "$RC" != "0" ] && [ "$n_total" = "1" ] && [ "$n_match" = "1" ]; then
+  pass "overlay-type-mismatch: rc!=0, 1 error naming the mismatch"
 else
-  fail "overlay-type-mismatch" "expected 1 error matching 'does not match shared reference type', got total=$n_total match=$n_match"
-  dump_solution_errors "$pdir" >&2
+  fail "overlay-type-mismatch" "expected rc!=0 and 1 error matching 'does not match shared reference type', got rc=$RC total=$n_total match=$n_match"
+  dump_solution_entries >&2
 fi
 
 # ─── Fixture 4: ref-incomplete-subscription ─────────────────────────────────
@@ -227,13 +245,14 @@ cat > "$pdir/solutions/_shared/acme-suite--dach.json" <<EOF
 }
 EOF
 write_overlay "$pdir" subscription "solutions/_shared/acme-suite--dach"
-n_total=$(count_solution_errors "$pdir")
-n_match=$(count_solution_errors "$pdir" "Shared reference (subscription/hybrid) missing required subscription object")
-if [ "$n_total" = "1" ] && [ "$n_match" = "1" ]; then
-  pass "ref-incomplete-subscription: 1 error on the reference, not the overlay"
+run_validator "$pdir"
+n_total=$(count_solution_entries errors)
+n_match=$(count_solution_entries errors "Shared reference (subscription/hybrid) missing required subscription object")
+if [ "$RC" != "0" ] && [ "$n_total" = "1" ] && [ "$n_match" = "1" ]; then
+  pass "ref-incomplete-subscription: rc!=0, 1 error on the reference, not the overlay"
 else
-  fail "ref-incomplete-subscription" "expected 1 error on the reference, got total=$n_total match=$n_match"
-  dump_solution_errors "$pdir" >&2
+  fail "ref-incomplete-subscription" "expected rc!=0 and 1 error on the reference, got rc=$RC total=$n_total match=$n_match"
+  dump_solution_entries >&2
 fi
 
 # ─── Fixture 5: ref-incomplete-project ──────────────────────────────────────
@@ -249,13 +268,14 @@ cat > "$pdir/solutions/_shared/acme-suite--dach.json" <<EOF
 }
 EOF
 write_overlay "$pdir" project "solutions/_shared/acme-suite--dach"
-n_total=$(count_solution_errors "$pdir")
-n_match=$(count_solution_errors "$pdir" "Shared reference (project) missing implementation phases")
-if [ "$n_total" = "1" ] && [ "$n_match" = "1" ]; then
-  pass "ref-incomplete-project: 1 error on the reference"
+run_validator "$pdir"
+n_total=$(count_solution_entries errors)
+n_match=$(count_solution_entries errors "Shared reference (project) missing implementation phases")
+if [ "$RC" != "0" ] && [ "$n_total" = "1" ] && [ "$n_match" = "1" ]; then
+  pass "ref-incomplete-project: rc!=0, 1 error on the reference"
 else
-  fail "ref-incomplete-project" "expected 1 error on the reference, got total=$n_total match=$n_match"
-  dump_solution_errors "$pdir" >&2
+  fail "ref-incomplete-project" "expected rc!=0 and 1 error on the reference, got rc=$RC total=$n_total match=$n_match"
+  dump_solution_entries >&2
 fi
 
 if [ "$failures" -gt 0 ]; then

--- a/cogni-portfolio/tests/test-validate-entities.sh
+++ b/cogni-portfolio/tests/test-validate-entities.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# Regression test for cogni-portfolio/scripts/validate-entities.sh covering the
+# shared_solution / messaging_overlay contract (issue #246).
+#
+# Fixtures are heredoc'd inline — no committed JSON blobs to maintain. Each
+# fixture builds a minimal portfolio project in a temp directory, runs the
+# validator, and asserts on the resulting JSON error set.
+#
+# Usage: bash cogni-portfolio/tests/test-validate-entities.sh
+# Exits non-zero on any assertion failure.
+
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+SCRIPT="$PLUGIN_DIR/scripts/validate-entities.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: validate-entities.sh not found at $SCRIPT" >&2
+  exit 1
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { printf 'OK   %s\n' "$1"; }
+fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+
+# Seed shared scaffolding (portfolio.json, product, feature, market, proposition)
+# Returns the project directory path.
+seed_project() {
+  local name="$1"
+  local product_type="${2:-subscription}"  # subscription | project
+  local pdir="$TMPROOT/$name"
+  mkdir -p "$pdir/products" "$pdir/features" "$pdir/markets" "$pdir/propositions" \
+           "$pdir/solutions/_shared"
+
+  cat > "$pdir/portfolio.json" <<EOF
+{"company": {"name": "Acme", "products": ["acme-suite"]}, "taxonomy": {}}
+EOF
+
+  cat > "$pdir/products/acme-suite.json" <<EOF
+{
+  "slug": "acme-suite",
+  "name": "Acme Suite",
+  "description": "Acme product suite.",
+  "revenue_model": "$product_type",
+  "shared_solution": true
+}
+EOF
+
+  cat > "$pdir/features/cogni-x.json" <<EOF
+{
+  "slug": "cogni-x",
+  "name": "Cogni X",
+  "description": "Acme feature for testing the validator's shared solution overlay contract end to end.",
+  "product_slug": "acme-suite"
+}
+EOF
+
+  cat > "$pdir/markets/dach.json" <<EOF
+{
+  "slug": "dach",
+  "name": "DACH",
+  "description": "DACH region for testing the validator's shared solution overlay contract.",
+  "region": "dach"
+}
+EOF
+
+  cat > "$pdir/propositions/cogni-x--dach.json" <<EOF
+{
+  "slug": "cogni-x--dach",
+  "feature_slug": "cogni-x",
+  "market_slug": "dach",
+  "is_statement": "Cogni X is a tool that does things for buyers in DACH region effectively daily.",
+  "does_statement": "It automates the things that buyers in DACH region need automated for productivity and growth.",
+  "means_statement": "Buyers in DACH region save time and money by adopting Cogni X for productivity and growth here."
+}
+EOF
+
+  echo "$pdir"
+}
+
+# Write a valid subscription-type shared reference at _shared/acme-suite--dach
+write_subscription_ref() {
+  local pdir="$1"
+  cat > "$pdir/solutions/_shared/acme-suite--dach.json" <<EOF
+{
+  "slug": "_shared/acme-suite--dach",
+  "shared_solution": true,
+  "product_slug": "acme-suite",
+  "market_slug": "dach",
+  "solution_type": "subscription",
+  "proposition_slug": "acme-suite--dach",
+  "subscription": {
+    "currency": "EUR",
+    "tiers": {
+      "pro": {"price_monthly": 149, "price_annual": 1490}
+    }
+  }
+}
+EOF
+}
+
+# Write a valid project-type shared reference at _shared/acme-suite--dach
+write_project_ref() {
+  local pdir="$1"
+  cat > "$pdir/solutions/_shared/acme-suite--dach.json" <<EOF
+{
+  "slug": "_shared/acme-suite--dach",
+  "shared_solution": true,
+  "product_slug": "acme-suite",
+  "market_slug": "dach",
+  "solution_type": "project",
+  "proposition_slug": "acme-suite--dach",
+  "implementation": [
+    {"phase": "discovery", "duration_weeks": 2}
+  ],
+  "pricing": {
+    "proof_of_value": {"price": 10000, "currency": "EUR"},
+    "small": {"price": 30000, "currency": "EUR"},
+    "medium": {"price": 80000, "currency": "EUR"},
+    "large": {"price": 200000, "currency": "EUR"}
+  }
+}
+EOF
+}
+
+# Write an overlay for cogni-x--dach pointing at the shared reference.
+# Args: pdir, solution_type, ref_path
+write_overlay() {
+  local pdir="$1"
+  local sol_type="$2"
+  local ref_path="$3"
+  cat > "$pdir/solutions/cogni-x--dach.json" <<EOF
+{
+  "slug": "cogni-x--dach",
+  "proposition_slug": "cogni-x--dach",
+  "solution_type": "$sol_type",
+  "messaging_overlay": true,
+  "shared_solution_ref": "$ref_path"
+}
+EOF
+}
+
+# Count solution-entity errors matching a substring. Other entity errors are
+# ignored so each fixture stays focused on the contract under test.
+count_solution_errors() {
+  local pdir="$1"
+  local substring="${2:-}"
+  bash "$SCRIPT" "$pdir" 2>/dev/null | python3 -c "
+import json, sys
+substring = sys.argv[1] if len(sys.argv) > 1 else ''
+doc = json.load(sys.stdin)
+n = 0
+for e in doc.get('errors', []):
+    if e.get('entity') != 'solution':
+        continue
+    if substring and substring not in e.get('message', ''):
+        continue
+    n += 1
+print(n)
+" "$substring"
+}
+
+# Print solution errors (for diagnostic output on failure).
+dump_solution_errors() {
+  local pdir="$1"
+  bash "$SCRIPT" "$pdir" 2>/dev/null | python3 -c "
+import json, sys
+doc = json.load(sys.stdin)
+for e in doc.get('errors', []):
+    if e.get('entity') == 'solution':
+        print('  ' + e.get('file','') + ': ' + e.get('message',''))
+"
+}
+
+# ─── Fixture 1: overlay-valid ───────────────────────────────────────────────
+pdir="$(seed_project overlay-valid subscription)"
+write_subscription_ref "$pdir"
+write_overlay "$pdir" subscription "solutions/_shared/acme-suite--dach"
+n=$(count_solution_errors "$pdir")
+if [ "$n" = "0" ]; then
+  pass "overlay-valid: 0 solution errors"
+else
+  fail "overlay-valid" "expected 0 solution errors, got $n"
+  dump_solution_errors "$pdir" >&2
+fi
+
+# ─── Fixture 2: overlay-missing-ref ─────────────────────────────────────────
+pdir="$(seed_project overlay-missing-ref subscription)"
+write_subscription_ref "$pdir"
+write_overlay "$pdir" subscription "solutions/_shared/does-not-exist"
+n_total=$(count_solution_errors "$pdir")
+n_match=$(count_solution_errors "$pdir" "references non-existent file")
+if [ "$n_total" = "1" ] && [ "$n_match" = "1" ]; then
+  pass "overlay-missing-ref: 1 error naming the missing path"
+else
+  fail "overlay-missing-ref" "expected 1 error matching 'references non-existent file', got total=$n_total match=$n_match"
+  dump_solution_errors "$pdir" >&2
+fi
+
+# ─── Fixture 3: overlay-type-mismatch ───────────────────────────────────────
+pdir="$(seed_project overlay-type-mismatch subscription)"
+write_subscription_ref "$pdir"
+write_overlay "$pdir" project "solutions/_shared/acme-suite--dach"
+n_total=$(count_solution_errors "$pdir")
+n_match=$(count_solution_errors "$pdir" "does not match shared reference type")
+if [ "$n_total" = "1" ] && [ "$n_match" = "1" ]; then
+  pass "overlay-type-mismatch: 1 error naming the mismatch"
+else
+  fail "overlay-type-mismatch" "expected 1 error matching 'does not match shared reference type', got total=$n_total match=$n_match"
+  dump_solution_errors "$pdir" >&2
+fi
+
+# ─── Fixture 4: ref-incomplete-subscription ─────────────────────────────────
+pdir="$(seed_project ref-incomplete-subscription subscription)"
+cat > "$pdir/solutions/_shared/acme-suite--dach.json" <<EOF
+{
+  "slug": "_shared/acme-suite--dach",
+  "shared_solution": true,
+  "product_slug": "acme-suite",
+  "market_slug": "dach",
+  "solution_type": "subscription",
+  "proposition_slug": "acme-suite--dach"
+}
+EOF
+write_overlay "$pdir" subscription "solutions/_shared/acme-suite--dach"
+n_total=$(count_solution_errors "$pdir")
+n_match=$(count_solution_errors "$pdir" "Shared reference (subscription/hybrid) missing required subscription object")
+if [ "$n_total" = "1" ] && [ "$n_match" = "1" ]; then
+  pass "ref-incomplete-subscription: 1 error on the reference, not the overlay"
+else
+  fail "ref-incomplete-subscription" "expected 1 error on the reference, got total=$n_total match=$n_match"
+  dump_solution_errors "$pdir" >&2
+fi
+
+# ─── Fixture 5: ref-incomplete-project ──────────────────────────────────────
+pdir="$(seed_project ref-incomplete-project project)"
+cat > "$pdir/solutions/_shared/acme-suite--dach.json" <<EOF
+{
+  "slug": "_shared/acme-suite--dach",
+  "shared_solution": true,
+  "product_slug": "acme-suite",
+  "market_slug": "dach",
+  "solution_type": "project",
+  "proposition_slug": "acme-suite--dach"
+}
+EOF
+write_overlay "$pdir" project "solutions/_shared/acme-suite--dach"
+n_total=$(count_solution_errors "$pdir")
+n_match=$(count_solution_errors "$pdir" "Shared reference (project) missing implementation phases")
+if [ "$n_total" = "1" ] && [ "$n_match" = "1" ]; then
+  pass "ref-incomplete-project: 1 error on the reference"
+else
+  fail "ref-incomplete-project" "expected 1 error on the reference, got total=$n_total match=$n_match"
+  dump_solution_errors "$pdir" >&2
+fi
+
+if [ "$failures" -gt 0 ]; then
+  printf '\n%d test(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nAll tests passed.\n'


### PR DESCRIPTION
## Summary

Fixes [#246](https://github.com/cogni-work/insight-wave/issues/246) — `validate-entities.sh` produced 262 false-positive errors on portfolios using the documented `shared_solution: true` pattern, and never inspected `solutions/_shared/*.json` references for per-`solution_type` fields. Three false-positive bugs share one root cause (validator predated the overlay/reference split) and one under-report fix is bundled in.

### Bugs fixed

| # | Symptom | Fix |
|---|---|---|
| 1 | `shared_solution_ref references non-existent file` (131 in test portfolio) | Drop hard-coded `solutions/` segment from path resolution — refs are project-root-relative |
| 2 | `Subscription/hybrid solution missing required subscription object` on overlays (105) | Add `messaging_overlay: true` short-circuit at top of solutions structural block |
| 3 | `Missing required fields (proposition_slug, implementation phases, pricing tiers)` on project overlays (26) | Same overlay short-circuit |
| 4 | 4 incomplete `_shared/` references silently passed | Extend `_shared/` block with per-`solution_type` field checks mirroring the non-overlay branches |

Plus: new `solution_type`-mismatch error between overlay and reference, and the same path-resolution fix mirrored in `project-status.sh:980` so `portfolio-resume`'s overlay-in-sync count is corrected too.

### Contract clarification

Canonical form for `shared_solution_ref` is **project-root-relative** (e.g. `solutions/_shared/<product>--<market>`). This matches data the planner agent already generates; doc drift (which showed the bare `_shared/<slug>` form) is fixed in this PR across `data-model.md`, `solutions/SKILL.md`, `solution-planner.md`, and `solution-review-assessor.md`.

### Test harness

New regression test at `cogni-portfolio/tests/test-validate-entities.sh` (5 inline fixtures, no committed JSON blobs, follows the `cogni-trends/tests/` pattern):

- `overlay-valid` — 0 errors
- `overlay-missing-ref` — 1 error naming the missing path
- `overlay-type-mismatch` — 1 error naming the mismatch
- `ref-incomplete-subscription` — 1 error on the reference file
- `ref-incomplete-project` — 1 error on the reference file

## Test plan

- [x] `bash cogni-portfolio/tests/test-validate-entities.sh` — all 5 fixtures pass
- [x] Regression check on `cogni-portfolio-evals/fixtures/t-systems-solutions` — 0 solution errors (unchanged from before)
- [ ] Live regression on `dt-security-offerings` (user's machine): expect `error_count` drop from 262 → 4, with the 4 surviving errors naming the genuinely incomplete `_shared/` references from the issue's "Additional context" section

https://claude.ai/code/session_014TMFFtGf3jqKHTazHLiCN1

---
_Generated by [Claude Code](https://claude.ai/code/session_014TMFFtGf3jqKHTazHLiCN1)_