### PR TITLE
cogni-copywriting 0.2.3 + cogni-portfolio 0.9.49: audience-tuned acronym expansion (closes #248)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -96,7 +96,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.49",
+      "version": "0.9.50",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -46,7 +46,7 @@
     {
       "name": "cogni-copywriting",
       "source": "./cogni-copywriting",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "maturity": "preview",
       "description": "Professional copywriting toolkit providing document polishing with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), stakeholder review via parallel persona Q&A, readability optimization, sales enhancement (Power Positions), multi-language support, JSON field polishing via the copy-json adapter, and arc contract audit against cogni-narrative.",
       "keywords": [
@@ -96,7 +96,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.48",
+      "version": "0.9.49",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
       "keywords": [

--- a/cogni-copywriting/.claude-plugin/plugin.json
+++ b/cogni-copywriting/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-copywriting",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Professional copywriting toolkit providing document polishing with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), stakeholder review via parallel persona Q&A, readability optimization, sales enhancement (Power Positions), multi-language support, JSON field polishing via the copy-json adapter, and arc contract audit against cogni-narrative.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-copywriting/CLAUDE.md
+++ b/cogni-copywriting/CLAUDE.md
@@ -123,7 +123,7 @@ commands/                                 2 slash commands
 
 1. **Parse parameters and load references** -- reads `00-index.md` decision tree to detect mode (arc/sales/standard) and load exactly the references needed
 2. **Apply structure** -- applies messaging framework pattern (Pyramid, BLUF, etc.); skipped in arc mode (arc IS the structure) or `--scope=tone|formatting`
-3. **Apply writing and formatting** -- language detection (EN/DE), voice transformation, paragraph splitting, bold anchoring, visual rhythm; loads impact techniques for high-impact or executive audiences
+3. **Apply writing and formatting** -- language detection (EN/DE), voice transformation, paragraph splitting, bold anchoring, visual rhythm, first-mention acronym expansion (audience-tuned via `AUDIENCE` arg → frontmatter `audience:` → `mixed`); loads impact techniques for high-impact or executive audiences
 4. **Review** -- optional stakeholder review via copy-reader skill (parallel personas) or automated checklist; never blocks delivery
 5. **Validate and write** -- German chars preserved, citations intact, readability scored, arc validation if active; backs up original before writing
 
@@ -195,6 +195,7 @@ cogni-research --> cogni-narrative --> cogni-copywriting --> cogni-visual
 - Arc mode is triggered by `arc_id` in YAML frontmatter or arc heading patterns; when active, the arc provides structure and element-specific techniques override generic frameworks
 - Sales mode (`MODE: sales`) enables Power Positions (IS-DOES-MEANS) enhancement with number plays on DOES layer and power words on MEANS layer
 - Bilingual support: English uses Flesch Reading Ease (target 50-60), German uses Amstad formula (target 30-50) with Wolf Schneider style rules
+- Acronym handling: first-mention expansion is audience-tuned (`expert` / `mixed` / `lay`); proper nouns, brand names, and arc/sales discipline markers (`**IS**:`, `**DOES**:`, `**MEANS**:`) are excluded; subsequent mentions verbatim. See `skills/copywriter/references/01-core-principles/acronym-handling-principles.md`.
 - Readability script: `python3 scripts/calculate_readability.py <file> [--lang de|en|auto]`
 - Output backup convention: original saved as `.{filename}` (hidden file) before overwrite
 - Copy-json adapter never polishes text itself -- it only handles JSON-to-MD format conversion and delegates all polishing to the copywriter skill

--- a/cogni-copywriting/agents/copywriter.md
+++ b/cogni-copywriting/agents/copywriter.md
@@ -18,6 +18,7 @@ Invoke the copywriter skill to polish a markdown document and return ONLY JSON t
 - `FILE_PATH`: Absolute path to markdown file (required)
 - `SCOPE`: "full" | "structure-only" | "tone-only" | "formatting-only" (default: full)
 - `MODE`: "standard" | "sales" (default: standard) - When "sales", enables Power Positions (IS-DOES-MEANS) enhancement
+- `AUDIENCE`: "expert" | "mixed" | "lay" (default: mixed) - Tunes audience-aware disciplines such as acronym expansion depth. Resolution order: this arg, then document frontmatter `audience:`, then default `mixed`.
 - `STAKEHOLDERS`: Array of perspectives for review (default: auto-select based on audience) - Options: executive, technical, legal, marketing, end-user
 - `REVIEW_MODE`: "automated" | "manual" | "skip" (default: automated) - Controls stakeholder review process
 - `QUALITY_TARGETS`: Custom targets (optional)
@@ -46,7 +47,7 @@ Invoke the copywriter skill to polish a markdown document and return ONLY JSON t
 <example>
 <invoke name="Skill">
   <parameter name="skill">cogni-copywriting:copywriter</parameter>
-  <parameter name="args">FILE_PATH={{FILE_PATH}} SCOPE={{SCOPE}} MODE={{MODE}} STAKEHOLDERS={{STAKEHOLDERS}} REVIEW_MODE={{REVIEW_MODE}} QUALITY_TARGETS={{QUALITY_TARGETS}}</parameter>
+  <parameter name="args">FILE_PATH={{FILE_PATH}} SCOPE={{SCOPE}} MODE={{MODE}} AUDIENCE={{AUDIENCE}} STAKEHOLDERS={{STAKEHOLDERS}} REVIEW_MODE={{REVIEW_MODE}} QUALITY_TARGETS={{QUALITY_TARGETS}}</parameter>
 </invoke>
 </example>
 

--- a/cogni-copywriting/skills/copywriter/CHANGELOG.md
+++ b/cogni-copywriting/skills/copywriter/CHANGELOG.md
@@ -5,6 +5,63 @@ All notable changes to the copywriter skill will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.0] - 2026-05-19
+
+### Added - Audience-Tuned First-Mention Acronym Expansion
+
+Acronym/abbreviation handling becomes a default polish discipline, sitting alongside Wolf-Schneider clarity, active voice, paragraph splitting, and bold anchoring in Step 3 of the workflow. Each acronym is expanded **once** on its first mention; subsequent mentions stay verbatim. The depth of expansion is tuned to the document's audience.
+
+Before this change, the discipline had to be ordered as a second, separate polish pass — typical pain: the DACH security portfolio pitch series (5 pitches × Wolf-Schneider polish) needed 5 extra copywriter dispatches just for acronym expansion.
+
+#### New `AUDIENCE` skill arg
+
+`AUDIENCE`: `expert` | `mixed` | `lay` (default: `mixed`).
+
+Resolution hierarchy (used by acronym handling and any future audience-aware discipline):
+
+1. Explicit `AUDIENCE` skill arg
+2. Document frontmatter `audience:` field
+3. Default: `mixed`
+
+#### Audience-tuned depth
+
+| Audience | Behaviour |
+|---|---|
+| `expert` | Expand only genuinely technical/ambiguous acronyms (`SIEM`, `MTTI`, `B3S`). Regulation proper nouns like `NIS2`, `DSGVO`, `BSI`, `DORA` stay unaltered. |
+| `mixed` *(default)* | Expand technical acronyms; explain common regulation acronyms once on first mention. |
+| `lay` | Expand virtually every acronym plus a short plain-language gloss in the document language: `MDR (Managed Detection and Response — ein Dienstleister erkennt und stoppt Angriffe rund um die Uhr für Sie)`. |
+
+#### Always-excluded tokens
+
+- Proper nouns: `KRITIS-Dachgesetz`, `EU AI Act`, `B3S`, `ISO 27001`, `TISAX`, `DAX`
+- Brand names: `Magenta Security`, `Open Telekom Cloud`, `Microsoft Entra ID`, `CrowdStrike Falcon`
+- Audience-trivial tokens: `IT`/`EU`/`USD` always; `M365` for non-`lay`
+- Arc/sales structure markers: `**IS**:`, `**DOES**:`, `**MEANS**:` and standalone arc-element labels (already preservation targets in `08-sales-techniques/power-positions.md` line 318)
+
+Compound references like `§38 BSIG-NIS2` carry the explanation on the **compound**, not on the bare token.
+
+#### Changed Files
+
+- **NEW `references/01-core-principles/acronym-handling-principles.md`**: Detection heuristic, audience-tuned depth table, format convention, exclusions, compound-reference rule, arc/sales preservation cross-reference, validation criteria. DE+EN worked examples.
+- **NEW `references/05-examples/example-acronyms-audience.md`**: Same source paragraph polished three times (`expert` / `mixed` / `lay`) demonstrating exclusions, lay-audience glosses, compound references, second-mention verbatim handling.
+- **`SKILL.md`**: Step 1 adds `AUDIENCE` parameter and resolution-order paragraph. Step 3 "Both languages — formatting" adds item 6 (acronym handling). Step 5 validation checklist adds one bullet. Bundled Resources lists the new reference.
+- **`references/00-index.md`**: Always-load core block in Standard and Arc modes now loads `acronym-handling-principles.md`. File Inventory entry added. Index version bumped to 8.1.
+- **`agents/copywriter.md`**: New `AUDIENCE` input; passed through in the Step 2 skill invocation. No new JSON output field — acronym info (if surfaced) fits in existing `improvements[]`.
+- **`CLAUDE.md`**: Copywriter Polish Flow Step 3 description and Key Conventions extended.
+
+#### Rationale
+
+This discipline is editorial-universal — as foundational as active voice or the Sie-Form for mixed B2B audiences — but was missing from the default polish loop. With audience-tuning, the discipline reads neither belehrend for experts (NIS2 not expanded in front of a KRITIS-CISO) nor opaque for lay readers (MDR carries a plain-language gloss for the SMB-Inhaber audience).
+
+Closes #248.
+
+#### Migration Notes
+
+- **Non-breaking**: Default `AUDIENCE=mixed` matches the reasonable middle ground; callers and frontmatter consumers continue to work without changes.
+- **For portfolio pitches**: `cogni-portfolio:portfolio-communicate` 0.9.49+ emits `audience:` and `personas:` in pitch frontmatter automatically — no manual backfill needed.
+
+---
+
 ## [7.1.0] - 2026-02-25
 
 ### Fixed - Language-Aware Flesch Targets for German

--- a/cogni-copywriting/skills/copywriter/SKILL.md
+++ b/cogni-copywriting/skills/copywriter/SKILL.md
@@ -71,6 +71,13 @@ These apply even in `--scope=tone` because they are readability essentials, not 
 - `framework` (optional): bluf | pyramid | scqa | star | psb | fab | inverted-pyramid
 - `impact_level` (optional): standard | high
 - `MODE` (optional): standard | sales (default: standard)
+- `AUDIENCE` (optional): expert | mixed | lay (default: mixed) — tunes audience-aware disciplines such as acronym expansion depth
+
+**Audience resolution order** (used by acronym handling and any future audience-aware discipline):
+
+1. Explicit `AUDIENCE` skill arg
+2. Document frontmatter `audience:` field
+3. Default: `mixed`
 
 **Load the reference index first:**
 
@@ -122,6 +129,7 @@ Key targets: max 12 words per clause, Satzklammer breaking, Mittelfeld shortenin
 3. **Heading levels**: Max 3 (H1, H2, H3). Restructure if H4 is needed.
 4. **Visual element rhythm**: Insert a visual element (table, list, callout) every 2-3 consecutive prose paragraphs.
 5. **White space**: Blank line between every paragraph, around every heading, list, table, and block quote.
+6. **Acronym handling on first mention**: expand acronyms once at first occurrence per document; depth tuned to AUDIENCE (expert / mixed / lay). See `references/01-core-principles/acronym-handling-principles.md`. Subsequent mentions verbatim; proper nouns, brand names, and arc/sales discipline markers (`**IS**:`, `**DOES**:`, `**MEANS**:`) excluded.
 
 **Impact techniques** (when `impact_level: high` or executive audience):
 
@@ -180,6 +188,7 @@ Review enhances quality but never blocks delivery — if review fails, continue 
 - Active voice: 80%+
 - Framework pattern applied (standard mode)
 - Baseline formatting met (paragraphs, bold anchoring, white space)
+- Acronyms expanded once on first mention (audience-tuned); subsequent mentions verbatim; proper nouns/brands/arc markers excluded
 
 **German-specific validation** (when detected language is German):
 - Average clause length: target 10-12 words
@@ -240,7 +249,7 @@ Auto-detects language. Returns `flesch_score`, `flesch_target_min/max`, `avg_par
 
 All references are organized in progressive disclosure tiers. Start with `references/00-index.md` — it routes you to exactly the files needed for any given task.
 
-**Core Principles** (01-core-principles/) — Clarity, conciseness, active voice, German style (Wolf Schneider), German hooks, plain language, readability
+**Core Principles** (01-core-principles/) — Clarity, conciseness, active voice, German style (Wolf Schneider), German hooks, plain language, readability, acronym handling (audience-tuned first-mention expansion)
 
 **Messaging Frameworks** (02-messaging-frameworks/) — BLUF, Pyramid, SCQA, Inverted Pyramid, STAR, PSB, FAB
 

--- a/cogni-copywriting/skills/copywriter/references/00-index.md
+++ b/cogni-copywriting/skills/copywriter/references/00-index.md
@@ -1,8 +1,8 @@
 ---
 title: Copywriting Skills Master Index
 type: index
-version: 8.0
-last_updated: 2026-02-25
+version: 8.1
+last_updated: 2026-05-19
 ---
 
 # Reference Loading Index
@@ -51,6 +51,7 @@ LOAD: 09-preservation-modes/arc-technique-map.md
 LOAD: 01-core-principles/clarity-principles.md
 LOAD: 01-core-principles/conciseness-principles.md
 LOAD: 01-core-principles/active-voice-principles.md
+LOAD: 01-core-principles/acronym-handling-principles.md
 LOAD: 07-impact-techniques/number-plays.md
 LOAD: 07-impact-techniques/power-words.md
 
@@ -81,12 +82,13 @@ Then continue to the Standard Loading Block for deliverable + framework selectio
 
 This is the normal path for all non-arc tasks (including sales mode, which adds to this).
 
-#### 2a. Core Principles (always load these three)
+#### 2a. Core Principles (always load these four)
 
 ```
 LOAD: 01-core-principles/clarity-principles.md
 LOAD: 01-core-principles/conciseness-principles.md
 LOAD: 01-core-principles/active-voice-principles.md
+LOAD: 01-core-principles/acronym-handling-principles.md
 ```
 
 #### 2b. Language-Conditional Principles
@@ -261,6 +263,7 @@ All reference files in this system, organized by directory. Use this as the sour
 - `clarity-principles.md` -- 15-20 word sentences, concrete language, simple words
 - `conciseness-principles.md` -- 3-5 sentence paragraphs, eliminate filler, strong verbs
 - `active-voice-principles.md` -- 80%+ active voice, clear subjects, transformation patterns
+- `acronym-handling-principles.md` -- First-mention acronym expansion, audience-tuned (expert/mixed/lay); proper-noun and structure-marker exclusions
 - `german-style-principles.md` -- Wolf Schneider rules: 12-word clauses, Satzklammer, Mittelfeld, Floskeln
 - `german-hook-principles.md` -- Wolf Schneider / Reiners / Nannen: 12 opening-sentence rules, Kuechenzuruf test, arc hook strategies
 - `plain-language-principles.md` -- Technical content accessibility

--- a/cogni-copywriting/skills/copywriter/references/01-core-principles/acronym-handling-principles.md
+++ b/cogni-copywriting/skills/copywriter/references/01-core-principles/acronym-handling-principles.md
@@ -1,0 +1,138 @@
+---
+title: Acronym Handling Principles (Audience-Tuned First-Mention Expansion)
+type: writing-principle
+category: core-principles
+tags: [acronyms, abbreviations, audience-tuning, clarity, first-mention, plain-language]
+audience: [all]
+related:
+  - clarity-principles
+  - plain-language-principles
+  - power-positions
+  - arc-preservation
+version: 1.0
+last_updated: 2026-05-19
+---
+
+# Acronym Handling Principles
+
+<context>
+You are applying acronym and abbreviation handling as a default polish discipline. This applies to every copywriting task — standard, sales, and arc modes — and sits alongside Wolf-Schneider clarity, active voice, paragraph splitting, and bold anchoring in Step 3 of the workflow.
+
+Your goal: on first mention, expand each acronym to a form the reader can carry through the rest of the document. On subsequent mentions, leave the acronym verbatim. Tune the depth of expansion to the AUDIENCE so the result reads neither belehrend (for experts) nor opaque (for lay readers).
+</context>
+
+## Audience Resolution
+
+The skill resolves `AUDIENCE` in this exact priority order (defined in `SKILL.md` Step 1):
+
+1. **Explicit `AUDIENCE` skill arg** — `expert` | `mixed` | `lay`
+2. **Frontmatter `audience:` field** — same vocabulary
+3. **Default** — `mixed`
+
+Treat `AUDIENCE` as the single source of truth for expansion depth. Do not infer it from other frontmatter fields (`market`, `seniority`, etc.) — upstream callers are responsible for setting `audience:` correctly.
+
+The stakeholder-review audience vocabulary (`executive` / `technical` / `general` / `legal` / `sales/marketing`) in `SKILL.md` Step 4 is a separate, parallel concept used for reviewer persona selection. Both vocabularies coexist; a future iteration may unify them.
+
+## Detection Heuristic
+
+Treat the following patterns as candidate acronyms/abbreviations:
+
+- **Two or more consecutive uppercase letters** — `SIEM`, `MDR`, `BSI`, `DSGVO`, `NIS2`, `MTTI`
+- **Mixed notations** — `BSI-C5`, `BSIG-NIS2`, `ISO 27001`, `M365`, `S/4HANA`
+- **Versioning suffixes** — `NIS2`, `DORA`, `IPv6`, `HTTP/2` (treat the version as part of the token)
+- **Compound references with a paragraph sigil or section number** — `§38 BSIG-NIS2`, `Art. 32 DSGVO`
+- **Domain-specific lowercase acronyms** — rare but real: `s.o.`, `z.B.` (these are usually expanded everywhere and are not the focus of this discipline; see plain-language-principles)
+
+Candidate ≠ expand. Apply the audience-tuned table and exclusions below.
+
+## Audience-Tuned Depth
+
+| Audience | Behaviour |
+|---|---|
+| `expert` | Expand only genuinely technical or ambiguous acronyms (`SIEM`, `MTTI`, `B3S`, niche product codes). Regulation proper nouns like `NIS2`, `DSGVO`, `BSI`, `DORA` stay unaltered — expanding them in front of a KRITIS-CISO reads as belehrend. |
+| `mixed` *(default)* | Expand technical acronyms in full; explain common regulation acronyms once on first mention (`DSGVO (Datenschutz-Grundverordnung)`). Keep it short — no plain-language gloss. |
+| `lay` | Expand virtually every acronym on first mention and add a short plain-language gloss in the document language: `MDR (Managed Detection and Response — ein Dienstleister erkennt und stoppt Angriffe rund um die Uhr für Sie)`. |
+
+### Worked Examples (DE pitch context)
+
+| Acronym | `expert` first mention | `mixed` first mention | `lay` first mention |
+|---|---|---|---|
+| `SIEM` | `SIEM (Security Information and Event Management)` | `SIEM (Security Information and Event Management)` | `SIEM (Security Information and Event Management — sammelt und korreliert Sicherheitsdaten aus dem ganzen Unternehmen)` |
+| `MDR` | `MDR (Managed Detection and Response)` | `MDR (Managed Detection and Response)` | `MDR (Managed Detection and Response — ein Dienstleister erkennt und stoppt Angriffe rund um die Uhr für Sie)` |
+| `MTTI` | `MTTI (Mean Time to Identify)` | `MTTI (Mean Time to Identify)` | `MTTI (Mean Time to Identify — wie schnell ein Angriff überhaupt bemerkt wird)` |
+| `NIS2` | `NIS2` *(unchanged — regulation proper noun)* | `NIS2 (Netz- und Informationssicherheitsrichtlinie 2)` | `NIS2 (Netz- und Informationssicherheitsrichtlinie 2 — die EU-Vorgabe, die Mindeststandards für die IT-Sicherheit vorschreibt)` |
+| `DSGVO` | `DSGVO` *(unchanged)* | `DSGVO (Datenschutz-Grundverordnung)` | `DSGVO (Datenschutz-Grundverordnung — die EU-Regel, wie persönliche Daten geschützt werden müssen)` |
+| `BSI` | `BSI` *(unchanged)* | `BSI (Bundesamt für Sicherheit in der Informationstechnik)` | `BSI (Bundesamt für Sicherheit in der Informationstechnik — die deutsche Behörde für IT-Sicherheit)` |
+
+### Worked Examples (EN context)
+
+| Acronym | `expert` | `mixed` | `lay` |
+|---|---|---|---|
+| `SIEM` | `SIEM (Security Information and Event Management)` | `SIEM (Security Information and Event Management)` | `SIEM (Security Information and Event Management — a system that collects and correlates security signals across your organization)` |
+| `NIS2` | `NIS2` | `NIS2 (Network and Information Security Directive 2)` | `NIS2 (Network and Information Security Directive 2 — the EU rule setting minimum IT-security standards for critical sectors)` |
+
+## Format Convention
+
+```
+ACRONYM (Vollform — optional plain-language gloss for lay)
+```
+
+Rules:
+
+- **Vollform language matches the document language** — DE document → German Vollform; EN document → English Vollform. Use the language detected in Step 3 of `SKILL.md`.
+- **The em-dash separator (`—`) precedes the lay gloss.** No em-dash for `expert` / `mixed`.
+- **First mention only.** Track which acronyms have already been introduced *in the current document*. The skill does not polish across files.
+- **Per-document scope.** Each document is treated independently.
+
+## Exclusions (never expand)
+
+### Proper nouns
+
+Recognised regulation, framework, and standard names with their own brand identity. Never expand these — they read as the proper noun, not the acronym they originated from:
+
+- `KRITIS-Dachgesetz`, `EU AI Act`, `BSI C5`, `B3S`, `ISO 27001`, `ISO 9001`, `TISAX`, `DAX`, `MDAX`, `SDAX`, `TecDAX`
+
+### Brand and product names
+
+Acronym-shaped brand names belong to their owners — leave them verbatim:
+
+- `Magenta Security`, `Open Telekom Cloud`, `T-Cloud`, `Microsoft Entra ID`, `CrowdStrike Falcon`, `SAP S/4HANA`
+
+### Audience-trivial tokens
+
+| Token | `expert` | `mixed` | `lay` |
+|---|---|---|---|
+| `IT`, `EU`, `USD`, `EUR`, `URL`, `PDF` | skip | skip | skip |
+| `M365` | skip | skip | expand |
+| `KI`/`AI` | skip | skip | expand once |
+
+### Arc and sales structure markers
+
+The Power Position markers `**IS**:`, `**DOES**:`, `**MEANS**:` and standalone `IS` / `DOES` / `MEANS` tokens used as arc-element labels in the portfolio JTBD map are **never** acronym candidates. They are structural markers, not abbreviations. See:
+
+- `08-sales-techniques/power-positions.md` — structure marker preservation (line 318)
+- `09-preservation-modes/arc-preservation.md` — arc structure preservation rules
+
+If you cannot tell from context whether a token is a structural marker or an acronym, treat it as a structural marker (safer default).
+
+## Compound Reference Rule
+
+When a compound reference like `§38 BSIG-NIS2` appears and the constituent acronym (`BSIG`) has not been introduced earlier, attach the explanation to the **compound**, not the bare token:
+
+- ✅ `§38 BSIG-NIS2 (BSI-Gesetz in der NIS-2-Umsetzungsfassung; §38 regelt die persönliche Haftung der Geschäftsleitung)`
+- ❌ Expanding bare `BSIG` later in the document when only the compound appeared earlier.
+
+This keeps the explanation co-located with the actual reader question ("what does §38 in this regulation say?") rather than splitting it across two introductions.
+
+## Validation
+
+A polished document satisfies this discipline when:
+
+1. Every auflösungswürdig acronym is expanded **once**, on its first occurrence.
+2. Every subsequent mention of the same acronym is **verbatim** — no re-expansion.
+3. Excluded tokens (proper nouns, brand names, audience-trivial words, arc/sales markers) are **unchanged** anywhere in the document.
+4. The expansion **depth** matches the resolved `AUDIENCE` (no lay glosses in `expert` output; no raw `MDR` in `lay` output).
+5. Vollform **language** matches the document language.
+6. Compound references carry the explanation on the compound, not the bare token.
+
+If any of (1)–(6) fail, fix in place — do not revert the whole polish.

--- a/cogni-copywriting/skills/copywriter/references/05-examples/example-acronyms-audience.md
+++ b/cogni-copywriting/skills/copywriter/references/05-examples/example-acronyms-audience.md
@@ -1,0 +1,75 @@
+---
+title: Example — Audience-Tuned Acronym Expansion (expert / mixed / lay)
+type: discipline-example
+category: discipline-example
+discipline: acronym-handling
+language: de
+audience: [all]
+related:
+  - acronym-handling-principles
+version: 1.0
+last_updated: 2026-05-19
+---
+
+# Example — Audience-Tuned Acronym Expansion
+
+## Purpose
+
+This reference shows the acronym-handling discipline applied to the *same source paragraph* across the three audience tiers (`expert`, `mixed`, `lay`). Study what changes per tier and what stays constant — first-mention only, structure markers preserved, proper nouns and brand names left raw.
+
+Use this as a calibration set when polishing DACH security pitches, regulated-industry briefs, or any document whose acronym density makes audience-tuning consequential.
+
+## Source Paragraph (DE, unpolished)
+
+> Unser MDR-Angebot deckt SIEM-Korrelation, Threat-Hunting und Incident Response über Magenta Security ab. Es ist auf §38 BSIG-NIS2 zugeschnitten und reduziert die MTTI auf unter 8 Minuten. Der Compliance-Bezug zu NIS2, DSGVO und den BSI C5-Kontrollen ist im Lieferumfang dokumentiert. Bei einer Folge-Eskalation übergibt das MDR-Team direkt an den Kunden-CISO.
+
+Token inventory: `MDR`, `SIEM`, `Magenta Security` (brand — excluded), `§38 BSIG-NIS2` (compound), `MTTI`, `NIS2`, `DSGVO`, `BSI C5` (proper noun — excluded), and a repeat `MDR` in the last sentence.
+
+---
+
+## Polished — `AUDIENCE=expert`
+
+> Unser MDR (Managed Detection and Response)-Angebot deckt SIEM (Security Information and Event Management)-Korrelation, Threat-Hunting und Incident Response über Magenta Security ab. Es ist auf §38 BSIG-NIS2 (BSI-Gesetz in der NIS-2-Umsetzungsfassung; §38 regelt die persönliche Haftung der Geschäftsleitung) zugeschnitten und reduziert die MTTI (Mean Time to Identify) auf unter 8 Minuten. Der Compliance-Bezug zu NIS2, DSGVO und den BSI C5-Kontrollen ist im Lieferumfang dokumentiert. Bei einer Folge-Eskalation übergibt das MDR-Team direkt an den Kunden-CISO.
+
+**What happened:**
+
+- `MDR`, `SIEM`, `MTTI` expanded with the bare German/English Vollform — no plain-language gloss, no belehrender Ton.
+- `NIS2`, `DSGVO` left raw — a KRITIS-CISO does not need these explained.
+- `BSI C5`, `Magenta Security` untouched (proper noun / brand).
+- `§38 BSIG-NIS2` carries the explanation on the **compound**, not on a later bare `BSIG`.
+- Second mention `MDR-Team` verbatim.
+
+## Polished — `AUDIENCE=mixed` *(default)*
+
+> Unser MDR (Managed Detection and Response)-Angebot deckt SIEM (Security Information and Event Management)-Korrelation, Threat-Hunting und Incident Response über Magenta Security ab. Es ist auf §38 BSIG-NIS2 (BSI-Gesetz in der NIS-2-Umsetzungsfassung; §38 regelt die persönliche Haftung der Geschäftsleitung) zugeschnitten und reduziert die MTTI (Mean Time to Identify) auf unter 8 Minuten. Der Compliance-Bezug zu NIS2 (Netz- und Informationssicherheitsrichtlinie 2), DSGVO (Datenschutz-Grundverordnung) und den BSI C5-Kontrollen ist im Lieferumfang dokumentiert. Bei einer Folge-Eskalation übergibt das MDR-Team direkt an den Kunden-CISO.
+
+**What changed vs. `expert`:**
+
+- `NIS2` and `DSGVO` now expand once with the bare Vollform — enough for a Pre-Sales-Ansprache where some readers may not carry the regulation alphabet by heart.
+- Everything else identical: technical acronyms expanded bare, brands untouched, compound reference handled on the compound, second mention verbatim.
+
+## Polished — `AUDIENCE=lay`
+
+> Unser MDR (Managed Detection and Response — ein Dienstleister erkennt und stoppt Angriffe rund um die Uhr für Sie)-Angebot deckt SIEM (Security Information and Event Management — sammelt und korreliert Sicherheitsdaten aus dem ganzen Unternehmen)-Korrelation, gezielte Angriffsjagd und Vorfallsbearbeitung über Magenta Security ab. Es ist auf §38 BSIG-NIS2 (BSI-Gesetz in der NIS-2-Umsetzungsfassung — die deutsche Auslegung der EU-Sicherheitsregel; §38 regelt die persönliche Haftung der Geschäftsleitung) zugeschnitten und reduziert die MTTI (Mean Time to Identify — wie schnell ein Angriff überhaupt bemerkt wird) auf unter 8 Minuten. Der Compliance-Bezug zu NIS2 (Netz- und Informationssicherheitsrichtlinie 2 — die EU-Vorgabe, die Mindeststandards für die IT-Sicherheit vorschreibt), DSGVO (Datenschutz-Grundverordnung — die EU-Regel, wie persönliche Daten geschützt werden müssen) und den BSI C5-Kontrollen ist im Lieferumfang dokumentiert. Bei einer Folge-Eskalation übergibt das MDR-Team direkt an den Kunden-CISO (Chief Information Security Officer — die Person im Unternehmen, die für IT-Sicherheit verantwortlich ist).
+
+**What changed vs. `mixed`:**
+
+- Every acronym (`MDR`, `SIEM`, `MTTI`, `NIS2`, `DSGVO`) now carries the em-dashed plain-language gloss in the document language.
+- Even `CISO` (typically `expert`/`mixed` audience-trivial) is glossed on first mention because the lay reader cannot be assumed to know the role.
+- The English-loanword "Threat-Hunting" / "Incident Response" softened to "gezielte Angriffsjagd" / "Vorfallsbearbeitung" — adjacent plain-language discipline, not strictly part of acronym handling but consistent with the lay audience.
+- `BSI C5` still untouched (proper noun).
+- `Magenta Security` still untouched (brand).
+- Second mention `MDR-Team` still verbatim.
+
+## What stays constant across all three
+
+| Token | `expert` | `mixed` | `lay` |
+|---|---|---|---|
+| `Magenta Security` | unchanged | unchanged | unchanged |
+| `BSI C5` | unchanged | unchanged | unchanged |
+| Second `MDR-Team` | verbatim | verbatim | verbatim |
+| `§38 BSIG-NIS2` | explanation on compound | explanation on compound | explanation on compound |
+
+## Arc-mode note
+
+If the same paragraph appeared *inside* a JTBD Portfolio arc element labelled `IS:` / `DOES:` / `MEANS:` (or with bold structure markers `**IS**:` / `**DOES**:` / `**MEANS**:`), the discipline marker tokens themselves are **never** treated as acronyms — they stay verbatim. See `09-preservation-modes/arc-preservation.md` and `08-sales-techniques/power-positions.md`.

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.48",
+  "version": "0.9.49",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.49",
+  "version": "0.9.50",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/skills/portfolio-communicate/references/templates-pitch.md
+++ b/cogni-portfolio/skills/portfolio-communicate/references/templates-pitch.md
@@ -67,6 +67,9 @@ source_file_count: {count of portfolio entity files referenced}
 type: portfolio-pitch
 market: "{market-slug}"
 provider: "{company_name from portfolio.json}"
+audience: "{expert|mixed|lay — derived from market-slug heuristic; see below}"
+personas:
+  - "{role from customers/{market-slug}.json profiles[].role}"
 ---
 ```
 
@@ -80,6 +83,31 @@ provider: "{company_name from portfolio.json}"
 - `title` + `subtitle` — extracted for the title slide
 - `language` — controls localized headers and IS/DOES/MEANS labels
 - `word_count` + `target_length` — used for slide count estimation
+- `audience` — consumed by `cogni-copywriting:copywriter` (0.2.3+) to tune acronym expansion depth and any future audience-aware polish discipline. Without this field the polisher falls back to `mixed`, losing the per-market signal.
+- `personas` — buyer roles surfaced for downstream visual / review tooling. Sourced from `customers/{market-slug}.json` `profiles[].role`. If `customers/{market-slug}.json` does not exist (or has no `profiles[]`), omit `personas:` entirely — do not emit an empty array.
+
+### Audience and personas derivation
+
+Emit `audience:` using the market-slug heuristic below. The mapping reflects realistic buyer profiles for B2B portfolio pitches; override only when the user gives explicit instruction.
+
+| Market slug pattern | Default `audience:` | Rationale |
+|---|---|---|
+| `portfolio-overview` (cross-market) | `mixed` | Investor / board / cross-functional mix |
+| `enterprise-large-*` | `expert` | KRITIS-CISO, GRC-Head — avoid belehrender Ton, do not expand `NIS2` / `DSGVO` / `BSI` |
+| `enterprise-mid-*` | `expert` | CISO function with small team — same expert register |
+| `smb-midmarket-*` | `mixed` | Geschäftsführer plus IT-Leiter — explain regulation acronyms once |
+| `smb-small-*` | `lay` | Inhaber without security background + MSP channel — full plain-language glosses |
+| anything else | `mixed` | Safe default |
+
+For `personas:`, read `customers/{market-slug}.json` and lift the value of each `profiles[].role` verbatim into the YAML list — for example:
+
+```yaml
+personas:
+  - "Geschäftsführer / Inhaber"
+  - "External IT-Dienstleister / MSP"
+```
+
+Do not paraphrase or translate the role string — downstream tooling matches on the exact label written by the customers skill.
 
 ---
 
@@ -325,6 +353,8 @@ Only count citations that have external URLs. Internal estimates don't count tow
 | **Invitation** | Market-specific entry point | Portfolio-level engagement path — total addressable value |
 
 **Title**: Portfolio-wide, not market-specific. "How {Company} Addresses the {Cross-Market Theme}" or "{Company}: {Portfolio-Level Value Statement}"
+
+**Frontmatter**: Use the same frontmatter shape as a per-market pitch with `market: "portfolio-overview"`. The audience/personas derivation rules apply — for this scope set `audience: mixed` (heterogeneous investor / board / cross-functional audience) and omit `personas:` unless a cross-market customer profile file (`customers/portfolio-overview.json`) exists.
 
 ---
 


### PR DESCRIPTION
## Summary

Resolves #248 with one cross-plugin commit. The discipline (first-mention acronym expansion, audience-tuned) lives in `cogni-copywriting`; the signal source (`audience:` + `personas:` frontmatter) is wired up in `cogni-portfolio:portfolio-communicate` so the new behaviour fires automatically on generated pitches without manual backfill.

### Shape of the change

```
cogni-portfolio                                cogni-copywriting
─────────────────                              ─────────────────
templates-pitch.md                             SKILL.md Step 1
  emit audience: + personas:        ────►        AUDIENCE arg
  market-slug heuristic                            │
  customers/{market}.json profiles[].role          ▼
                                                 Step 3 item 6
                                                   acronym handling
                                                 references/01-core-principles/
                                                   acronym-handling-principles.md (new)
                                                 references/05-examples/
                                                   example-acronyms-audience.md (new)
```

Audience resolution hierarchy in the polisher: explicit `AUDIENCE` arg → frontmatter `audience:` → `mixed` default.

### cogni-copywriting 0.2.3 (skill CHANGELOG 7.2.0)

- **New reference** `01-core-principles/acronym-handling-principles.md` — always-loaded in standard and arc modes. Detection heuristic, audience-tuned depth table, format convention (`ACRONYM (Vollform — optional gloss)`), exclusions (proper nouns, brands, audience-trivial tokens, arc/sales structure markers `**IS**:`/`**DOES**:`/`**MEANS**:`), compound-reference rule (`§38 BSIG-NIS2`).
- **New example** `05-examples/example-acronyms-audience.md` — same DACH-security paragraph polished three times (`expert` / `mixed` / `lay`) demonstrating exclusions, lay glosses, compound references, second-mention verbatim handling.
- **SKILL.md** — Step 1 adds `AUDIENCE` parameter + resolution-order paragraph; Step 3 "Both languages — formatting" adds item 6 (acronym handling); Step 5 validation checklist adds one bullet; Bundled Resources updated.
- **00-index.md** — always-load core block now four files; arc-load block also loads acronym handling; file inventory entry added; index 8.0 → 8.1.
- **agents/copywriter.md** — new `AUDIENCE` input, threaded through Step 2 skill invocation. No new JSON output field.
- **CLAUDE.md** — Polish Flow Step 3 description and Key Conventions bullet extended.

### cogni-portfolio 0.9.49

- **templates-pitch.md** — pitch frontmatter spec now emits `audience:` and `personas:`. New "Audience and personas derivation" subsection documents:
  - `audience:` from market-slug heuristic — `smb-small-*` → `lay`, `smb-midmarket-*` → `mixed`, `enterprise-{mid,large}-*` → `expert`, `portfolio-overview` → `mixed`, anything else → `mixed`.
  - `personas:` lifted verbatim from `customers/{market-slug}.json` → `profiles[].role`. If the file is missing or has no `profiles[]`, omit `personas:` entirely (no empty array).
- Cross-market scope ("Portfolio-Wide Scope: Overview Narrative") gets explicit `audience: mixed`.

### Out of scope (deferred)

- `--audience=...` flag on `/copywrite` command and `copy-json` skill — callers can pass via `args` today.
- Auto-injecting `AUDIENCE` at other upstream callers (`cogni-marketing`, `narrative-adapt`).
- Telemetry of expansion counts in JSON output.
- Cross-document acronym memory.
- `seniority`-based audience inference (heuristic is the agreed first cut).

## Test plan

LLM-driven skill — no automated tests. Verification is manual:

**cogni-copywriting:**
- [ ] Smoke `lay`: skill on the example paragraph with `AUDIENCE=lay` — `SIEM`/`MDR`/`NIS2`/`BSI`/`MTTI` expanded on first mention; second `SIEM` verbatim; `MDR` carries lay gloss.
- [ ] Audience tuning `expert`: same paragraph, `AUDIENCE=expert` — `NIS2`/`DSGVO`/`BSI` raw; `SIEM`/`MTTI`/`B3S` expanded.
- [ ] Frontmatter fallback: paragraph with `audience: lay` in frontmatter, no arg → lay behaviour.
- [ ] Default fallback: no arg, no frontmatter → `mixed` behaviour.
- [ ] Exclusions: `Magenta Security` / `Microsoft Entra ID` / `B3S` / `ISO 27001` — none expanded.
- [ ] Arc-mode protection: arc document with `**IS**:` / `**DOES**:` / `**MEANS**:` — markers verbatim; acronyms in layer text expanded.
- [ ] Compound reference: `§38 BSIG-NIS2` — explanation hangs on the compound.
- [ ] Regression: DE document without acronyms — output character-identical, citations preserved, `python3 cogni-copywriting/skills/copywriter/scripts/calculate_readability.py <file> --lang de` Flesch 30–50.
- [ ] Regression: agent returns existing JSON schema unchanged.

**cogni-portfolio:**
- [ ] `portfolio-communicate` pitch on a project with `customers/smb-small-dach.json` → frontmatter shows `audience: lay` + `personas:` matching `profiles[].role`.
- [ ] Heuristic variants: `enterprise-large-dach` → `expert`; `smb-midmarket-dach` → `mixed`.
- [ ] Missing `customers/{market}.json` → `personas:` omitted; `audience: mixed` default.
- [ ] End-to-end: generate `smb-small-dach` pitch, then run `copywriter` skill without `AUDIENCE` arg — lay-depth expansion fires from frontmatter alone.

**Metadata:**
- [ ] `cogni-copywriting/.claude-plugin/plugin.json` → `0.2.3`; marketplace mirror updated; skill CHANGELOG top entry `[7.2.0]`.
- [ ] `cogni-portfolio/.claude-plugin/plugin.json` → `0.9.49`; marketplace mirror updated.

https://claude.ai/code/session_01TB77dikQAGWVpCpKsjU766

---
_Generated by [Claude Code](https://claude.ai/code/session_01TB77dikQAGWVpCpKsjU766)_