### PR TITLE
cogni-copywriting 0.3.0: EN↔DE translation pass (translate-then-polish)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -46,9 +46,9 @@
     {
       "name": "cogni-copywriting",
       "source": "./cogni-copywriting",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "maturity": "preview",
-      "description": "Professional copywriting toolkit providing document polishing with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), stakeholder review via parallel persona Q&A, readability optimization, sales enhancement (Power Positions), multi-language support, JSON field polishing via the copy-json adapter, and arc contract audit against cogni-narrative.",
+      "description": "Professional copywriting toolkit providing document polishing with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), stakeholder review via parallel persona Q&A, readability optimization, sales enhancement (Power Positions), multi-language support, JSON field polishing via the copy-json adapter, arc contract audit against cogni-narrative, and EN↔DE translation pass (translate then polish).",
       "keywords": [
         "copywriting",
         "document-polishing",
@@ -56,6 +56,8 @@
         "readability",
         "sales-copy",
         "power-positions",
+        "translation",
+        "en-de",
         "agent"
       ]
     },

--- a/cogni-copywriting/.claude-plugin/plugin.json
+++ b/cogni-copywriting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cogni-copywriting",
-  "version": "0.2.3",
-  "description": "Professional copywriting toolkit providing document polishing with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), stakeholder review via parallel persona Q&A, readability optimization, sales enhancement (Power Positions), multi-language support, JSON field polishing via the copy-json adapter, and arc contract audit against cogni-narrative.",
+  "version": "0.3.0",
+  "description": "Professional copywriting toolkit providing document polishing with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), stakeholder review via parallel persona Q&A, readability optimization, sales enhancement (Power Positions), multi-language support, JSON field polishing via the copy-json adapter, arc contract audit against cogni-narrative, and EN↔DE translation pass (translate then polish).",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
@@ -19,6 +19,8 @@
     "sales-copy",
     "power-positions",
     "bilingual",
+    "translation",
+    "en-de",
     "arc-audit",
     "copy-json",
     "agent"

--- a/cogni-copywriting/CLAUDE.md
+++ b/cogni-copywriting/CLAUDE.md
@@ -119,15 +119,26 @@ commands/                                 2 slash commands
 
 ### Copywriter Polish Flow
 
-5-step sequential workflow with scope-dependent step skipping:
+5-step sequential workflow with scope-dependent step skipping (extended to a 5.5-step flow when `TARGET_LANG` is set — see Translation Flow below):
 
-1. **Parse parameters and load references** -- reads `00-index.md` decision tree to detect mode (arc/sales/standard) and load exactly the references needed
-2. **Apply structure** -- applies messaging framework pattern (Pyramid, BLUF, etc.); skipped in arc mode (arc IS the structure) or `--scope=tone|formatting`
+1. **Parse parameters and load references** -- reads `00-index.md` decision tree to detect mode (arc/sales/standard) and load exactly the references needed; resolves `AUDIENCE` (`expert`/`mixed`/`lay`) and `TARGET_LANG` (`de`/`en`/unset) each via three-tier resolution (skill arg → frontmatter → default)
+2. **Apply structure** -- applies messaging framework pattern (Pyramid, BLUF, etc.); skipped in arc mode (arc IS the structure), `--scope=tone|formatting`, or when `TARGET_LANG` is set (translation preserves source structure)
 3. **Apply writing and formatting** -- language detection (EN/DE), voice transformation, paragraph splitting, bold anchoring, visual rhythm, first-mention acronym expansion (audience-tuned via `AUDIENCE` arg → frontmatter `audience:` → `mixed`); loads impact techniques for high-impact or executive audiences
 4. **Review** -- optional stakeholder review via copy-reader skill (parallel personas) or automated checklist; never blocks delivery
 5. **Validate and write** -- German chars preserved, citations intact, readability scored, arc validation if active; backs up original before writing
 
-Scope matrix determines which steps run: `full` runs all, `structure` runs 1+2+5, `tone` runs 1+3+5, `formatting` runs 1+3+5.
+Scope matrix determines which steps run: `full` runs all, `structure` runs 1+2+5, `tone` runs 1+3+5, `formatting` runs 1+3+5. When `TARGET_LANG` is set, scope is overridden: Step 2 always skips, Steps 3 + 5 always run.
+
+### Translation Flow
+
+When `TARGET_LANG` is set on the copywriter skill, the workflow runs a translate-then-polish two-pass flow:
+
+- **Pre-checks (Step 1)**: resolve source language via the existing detector; abort if `source_lang == TARGET_LANG` (no-op); abort if `arc_id` is in frontmatter (arc-mode translation blocked in v1 — arc heading texts require exact-match preservation per `09-preservation-modes/arc-preservation.md`); abort if `TARGET_LANG` is anything other than `de` or `en` (Phase 2 scope).
+- **Pass A — Translate (new Step 2.5)**: loads `01-core-principles/translation-principles.md` plus direction-specific guide (`translation-en-to-de.md` or `translation-de-to-en.md`). Translates prose; preserves byte-identical: citations (markers + URLs), URLs in inline links, code blocks, frontmatter technical IDs (`arc_id`/`source_url`/`entity_ref`), protected content (`<diagram-placeholder>`, `Figure N`/`Abbildung N`, `![[assets/*.svg]]`, kanban tables), Power Position markers (`**IS**:`, `**DOES**:`, `**MEANS**:`), and acronyms (acronym expansion is Step 3's job, running on the translated text).
+- **Pass B — Polish (existing Step 3)**: applies target-language style discipline. For DE output: Wolf-Schneider rules (12-word clauses, Satzklammer breaking, Mittelfeld shortening, Floskel elimination). For EN output: 15–20 word sentences, 80%+ active voice, Flesch 50–60. Audience-tuned acronym expansion runs here, on the translated text.
+- **Validation (Step 5)**: existing checks plus translation-specific bullets — target charset matches (umlauts present for `de`, absent for `en`); citation count exactly preserved (not just `>=`); URLs byte-identical; frontmatter technical IDs unchanged.
+
+v1 limits: EN ↔ DE only; arc-mode blocked. Phase 2 follow-up issue tracks FR/IT/PL/NL/ES and arc-mode translation (which requires heading-set substitution via `cogni-narrative/skills/narrative/references/language-templates.md`).
 
 ### Copy-Reader Stakeholder Review Flow
 
@@ -145,8 +156,8 @@ Scope matrix determines which steps run: `full` runs all, `structure` runs 1+2+5
 4-step JSON-to-markdown-to-JSON bridge:
 
 1. **Parse and extract** -- validate `.json` file, resolve FIELDS dot-path selectors (`plugins[*].description`), collect string values >= 10 chars
-2. **Build temp MD and invoke copywriter** -- assemble extracted texts with `<!-- FIELD: ... -->` delimiters into temp markdown file, delegate to copywriter skill with scope (default: `tone`)
-3. **Parse back and validate** -- split polished MD by delimiters, validate: German chars preserved, no markdown injection (`**`, `#`, `- `), length guard (max 2x original), citations preserved
+2. **Build temp MD and invoke copywriter** -- assemble extracted texts with `<!-- FIELD: ... -->` delimiters into temp markdown file, delegate to copywriter skill with scope (default: `tone`); pass `TARGET_LANG` through when set
+3. **Parse back and validate** -- split polished MD by delimiters, validate: direction-aware German-char check (preservation when unset; umlauts required when `TARGET_LANG=de`; umlauts absent when `TARGET_LANG=en`), no markdown injection (`**`, `#`, `- `), length guard (2x original; 2.5x for translations), citations preserved (exact count match for translations)
 4. **Write and report** -- backup original, update JSON with polished values preserving indentation, show before/after diff table
 
 ### Audit-Copywriter Arc Audit Flow

--- a/cogni-copywriting/README.md
+++ b/cogni-copywriting/README.md
@@ -31,6 +31,7 @@ A professional editing toolkit for the insight-wave ecosystem. Seven messaging f
 4. **Preserve arcs** — when paired with cogni-narrative, detects story arc frontmatter and applies element-specific techniques without breaking arc structure
 5. **Polish JSON** — extract and polish text fields inside structured JSON files (plugin descriptions, propositions, category names) via the copy-json adapter
 6. **Audit** arc-preservation references against upstream cogni-narrative definitions — detect missing arcs, heading mismatches, technique inconsistencies
+7. **Translate** EN↔DE in a single pass — translates first, then applies target-language style discipline (Wolf-Schneider for DE, Flesch tuning for EN), preserving citations, frontmatter technical IDs, and protected content byte-identical
 
 ## What it means for you
 
@@ -54,6 +55,7 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 ```
 /copywrite quarterly-report.md              # full polish
 /copywrite research-paper.md --scope=tone   # tone only
+/copywrite product-overview.md --translate=de  # translate EN→DE and polish
 /review-doc quarterly-report.md             # stakeholder review + auto-apply
 /review-doc proposal.md --no-improve        # feedback only, no changes
 ```
@@ -106,10 +108,12 @@ Detects German language automatically, loads Wolf Schneider style rules — brea
 
 ## Language support
 
-| Language | Readability | Style Rules | Target Score |
-|----------|-------------|-------------|--------------|
-| English | Flesch Reading Ease | Messaging frameworks, active voice, visual hierarchy | 50-60 |
-| German | Amstad | Wolf Schneider (7 rules: Satzklammer, Mittelfeld, Floskeln, Rhythmus, etc.) | 30-50 |
+| Language | Readability | Style Rules | Target Score | Translation |
+|----------|-------------|-------------|--------------|-------------|
+| English | Flesch Reading Ease | Messaging frameworks, active voice, visual hierarchy | 50-60 | EN ↔ DE via `--translate=en` |
+| German | Amstad | Wolf Schneider (7 rules: Satzklammer, Mittelfeld, Floskeln, Rhythmus, etc.) | 30-50 | EN ↔ DE via `--translate=de` |
+
+Translation runs as a two-pass translate-then-polish flow: Pass A transfers meaning (preserving citations, URLs, frontmatter technical IDs, and protected content byte-identical); Pass B applies the target-language style discipline above. Arc-mode translation (documents with `arc_id` frontmatter) is not supported in v1 — additional languages (FR/IT/PL/NL/ES) and arc-mode translation are tracked as Phase 2 work.
 
 ## Components
 

--- a/cogni-copywriting/agents/copywriter.md
+++ b/cogni-copywriting/agents/copywriter.md
@@ -19,6 +19,7 @@ Invoke the copywriter skill to polish a markdown document and return ONLY JSON t
 - `SCOPE`: "full" | "structure-only" | "tone-only" | "formatting-only" (default: full)
 - `MODE`: "standard" | "sales" (default: standard) - When "sales", enables Power Positions (IS-DOES-MEANS) enhancement
 - `AUDIENCE`: "expert" | "mixed" | "lay" (default: mixed) - Tunes audience-aware disciplines such as acronym expansion depth. Resolution order: this arg, then document frontmatter `audience:`, then default `mixed`.
+- `TARGET_LANG`: "de" | "en" (optional) - When set, runs a translate-then-polish two-pass flow (Pass A translates source to target language preserving citations/protected content; Pass B applies target-language style discipline). Resolution order: this arg, then document frontmatter `target_language:`, then unset. v1 supports EN↔DE only and blocks arc-mode (when `arc_id` frontmatter is present).
 - `STAKEHOLDERS`: Array of perspectives for review (default: auto-select based on audience) - Options: executive, technical, legal, marketing, end-user
 - `REVIEW_MODE`: "automated" | "manual" | "skip" (default: automated) - Controls stakeholder review process
 - `QUALITY_TARGETS`: Custom targets (optional)
@@ -47,7 +48,7 @@ Invoke the copywriter skill to polish a markdown document and return ONLY JSON t
 <example>
 <invoke name="Skill">
   <parameter name="skill">cogni-copywriting:copywriter</parameter>
-  <parameter name="args">FILE_PATH={{FILE_PATH}} SCOPE={{SCOPE}} MODE={{MODE}} AUDIENCE={{AUDIENCE}} STAKEHOLDERS={{STAKEHOLDERS}} REVIEW_MODE={{REVIEW_MODE}} QUALITY_TARGETS={{QUALITY_TARGETS}}</parameter>
+  <parameter name="args">FILE_PATH={{FILE_PATH}} SCOPE={{SCOPE}} MODE={{MODE}} AUDIENCE={{AUDIENCE}} TARGET_LANG={{TARGET_LANG}} STAKEHOLDERS={{STAKEHOLDERS}} REVIEW_MODE={{REVIEW_MODE}} QUALITY_TARGETS={{QUALITY_TARGETS}}</parameter>
 </invoke>
 </example>
 
@@ -84,6 +85,9 @@ The skill executes:
   "header_levels": 0,
   "improvements": [],
   "protected_content_preserved": true,
+  "source_lang": "en",
+  "target_lang": "de",
+  "translation_applied": true,
   "stakeholder_reviews": [
     {
       "perspective": "executive",

--- a/cogni-copywriting/commands/copywrite.md
+++ b/cogni-copywriting/commands/copywrite.md
@@ -1,7 +1,7 @@
 ---
 name: copywrite
 description: Polish markdown documents for executive readability using McKinsey Pyramid Principle, or polish text fields inside JSON files via the copy-json adapter
-usage: /copywrite <file> [--scope=full|structure|tone|formatting] [--flesch-target=50-60] [--fields="selector"] [--mode=standard|sales] [--dry-run]
+usage: /copywrite <file> [--scope=full|structure|tone|formatting] [--flesch-target=50-60] [--fields="selector"] [--mode=standard|sales] [--translate=de|en] [--dry-run]
 aliases: [polish, executive-polish]
 category: content-editing
 allowed-tools: [Read, Task, Bash, Skill]
@@ -14,8 +14,8 @@ Polish markdown documents into executive-ready content through the copywriter ag
 ## Usage
 
 ```
-/copywrite <file.md> [--scope=full|structure|tone|formatting] [--flesch-target=50-60]
-/copywrite <file.json> --fields="<selector>" [--scope=tone] [--mode=standard|sales] [--dry-run]
+/copywrite <file.md> [--scope=full|structure|tone|formatting] [--flesch-target=50-60] [--translate=de|en]
+/copywrite <file.json> --fields="<selector>" [--scope=tone] [--mode=standard|sales] [--translate=de|en] [--dry-run]
 ```
 
 ## Parameters
@@ -51,6 +51,14 @@ Polish markdown documents into executive-ready content through the copywriter ag
 - **--mode** - Copywriting mode for JSON files (default: `standard`)
   - `standard` — general-purpose polishing
   - `sales` — apply IS/DOES/MEANS sales messaging and Power Positions
+
+- **--translate** - Translate source content into the target language before polishing (default: unset)
+  - `de` — translate to German, then apply Wolf-Schneider style discipline
+  - `en` — translate to English, then apply Flesch readability targets
+  - Requires source language ≠ target. Source language is detected automatically (or set via `--lang`).
+  - v1 supports EN↔DE only. Other target languages will be rejected.
+  - **Not supported in arc mode** — when the document frontmatter contains `arc_id`, translation aborts (arc heading texts require exact-match preservation).
+  - When set, scope is overridden to ensure a full translate-and-polish cycle (Step 2 framework restructure is skipped; Steps 3 + 5 always run).
 
 - **--dry-run** - Show before/after diff without modifying the file (JSON only)
 
@@ -232,6 +240,38 @@ Applies sales messaging techniques (Power Positions, FAB) to proposition layer f
 
 Shows before/after diff for each field without modifying the JSON file.
 
+### Example 9: Translate EN → DE
+
+```bash
+/copywrite quarterly-report.md --translate=de
+```
+
+Translates the English source document to German, then applies Wolf-Schneider style discipline (Satzklammer breaking, Mittelfeld shortening, Floskel elimination) and Amstad readability tuning.
+
+**Output:**
+```
+**Document Polished**: quarterly-report.md
+
+**Translation**: en → de (translate-then-polish)
+
+**Quality Metrics:**
+- Amstad Score: 38 (target: 30-50) ✓
+- Avg Clause Length: 11 words (target: ≤12) ✓
+- Citations preserved: 6 of 6 ✓
+- Umlauts present: ✓
+- Protected content unchanged: ✓
+
+**Key Improvements:**
+1. Translated 12 paragraphs preserving all 6 citations
+2. Applied Wolf-Schneider clause-length discipline
+3. Resolved 4 compound nouns (Cloud-Migrationsstrategie, IT-Betriebsmodell, ...)
+4. Sie-form applied throughout
+
+**Backup**: .quarterly-report.md
+
+**Status**: ✅ Translated and polished
+```
+
 ## Features
 
 ✅ **Complete Copywriting Workflow**
@@ -279,6 +319,7 @@ PARSE flags from $ARGUMENTS:
   - --flesch-target: Extract range (e.g., "50-60"), default: "50-60"
   - --fields: Extract dot-path selector (required for .json files)
   - --mode: Extract value (standard|sales), default: standard
+  - --translate: Extract value (de|en), default: unset
   - --dry-run: Boolean flag, default: false
 
 VALIDATE parsed values:
@@ -286,6 +327,10 @@ VALIDATE parsed values:
   - Flesch target must be numeric range
   - IF .json: --fields must be provided
   - IF .md: --fields, --mode, --dry-run are ignored
+  - IF --translate set: value must be `de` or `en` (v1); other languages rejected with a Phase 2 pointer
+
+ROUTE --translate value through to the copywriter agent as TARGET_LANG=<value>.
+The agent passes it to the copywriter skill, which runs the translate-then-polish two-pass flow (Step 2.5 then Step 3).
 ```
 
 ### 1b. Route by File Extension
@@ -505,3 +550,4 @@ IF copywriter agent fails:
 - JSON files get an automatic backup (`.pre-copy-json.json`) before modification
 - JSON polishing preserves original file indentation
 - Use `--dry-run` with JSON to preview changes before committing them
+- `--translate` creates the same `.{filename}` backup as a regular polish (no separate translation backup naming); v1 supports `de` and `en` only and aborts when the document has `arc_id` in its frontmatter

--- a/cogni-copywriting/copywriter-workspace/eval_set.json
+++ b/cogni-copywriting/copywriter-workspace/eval_set.json
@@ -65,7 +65,7 @@
   },
   {
     "query": "can you translate this document from English to German? It's our product description at docs/product-overview.md and we need it for the DACH market launch",
-    "should_trigger": false
+    "should_trigger": true
   },
   {
     "query": "I want to create an interactive dashboard showing our sales pipeline data. I have the data in a JSON file at api/pipeline.json and want to use React with charts",

--- a/cogni-copywriting/skills/copy-json/SKILL.md
+++ b/cogni-copywriting/skills/copy-json/SKILL.md
@@ -17,6 +17,7 @@ Adapter that bridges JSON files to the copywriter skill. Extracts text fields fr
 | `FIELDS` | yes | — | Dot-path field selector (e.g. `plugins[*].description`) |
 | `SCOPE` | no | `tone` | Passed to copywriter (`tone` is the right default for short JSON text) |
 | `MODE` | no | `standard` | `sales` for IS/DOES/MEANS fields |
+| `TARGET_LANG` | no | unset | `de` or `en` — when set, copywriter runs translate-then-polish on each field before writing back. v1 supports EN↔DE only. |
 | `DRY_RUN` | no | `false` | Show before/after without writing |
 
 ## FIELDS Selector Syntax
@@ -72,14 +73,16 @@ Simple dot-path with `[*]` for arrays:
 
    FILE_PATH = {path to temp MD}
    SCOPE = {SCOPE parameter, default: tone}
+   TARGET_LANG = {TARGET_LANG parameter, omitted when unset}
    ```
 
    Additional instructions to copywriter:
-   - Preserve all `<!-- FIELD: ... -->` comment delimiters exactly as-is
+   - Preserve all `<!-- FIELD: ... -->` comment delimiters exactly as-is (they fall under the protected-content invariant — the translate pass must also leave them byte-identical)
    - Each field is an independent text snippet — do not merge or reorder them
    - These are JSON string values — do NOT add markdown formatting (no `**bold**`, `# headings`, `- lists`)
    - Keep each field as a single paragraph unless the original has line breaks
    - If MODE=sales: apply IS/DOES/MEANS sales messaging techniques (Power Positions, FAB)
+   - If TARGET_LANG is set: each field is translated then polished into the target language in place; the field delimiter format is unchanged
 
 4. Wait for copywriter skill completion
 
@@ -88,10 +91,13 @@ Simple dot-path with `[*]` for arrays:
 1. Read the polished temp MD file
 2. Split content by `<!-- FIELD: ... -->` delimiters to recover per-field text
 3. For each extracted field, trim whitespace and validate:
-   - **German chars preserved**: ä, ö, ü, ß and uppercase forms still present if they were in original
+   - **German chars** — direction-aware:
+     - `TARGET_LANG` unset: ä/ö/ü/ß and uppercase forms still present if they were in original (preservation)
+     - `TARGET_LANG=de`: output must contain ä/ö/ü/ß where target prose requires them; never ASCII substitutes (ae/oe/ue/ss)
+     - `TARGET_LANG=en`: output must contain no ä/ö/ü/ß characters (except inside preserved proper nouns)
    - **No markdown injection**: reject if polished text contains `**`, `__`, `# `, `- ` list markers, or `| table |` syntax (these don't belong in JSON string values)
-   - **Length guard**: polished text must not exceed 2x length of original (prevents prose expansion)
-   - **Citations preserved**: if original contained `[P1-1]` or similar citation markers, they must still be present
+   - **Length guard**: polished text must not exceed 2x length of original (prevents prose expansion). For translations, allow 2.5x — German translations of English text are typically 20-30% longer.
+   - **Citations preserved**: if original contained `[P1-1]` or similar citation markers, they must still be present (translation requires exact count match; non-translation requires count >= original)
 4. If any validation fails, keep original text for that field and log a warning
 5. Delete the temp MD file
 

--- a/cogni-copywriting/skills/copywriter/CHANGELOG.md
+++ b/cogni-copywriting/skills/copywriter/CHANGELOG.md
@@ -36,18 +36,9 @@ This split gives clean diagnostics: meaning failures land in Pass A; style failu
 
 #### Changed Files
 
-- **NEW `references/01-core-principles/translation-principles.md`**: Two-pass philosophy, translate-vs-preserve list, citation-anchored translation rules, compound-noun strategies per direction, audience-expansion deferred to Step 3.
-- **NEW `references/01-core-principles/translation-en-to-de.md`**: Sie-form default, umlaut/eszett correctness (reinforces SKILL.md preservation), Satzklammer formation guidance, compound-vs-preposition heuristic, gender resolution table for technical loan-words, worked example from `english-memo.md`.
-- **NEW `references/01-core-principles/translation-de-to-en.md`**: Compound decomposition table, long-sentence splitting, nominal→verbal style conversion, citation marker preservation, number/date formatting, proper-noun handling for German institutions, worked example from `german-with-citations.md`.
-- **`SKILL.md`**: Step 1 adds `TARGET_LANG` parameter, three-tier resolution, translation pre-checks (arc-mode block, source==target no-op, EN↔DE-only). Scope-handling note added: when `TARGET_LANG` is set, Step 2 always skips and Steps 3/5 always run regardless of input `--scope`. New Step 2.5 (Translate Pass) documents the seven preservation invariants and what Pass A does NOT do (style, acronyms, restructure). Step 5 adds four translation-specific validation bullets (target charset, citation-count-exact, frontmatter IDs, protected content). Bundled Resources extended.
-- **`references/00-index.md`**: Bumped to version 8.2. New CHECK 0 in mode detection: when `TARGET_LANG` is set, load translation references on top of standard/sales mode and forbid arc-mode trigger. File Inventory updated with three new references.
-- **`agents/copywriter.md`**: New optional `TARGET_LANG` input with resolution-order paragraph; passed through in Skill invocation example; three new success-JSON fields (`source_lang`, `target_lang`, `translation_applied`).
-- **`commands/copywrite.md`**: New `--translate=de|en` flag documented in Usage and Optional Flags; new Example 9; parse-args block extended.
-- **`skills/copy-json/SKILL.md`**: Pass-through `TARGET_LANG` parameter to copywriter delegation; per-field validation flips German-char check direction based on target.
-- **`CLAUDE.md`**: New "Translation Flow" subsection under Key Workflows; Step 1 description extended with `TARGET_LANG`.
-- **`README.md`**: Translation example added to Quick Start; "What it does" extended; Language support table notes EN↔DE translation.
-- **`copywriter-workspace/eval_set.json`**: Translation query flipped from `should_trigger: false` to `should_trigger: true`.
-- **`.claude-plugin/plugin.json`**: Plugin version 0.2.3 → 0.3.0; new keywords `translation`, `en-de`; description extended.
+- **NEW** under `references/01-core-principles/`: `translation-principles.md` (two-pass philosophy, preserve-vs-translate list, citation anchoring), `translation-en-to-de.md` (Sie-form, umlaut traps, Satzklammer, compound nouns, gender resolution), `translation-de-to-en.md` (compound decomposition, sentence splitting, nominal→verbal style, number/date formatting).
+- **Workflow surface**: `SKILL.md` (Step 1 `TARGET_LANG` + pre-checks, new Step 2.5 Translate Pass, Step 5 translation validation), `references/00-index.md` (CHECK 0 conditional load, v8.2), `agents/copywriter.md` (input + JSON output), `commands/copywrite.md` (`--translate=de|en`), `skills/copy-json/SKILL.md` (pass-through + direction-aware charset check).
+- **Docs and version**: `CLAUDE.md`, `README.md`, `.claude-plugin/plugin.json` (0.2.3 → 0.3.0), marketplace mirror, `copywriter-workspace/eval_set.json` (translation query flipped to `should_trigger: true`).
 
 #### Rationale
 

--- a/cogni-copywriting/skills/copywriter/CHANGELOG.md
+++ b/cogni-copywriting/skills/copywriter/CHANGELOG.md
@@ -5,6 +5,64 @@ All notable changes to the copywriter skill will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.0] - 2026-05-19
+
+### Added - Translation Mode (EN↔DE)
+
+The copywriter skill gains a translate-then-polish two-pass flow. Before this change, users with existing English content who needed German output (or vice versa) had no path inside the insight-wave ecosystem — every generation plugin assumes you regenerate in the target language from upstream. Regeneration is often not viable: source content was hand-edited, the originating project is closed, or teams collaborate across languages off a canonical English narrative.
+
+#### New `TARGET_LANG` skill arg
+
+`TARGET_LANG`: `de` | `en` (optional; default: unset, no translation).
+
+Resolution hierarchy (mirrors the `AUDIENCE` precedent from v7.2.0):
+
+1. Explicit `TARGET_LANG` skill arg
+2. Document frontmatter `target_language:` field
+3. Unset (no translation; skill polishes in source language only)
+
+#### Two-pass model
+
+- **Pass A — Translate (new Step 2.5)**: faithful semantic transfer from source to target language. Citations, URLs, frontmatter technical IDs, protected content, code blocks, and Power Position structure markers stay byte-identical. Acronyms pass through unchanged.
+- **Pass B — Polish (existing Step 3)**: target-language style discipline. Wolf-Schneider rules for DE output (12-word clauses, Satzklammer breaking, Mittelfeld shortening, Floskel elimination); Flesch tuning and active-voice transformation for EN output. Audience-tuned acronym expansion runs here on the translated text.
+
+This split gives clean diagnostics: meaning failures land in Pass A; style failures land in Pass B.
+
+#### v1 scope and limits
+
+- **Languages**: EN ↔ DE only. Other `TARGET_LANG` values abort with a clear message.
+- **Arc mode blocked**: when document frontmatter contains `arc_id`, translation aborts. Arc-element heading texts require exact-match preservation (see `09-preservation-modes/arc-preservation.md` lines 87–97), and the EN/DE heading mapping integration with `cogni-narrative/skills/narrative/references/language-templates.md` is non-trivial. Deferred to Phase 2.
+- **Source == target**: no-op. The skill logs a message and falls through to standard polish in the source language.
+
+#### Changed Files
+
+- **NEW `references/01-core-principles/translation-principles.md`**: Two-pass philosophy, translate-vs-preserve list, citation-anchored translation rules, compound-noun strategies per direction, audience-expansion deferred to Step 3.
+- **NEW `references/01-core-principles/translation-en-to-de.md`**: Sie-form default, umlaut/eszett correctness (reinforces SKILL.md preservation), Satzklammer formation guidance, compound-vs-preposition heuristic, gender resolution table for technical loan-words, worked example from `english-memo.md`.
+- **NEW `references/01-core-principles/translation-de-to-en.md`**: Compound decomposition table, long-sentence splitting, nominal→verbal style conversion, citation marker preservation, number/date formatting, proper-noun handling for German institutions, worked example from `german-with-citations.md`.
+- **`SKILL.md`**: Step 1 adds `TARGET_LANG` parameter, three-tier resolution, translation pre-checks (arc-mode block, source==target no-op, EN↔DE-only). Scope-handling note added: when `TARGET_LANG` is set, Step 2 always skips and Steps 3/5 always run regardless of input `--scope`. New Step 2.5 (Translate Pass) documents the seven preservation invariants and what Pass A does NOT do (style, acronyms, restructure). Step 5 adds four translation-specific validation bullets (target charset, citation-count-exact, frontmatter IDs, protected content). Bundled Resources extended.
+- **`references/00-index.md`**: Bumped to version 8.2. New CHECK 0 in mode detection: when `TARGET_LANG` is set, load translation references on top of standard/sales mode and forbid arc-mode trigger. File Inventory updated with three new references.
+- **`agents/copywriter.md`**: New optional `TARGET_LANG` input with resolution-order paragraph; passed through in Skill invocation example; three new success-JSON fields (`source_lang`, `target_lang`, `translation_applied`).
+- **`commands/copywrite.md`**: New `--translate=de|en` flag documented in Usage and Optional Flags; new Example 9; parse-args block extended.
+- **`skills/copy-json/SKILL.md`**: Pass-through `TARGET_LANG` parameter to copywriter delegation; per-field validation flips German-char check direction based on target.
+- **`CLAUDE.md`**: New "Translation Flow" subsection under Key Workflows; Step 1 description extended with `TARGET_LANG`.
+- **`README.md`**: Translation example added to Quick Start; "What it does" extended; Language support table notes EN↔DE translation.
+- **`copywriter-workspace/eval_set.json`**: Translation query flipped from `should_trigger: false` to `should_trigger: true`.
+- **`.claude-plugin/plugin.json`**: Plugin version 0.2.3 → 0.3.0; new keywords `translation`, `en-de`; description extended.
+
+#### Rationale
+
+A separate translation plugin would fight the existing grain. cogni-copywriting already has every prerequisite: bilingual EN/DE awareness, Wolf-Schneider DE style discipline, language-aware Flesch/Amstad scoring, language detection in Step 3, the three preservation invariants (German chars / citations / protected content) that translation must honour anyway, and the proven `copy-json` delegate-with-a-mode adapter pattern. Extending the copywriter skill with a parallel parameter to `AUDIENCE` is the smallest architectural surface.
+
+Closes #TBD.
+
+#### Migration Notes
+
+- **Non-breaking**: default `TARGET_LANG` unset preserves all existing polish behaviour exactly.
+- **Existing `--lang` parameter unchanged**: it remains the *source*-language override for the language detector. `TARGET_LANG` is the new orthogonal *target* hint.
+- **Phase 2 follow-up**: tracked as a GitHub issue covering FR/IT/PL/NL/ES translation directions and arc-mode translation (which requires heading-set substitution via `language-templates.md`).
+
+---
+
 ## [7.2.0] - 2026-05-19
 
 ### Added - Audience-Tuned First-Mention Acronym Expansion

--- a/cogni-copywriting/skills/copywriter/CHANGELOG.md
+++ b/cogni-copywriting/skills/copywriter/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.3.0] - 2026-05-19
 
+> Note: this `7.x.x` line tracks the **copywriter skill's internal versioning** (independent of the plugin's external `version` in `.claude-plugin/plugin.json`). The skill internal bump 7.2.0 → 7.3.0 ships in plugin release 0.3.0.
+
 ### Added - Translation Mode (EN↔DE)
 
 The copywriter skill gains a translate-then-polish two-pass flow. Before this change, users with existing English content who needed German output (or vice versa) had no path inside the insight-wave ecosystem — every generation plugin assumes you regenerate in the target language from upstream. Regeneration is often not viable: source content was hand-edited, the originating project is closed, or teams collaborate across languages off a canonical English narrative.

--- a/cogni-copywriting/skills/copywriter/SKILL.md
+++ b/cogni-copywriting/skills/copywriter/SKILL.md
@@ -53,6 +53,13 @@ When polishing an existing document, scope determines which steps run:
 
 When `arc_mode` is active, arc-preservation rules override scope. See `arc-preservation.md`.
 
+**When `TARGET_LANG` is set**, scope is overridden to ensure a complete translate-and-polish cycle:
+
+- Step 2 (Structure) is **always skipped** — translation preserves the source document's structure; do not impose a framework on the translated output.
+- Step 2.5 (Translate) runs.
+- Steps 3 and 5 always run, regardless of input `--scope` value (the translated draft needs full polish to clean up literal translation artefacts and to enforce target-language style/readability).
+- Step 4 (Review) follows the normal rules (skipped for informal deliverables or `skip_review: true`).
+
 ### Baseline Formatting (all scopes)
 
 Every polished output meets these readability fundamentals, regardless of scope:
@@ -72,12 +79,26 @@ These apply even in `--scope=tone` because they are readability essentials, not 
 - `impact_level` (optional): standard | high
 - `MODE` (optional): standard | sales (default: standard)
 - `AUDIENCE` (optional): expert | mixed | lay (default: mixed) — tunes audience-aware disciplines such as acronym expansion depth
+- `TARGET_LANG` (optional): de | en — when set, runs a translate-then-polish two-pass flow (see Step 2.5). When unset, the skill polishes in the source language only.
 
 **Audience resolution order** (used by acronym handling and any future audience-aware discipline):
 
 1. Explicit `AUDIENCE` skill arg
 2. Document frontmatter `audience:` field
 3. Default: `mixed`
+
+**Target-language resolution order** (used by Step 2.5 translate pass):
+
+1. Explicit `TARGET_LANG` skill arg
+2. Document frontmatter `target_language:` field
+3. Unset (no translation; polish in source language)
+
+**Translation pre-checks** (run only when `TARGET_LANG` resolves to a value):
+
+1. Resolve `source_lang` via the existing detector in Step 3 (`--lang` → workspace config → content analysis).
+2. If `source_lang == TARGET_LANG`, log "source language already matches target — skipping translation pass" and fall through to standard polish.
+3. If document frontmatter contains `arc_id`, abort with: "Arc-mode translation is not supported in v1 (arc heading texts require exact-match preservation; translating them would break the arc contract). Run translation on the non-arc document, or follow the Phase 2 issue for arc-mode translation support." Do not modify the file.
+4. In v1, accept only `de` and `en`. Any other value: abort with "TARGET_LANG=`{value}` is not supported in v1 (EN↔DE only). See the follow-up issue for FR/IT/PL/NL/ES."
 
 **Load the reference index first:**
 
@@ -107,6 +128,46 @@ Follow the index's decision tree to detect the operating mode (arc, sales, or st
 - Output path
 
 Then apply the framework pattern from the loaded framework reference. If the user didn't specify a framework, use the deliverable type's recommended default.
+
+### Step 2.5: Translate Pass (only when TARGET_LANG is set)
+
+Skip entirely when `TARGET_LANG` is unset. When set, this pass runs after Step 2 (which was skipped per the scope override above) and before Step 3.
+
+**Load translation references:**
+
+```text
+READ: references/01-core-principles/translation-principles.md
+```
+
+Then load the direction-specific guide:
+
+```text
+IF source_lang = en AND TARGET_LANG = de:
+  READ: references/01-core-principles/translation-en-to-de.md
+IF source_lang = de AND TARGET_LANG = en:
+  READ: references/01-core-principles/translation-de-to-en.md
+```
+
+**Perform the translation (Pass A):**
+
+Translate the entire document to `TARGET_LANG`, holding to these invariants:
+
+1. **Citation markers byte-identical** — every `[P\d+-\d+]`, `[P\d+-\d+](url)`, `<sup>[N]</sup>`, `[portfolio-validated]` stays exactly as written, URL included. Count must match the source.
+2. **URLs byte-identical** — never translate URLs, even in inline `[text](url)` links.
+3. **Protected content byte-identical** — `<diagram-placeholder>` XML blocks, `Figure N`/`Abbildung N` numeric refs, `![[assets/*.svg]]` Obsidian embeds, kanban tables with `| Dimension | Act | Plan | Observe |` headers.
+4. **Frontmatter technical IDs unchanged** — `arc_id`, `source_url`, `entity_ref`, schema keys, filenames. Update `target_language:` to the new value (add the field if absent).
+5. **Code blocks** — fenced and inline code never translated.
+6. **Power Position structure markers** — `**IS**:`, `**DOES**:`, `**MEANS**:` stay unchanged (structural, not vocabulary).
+7. **Acronyms pass through unchanged** — the audience-tuned first-mention expansion is Step 3's job, running on the translated text. Do not expand here.
+
+**Do NOT in this pass:**
+
+- Apply target-language style discipline (Wolf-Schneider clause-length rules, Flesch tuning, Floskel elimination) — that is Step 3.
+- Expand acronyms — that is Step 3.
+- Restructure paragraphs or change the heading hierarchy — preserve the source structure.
+- Apply messaging frameworks — Step 2 was already skipped.
+
+The translate pass output is an intermediate draft. Step 3 will tighten clause length, break Satzklammer (for DE output), apply acronym expansion per `AUDIENCE`, and validate against language-specific readability targets.
 
 ### Step 3: Apply Writing & Formatting
 
@@ -190,6 +251,13 @@ Review enhances quality but never blocks delivery — if review fails, continue 
 - Baseline formatting met (paragraphs, bold anchoring, white space)
 - Acronyms expanded once on first mention (audience-tuned); subsequent mentions verbatim; proper nouns/brands/arc markers excluded
 
+**Translation-specific validation** (only when `TARGET_LANG` was set):
+
+- **Target charset matches** — when `TARGET_LANG=de`, output contains German umlauts/eszett (ä/ö/ü/ß) where the German prose requires them; never ASCII substitutes (ae/oe/ue/ss). When `TARGET_LANG=en`, output contains no ä/ö/ü/ß characters except inside preserved proper nouns or quoted German terms.
+- **Citation count exactly preserved** — the regex count of `\[P\d+-\d+\]` (and any other citation-marker patterns in the source) in the output equals the source count. URLs from all markers are byte-identical to source URLs.
+- **Frontmatter technical IDs unchanged** — `arc_id`, `source_url`, `entity_ref`, and any other technical identifier fields in the frontmatter are byte-identical to source values. The `target_language:` field is set to the new value (added if absent).
+- **Protected content byte-identical** — diagram-placeholder blocks, figure/Abbildung numeric refs, Obsidian embeds, kanban tables match the source byte-for-byte.
+
 **German-specific validation** (when detected language is German):
 - Average clause length: target 10-12 words
 - Floskel count: 0
@@ -249,7 +317,7 @@ Auto-detects language. Returns `flesch_score`, `flesch_target_min/max`, `avg_par
 
 All references are organized in progressive disclosure tiers. Start with `references/00-index.md` — it routes you to exactly the files needed for any given task.
 
-**Core Principles** (01-core-principles/) — Clarity, conciseness, active voice, German style (Wolf Schneider), German hooks, plain language, readability, acronym handling (audience-tuned first-mention expansion)
+**Core Principles** (01-core-principles/) — Clarity, conciseness, active voice, German style (Wolf Schneider), German hooks, plain language, readability, acronym handling (audience-tuned first-mention expansion), translation (EN↔DE two-pass translate-then-polish)
 
 **Messaging Frameworks** (02-messaging-frameworks/) — BLUF, Pyramid, SCQA, Inverted Pyramid, STAR, PSB, FAB
 

--- a/cogni-copywriting/skills/copywriter/SKILL.md
+++ b/cogni-copywriting/skills/copywriter/SKILL.md
@@ -96,9 +96,11 @@ These apply even in `--scope=tone` because they are readability essentials, not 
 **Translation pre-checks** (run only when `TARGET_LANG` resolves to a value):
 
 1. Resolve `source_lang` via the existing detector in Step 3 (`--lang` → workspace config → content analysis).
-2. If `source_lang == TARGET_LANG`, log "source language already matches target — skipping translation pass" and fall through to standard polish.
+2. If `source_lang == TARGET_LANG`, log "source language already matches target — skipping translation pass" and fall through to standard polish. **Also unset the translation scope override below** so the user's explicit `--scope` is honoured (a user invoking `--scope=full` on a same-language doc expects Step 2 to run normally).
 3. If document frontmatter contains `arc_id`, abort with: "Arc-mode translation is not supported in v1 (arc heading texts require exact-match preservation; translating them would break the arc contract). Run translation on the non-arc document, or follow the Phase 2 issue for arc-mode translation support." Do not modify the file.
 4. In v1, accept only `de` and `en`. Any other value: abort with "TARGET_LANG=`{value}` is not supported in v1 (EN↔DE only). See the follow-up issue for FR/IT/PL/NL/ES."
+
+The scope override and Step 2.5 below apply only when `TARGET_LANG` is set **and** the source==target no-op did not fire (i.e. translation actually runs).
 
 **Load the reference index first:**
 
@@ -254,7 +256,12 @@ Review enhances quality but never blocks delivery — if review fails, continue 
 **Translation-specific validation** (only when `TARGET_LANG` was set):
 
 - **Target charset matches** — when `TARGET_LANG=de`, output contains German umlauts/eszett (ä/ö/ü/ß) where the German prose requires them; never ASCII substitutes (ae/oe/ue/ss). When `TARGET_LANG=en`, output contains no ä/ö/ü/ß characters except inside preserved proper nouns or quoted German terms.
-- **Citation count exactly preserved** — the regex count of `\[P\d+-\d+\]` (and any other citation-marker patterns in the source) in the output equals the source count. URLs from all markers are byte-identical to source URLs.
+- **Citation count exactly preserved** — for each of the four citation-marker patterns supported by the skill, the regex count in the output equals the source count, and every URL is byte-identical to its source URL:
+  1. Inline cite with URL: `\[P\d+-\d+\]\([^)]+\)`
+  2. Inline cite without URL: `\[P\d+-\d+\](?!\()`
+  3. Superscript footnote: `<sup>\[\d+\]</sup>`
+  4. Source tag: `\[(portfolio-validated|claim-verified|[a-z-]+-validated)\]`
+  (These mirror the four marker types enumerated in `translation-principles.md` § "Preserve byte-identical".)
 - **Frontmatter technical IDs unchanged** — `arc_id`, `source_url`, `entity_ref`, and any other technical identifier fields in the frontmatter are byte-identical to source values. The `target_language:` field is set to the new value (added if absent).
 - **Protected content byte-identical** — diagram-placeholder blocks, figure/Abbildung numeric refs, Obsidian embeds, kanban tables match the source byte-for-byte.
 

--- a/cogni-copywriting/skills/copywriter/references/00-index.md
+++ b/cogni-copywriting/skills/copywriter/references/00-index.md
@@ -1,7 +1,7 @@
 ---
 title: Copywriting Skills Master Index
 type: index
-version: 8.1
+version: 8.2
 last_updated: 2026-05-19
 ---
 
@@ -17,6 +17,21 @@ Before loading any deliverable or framework references, check for these special 
 
 <mode_detection>
 Think through these checks in order. Stop at the FIRST match.
+
+CHECK 0 -- TRANSLATION MODE (orthogonal to mode below)
+If `TARGET_LANG` is set and resolves to a different value from the detected source language, **additionally** load the translation references on top of whatever mode CHECK 1/2/3 selects:
+
+```
+LOAD: 01-core-principles/translation-principles.md
+IF source_lang = en AND TARGET_LANG = de:
+  LOAD: 01-core-principles/translation-en-to-de.md
+IF source_lang = de AND TARGET_LANG = en:
+  LOAD: 01-core-principles/translation-de-to-en.md
+```
+
+When `TARGET_LANG` is set, CHECK 1 (Arc) must NOT trigger — arc-mode translation is blocked in v1 (the skill aborts in Step 1 with an error). Proceed only into CHECK 2 (sales) or CHECK 3 (standard).
+
+After loading the translation references, continue with normal mode detection below.
 
 CHECK 1 -- ARC PRESERVATION MODE
 Trigger conditions (any one is sufficient):
@@ -268,6 +283,9 @@ All reference files in this system, organized by directory. Use this as the sour
 - `german-hook-principles.md` -- Wolf Schneider / Reiners / Nannen: 12 opening-sentence rules, Kuechenzuruf test, arc hook strategies
 - `plain-language-principles.md` -- Technical content accessibility
 - `readability-principles.md` -- Visual hierarchy and scannability
+- `translation-principles.md` -- Two-pass translate-then-polish philosophy; what to translate vs preserve; citation-anchored translation
+- `translation-en-to-de.md` -- EN→DE: Satzklammer formation, compound nouns, gender resolution, Sie-form, umlaut correctness
+- `translation-de-to-en.md` -- DE→EN: compound decomposition, sentence splitting, nominal→verbal style, number/date formatting
 
 ### 02-messaging-frameworks/
 - `bluf-framework.md` -- Bottom Line Up Front

--- a/cogni-copywriting/skills/copywriter/references/01-core-principles/translation-de-to-en.md
+++ b/cogni-copywriting/skills/copywriter/references/01-core-principles/translation-de-to-en.md
@@ -1,0 +1,132 @@
+---
+title: Translation DE → EN
+type: writing-principle
+category: core-principles
+tags: [translation, de-en, compound-decomposition, nominal-vs-verbal, sentence-splitting]
+audience: [all]
+related:
+  - translation-principles
+  - clarity-principles
+  - conciseness-principles
+  - active-voice-principles
+  - acronym-handling-principles
+version: 1.0
+last_updated: 2026-05-19
+---
+
+# Translation DE → EN
+
+<context>
+This file applies to the Step 2.5 translate pass when `source_lang = de` and `TARGET_LANG = en`. The Step 3 polish pass that runs after this applies English clarity targets (15–20 word sentences, 80% active voice, 3–5 sentence paragraphs, Flesch 50–60). Your job here is faithful semantic transfer into grammatical English prose. Pass B handles the Flesch tuning.
+</context>
+
+## Decompose German Compounds
+
+German compound nouns rarely have one-to-one English equivalents. Decompose them into noun phrases or, in extreme cases, full clauses.
+
+| German | Idiomatic English | Wrong: transliteration |
+|---|---|---|
+| `Digitalisierungsstrategie` | `digitalization strategy` | "digitalizationstrategy" |
+| `Geschäftsführung` | `executive leadership` / `management board` | "businessleadership" |
+| `Wettbewerbsfähigkeit` | `competitiveness` (when the compound is lexicalized) | "competitionfähigability" |
+| `Datenschutz-Grundverordnung` | `General Data Protection Regulation` (proper-noun expansion of DSGVO) | "data-protection foundation-regulation" |
+| `Qualitätssicherungssysteme` | `quality assurance systems` | "qualityassurance-systems" |
+| `Bestandsaufnahme` | `inventory` / `current-state assessment` | "stock-uptaking" |
+
+For ambiguous compounds (`Mittelstand` — culturally specific German SME term), prefer a short noun phrase (`mid-sized businesses`) over a calque (`middle-stand`). The first occurrence may carry a one-time parenthetical: `mid-sized businesses (the German Mittelstand)`.
+
+## Split Long German Sentences
+
+German tolerates 30–40 word sentences with multiple subordinate clauses; English readers do not. Split aggressively when a German sentence exceeds 25 words.
+
+**DE source (38 words, one sentence):**
+```
+Die zunehmende Vernetzung von Geschäftsprozessen, die steigende Bedeutung von Datenanalyse und die wachsenden Kundenerwartungen an digitale Interaktionsmöglichkeiten erfordern eine grundlegende Neuausrichtung der IT-Infrastruktur und der Geschäftsmodelle.
+```
+
+**Pass-A EN output (two sentences, ~20 words each):**
+```
+Three forces are reshaping how mid-sized businesses operate: tighter process integration, the rising importance of data analysis, and growing customer expectations for digital interaction. Together they require a fundamental redesign of IT infrastructure and business models.
+```
+
+Pass B (Step 3 English polish) will further tune sentence length to 15–20 words on average and check Flesch score, but Pass A should already deliver readable English structure.
+
+## Replace Nominal with Verbal Style
+
+German leans nominal ("Substantivstil") — long noun phrases describing actions. English leans verbal — verbs carry the meaning. Convert when natural.
+
+| German nominal | English verbal |
+|---|---|
+| `die Durchführung der Bestandsaufnahme` | `conducting the assessment` |
+| `die Implementierung der Strategie erfolgte` | `the team implemented the strategy` |
+| `eine Steigerung der Erfolgsquote um 60 %` | `success rates rise by 60%` |
+| `die Berücksichtigung der Mitarbeiterkompetenzen` | `accounting for employee skills` |
+
+This is consistent with the active-voice and concrete-verb principles in `clarity-principles.md` and `active-voice-principles.md` that Pass B applies on top.
+
+## Preserve Citation Markers Exactly
+
+Every `[P1-1]`, `[P1-1](https://...)`, `<sup>[1]</sup>` stays byte-identical, including the URL. Translate the surrounding sentence; the marker stays at the equivalent position.
+
+**DE source:**
+```
+Laut einer aktuellen Studie [P1-1](https://www.bitkom.org/digital-index-2025) haben nur etwa 35 % der deutschen Mittelständler eine umfassende Digitalisierungsstrategie implementiert.
+```
+
+**EN target (correct):**
+```
+A recent study [P1-1](https://www.bitkom.org/digital-index-2025) finds that only about 35% of German mid-sized businesses have implemented a comprehensive digitalization strategy.
+```
+
+The marker `[P1-1](https://www.bitkom.org/digital-index-2025)` is identical. Step 5 validation enforces this — any change to marker identifier or URL rejects the output.
+
+## Number and Date Formatting
+
+| German | English |
+|---|---|
+| `35 %` (thin space) | `35%` (no space) |
+| `1.234.567` (period as thousands separator) | `1,234,567` |
+| `1,5 Millionen` (comma as decimal) | `1.5 million` |
+| `19.05.2026` | `May 19, 2026` or `2026-05-19` (ISO; pick one and stay consistent) |
+| `5,6 Mio. €` | `€5.6M` or `EUR 5.6 million` |
+| `Q1/2026` | `Q1 2026` |
+
+Currency-symbol position: English typically prefixes (`€5M`), German typically suffixes (`5 Mio. €`). Apply target-language convention.
+
+## Proper Nouns Stay German
+
+Regulation names, agency names, and German-specific institutions keep their original form on first English occurrence, with a parenthetical when the English reader cannot reasonably know them:
+
+- `BSI (Federal Office for Information Security)` on first mention; bare `BSI` thereafter
+- `KRITIS-Dachgesetz` (no English translation; can add a parenthetical "Critical-Infrastructure Umbrella Act")
+- `DSGVO` / `GDPR` — both are valid; prefer `GDPR` for English-only audiences
+- `Mittelstand` — keep German term; add parenthetical "Germany's mid-sized business segment" on first mention
+
+The audience-tuned acronym expansion in Step 3 (`acronym-handling-principles.md`) handles these parentheticals based on `AUDIENCE`. Do not expand here — pass through and let Pass B add the parenthetical.
+
+## Worked Example (from german-with-citations.md)
+
+**DE source:**
+```
+Die Digitalisierung stellt für viele mittelständische Unternehmen eine große Herausforderung dar.
+Laut einer aktuellen Studie [P1-1](https://www.bitkom.org/digital-index-2025) haben nur etwa 35 % der
+deutschen Mittelständler eine umfassende Digitalisierungsstrategie implementiert. Dies führt dazu,
+dass erhebliche Effizienzpotenziale ungenutzt bleiben und die Wettbewerbsfähigkeit langfristig
+gefährdet wird.
+```
+
+**Pass-A EN output (translate only — Pass B will tune Flesch and active voice):**
+```
+Digitalization is a major challenge for many mid-sized businesses.
+A recent study [P1-1](https://www.bitkom.org/digital-index-2025) finds that only about 35% of
+Germany's mid-sized businesses have implemented a comprehensive digitalization strategy. The
+result: significant efficiency gains go untapped, and long-term competitiveness is at risk.
+```
+
+Note:
+- Citation marker `[P1-1](https://www.bitkom.org/digital-index-2025)` byte-identical.
+- `mittelständische Unternehmen` decomposed to `mid-sized businesses`.
+- `Mittelständler` rendered as `Germany's mid-sized businesses` on first mention.
+- `35 %` (thin space) → `35%` (no space) per English convention.
+- Long German sentence split into a shorter setup + a punchy "The result:" sentence — Pass B may tighten further.
+- No umlauts present in the English output (Step 5 charset check will pass).

--- a/cogni-copywriting/skills/copywriter/references/01-core-principles/translation-en-to-de.md
+++ b/cogni-copywriting/skills/copywriter/references/01-core-principles/translation-en-to-de.md
@@ -1,0 +1,127 @@
+---
+title: Translation EN → DE
+type: writing-principle
+category: core-principles
+tags: [translation, en-de, satzklammer, compound-nouns, sie-form, umlaut]
+audience: [all]
+related:
+  - translation-principles
+  - german-style-principles
+  - german-hook-principles
+  - acronym-handling-principles
+version: 1.0
+last_updated: 2026-05-19
+---
+
+# Translation EN → DE
+
+<context>
+This file applies to the Step 2.5 translate pass when `source_lang = en` and `TARGET_LANG = de`. The Step 3 polish pass that runs after this applies Wolf-Schneider rules (`german-style-principles.md`) — that is where Satzklammer-breaking, Mittelfeld-shortening, and Floskel-elimination happen. Your job here is faithful semantic transfer into grammatical German prose. You may produce long sentences; Pass B will break them.
+</context>
+
+## Register: Sie by Default
+
+Business documents in the insight-wave ecosystem use **Sie** unless the source explicitly signals informal address (e.g. a casual internal blog post in the source uses "you" in a peer-to-peer way, with no exec audience). When in doubt, use Sie.
+
+- `you reduce diagnostic errors` → `Sie reduzieren Diagnosefehler`
+- `your team` → `Ihr Team` (capitalized possessive)
+- Verbs conjugate to Sie-form: `Sie haben`, `Sie können`, `Sie sollten`
+
+If the source document is a B2C blog or social copy and clearly addresses individuals casually, use Du — but flag this in the validation report so the user can override.
+
+## Umlaut and Eszett Correctness
+
+German characters are mandatory. Never substitute ASCII equivalents:
+
+| Wrong | Right | Why |
+|---|---|---|
+| `Massnahme` | `Maßnahme` | "ss" loses the meaning distinction (Masse vs Maße) |
+| `Geschaeftsfuehrung` | `Geschäftsführung` | "ae"/"ue" mark the text as machine-processed |
+| `Strasse` | `Straße` | Eszett is required outside Switzerland |
+| `fuer` | `für` | ASCII substitutes signal a broken pipeline |
+
+This reinforces the preservation rule in `SKILL.md` (lines 13–15). Step 5 validation will reject any output that contains ASCII substitutes where umlauts/eszett are required.
+
+## Satzklammer Formation (Pass A vs Pass B)
+
+German splits verbs into two parts. The finite verb sits in position 2; the rest (infinitive, past participle, separable prefix) lands at the end. Everything between them is the Mittelfeld.
+
+```
+Wir haben [... Mittelfeld ...] migriert.
+   ^                            ^
+   Verb-Teil 1                  Verb-Teil 2
+```
+
+In the **translate pass** (this file), produce grammatical Satzklammer constructions — do not flatten German syntax into English-style SVO chains. Pass B (Step 3, `german-style-principles.md`) will shorten the Mittelfeld and break overlong clauses. If your translate-pass Mittelfeld reaches 8–12 words, that is acceptable for now; Pass B handles it.
+
+**EN source:**
+```
+We have successfully migrated about 75% of our workloads to AWS, which is ahead of schedule.
+```
+
+**Acceptable Pass-A output (Satzklammer present, Pass B will tighten):**
+```
+Wir haben etwa 75 % unserer Workloads erfolgreich nach AWS migriert, was über dem ursprünglichen Zeitplan liegt.
+```
+
+Do **not** flatten into:
+```
+Wir migrierten erfolgreich etwa 75 % unserer Workloads nach AWS, das ist vor dem Plan.
+```
+The flattened form loses idiomatic German verb placement and produces awkward subordinate-clause phrasing.
+
+## Compound Noun vs Preposition Phrase
+
+English noun phrases (`the cloud migration strategy`) map to either German compounds (`die Cloud-Migrationsstrategie`) or preposition phrases (`die Strategie für die Cloud-Migration`).
+
+Heuristic for choosing:
+
+| Source pattern | Prefer compound when | Prefer preposition phrase when |
+|---|---|---|
+| 2-noun phrase (`security gap`) | Always (`Sicherheitslücke`) | Never |
+| 3-noun phrase (`cloud security posture`) | Reads naturally (`Cloud-Sicherheitslage`) | Compound would exceed ~25 characters or feel artificial |
+| 4+-noun phrase (`enterprise IT operations strategy`) | Almost never | Always: `die Strategie für den IT-Betrieb im Unternehmen` |
+| Genitive English (`the cost of inaction`) | Almost never | `die Kosten der Untätigkeit` (genitive) or `die Kosten für Untätigkeit` |
+
+Hyphenated compounds are acceptable and often clearer than agglutinated forms: prefer `Cloud-Migrationsstrategie` over `Cloudmigrationsstrategie`.
+
+## Gender Resolution for Technical Terms
+
+When translating a noun whose gender is not obvious in German, follow this priority:
+
+1. **Established German loan-word gender** — `der Server`, `die Cloud`, `das Cloud-Computing`, `der Workflow`, `die API`, `das Backup`, `die App`, `der Container`, `das Kubernetes`.
+2. **Analogous German native term** — `die Migration` (`Wanderung`), `der Trend` (`die Tendenz` → masculine in tech usage), `der Container` (`der Behälter`).
+3. **Default to neuter for ambiguous English nouns ending in -ing** — `das Caching`, `das Monitoring`, `das Logging`.
+4. **Consistency within the document** — once chosen, do not flip gender across the document.
+
+If genuinely ambiguous, flag the term in the validation report rather than guess silently.
+
+## Acronyms: Pass Through Unchanged
+
+The Step 3 audience-tuned acronym expansion (see `acronym-handling-principles.md`) runs after this pass. Do not expand acronyms here, with one exception:
+
+- If the source contains a parenthetical Vollform (e.g. `SIEM (Security Information and Event Management)`), keep both halves and translate any prose around them. Step 3 will adjust for `AUDIENCE`.
+- Otherwise leave `NIS2`, `DSGVO`, `BSI`, `DORA`, `MDR`, `SIEM`, `MTTI` unchanged.
+
+## Worked Example (from english-memo.md)
+
+**EN source:**
+```
+We have successfully migrated about 75% of our workloads to AWS which is ahead of schedule.
+The team has been working really hard and we should be proud of what we've accomplished so far.
+Performance has improved significantly and we're seeing much better response times across the board.
+```
+
+**Pass-A DE output (translate only — Pass B will tighten):**
+```
+Wir haben etwa 75 % unserer Workloads erfolgreich nach AWS migriert und liegen damit über dem ursprünglichen Zeitplan.
+Das Team hat sehr engagiert gearbeitet und kann auf das bisher Erreichte stolz sein.
+Die Performance hat sich deutlich verbessert, und wir beobachten durchweg bessere Antwortzeiten.
+```
+
+Note:
+- Umlauts present (`über`, `für`).
+- Sie-form for the implied audience (though "we" here is internal, so wir-form is correct).
+- 75% formatted with the German thin space (`75 %`).
+- Sentence lengths are reasonable but Pass B (Wolf Schneider) may still split the first sentence further.
+- No citations in this source — output count matches.

--- a/cogni-copywriting/skills/copywriter/references/01-core-principles/translation-en-to-de.md
+++ b/cogni-copywriting/skills/copywriter/references/01-core-principles/translation-en-to-de.md
@@ -31,16 +31,18 @@ If the source document is a B2C blog or social copy and clearly addresses indivi
 
 ## Umlaut and Eszett Correctness
 
-German characters are mandatory. Never substitute ASCII equivalents:
+The general rule lives in `SKILL.md` § "German Character Preservation" — never substitute ASCII equivalents (ae/oe/ue/ss). In a translate pass, this means the *output* must already contain the correct German characters; relying on a post-translation fixup is fragile. Translator must produce them at write time.
 
-| Wrong | Right | Why |
+Common translation traps:
+
+| Source EN | Wrong DE output | Right DE output |
 |---|---|---|
-| `Massnahme` | `Maßnahme` | "ss" loses the meaning distinction (Masse vs Maße) |
-| `Geschaeftsfuehrung` | `Geschäftsführung` | "ae"/"ue" mark the text as machine-processed |
-| `Strasse` | `Straße` | Eszett is required outside Switzerland |
-| `fuer` | `für` | ASCII substitutes signal a broken pipeline |
+| `the measure` | `Massnahme` | `Maßnahme` |
+| `the executive board` | `Geschaeftsfuehrung` | `Geschäftsführung` |
+| `the street` | `Strasse` | `Straße` |
+| `for the team` | `fuer das Team` | `für das Team` |
 
-This reinforces the preservation rule in `SKILL.md` (lines 13–15). Step 5 validation will reject any output that contains ASCII substitutes where umlauts/eszett are required.
+Step 5 validation rejects any output that contains ASCII substitutes where the German lexicon requires umlauts/eszett.
 
 ## Satzklammer Formation (Pass A vs Pass B)
 

--- a/cogni-copywriting/skills/copywriter/references/01-core-principles/translation-principles.md
+++ b/cogni-copywriting/skills/copywriter/references/01-core-principles/translation-principles.md
@@ -47,7 +47,7 @@ Translate the prose. Preserve the scaffolding. The list below is exhaustive — 
 - **Code blocks** — fenced (```` ``` ````) and inline (`` ` ``) — never translated, even if they contain natural-language strings (those are likely identifiers).
 - **Technical IDs** — `arc_id`, `entity_ref`, `source_url`, schema keys, filenames, paths.
 - **Frontmatter** — the entire YAML block. Add `target_language:` if not already set, but do not translate existing values.
-- **Protected content** (per `SKILL.md` lines 25–31):
+- **Protected content** (the four categories listed under `SKILL.md` § "Protected Content"):
   - `<diagram-placeholder>` XML blocks (full structure including child elements)
   - `Figure N` / `Abbildung N` numeric references — but `Figure` ↔ `Abbildung` itself stays in the source-language form if it appears in inline prose; the numeric identifier never changes
   - `![[assets/*.svg]]` Obsidian embeds

--- a/cogni-copywriting/skills/copywriter/references/01-core-principles/translation-principles.md
+++ b/cogni-copywriting/skills/copywriter/references/01-core-principles/translation-principles.md
@@ -54,7 +54,7 @@ Translate the prose. Preserve the scaffolding. The list below is exhaustive — 
   - Kanban tables with `| Dimension | Act | Plan | Observe |` headers, wikilinks, legends, and `<!-- kanban-board -->` placeholders
 - **Power Position structure markers** — `**IS**:`, `**DOES**:`, `**MEANS**:` and standalone `IS` / `DOES` / `MEANS` arc-element labels. These are structural, not vocabulary.
 - **Proper nouns and brand names** — `BSI`, `KRITIS-Dachgesetz`, `Magenta Security`, `Open Telekom Cloud`, `SAP S/4HANA`. Regulation acronyms (`NIS2`, `DSGVO`, `DORA`) stay in their original form. The audience-tuned acronym expansion that runs in Step 3 will handle any first-mention parentheticals on the target-language output.
-- **Number formats inside data points** — keep `$5.6M`, `40%`, `2026` exactly. The acronym/expansion discipline runs in Step 3 — do not pre-localize numbers here (Step 3 handles `,` vs `.` decimal conventions where needed).
+- **Number values inside data points** — keep numeric magnitudes (`5.6`, `40`, `2026`) and currency symbols/codes (`$`, `€`, `EUR`) faithful to the source. Apply target-language *formatting conventions* (thin-space vs no-space before `%`, comma vs period as decimal/thousands separator, currency-symbol position) per the direction guide (`translation-en-to-de.md` / `translation-de-to-en.md`). The acronym/expansion discipline still runs in Step 3.
 
 ## Citation-Anchored Translation
 

--- a/cogni-copywriting/skills/copywriter/references/01-core-principles/translation-principles.md
+++ b/cogni-copywriting/skills/copywriter/references/01-core-principles/translation-principles.md
@@ -1,0 +1,97 @@
+---
+title: Translation Principles (Two-Pass Translate-then-Polish)
+type: writing-principle
+category: core-principles
+tags: [translation, en-de, de-en, two-pass, citations, preservation]
+audience: [all]
+related:
+  - german-style-principles
+  - acronym-handling-principles
+  - clarity-principles
+  - citation-formatting
+version: 1.0
+last_updated: 2026-05-19
+---
+
+# Translation Principles
+
+<context>
+You are running the translation pass (Step 2.5 of the copywriter workflow). Your output is an intermediate target-language draft. The Step 3 polish pass will apply target-language style discipline (Wolf-Schneider for German, Flesch targets for English, audience-tuned acronym expansion) on top of your output. Do not pre-empt Step 3's job.
+</context>
+
+## Why Two Passes
+
+A single combined translate-and-polish pass conflates two failure modes. When the output is wrong, you cannot tell whether the meaning slipped (translation problem) or the style is off (polish problem). Splitting the work gives a clear diagnosis:
+
+- **Pass A (this step)** — faithful semantic transfer from source to target language. Sentence structure may stay close to the source. Wolf-Schneider rules do not apply yet.
+- **Pass B (Step 3)** — target-language style discipline. Break long sentences, restructure Satzklammer, expand acronyms per audience, hit Flesch/Amstad targets.
+
+Failures in Pass A are translation failures (wrong word, lost nuance, broken citation). Failures in Pass B are style failures (clause too long, Floskel slipped in). The diagnostic clarity is worth the extra pass.
+
+## Translate vs Preserve
+
+Translate the prose. Preserve the scaffolding. The list below is exhaustive — when in doubt, preserve.
+
+### Translate (target language)
+
+- Body paragraphs, sentences, clauses
+- Heading text (H1, H2, H3) — except when `arc_id` is present (arc-mode translation is blocked in v1)
+- Image captions, table cell prose, list item prose
+- Block-quote prose
+- Bold and italic phrase content (preserve the formatting markers, translate the text inside)
+
+### Preserve byte-identical
+
+- **URLs** — every `https://...` string. URLs never localize.
+- **Citation markers** — `[P1-1]`, `[P1-1](https://...)`, `<sup>[1]</sup>`, `[portfolio-validated]`. Marker format, identifier, and URL all stay exactly as written.
+- **Code blocks** — fenced (```` ``` ````) and inline (`` ` ``) — never translated, even if they contain natural-language strings (those are likely identifiers).
+- **Technical IDs** — `arc_id`, `entity_ref`, `source_url`, schema keys, filenames, paths.
+- **Frontmatter** — the entire YAML block. Add `target_language:` if not already set, but do not translate existing values.
+- **Protected content** (per `SKILL.md` lines 25–31):
+  - `<diagram-placeholder>` XML blocks (full structure including child elements)
+  - `Figure N` / `Abbildung N` numeric references — but `Figure` ↔ `Abbildung` itself stays in the source-language form if it appears in inline prose; the numeric identifier never changes
+  - `![[assets/*.svg]]` Obsidian embeds
+  - Kanban tables with `| Dimension | Act | Plan | Observe |` headers, wikilinks, legends, and `<!-- kanban-board -->` placeholders
+- **Power Position structure markers** — `**IS**:`, `**DOES**:`, `**MEANS**:` and standalone `IS` / `DOES` / `MEANS` arc-element labels. These are structural, not vocabulary.
+- **Proper nouns and brand names** — `BSI`, `KRITIS-Dachgesetz`, `Magenta Security`, `Open Telekom Cloud`, `SAP S/4HANA`. Regulation acronyms (`NIS2`, `DSGVO`, `DORA`) stay in their original form. The audience-tuned acronym expansion that runs in Step 3 will handle any first-mention parentheticals on the target-language output.
+- **Number formats inside data points** — keep `$5.6M`, `40%`, `2026` exactly. The acronym/expansion discipline runs in Step 3 — do not pre-localize numbers here (Step 3 handles `,` vs `.` decimal conventions where needed).
+
+## Citation-Anchored Translation
+
+Citation markers are atomic. Translate the surrounding sentence; do not disturb the marker. The marker sits inside the sentence at the source position; keep it at the equivalent position in the target sentence.
+
+**EN source:**
+```
+Industry research indicates that organizations using traditional monitoring approaches experience an average of 15 major incidents per month [P1-2](https://www.pagerduty.com/state-of-digital-ops-2025).
+```
+
+**DE target (correct):**
+```
+Branchenstudien zeigen, dass Organisationen mit klassischen Monitoring-Ansätzen durchschnittlich 15 schwere Vorfälle pro Monat erleben [P1-2](https://www.pagerduty.com/state-of-digital-ops-2025).
+```
+
+The marker `[P1-2](https://www.pagerduty.com/state-of-digital-ops-2025)` is byte-identical. The prose around it is translated. The marker stays at the end of the sentence because that is where it sits in the source.
+
+**Validation rule:** after the translate pass, the regex count of `\[P\d+-\d+\]` (and any other citation-marker patterns present in the source) in the output must equal the count in the source. URLs from those markers must all be present in the output. Step 5 enforces this.
+
+## Compound-Noun Strategies
+
+Translation direction changes the noun strategy.
+
+- **EN → DE** — English noun phrases (`the cloud migration strategy`) often map to German compounds (`die Cloud-Migrationsstrategie`) or hyphenated forms. Prefer the compound when it reads naturally; fall back to a preposition phrase (`die Strategie für die Cloud-Migration`) when the compound would exceed ~25 characters or three constituents. See `translation-en-to-de.md` for the heuristic.
+- **DE → EN** — German compounds (`Digitalisierungsstrategie`) decompose into English noun phrases (`digitalization strategy`) or, in extreme cases, full clauses. Do not transliterate the compound. See `translation-de-to-en.md` for the rules.
+
+## Audience Expansion is Step 3's Job
+
+Do NOT expand acronyms in the translate pass. The `AUDIENCE`-tuned first-mention expansion runs in Step 3 on the translated text, so any `NIS2 (...)` parenthetical is added downstream. If you expand here, Step 3 may double-expand or skip the expansion. Pass through acronyms unchanged.
+
+The one exception is when the source already contains a parenthetical (e.g., `MDR (Managed Detection and Response)`). Translate both halves: `MDR (Managed Detection and Response — ein Dienstleister erkennt und stoppt Angriffe rund um die Uhr für Sie)` for DE-lay audiences is what Step 3 will produce, but in Pass A simply translate the existing parenthetical (`MDR (Managed Detection and Response)` stays as is since the Vollform happens to be English-only) — Step 3 will add or extend the gloss.
+
+## Per-Direction References
+
+Load the matching direction file for source-target-specific rules:
+
+- **EN → DE** — `translation-en-to-de.md`
+- **DE → EN** — `translation-de-to-en.md`
+
+These files contain the linguistic specifics (Satzklammer setup, gender resolution, compound decomposition) that the generic principles above do not cover.


### PR DESCRIPTION
## Summary

- Adds a `TARGET_LANG` (`de`/`en`) parameter to the copywriter skill that runs a two-pass **translate-then-polish** flow. Pass A (new Step 2.5) transfers meaning while preserving citations, URLs, frontmatter technical IDs, and protected content byte-identical. Pass B (existing Step 3) applies target-language style discipline — Wolf-Schneider for DE, Flesch tuning for EN — and audience-tuned acronym expansion on the translated text.
- Mirrors the v0.2.3 `AUDIENCE` precedent: one optional skill arg with three-tier resolution (skill arg → frontmatter `target_language:` → unset), conditional Step 2.5 behaviour, dedicated Step 5 validation bullets, companion principle files under `01-core-principles/`.
- **v1 scope**: EN ↔ DE only; arc-mode (`arc_id` frontmatter) is blocked because arc heading texts require exact-match preservation. FR/IT/PL/NL/ES and arc-mode translation are deferred to a Phase 2 follow-up issue.

## Why

Users with existing EN content who need DE output (or vice versa) had no path inside the insight-wave ecosystem — every generation plugin assumes you regenerate in the target language from upstream. Regeneration is often not viable (source is hand-edited, originating project is closed, teams collaborate across languages). The existing `copywriter-workspace/eval_set.json` explicitly marked translation queries as `should_trigger: false`, confirming this is a deliberate gap. cogni-copywriting already had every prerequisite (bilingual EN/DE awareness, Wolf-Schneider rules, language-aware Flesch/Amstad, language detection, the three preservation invariants, the proven `copy-json` delegate-with-a-mode adapter pattern), so extending the copywriter skill was a smaller surface than a new plugin.

## What's in the diff

- **3 new reference files** under `skills/copywriter/references/01-core-principles/`: `translation-principles.md` (two-pass philosophy, preserve-vs-translate list, citation anchoring), `translation-en-to-de.md` (Sie-form, umlaut traps, Satzklammer, compound nouns, gender), `translation-de-to-en.md` (compound decomposition, sentence splitting, nominal→verbal style, number/date formatting)
- **Workflow surface**: `SKILL.md` (Step 1 `TARGET_LANG` + pre-checks, new Step 2.5 Translate Pass, Step 5 translation validation), `00-index.md` (CHECK 0 conditional load, v8.2), `agents/copywriter.md` (input + JSON output), `commands/copywrite.md` (`--translate=de|en`), `copy-json/SKILL.md` (pass-through + direction-aware charset check)
- **Docs and version**: `CLAUDE.md` (Translation Flow subsection), `README.md` (Quick Start example, Language support table), `plugin.json` 0.2.3 → 0.3.0 (with marketplace mirror), `eval_set.json` (translation query flipped to `should_trigger: true`), CHANGELOG `[7.3.0]`

## Test plan

- [ ] EN → DE: `Skill: cogni-copywriting:copywriter args: FILE_PATH=copywriter-workspace/test-docs/english-memo.md TARGET_LANG=de` → German output with umlauts, Wolf-Schneider validation passes
- [ ] DE → EN: `Skill: cogni-copywriting:copywriter args: FILE_PATH=copywriter-workspace/test-docs/german-with-citations.md TARGET_LANG=en` → English output, all 6 citations preserved with URLs byte-identical, Flesch 50–60
- [ ] Arc-mode block: same skill against `test-docs/arc-narrative.md` (has `arc_id` frontmatter) → clear error, file not modified
- [ ] Source == target no-op: `TARGET_LANG=en` on an English doc → log message, falls through to standard polish
- [ ] JSON adapter: `/copywrite plugins.json --fields="plugins[*].description" --translate=de` → per-field translation, direction-aware German-char validation
- [ ] No regression: existing `--scope=tone` polish without `--translate` behaves identically to v0.2.3
- [ ] Version mirror: `jq .version cogni-copywriting/.claude-plugin/plugin.json` and the marketplace entry both return `"0.3.0"`


---
_Generated by [Claude Code](https://claude.ai/code/session_01YD5h3eWJ3jyjscGjJDdF3J)_