### PR TITLE
cogni-copywriting 0.3.3: gate silent-e by source language (closes #261)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -46,7 +46,7 @@
     {
       "name": "cogni-copywriting",
       "source": "./cogni-copywriting",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "maturity": "preview",
       "description": "Professional copywriting toolkit providing document polishing with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), stakeholder review via parallel persona Q&A, readability optimization, sales enhancement (Power Positions), multi-language support, JSON field polishing via the copy-json adapter, arc contract audit against cogni-narrative, and EN↔DE translation pass (translate then polish).",
       "keywords": [

--- a/cogni-copywriting/.claude-plugin/plugin.json
+++ b/cogni-copywriting/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-copywriting",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Professional copywriting toolkit providing document polishing with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), stakeholder review via parallel persona Q&A, readability optimization, sales enhancement (Power Positions), multi-language support, JSON field polishing via the copy-json adapter, arc contract audit against cogni-narrative, and EN↔DE translation pass (translate then polish).",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-copywriting/copywriter-workspace/test-fixtures/readability-rule/README.md
+++ b/cogni-copywriting/copywriter-workspace/test-fixtures/readability-rule/README.md
@@ -37,7 +37,7 @@ bash cogni-copywriting/copywriter-workspace/test-fixtures/readability-rule/run.s
 Output is one line per fixture plus a summary, e.g.:
 
 ```
-[de-dense] src=-13.6 out=7.2 margin=25.8 actual=PASS expect=PASS
+[de-dense] src=-32.1 out=7.2 margin=44.3 actual=PASS expect=PASS
 [degraded] src=69.6 out=48.1 margin=-16.5 actual=FAIL expect=FAIL
 Summary: 2 matched, 0 mismatched
 ```

--- a/cogni-copywriting/skills/copywriter/CHANGELOG.md
+++ b/cogni-copywriting/skills/copywriter/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the copywriter skill will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.3] - 2026-05-19
+
+> The skill internal bump 7.3.2 → 7.3.3 ships in plugin release 0.3.3.
+
+### Fixed — Silent-e adjustment under-counted German -e-final words in cross-language mode
+
+`count_syllables_en` in `scripts/calculate_readability.py` unconditionally subtracted 1 syllable for any word ending in `-e` (silent-`e`). That is correct English (`hope`, `time`, `gave`), but wrong on German prose where final `-e` is almost always pronounced (`Phase`, `Hilfe`, `Strategie`, `Industrie`, plus short function words like `die`, `eine` and plurals like `Pilotprojekte`). When Step 5 translation validation scores DE source text on the EN scale via `--lang en` (the cross-language pattern introduced in PR #257, v0.3.1), every `-e`-final German word lost 1 syllable. Under the EN Flesch formula's `−84.6·ASW` penalty, that **inflated** the EN-scaled source score and made the relative-to-source rule `output_score ≥ source_score − 5` artificially easier — same direction of bias as #258, different word set.
+
+Fix: gate the silent-`e` adjustment on the detected source-prose language. `count_syllables_en` gains an optional `source_lang='en'` parameter; `calculate_flesch_score` always runs `detect_language` on the cleaned prose and passes the result through. The Flesch *formula* still runs on the requested target-language scale (`lang`); only the *syllable counter* now reflects the actual source-prose phonology (`source_lang`). When the two coincide (pure-EN, pure-DE) the behaviour is byte-identical to v0.3.2; the only callers whose scores shift are cross-language ones — exactly the bug.
+
+Empirical impact on the anchor case from #261: scoring `test-docs/german-with-citations.md` with `--lang en` moves from `-13.6` (post-#258, v0.3.2) to `-32.1` post-fix — an 18.5-point downward correction. The issue estimated ~3–5 units; the measured shift is larger because the bug fires on every `-e`-final token (70 of 320 words), not only the visible content lemmas. Same direction of correction as #258, larger magnitude. Standing fixture `de-dense` margin widens from 25.8 to 44.3 (still PASS); `degraded` fixture and EN translation output are byte-identical (real-EN prose, silent-e still fires).
+
+#### Changed Files
+
+- `skills/copywriter/scripts/calculate_readability.py` — `count_syllables_en` gains `source_lang='en'` parameter; silent-`e` adjustment gated on `source_lang == 'en'`. `calculate_flesch_score` runs `detect_language` unconditionally and passes the result as `source_lang`.
+- `skills/copywriter/references/01-core-principles/translation-principles.md` — new "Language-faithful syllable counting" paragraph in the "Readability in Translation Mode" section.
+- `copywriter-workspace/test-fixtures/readability-rule/README.md` — sample-output block updated with post-fix measured values (`de-dense` `src=-32.1`, `margin=44.3`).
+- `.claude-plugin/plugin.json` — `0.3.2` → `0.3.3`.
+- `.claude-plugin/marketplace.json` (repo root) — cogni-copywriting entry `0.3.2` → `0.3.3`.
+- `CHANGELOG.md` — this entry.
+
+#### Migration Notes
+
+Non-breaking. Single-language callers (the entire pre-0.3.1 calling pattern) see byte-identical scores — pure-English prose detects as `source_lang == 'en'` and the silent-`e` adjustment still fires unchanged; pure-German prose uses `count_syllables_de`, which never had the adjustment. The only callers whose scores shift are DE-in-EN-mode (Step 5 cross-language scoring) invocations — which is the entire point of the fix. The shift is downward (more accurate), making the relative rule slightly stricter for dense DE→EN translations. No downstream consumers to coordinate.
+
+Closes #261.
+
 ## [7.3.2] - 2026-05-19
 
 > The skill internal bump 7.3.1 → 7.3.2 ships in plugin release 0.3.2.

--- a/cogni-copywriting/skills/copywriter/references/01-core-principles/translation-principles.md
+++ b/cogni-copywriting/skills/copywriter/references/01-core-principles/translation-principles.md
@@ -102,6 +102,8 @@ python3 scripts/calculate_readability.py <output.md> --lang $TARGET_LANG   # out
 
 **The 5-point soft floor.** Covers compound-length drift (EN→DE: German compounds inflate average word length, pushing Amstad down 2–4 points even for a clean rendering) and sentence-splitting drift (DE→EN: long German sentences often decompose into multiple shorter English ones with their own syllable budgets). Five points is the empirical headroom needed to absorb this without licensing genuine degradation.
 
+**Language-faithful syllable counting.** The Flesch *formula* runs on the target-language scale (per the rule above), but the *syllable counter* always reflects the actual source prose: the EN vowel set includes umlauts (so DE words score correctly), and the silent-`e` adjustment is skipped when source prose is detected as non-English. This keeps the score sensitive to information density rather than phonological-rule mismatches. See `scripts/calculate_readability.py` (`count_syllables_en` `source_lang` parameter).
+
 **Step 3 still runs.** Pass B continues to apply target-language style discipline — Wolf-Schneider for DE (12-word clauses, Satzklammer, Floskel elimination); 15–20 word sentences and 80%+ active voice for EN. The relative rule is a *floor*, not a *ceiling*: landing inside the absolute band is still preferable, just not required. If translation work *can* hit the absolute band without paraphrasing source vocabulary, do so.
 
 See `SKILL.md` § Step 5 "Translation-specific validation" → "Readability relative to source" for the validator wiring.

--- a/cogni-copywriting/skills/copywriter/scripts/calculate_readability.py
+++ b/cogni-copywriting/skills/copywriter/scripts/calculate_readability.py
@@ -98,8 +98,15 @@ def detect_language(text):
 
 # --- Syllable Counting ---
 
-def count_syllables_en(word):
-    """Estimate syllable count for an English word."""
+def count_syllables_en(word, source_lang='en'):
+    """Estimate syllable count for an English word.
+
+    The silent-'e' adjustment is English-specific. When scoring non-English
+    prose on the EN scale (cross-language Step 5 mode), pass the actual
+    source language so the adjustment is skipped — German final-e is almost
+    always pronounced (Hilfe, Strategie, Industrie), and the EN -84.6 ASW
+    penalty inflates the score otherwise.
+    """
     word = word.lower()
     count = 0
     vowels = "aeiouyäöü"
@@ -111,8 +118,8 @@ def count_syllables_en(word):
             count += 1
         previous_was_vowel = is_vowel
 
-    # Adjust for silent 'e'
-    if word.endswith('e'):
+    # Silent-e is English-only.
+    if word.endswith('e') and source_lang == 'en':
         count -= 1
 
     # Ensure at least 1 syllable
@@ -172,9 +179,13 @@ def calculate_flesch_score(text, lang='auto'):
     text = re.sub(r'\[([^\]]+)\]\([^\)]+\)', r'\1', text)  # Links
     text = re.sub(r'[*_`#>-]', '', text)  # Markdown symbols
 
-    # Detect language if auto
+    # `lang` is the Flesch FORMULA language (target). `source_lang` is the
+    # actual prose language (used for source-faithful syllable adjustments).
+    # The two differ in Step 5 cross-language scoring (e.g. DE prose on the
+    # EN scale).
+    source_lang = detect_language(text)
     if lang == 'auto':
-        lang = detect_language(text)
+        lang = source_lang
 
     # Split into sentences
     sentences = re.split(r'[.!?]+', text)
@@ -189,8 +200,12 @@ def calculate_flesch_score(text, lang='auto'):
         return 0, lang
 
     # Count syllables using language-appropriate function
-    syllable_fn = count_syllables_de if lang == 'de' else count_syllables_en
-    total_syllables = sum(syllable_fn(word) for word in words)
+    if lang == 'de':
+        total_syllables = sum(count_syllables_de(word) for word in words)
+    else:
+        total_syllables = sum(
+            count_syllables_en(word, source_lang=source_lang) for word in words
+        )
 
     total_words = len(words)
     total_sentences = len(sentences)


### PR DESCRIPTION
## Summary

Closes #261 — the sibling follow-up to #258. `count_syllables_en` in `scripts/calculate_readability.py` unconditionally subtracted 1 syllable for any `-e`-final word (silent-`e`). Correct for English; wrong for German prose where final `-e` is almost always pronounced (`Phase`, `Hilfe`, `Strategie`; short forms `die`/`eine`; plurals like `Pilotprojekte`). Under Step 5 cross-language scoring (`--lang en` on DE source, the pattern introduced in PR #257), every `-e`-final German word lost 1 syllable, inflating the EN-scaled Flesch score under the `−84.6·ASW` penalty and making the relative rule `output_score ≥ source_score − 5` artificially easier.

**Fix.** Gate the silent-`e` adjustment on the detected source-prose language. `count_syllables_en` gains an optional `source_lang='en'` parameter; `calculate_flesch_score` runs `detect_language` unconditionally and passes the result through. The Flesch *formula* still runs on the requested target-language scale (`lang`); only the *syllable counter* now reflects the actual source-prose phonology (`source_lang`). When the two coincide (pure-EN, pure-DE) the behaviour is byte-identical to v0.3.2.

## Empirical shift

| Doc / mode | v0.3.2 | v0.3.3 | Δ |
|---|---|---|---|
| `english-memo.md --lang en` (pure-EN sentinel) | 57.3 | **57.3** | 0 (byte-identical) |
| `german-with-citations.md --lang de` (DE counter, untouched) | 8.8 | **8.8** | 0 (byte-identical) |
| `german-with-citations.md --lang en` (the bug) | −13.6 | **−32.1** | **−18.5** |

Issue estimated ~3–5 units; measured shift is larger because the bug fires on every `-e`-final token (70 of 320 words), not only the visible content lemmas. Same direction of correction as #258, larger magnitude.

## Standing fixtures (PR #260) — pre/post

**Pre-fix (v0.3.2 baseline):**
```
[de-dense] src=-13.6 out=7.2 margin=25.8 actual=PASS expect=PASS
[degraded] src=69.6  out=48.1 margin=-16.5 actual=FAIL expect=FAIL
Summary: 2 matched, 0 mismatched
```

**Post-fix (v0.3.3):**
```
[de-dense] src=-32.1 out=7.2 margin=44.3 actual=PASS expect=PASS
[degraded] src=69.6  out=48.1 margin=-16.5 actual=FAIL expect=FAIL
Summary: 2 matched, 0 mismatched
```

`de-dense` margin widens (DE source on EN scale tightens, output unchanged — EN translation's silent-e still fires); `degraded` fixture is byte-identical. Both fixtures still match their expected verdicts. The README sample-output block was updated to the post-fix values.

## Test plan

- [x] Pre-fix and post-fix `run.sh` exits 0; both verdicts unchanged.
- [x] `english-memo.md --lang en` byte-identical (57.3 → 57.3) — pure-EN regression sentinel.
- [x] `german-with-citations.md --lang de` byte-identical (8.8 → 8.8) — DE counter untouched.
- [x] `german-with-citations.md --lang en` shifts (−13.6 → −32.1) — bug fixed.
- [x] `--lang auto` still auto-detects `de` for the DE doc (8.8) — auto-detect path intact.
- [ ] `cogni-service:service-review` returns `pass`.

## Files changed

- `cogni-copywriting/skills/copywriter/scripts/calculate_readability.py` — `count_syllables_en` gains `source_lang='en'` param; silent-`e` gated on it. `calculate_flesch_score` runs `detect_language` unconditionally.
- `cogni-copywriting/skills/copywriter/references/01-core-principles/translation-principles.md` — new "Language-faithful syllable counting" paragraph.
- `cogni-copywriting/copywriter-workspace/test-fixtures/readability-rule/README.md` — sample-output block updated with post-fix values.
- `cogni-copywriting/skills/copywriter/CHANGELOG.md` — new `[7.3.3]` entry.
- `cogni-copywriting/.claude-plugin/plugin.json` — `0.3.2` → `0.3.3`.
- `.claude-plugin/marketplace.json` — cogni-copywriting `0.3.2` → `0.3.3`.

## Migration notes

Non-breaking. Single-language callers (pre-0.3.1 contract) see byte-identical scores. Only callers whose scores shift are DE-in-EN-mode (Step 5 cross-language) — exactly the bug. Shift is downward, making the relative rule slightly stricter for dense DE→EN translations.

**Follow-up worth tracking.** The EN-scaled DE source score is now materially stricter (`german-with-citations.md`: −13.6 → −32.1, an 18.5-point shift). The 5-point soft floor in the relative-to-source rule was tuned against the pre-fix scoring; whether it still has the right empirical headroom for dense DE→EN translations is worth a real-world watch over the next few translation polishes. Not blocking — flagging for a future tuning issue if observed regressions appear.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Si73y9nSDzTz9v7vzBFMRL)_
