### PR TITLE
cogni-knowledge 0.0.17: M2-finish + M3 + M4 — plan → curate → fetch (#264)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -277,7 +277,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.0.15",
+      "version": "0.0.17",
       "maturity": "incubating",
       "description": "Wiki-first research that compounds. Binds a cogni-research project to a cogni-wiki knowledge base so every research run deposits into the same persistent, queryable, interlinked markdown wiki — and so future runs read what previous runs filed instead of starting from zero. Thin orchestrator over cogni-research and cogni-wiki; no forked agents, no duplicated scripts. The differentiator vs. one-shot deep-research tools (OpenAI Deep Research, Perplexity Spaces, GPT Researcher) is the binding: knowledge accumulates across projects instead of dying in chat history.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.0.15",
+  "version": "0.0.17",
   "description": "Wiki-first research that compounds. Binds a cogni-research project to a cogni-wiki knowledge base so every research run deposits into the same persistent, queryable, interlinked markdown wiki — and so future runs read what previous runs filed instead of starting from zero. Thin orchestrator over cogni-research and cogni-wiki; no forked agents, no duplicated scripts. The differentiator vs. one-shot deep-research tools (OpenAI Deep Research, Perplexity Spaces, GPT Researcher) is the binding: knowledge accumulates across projects instead of dying in chat history.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/CHANGELOG.md
+++ b/cogni-knowledge/CHANGELOG.md
@@ -18,6 +18,7 @@ Phase 5 milestones M2-finish + M3 + M4 — the `plan → curate → fetch` chain
 ### Changed
 
 - `CLAUDE.md` — Skills table gains rows for `knowledge-plan` / `knowledge-curate` / `knowledge-fetch`. Scripts table gains `candidate-store.py`. "Future phases" paragraph rewritten to delegate the milestone narrative to `references/absorption-roadmap.md` (the source of truth) with a one-line progress pointer.
+- `fetch-cache.py` `_url_key` now hashes the **normalized** URL form (`normalize_url` — same canonicalization `candidate-store.py` applies for dedup) rather than the raw URL. Any cache entries written between PR #269 and v0.0.17 are keyed against the un-normalized hash and will be invisible to post-v0.0.17 lookups. PR #269 only just shipped so production caches are unlikely, but if you have one, run `python3 cogni-knowledge/scripts/fetch-cache.py evict --older-than-days 0` to clear it.
 
 ### Dependencies
 

--- a/cogni-knowledge/CHANGELOG.md
+++ b/cogni-knowledge/CHANGELOG.md
@@ -1,5 +1,28 @@
 # cogni-knowledge changelog
 
+## 0.0.17 — 2026-05-20
+
+Phase 5 milestones M2-finish + M3 + M4 — the `plan → curate → fetch` chain of the v0.1.0 inverted pipeline. PR #269 (M1 + M2-script) shipped the foundation without a version bump; this release surfaces the first user-visible inverted-pipeline skills. Plugin stays at `0.0.x`/maturity `incubating` per the absorption-roadmap M-table — the maturity flip to Preview ships at M12 alongside the alpha re-run + 0.1.0 bump. The `0.0.16` slot is reserved for the alpha-re-run measurement record referenced in `references/alpha-findings.md` and the `knowledge-binding.py` comment block; no released artefact ships under that tag.
+
+### Added
+
+- `agents/source-curator.md` — point-in-time fork of `cogni-research/agents/source-curator.md` (SHA `d2ee309` at fork time). Phase 2 curator for the inverted pipeline. Reshapes output: writes `<project>/.metadata/candidates.json` instead of `curated-sources.json`; renames `composite_score → score`; adds `tier`, `sub_question_refs[]`; drops emission of `dimensions{}`, `annotation`, `diversity{}` (computation stays internal; the M12 alpha gate is content-not-process). Composite scoring weights (0.30/0.25/0.15/0.15/0.15) unchanged at fork time. WebSearch only — no WebFetch (Phase 3's job). M3.
+- `agents/source-fetcher.md` — NEW agent (no upstream). Phase 3 fetcher. Per-URL loop: `fetch-cache.py fetch` (cache lookup) → WebFetch → cobrowse fallback (via `claude-in-chrome` MCP when present) → `fetch-cache.py store` for both success and `unavailable` outcomes. Negative-cache symmetric with positive per `fetch-cache-design.md:53`. Never decides to drop a URL — only records availability. Closed `webfetch_error_class` vocabulary so downstream summarisation is stable. M2-finish.
+- `skills/knowledge-plan/SKILL.md` — Phase 1 skill. Decomposes a topic into 3-7 sub-questions with per-sub-question `candidate_domains[]` (no web). Writes `<project>/.metadata/plan.json` schema `0.1.0` per `references/inverted-pipeline.md:41-57`. Creates the project directory at `<knowledge-root>/<topic-slug>-<YYYY-MM-DD>/`. Probes only `cogni-wiki` (clean-break — no cogni-research dispatch). Binding append deferred to M9 (`knowledge-finalize`). M4 part 1/3.
+- `skills/knowledge-curate/SKILL.md` — Phase 2 orchestrator. Reads `plan.json` + `binding.curator_defaults`, fans out one `source-curator` dispatch per sub-question (parallel when ≤3, sequential otherwise), merges per-sub-question batches into `candidates.json` via `candidate-store.py append-batch`. Legacy-binding fallback: applies `DEFAULT_CURATOR_DEFAULTS` from `knowledge-binding.py` when pre-v0.0.3 bindings lack `curator_defaults`. M4 part 2/3.
+- `skills/knowledge-fetch/SKILL.md` — Phase 3 orchestrator. Reads `candidates.json` + `binding.curator_defaults.fetch_cache_max_age_days`, builds batches (default 8 URLs each, sorted by `fetch_priority`), dispatches `source-fetcher` per batch (sequential at v0.0.17 for WebFetch rate-limit awareness), merges `fetched[]` + `unavailable[]` into `<project>/.metadata/fetch-manifest.json` schema `0.1.0` per `references/inverted-pipeline.md:91-109`. Optional `--tier` flag scopes fetches to a single tier. Non-blocking warning when unavailable rate exceeds 30%. M4 part 3/3.
+- `scripts/candidate-store.py` — stdlib helper for file-locked (`fcntl.flock`) merge of parallel curator output batches into `<project>/.metadata/candidates.json`. Subcommands `init` / `append-batch` / `read`. Dedup key is URL-normalized (lowercase scheme+host, trailing-slash-stripped, `utm_*` / `ref` / `fbclid` / `gclid` params dropped, fragment dropped). Merge semantics on collision: higher score wins, earliest `discovered_at` wins, `sub_question_refs[]` unioned, `tier` + `fetch_priority` recomputed. Posix-only (consistent with `tests/README.md` Linux/macOS posture). M4 supporting infrastructure.
+- `tests/test_candidate_store.sh` — 8 assertions: init idempotency + schema `0.1.0`, dedup+merge+ref-union+fetch_priority assignment, concurrent-append lock correctness (two parallel subshells racing on the same project), three malformed-input rejection cases (non-array, missing url, out-of-range score), URL normalization collapsing case + trailing slash + tracking params.
+- `tests/test_skill_contracts.sh` — grep-based SKILL.md / agent-md contract assertions for the 6 new files. Catches silent contract drift (path, flag, or step disappearing). Includes a clean-break invariant check that asserts no new file dispatches a `cogni-research:` or `cogni-claims:` skill/agent.
+
+### Changed
+
+- `CLAUDE.md` — Skills table gains rows for `knowledge-plan` / `knowledge-curate` / `knowledge-fetch`. Scripts table gains `candidate-store.py`. "Future phases" paragraph rewritten to delegate the milestone narrative to `references/absorption-roadmap.md` (the source of truth) with a one-line progress pointer.
+
+### Dependencies
+
+No new minimum-version requirements. cogni-wiki ≥ 0.0.43 from v0.0.14 still holds. (cogni-wiki 0.0.44's `type: source` allowlist is the next slice's dep — M6 `knowledge-ingest` — not this slice's.)
+
 ## 0.0.15 — 2026-05-20
 
 Phase 4 alpha re-run on a fresh `eu-ai-act` knowledge base completed end-to-end without chain-breaker regression. Docs-only release recording the go decision for Phase 5 graduation.

--- a/cogni-knowledge/CLAUDE.md
+++ b/cogni-knowledge/CLAUDE.md
@@ -32,8 +32,20 @@ They live as siblings. The wiki is the substrate; the binding records which rese
 | `knowledge-query` | Ask a question against the bound base. Resolves the wiki path from `binding.json`, dispatches `cogni-wiki:wiki-query` against it, appends a one-line knowledge-base footer. Read-only. Phase 3, v0.0.8+. |
 | `knowledge-dashboard` | Render an HTML overview. Dispatches `cogni-wiki:wiki-dashboard` against the bound wiki, then writes a `knowledge-overlay.md` sidecar listing deposited projects + latest lint-audit `claim_drift` count. Phase 3, v0.0.9+. |
 | `knowledge-refresh` | Self-healing loop. Pull-mode delegates to `cogni-wiki:wiki-refresh`. Push-mode lints the wiki, asks which stale topics to re-research, then sequentially dispatches `knowledge-research` + `wiki-refresh` per selected topic. Phase 3, v0.0.10+. |
+| `knowledge-plan` | **v0.1.0 inverted pipeline, Phase 1.** Decomposes a topic into 3-7 sub-questions with per-sub-question `candidate_domains[]` (no web). Writes `<project>/.metadata/plan.json` schema `0.1.0`. Probes only `cogni-wiki` — the v0.1.0 path does not dispatch cogni-research. Phase 5, v0.0.17+. |
+| `knowledge-curate` | **v0.1.0 inverted pipeline, Phase 2.** Reads `plan.json`, fans out one `source-curator` dispatch per sub-question (WebSearch + score, no fetch), merges per-sub-question batches into `<project>/.metadata/candidates.json` via `candidate-store.py append-batch`. Phase 5, v0.0.17+. |
+| `knowledge-fetch` | **v0.1.0 inverted pipeline, Phase 3.** Reads `candidates.json`, dispatches `source-fetcher` per batch (WebFetch + cobrowse fallback), merges into `<project>/.metadata/fetch-manifest.json`. Successful bodies land in the shared `.cogni-knowledge/fetch-cache/`; unavailable URLs are negatively cached. Phase 5, v0.0.17+. |
 
 Phase 2 closes the round-trip — `knowledge-report` reads the wiki, re-deposits via `wiki-from-research` Mode B with the opt-in flags, and `cycle-guard.py` refuses self-citing loops. The differentiation thesis (knowledge compounds across projects) holds only with this loop closed; before v0.0.6 a second research run could only deposit, never compose-and-deposit.
+
+## Agents (v0.1.0 inverted pipeline)
+
+Starting at v0.0.17, cogni-knowledge has an `agents/` directory. v0.0.x had none by design (everything delegated to upstream cogni-research agents); the v0.1.0 clean break forks agents locally so the runtime path is 0% cogni-research. The v0.0.x "What about `agents/`?" paragraph in `references/delegation-contract.md` is the legacy contract — `references/inverted-pipeline.md` is the v0.1.0 source of truth.
+
+| Agent | Role |
+|---|---|
+| `source-curator` | Phase 2. Forked from `cogni-research/agents/source-curator.md` (point-in-time copy; drift acceptable). Per-sub-question WebSearch + scoring. Emits a batch JSON array for merge into `candidates.json`. v0.0.17+. |
+| `source-fetcher` | Phase 3. NEW (no upstream). Per-URL WebFetch with `claude-in-chrome` cobrowse fallback; reads/writes through `fetch-cache.py`. Emits per-batch `{fetched[], unavailable[]}` for merge into `fetch-manifest.json`. v0.0.17+. |
 
 ## Scripts
 
@@ -42,6 +54,8 @@ Phase 2 closes the round-trip — `knowledge-report` reads the wiki, re-deposits
 | `knowledge-binding.py` | `init` / `append-project` / `read` subcommands against `.cogni-knowledge/binding.json` | No (stdlib only) |
 | `lineage-stamp.py` | Stamps `derived_from_research: <slug>` into the YAML frontmatter of deposited wiki pages | No (stdlib only) |
 | `cycle-guard.py` | Detects direct self-cycles before a wiki-mode re-deposit: walks the candidate project's `02-sources/data/src-*.md` for `wiki://<bound-slug>/<page-id>` citations and checks each resolved page's frontmatter for `derived_from_research: <candidate-slug>`. Exit 1 on `cycle_detected`, exit 0 on `clear` or `not_applicable` (web/local mode). | No (stdlib only) |
+| `fetch-cache.py` | **v0.1.0 inverted pipeline.** Content-addressed URL→body cache at `.cogni-knowledge/fetch-cache/<sha256>.json`. Subcommands `store` / `fetch` (with `--max-age-days` staleness gate) / `evict` / `stat` / `key`. Negative caching for unavailable URLs; freshness symmetric with positive entries. Atomic temp+rename per entry. v0.0.16-foundation (shipped via PR #269, no version bump); consumed by `source-fetcher` at v0.0.17. | No (stdlib only) |
+| `candidate-store.py` | **v0.1.0 inverted pipeline.** File-locked (`fcntl.flock`) merge of parallel `source-curator` output batches into `<project>/.metadata/candidates.json`. Subcommands `init` / `append-batch` / `read`. Dedup key URL-normalized (lowercase scheme+host, trailing-slash-stripped, common tracking params dropped). On collision: higher score wins, earliest `discovered_at` wins, `sub_question_refs[]` unioned, `tier` + `fetch_priority` recomputed. Posix-only. v0.0.17+. | No (stdlib only) |
 
 All scripts return `{"success": bool, "data": {...}, "error": "..."}` per the insight-wave convention (`../CLAUDE.md` §"Script Output Format"). Stdlib only — no pip dependencies.
 
@@ -113,4 +127,6 @@ Only the frontmatter changes — page bodies are never touched.
 
 ## Future phases
 
-Phase 2 (v0.0.6) shipped — `knowledge-report` + `cycle-guard.py` close the wiki-roundtrip loop. Phase 3 (v0.0.11) shipped — `knowledge-query`, `knowledge-dashboard`, `knowledge-refresh` make the accumulated knowledge legible and self-healing. Phase 2/3 follow-up debt cleared at v0.0.13 (transitive cycle detection, slug→path index, factored project-config reader, pre-flight dependency check in `knowledge-setup`, cycle-guard docstring precision; cogni-wiki contract regression tests landed alongside as cogni-wiki v0.0.42). Phase 4 (the internal alpha) surfaced findings F1–F10 — F1–F4 fixed at v0.0.14 (F5 transitively via F4) alongside PR-#267 reviewer-deferred items A1–A4 (`read-project-config.py --bare`, binding `project_path` schema 0.0.2, `cogni-knowledge/tests/`, probe rolled to all 7 skills). cogni-wiki contract tests for F2/F3/F4 landed alongside as cogni-wiki v0.0.43. F6–F10 remain deferred — see `references/alpha-findings.md`. Phase 5 graduates to v0.1.0 (Preview) once the v0.0.16 alpha re-run completes clean end-to-end. Phase 6 absorbs `cogni-research`. See `references/absorption-roadmap.md`.
+Phases 1-3 shipped (v0.0.1 → v0.0.11), 2/3 follow-up debt cleared at v0.0.13, Phase 4 alpha completed at v0.0.15 with a **GO** recommendation. **Phase 5 is in flight as one big v0.1.0 inverted-pipeline clean break** — see `references/absorption-roadmap.md` for the canonical 12-milestone (M1–M12) table and current status. The plugin stays at `0.0.x`/maturity `incubating` until M12 ships the alpha re-run + version bump to 0.1.0 + maturity flip in a single landing. Phase 6 (cogni-research deprecation cleanup) follows Phase 5.
+
+Inverted-pipeline progress: M1 (plumbing) + M2-script (fetch-cache.py) shipped at PR #269 with no version bump. M2-finish (`source-fetcher` agent) + M3 (`source-curator` fork) + M4 (`knowledge-plan` / `knowledge-curate` / `knowledge-fetch` skills + `candidate-store.py`) ship at v0.0.17. Next slice: M5 (`claim-extractor` fork + `source-ingester` agent) + M6 (`knowledge-ingest` skill; unblocked by cogni-wiki 0.0.44's `type: source` allowlist).

--- a/cogni-knowledge/agents/source-curator.md
+++ b/cogni-knowledge/agents/source-curator.md
@@ -1,0 +1,144 @@
+---
+name: source-curator
+description: Phase-2 source curator for the inverted pipeline. Reads a sub-question, runs WebSearch, scores candidates on 5 dimensions, emits a per-batch JSON array of candidate objects for merge into <project>/.metadata/candidates.json. Does NOT fetch URL bodies — that is Phase 3's source-fetcher.
+model: sonnet
+color: yellow
+tools: ["Read", "Write", "Glob", "Grep", "Bash", "WebSearch"]
+---
+
+<!--
+Forked from cogni-research/agents/source-curator.md at SHA
+d2ee309ba6e37d0b8b3b0761fb2eccf713a6fa31 on 2026-05-20. Per
+`cogni-knowledge/references/inverted-pipeline.md` ("What is no longer in the
+runtime path"), forks are point-in-time copies — drift from upstream is
+acceptable and expected.
+
+Reshape vs upstream (kept narrow on purpose):
+ - Output file: .metadata/curated-sources.json → .metadata/candidates.json
+ - composite_score → score
+ - Add: sub_question_refs[] (carried from plan.json)
+ - Add: fetch_priority (assigned by candidate-store.py at merge time)
+ - Drop emission of dimensions{}, annotation, diversity{} blocks
+   (the M12 alpha gate is content-not-process; computation stays internal)
+ - Input: SUB_QUESTION rather than the cogni-research 02-sources walk —
+   this curator runs per-sub-question, dispatched once per sq by
+   knowledge-curate; output is merged through candidate-store.py.
+ - No WebFetch / claim extraction — this is Phase 2 only.
+
+Composite scoring weights (0.30/0.25/0.15/0.15/0.15) are identical to the
+upstream at fork time; future tuning is local. See also
+`agents/source-fetcher.md` (Phase 3) and `scripts/candidate-store.py` (merge).
+-->
+
+# Source Curator Agent (inverted pipeline, Phase 2)
+
+## Role
+
+You score and rank web-discovered source candidates for a single sub-question. You produce a JSON array of candidate objects, written to a batch file the orchestrator (`knowledge-curate`) merges into `<project>/.metadata/candidates.json` via `candidate-store.py append-batch`.
+
+You **do not fetch URL bodies**. That is Phase 3 (`source-fetcher`). You also do not extract claims — that is Phase 4 (`source-ingester`).
+
+## Input Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `PROJECT_PATH` | Yes | Absolute path to the project directory (`<knowledge-root>/<topic-slug>-<YYYY-MM-DD>/`) |
+| `SUB_QUESTION_ID` | Yes | sq-id from `plan.json`, e.g. `sq-01` |
+| `BATCH_OUTPUT_PATH` | Yes | Absolute path the orchestrator wants this batch's JSON array written to, e.g. `<project>/.metadata/.candidates.batch.sq-01.json` |
+| `MARKET` | Yes | Region code. Must be one of the keys in `${CLAUDE_PLUGIN_ROOT}/../cogni-research/references/market-sources.json`: `dach`, `de`, `fr`, `it`, `pl`, `nl`, `es`, `us`, `uk`, `eu`. Drives market-localized search queries and authority scoring. Fall back to `_default` if unexpectedly absent. |
+| `MAX_CANDIDATES` | No | Cap on candidates this curator emits for the sub-question (default 12; read from `binding.curator_defaults.max_candidates_per_sq`). |
+| `SCORE_THRESHOLD` | No | Minimum composite score to emit (default 0.5; read from `binding.curator_defaults.score_threshold`). |
+| `CURRENT_YEAR` | No | Four-digit year. Used for recency-aware queries. |
+
+The market-sources.json reference is reached via `${CLAUDE_PLUGIN_ROOT}/../cogni-research/references/market-sources.json` — the **clean-break commitment** is that cogni-knowledge's runtime path does not dispatch cogni-research skills/agents, but reading a static reference file from a sibling plugin is permitted (and unavoidable until that file moves to cogni-workspace at M11+).
+
+## Core Workflow
+
+```text
+Phase 0 → Phase 1 → Phase 2 → Phase 3
+```
+
+### Phase 0: Load Inputs
+
+1. Read `<PROJECT_PATH>/.metadata/plan.json`. Locate the sub-question with `id == SUB_QUESTION_ID`. Extract `query`, `search_guidance`, `candidate_domains[]`.
+2. Read `${CLAUDE_PLUGIN_ROOT}/../cogni-research/references/market-sources.json`, extract the entry for `MARKET` (fall back to `_default`). Store as `market_config`.
+3. Confirm `BATCH_OUTPUT_PATH`'s parent directory exists; create if not.
+
+### Phase 1: Search Query Generation
+
+Generate 5-7 diverse WebSearch queries for the sub-question. Vary formulations: factual, analytical, recent developments, expert perspectives, quantitative.
+
+Apply intent-based language routing using `market_config`:
+- Regulatory / government / national statistics: search in the **local language** (use `market_config.local_query_tips.compound_nouns` as translation cues).
+- Academic / international consulting: search in **English**.
+- Business media: one query in each.
+
+If `candidate_domains[]` is non-empty from the plan, append `site:<domain>` operators on the most relevant 1-2 queries. Generate 1-2 unfiltered queries as fallback when domain-restricted searches return thin results.
+
+**Authority site-searches.** From `market_config.authority_sources`, pick the 1-2 sources most relevant to this sub-question's topic. Use their `search_pattern` template (substitute `{TOPIC_LOCAL}` and `{YEAR}`).
+
+### Phase 2: Web Search + Triage
+
+1. Execute all queries in parallel (single message, multiple WebSearch tool calls).
+2. Aggregate results. Deduplicate by URL (case-insensitive scheme+host, trailing-slash-stripped — match the `normalize_url` convention used by `candidate-store.py` so downstream merges agree).
+3. **Do not WebFetch.** Use search snippets + metadata only. Phase 3 (`source-fetcher`) handles bodies.
+4. Discard candidates whose composite (Phase 3 below) would obviously fall under `SCORE_THRESHOLD` — typically forum posts, marketing pages, broken links.
+
+### Phase 3: Score + Emit
+
+For each surviving candidate, score on 5 dimensions (0.0-1.0):
+
+| Dimension | Weight | Guidance |
+|-----------|--------|----------|
+| Relevance | 0.30 | How directly does this source address the sub-question? |
+| Authority | 0.25 | Academic/government/established analysts = high; blogs/forums = low. If the source's domain matches an entry in `market_config.authority_sources`, apply the declared `authority` score (5 = highest, 2 = vendor/promotional) as a credibility boost. |
+| Recency | 0.15 | Last 1-2 years scores highest for fast-moving topics; historical analysis weighs less. For annual reports, check whether a newer edition exists before accepting an older one. |
+| Specificity | 0.15 | Quantitative sources (data, statistics, dates) score higher than general commentary. |
+| Uniqueness | 0.15 | Sources providing information not covered by others in the set score higher. |
+
+Composite: `0.30*relevance + 0.25*authority + 0.15*recency + 0.15*specificity + 0.15*uniqueness`.
+
+Filter: drop any candidate whose composite < `SCORE_THRESHOLD`. Cap the surviving list at `MAX_CANDIDATES`, keeping the highest-composite entries.
+
+For each surviving candidate, emit an object with the following shape (per `references/inverted-pipeline.md:65-81`):
+
+```json
+{
+  "url": "https://...",
+  "title": "...",
+  "score": 0.91,
+  "tier": "primary",
+  "sub_question_refs": ["sq-01"],
+  "publisher": "europa.eu",
+  "discovered_at": "2026-05-20T..."
+}
+```
+
+- `score` is the composite (renamed from upstream `composite_score`).
+- `tier` is derived: `primary` if score >= 0.80, `secondary` if 0.50-0.79, `supporting` if < 0.50. (`candidate-store.py` recomputes after merge — emit the local tier for clarity.)
+- `sub_question_refs` always contains exactly `[SUB_QUESTION_ID]` from this curator. The merge step in `candidate-store.py` unions refs across curators if the same URL is discovered for multiple sub-questions.
+- `publisher` is the registered domain (no subdomain) — `europa.eu`, not `eur-lex.europa.eu`.
+- `discovered_at` is the curator's now-timestamp in ISO 8601 UTC.
+- **Do not emit** `dimensions{}`, `annotation`, or `diversity{}`. Computation is internal to this curator at v0.1.0.
+- **Do not emit** `fetch_priority`. `candidate-store.py` assigns it across all candidates at merge time.
+
+Write the JSON array to `BATCH_OUTPUT_PATH` using the Write tool. Output is a top-level JSON array (not an object).
+
+Return a compact summary:
+
+```json
+{"ok": true, "sub_question_id": "sq-01", "candidates_emitted": 9,
+ "tiers": {"primary": 3, "secondary": 5, "supporting": 1},
+ "filtered_below_threshold": 4,
+ "cost_estimate": {"input_words": 0, "output_words": 1200, "estimated_usd": 0.018}}
+```
+
+`cost_estimate` covers content read (search results inspected) and produced (batch JSON). See `cogni-research/references/model-strategy.md` for the formula; carry it through unchanged at fork time.
+
+## What this agent does NOT do
+
+- No WebFetch (Phase 3).
+- No claim extraction (Phase 4).
+- No wiki writes (Phase 4).
+- No verification (Phase 6).
+- No direct write to `candidates.json` — only to the batch file the orchestrator merges through `candidate-store.py`.

--- a/cogni-knowledge/agents/source-curator.md
+++ b/cogni-knowledge/agents/source-curator.md
@@ -45,12 +45,18 @@ You **do not fetch URL bodies**. That is Phase 3 (`source-fetcher`). You also do
 | `PROJECT_PATH` | Yes | Absolute path to the project directory (`<knowledge-root>/<topic-slug>-<YYYY-MM-DD>/`) |
 | `SUB_QUESTION_ID` | Yes | sq-id from `plan.json`, e.g. `sq-01` |
 | `BATCH_OUTPUT_PATH` | Yes | Absolute path the orchestrator wants this batch's JSON array written to, e.g. `<project>/.metadata/.candidates.batch.sq-01.json` |
-| `MARKET` | Yes | Region code. Must be one of the keys in `${CLAUDE_PLUGIN_ROOT}/../cogni-research/references/market-sources.json`: `dach`, `de`, `fr`, `it`, `pl`, `nl`, `es`, `us`, `uk`, `eu`. Drives market-localized search queries and authority scoring. Fall back to `_default` if unexpectedly absent. |
+| `MARKET` | Yes | Region code: `dach`, `de`, `fr`, `it`, `pl`, `nl`, `es`, `us`, `uk`, `eu`. Drives market-localized search queries and authority scoring. Resolved through `cogni-workspace/scripts/get-market-config.py --plugin research --market <MARKET>` (see Phase 0). |
 | `MAX_CANDIDATES` | No | Cap on candidates this curator emits for the sub-question (default 12; read from `binding.curator_defaults.max_candidates_per_sq`). |
 | `SCORE_THRESHOLD` | No | Minimum composite score to emit (default 0.5; read from `binding.curator_defaults.score_threshold`). |
 | `CURRENT_YEAR` | No | Four-digit year. Used for recency-aware queries. |
 
-The market-sources.json reference is reached via `${CLAUDE_PLUGIN_ROOT}/../cogni-research/references/market-sources.json` — the **clean-break commitment** is that cogni-knowledge's runtime path does not dispatch cogni-research skills/agents, but reading a static reference file from a sibling plugin is permitted (and unavoidable until that file moves to cogni-workspace at M11+).
+Market configuration is read via the canonical workspace helper:
+
+```
+python3 "${WORKSPACE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/insight-wave/cogni-workspace/*/ | head -1)}/scripts/get-market-config.py" --plugin research --market <MARKET>
+```
+
+This is the same path cogni-portfolio's `customer-researcher` agent uses (`cogni-portfolio/agents/customer-researcher.md`). It joins the canonical registry at `cogni-workspace/references/supported-markets-registry.json` with the research plugin overlay and returns a merged config — meaning this agent reaches zero cogni-research code at runtime, honouring the clean-break commitment. Falls back to `_default` if the requested market is missing.
 
 ## Core Workflow
 
@@ -61,7 +67,7 @@ Phase 0 → Phase 1 → Phase 2 → Phase 3
 ### Phase 0: Load Inputs
 
 1. Read `<PROJECT_PATH>/.metadata/plan.json`. Locate the sub-question with `id == SUB_QUESTION_ID`. Extract `query`, `search_guidance`, `candidate_domains[]`.
-2. Read `${CLAUDE_PLUGIN_ROOT}/../cogni-research/references/market-sources.json`, extract the entry for `MARKET` (fall back to `_default`). Store as `market_config`.
+2. Load market config via the workspace helper (see above). Parse `data.config` from the JSON envelope; on a missing-market error, fall back to `_default`. Store as `market_config`.
 3. Confirm `BATCH_OUTPUT_PATH`'s parent directory exists; create if not.
 
 ### Phase 1: Search Query Generation

--- a/cogni-knowledge/agents/source-fetcher.md
+++ b/cogni-knowledge/agents/source-fetcher.md
@@ -3,7 +3,7 @@ name: source-fetcher
 description: Phase-3 source fetcher for the inverted pipeline. Reads a batch of URLs from candidates.json, looks them up in the shared fetch-cache, fetches misses via WebFetch (cobrowse fallback when claude-in-chrome is present), writes through fetch-cache.py. Emits per-batch {fetched[], unavailable[]} for merge into fetch-manifest.json. Records availability — never decides to drop a URL.
 model: sonnet
 color: blue
-tools: ["Bash", "WebFetch"]
+tools: ["Bash", "WebFetch", "mcp__claude-in-chrome__tabs_create_mcp", "mcp__claude-in-chrome__navigate", "mcp__claude-in-chrome__get_page_text", "mcp__claude-in-chrome__read_page", "mcp__claude-in-chrome__find"]
 ---
 
 <!--
@@ -13,10 +13,10 @@ cogni-research's section-researcher conflated both. See
 `cogni-knowledge/references/inverted-pipeline.md` Phase 3 contract and
 `references/fetch-cache-design.md` for the cache mechanics.
 
-Cobrowse fallback uses the `claude-in-chrome` MCP server (mirrors the
-pattern cogni-claims uses for the same enum value `cobrowse_interactive`).
-MCP tools are exposed to the agent automatically when the server is
-installed — the `tools:` array intentionally does not enumerate them.
+Cobrowse fallback uses the `claude-in-chrome` MCP server, mirroring the
+tool names cogni-claims/source-inspector enumerates. When the server is
+not installed, those tool calls fail and the loop falls through to the
+unavailable[] path with `cobrowse_unavailable`.
 -->
 
 # Source Fetcher Agent (inverted pipeline, Phase 3)

--- a/cogni-knowledge/agents/source-fetcher.md
+++ b/cogni-knowledge/agents/source-fetcher.md
@@ -1,0 +1,165 @@
+---
+name: source-fetcher
+description: Phase-3 source fetcher for the inverted pipeline. Reads a batch of URLs from candidates.json, looks them up in the shared fetch-cache, fetches misses via WebFetch (cobrowse fallback when claude-in-chrome is present), writes through fetch-cache.py. Emits per-batch {fetched[], unavailable[]} for merge into fetch-manifest.json. Records availability — never decides to drop a URL.
+model: sonnet
+color: blue
+tools: ["Bash", "WebFetch"]
+---
+
+<!--
+NEW agent at v0.0.17 — no upstream. The inverted pipeline separates
+curation (Phase 2, source-curator) from fetching (Phase 3), where
+cogni-research's section-researcher conflated both. See
+`cogni-knowledge/references/inverted-pipeline.md` Phase 3 contract and
+`references/fetch-cache-design.md` for the cache mechanics.
+
+Cobrowse fallback uses the `claude-in-chrome` MCP server (mirrors the
+pattern cogni-claims uses for the same enum value `cobrowse_interactive`).
+MCP tools are exposed to the agent automatically when the server is
+installed — the `tools:` array intentionally does not enumerate them.
+-->
+
+# Source Fetcher Agent (inverted pipeline, Phase 3)
+
+## Role
+
+You take a batch of candidate URLs from `<project>/.metadata/candidates.json`, attempt to fetch each one's body, and record availability. Successful fetches go to the shared `<knowledge-root>/.cogni-knowledge/fetch-cache/` (URL-keyed). Failures get a negative-cache entry so a re-run within the freshness window does not re-attempt.
+
+You **never decide whether a URL should be dropped from the project**. You record `fetched[]` and `unavailable[]` for the batch; the orchestrator (`knowledge-fetch`) decides whether the overall unavailable rate is acceptable.
+
+## Input Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `CANDIDATES_PATH` | Yes | Absolute path to `<project>/.metadata/candidates.json` |
+| `KNOWLEDGE_ROOT` | Yes | Absolute path to the knowledge-base root (the dir containing `.cogni-knowledge/`). Forwarded to `fetch-cache.py` as `--knowledge-root` |
+| `BATCH_URLS` | Yes | Comma-separated subset of URLs the orchestrator wants this fetcher to handle. URLs must appear in `candidates.json`'s `candidates[].url` set |
+| `MAX_AGE_DAYS` | No | Cache freshness window in days (default 30; read from `binding.curator_defaults.fetch_cache_max_age_days`). Forwarded to `fetch-cache.py fetch --max-age-days` |
+| `BATCH_OUTPUT_PATH` | Yes | Absolute path to write the per-batch result JSON (the orchestrator merges several into `fetch-manifest.json`) |
+
+## Core Workflow
+
+```text
+Phase 0 → Phase 1 → Phase 2
+```
+
+### Phase 0: Resolve
+
+1. Read `CANDIDATES_PATH`. Parse out the candidate objects matching `BATCH_URLS` (by exact URL string match — the curator and the cache use the same `normalize_url` form, so no normalization needed here).
+2. Locate `${CLAUDE_PLUGIN_ROOT}/scripts/fetch-cache.py`. All cache interactions go through this script — never read or write `.cogni-knowledge/fetch-cache/<sha256>.json` directly.
+3. Resolve the `claude-in-chrome` MCP server's availability (presence of the cobrowse tool prefix in your tool list determines fallback eligibility).
+
+### Phase 1: Per-URL Fetch Loop
+
+For each URL in the batch, in order:
+
+**Step 1 — cache lookup.**
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/fetch-cache.py fetch \
+    --knowledge-root <KNOWLEDGE_ROOT> \
+    --url <URL> \
+    --max-age-days <MAX_AGE_DAYS>
+```
+
+- `success: true` → cache hit. Inspect `data.entry.status`:
+  - `ok` → emit a `fetched[]` entry referencing `data.cache_key` + `data.entry.content_hash` + `data.entry.fetch_method`. Skip to next URL.
+  - `unavailable` → negative-cache hit. Emit an `unavailable[]` entry with `reason: <data.entry.reason>` + `fallback_attempted: false` + `attempted_at: <now>` + `from_cache: true`. Skip to next URL.
+- `success: false` with `data.reason == "miss"` or `"stale"` → proceed to Step 2.
+
+**Step 2 — WebFetch.**
+
+WebFetch the URL with a brief, generic prompt (e.g., `Extract the full text content of this page.`). On success:
+
+1. Write the fetched body to a temp file (use `mktemp`; remove on exit).
+2. Store it:
+   ```
+   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/fetch-cache.py store \
+       --knowledge-root <KNOWLEDGE_ROOT> \
+       --url <URL> \
+       --body-file <TMP_PATH> \
+       --fetch-method webfetch \
+       --status ok \
+       --publisher <publisher from candidate> \
+       --http-status 200
+   ```
+3. Emit `fetched[]` entry with the returned `cache_key` and `content_hash`.
+
+On WebFetch failure (timeout, 4xx, 5xx, blocked, refusal) → proceed to Step 3.
+
+**Step 3 — cobrowse fallback (if available).**
+
+If the `claude-in-chrome` MCP tools are available in your tool list, invoke the cobrowse equivalent (navigate to URL, extract page text, return body). On success: same `fetch-cache.py store` as Step 2 but with `--fetch-method cobrowse_interactive`. Emit `fetched[]` entry.
+
+If MCP is not available, or cobrowse also fails → proceed to Step 4.
+
+**Step 4 — record unavailable.**
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/fetch-cache.py store \
+    --knowledge-root <KNOWLEDGE_ROOT> \
+    --url <URL> \
+    --fetch-method webfetch \
+    --status unavailable \
+    --reason "<webfetch_error_class>"
+```
+
+`<webfetch_error_class>` is a short stable token: `webfetch_timeout`, `webfetch_4xx`, `webfetch_5xx`, `webfetch_blocked`, `webfetch_refused`, `cobrowse_unavailable`, `cobrowse_failed`. The vocabulary is closed; downstream summarisation depends on it.
+
+Emit an `unavailable[]` entry:
+
+```json
+{
+  "url": "...",
+  "reason": "webfetch_timeout",
+  "attempted_at": "<ISO 8601 UTC>",
+  "fallback_attempted": true,
+  "from_cache": false
+}
+```
+
+`fallback_attempted` is `true` iff Step 3 ran (regardless of whether it succeeded or failed before falling through to Step 4).
+
+### Phase 2: Emit Batch Result
+
+Write a top-level JSON object to `BATCH_OUTPUT_PATH`:
+
+```json
+{
+  "schema_version": "0.1.0",
+  "fetched": [
+    {"url": "...", "cache_key": "<sha256>", "content_hash": "sha256:...",
+     "fetch_method": "webfetch", "fetched_at": "...", "from_cache": false}
+  ],
+  "unavailable": [
+    {"url": "...", "reason": "webfetch_timeout", "attempted_at": "...",
+     "fallback_attempted": false, "from_cache": false}
+  ]
+}
+```
+
+`fetched_at` on `fetched[]` entries: for fresh fetches use the now-timestamp Step 2 stored; for cache hits use the entry's stored `fetched_at` (from `data.entry.fetched_at` in Step 1's response).
+
+Return a compact summary:
+
+```json
+{"ok": true, "batch_size": 8, "fetched": 6, "cache_hits": 4,
+ "unavailable": 2, "reasons": {"webfetch_4xx": 1, "webfetch_timeout": 1},
+ "cost_estimate": {"input_words": 0, "output_words": 12000, "estimated_usd": 0.024}}
+```
+
+`cache_hits` is a subset of `fetched` (where Step 1 short-circuited).
+
+## What this agent does NOT do
+
+- Does NOT WebSearch (Phase 2's source-curator already discovered the URLs).
+- Does NOT extract claims (Phase 4's source-ingester does).
+- Does NOT write `fetch-manifest.json` directly — only the per-batch result; the orchestrator merges.
+- Does NOT decide to skip / drop a URL because it looks low-quality — your job is to attempt the fetch and record what happened.
+- Does NOT bypass `fetch-cache.py` — even for the temp body file. All cache writes go through `store`.
+
+## Failure-mode invariants
+
+- An exception while WebFetching one URL must not abort the batch. Move on, record `unavailable[]` with `reason: "webfetch_refused"` or the closest applicable class.
+- If `fetch-cache.py store` itself fails (disk full, permission denied) — surface in the per-URL entry's `reason` as `cache_write_failed` and continue the loop. The orchestrator will see the rate climb and decide.
+- Temp files are removed at end of batch (use `trap rm -f "$TMP" EXIT` patterns or equivalent — `mktemp` files left behind on a crash are tolerable but unsightly).

--- a/cogni-knowledge/agents/source-fetcher.md
+++ b/cogni-knowledge/agents/source-fetcher.md
@@ -45,7 +45,7 @@ Phase 0 → Phase 1 → Phase 2
 
 ### Phase 0: Resolve
 
-1. Read `CANDIDATES_PATH`. Parse out the candidate objects matching `BATCH_URLS` (by exact URL string match — the curator and the cache use the same `normalize_url` form, so no normalization needed here).
+1. Read `CANDIDATES_PATH`. Parse out the candidate objects matching `BATCH_URLS` (by exact URL string match — `candidate-store.py` and `fetch-cache.py` both apply the same `normalize_url` form at write/key time, so a URL emitted by the curator and a URL passed to the cache lookup land on the same key without further work here).
 2. Locate `${CLAUDE_PLUGIN_ROOT}/scripts/fetch-cache.py`. All cache interactions go through this script — never read or write `.cogni-knowledge/fetch-cache/<sha256>.json` directly.
 3. Resolve the `claude-in-chrome` MCP server's availability (presence of the cobrowse tool prefix in your tool list determines fallback eligibility).
 

--- a/cogni-knowledge/scripts/candidate-store.py
+++ b/cogni-knowledge/scripts/candidate-store.py
@@ -126,12 +126,8 @@ def _tier_for(score: float) -> str:
 
 
 def _recompute_priorities(candidates: list[dict]) -> None:
-    """Assign fetch_priority in-place: tier order then score desc within tier.
-
-    fetch_priority is 1-indexed; lower fetches first. Stable on equal score
-    via the candidate's existing list position so the assignment is
-    deterministic across re-merges.
-    """
+    # Tie-break on original list position so re-merges produce a stable
+    # priority assignment instead of shuffling on equal scores.
     tier_order = {"primary": 0, "secondary": 1, "supporting": 2}
     indexed = list(enumerate(candidates))
     indexed.sort(
@@ -167,7 +163,6 @@ def _empty_payload() -> dict:
 
 
 def _validate_candidate(entry: dict) -> str | None:
-    """Return an error string if the entry is malformed; None if valid."""
     if not isinstance(entry, dict):
         return f"candidate is not an object: {entry!r}"
     url = entry.get("url")
@@ -185,18 +180,17 @@ def _validate_candidate(entry: dict) -> str | None:
 
 
 def _merge_entry(existing: dict, incoming: dict) -> dict:
-    """Merge an incoming candidate into an existing one with the same normalized URL.
+    """Merge an incoming candidate with an existing entry for the same URL.
 
-    - Higher score wins.
+    - Higher score wins; non-URL fields come from the winner.
     - Earlier discovered_at wins (curator emits ISO 8601 UTC).
-    - sub_question_refs are unioned (order: existing first, then new refs).
-    - Other fields from the higher-score entry win.
+    - sub_question_refs are unioned (existing first, then new refs).
     - tier + fetch_priority recomputed by the caller after all merges.
     """
     if float(incoming.get("score", 0.0)) > float(existing.get("score", 0.0)):
-        winner, loser = incoming, existing
+        winner = incoming
     else:
-        winner, loser = existing, incoming
+        winner = existing
     merged = dict(winner)
     existing_at = existing.get("discovered_at") or ""
     incoming_at = incoming.get("discovered_at") or ""
@@ -220,38 +214,36 @@ def _merge_entry(existing: dict, incoming: dict) -> dict:
 
 def cmd_init(args: argparse.Namespace) -> int:
     project_path = Path(args.project_path).resolve()
-    if not project_path.is_dir():
-        return _emit(False, error=f"project_path does not exist: {project_path}")
-    _metadata_dir(project_path).mkdir(parents=True, exist_ok=True)
+    try:
+        _metadata_dir(project_path).mkdir(parents=True, exist_ok=True)
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        return _emit(False, error=f"project_path is not a usable directory: {exc}")
     target = _candidates_path(project_path)
-    if target.is_file():
-        try:
-            existing = json.loads(target.read_text(encoding="utf-8"))
-        except json.JSONDecodeError as exc:
-            return _emit(False, error=f"existing candidates.json is malformed: {exc}")
-        return _emit(
-            True,
-            data={
-                "path": str(target),
-                "candidates_count": len(existing.get("candidates", [])),
-                "created": False,
-            },
-        )
-    _atomic_write(target, _empty_payload())
-    return _emit(True, data={"path": str(target), "candidates_count": 0, "created": True})
+    try:
+        existing = json.loads(target.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        _atomic_write(target, _empty_payload())
+        return _emit(True, data={"path": str(target), "candidates_count": 0, "created": True})
+    except json.JSONDecodeError as exc:
+        return _emit(False, error=f"existing candidates.json is malformed: {exc}")
+    return _emit(
+        True,
+        data={
+            "path": str(target),
+            "candidates_count": len(existing.get("candidates", [])),
+            "created": False,
+        },
+    )
 
 
 def cmd_append_batch(args: argparse.Namespace) -> int:
     project_path = Path(args.project_path).resolve()
-    if not project_path.is_dir():
-        return _emit(False, error=f"project_path does not exist: {project_path}")
-
     batch_file = Path(args.batch_file).resolve()
-    if not batch_file.is_file():
-        return _emit(False, error=f"batch_file does not exist: {batch_file}")
 
     try:
         batch = json.loads(batch_file.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return _emit(False, error=f"batch_file does not exist: {batch_file}")
     except json.JSONDecodeError as exc:
         return _emit(False, error=f"batch_file is not valid JSON: {exc}")
 
@@ -266,38 +258,48 @@ def cmd_append_batch(args: argparse.Namespace) -> int:
         if err:
             return _emit(False, error=err)
 
-    # Lock + read-modify-write. Lock file is created lazily and never
-    # deleted — deletion races with the next acquirer's flock-acquire.
-    _metadata_dir(project_path).mkdir(parents=True, exist_ok=True)
-    lock = _lock_path(project_path)
     target = _candidates_path(project_path)
+    # Skip the lock + rewrite cycle when the batch contributes nothing —
+    # otherwise an empty curator batch still incurs an atomic-write.
+    if not batch:
+        try:
+            payload = json.loads(target.read_text(encoding="utf-8"))
+            count = len(payload.get("candidates", []))
+        except FileNotFoundError:
+            count = 0
+        except json.JSONDecodeError as exc:
+            return _emit(False, error=f"existing candidates.json is malformed: {exc}")
+        return _emit(True, data={"path": str(target), "added": 0, "merged": 0, "candidates_count": count})
+
+    try:
+        _metadata_dir(project_path).mkdir(parents=True, exist_ok=True)
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        return _emit(False, error=f"project_path is not a usable directory: {exc}")
+    # Lock file is created lazily and never deleted — unlinking it would
+    # race the next acquirer's flock against a different inode.
+    lock = _lock_path(project_path)
 
     with open(lock, "a+", encoding="utf-8") as lock_fh:
         fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
         try:
-            if target.is_file():
-                try:
-                    payload = json.loads(target.read_text(encoding="utf-8"))
-                except json.JSONDecodeError as exc:
-                    return _emit(False, error=f"existing candidates.json is malformed: {exc}")
-            else:
+            try:
+                payload = json.loads(target.read_text(encoding="utf-8"))
+            except FileNotFoundError:
                 payload = _empty_payload()
+            except json.JSONDecodeError as exc:
+                return _emit(False, error=f"existing candidates.json is malformed: {exc}")
 
             existing = payload.setdefault("candidates", [])
             payload.setdefault("schema_version", SCHEMA_VERSION)
 
-            # Build an index by normalized URL for O(1) merge lookup.
-            index: dict[str, int] = {}
-            for idx, entry in enumerate(existing):
-                key = normalize_url(entry.get("url", ""))
-                # Last-writer-wins on a pre-existing duplicate (shouldn't happen,
-                # but tolerate legacy files).
-                index[key] = idx
+            index: dict[str, int] = {
+                normalize_url(entry.get("url", "")): idx
+                for idx, entry in enumerate(existing)
+            }
 
             added = 0
             merged = 0
             for incoming in batch:
-                # Stamp tier from score if absent (curator-side defaults).
                 if "tier" not in incoming:
                     incoming["tier"] = _tier_for(float(incoming.get("score", 0.0)))
                 key = normalize_url(incoming.get("url", ""))
@@ -307,7 +309,6 @@ def cmd_append_batch(args: argparse.Namespace) -> int:
                     merged += 1
                 else:
                     new_entry = dict(incoming)
-                    new_entry["url"] = incoming.get("url", "")  # preserve canonical form caller passed
                     new_entry["tier"] = _tier_for(float(new_entry.get("score", 0.0)))
                     existing.append(new_entry)
                     index[key] = len(existing) - 1

--- a/cogni-knowledge/scripts/candidate-store.py
+++ b/cogni-knowledge/scripts/candidate-store.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""
+candidate-store.py — file-locked merge of parallel source-curator output
+batches into `<project>/.metadata/candidates.json`.
+
+The Phase 2 (`knowledge-curate`) skill fans out one `source-curator` agent
+per sub-question. Each curator writes a JSON array of candidate objects to
+a per-sub-question batch file; the skill then calls this script's
+`append-batch` to merge that batch into the canonical project-local
+`candidates.json` under an `fcntl.flock` lock so parallel merges cannot
+race.
+
+Subcommands:
+  init           Create an empty `candidates.json` (schema 0.1.0). Idempotent.
+  append-batch   Read a JSON array of candidate objects from --batch-file,
+                 merge into candidates.json under lock, write atomically.
+                 Dedup key is the URL-normalized form (see normalize_url).
+                 On collision: union sub_question_refs, keep higher score,
+                 keep earlier discovered_at, recompute tier + fetch_priority
+                 on the merged entry.
+  read           Emit the current candidates.json content in the envelope.
+
+The dedup helper `normalize_url` is the source of truth for URL identity in
+the inverted pipeline. `source-fetcher` uses it too at lookup time so the
+curator-side merge and the fetcher-side cache lookup agree.
+
+All output uses the insight-wave script envelope:
+  {"success": bool, "data": {...}, "error": "..."}
+
+Stdlib only. No pip dependencies. fcntl.flock — posix only (consistent
+with the existing tests/README.md bash 3.2 + Linux/macOS posture).
+
+See `references/inverted-pipeline.md` Phase 2 contract for the candidates.json
+schema this script enforces.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import fcntl
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
+
+SCHEMA_VERSION = "0.1.0"
+CANDIDATES_FILENAME = "candidates.json"
+LOCK_SUFFIX = ".lock"
+METADATA_DIRNAME = ".metadata"
+
+# Score → tier thresholds. Match the upstream source-curator (kept identical
+# at fork time per the plan's "fork discipline" note). See
+# `cogni-knowledge/agents/source-curator.md` Phase 3.
+TIER_PRIMARY_MIN = 0.80
+TIER_SECONDARY_MIN = 0.50
+
+# Tracking-param prefixes/names stripped during URL normalization. Covers
+# the common cases seen in EU regulatory crawls; conservative on purpose —
+# only well-known tracking params are dropped to avoid breaking URLs that
+# rely on a query string for content identity.
+_STRIP_QUERY_PREFIXES = ("utm_",)
+_STRIP_QUERY_EXACT = frozenset({"ref", "fbclid", "gclid"})
+
+
+def _emit(success: bool, data: dict | None = None, error: str = "") -> int:
+    payload = {"success": success, "data": data or {}, "error": error}
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0 if success else 1
+
+
+def _now() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _metadata_dir(project_path: Path) -> Path:
+    return project_path / METADATA_DIRNAME
+
+
+def _candidates_path(project_path: Path) -> Path:
+    return _metadata_dir(project_path) / CANDIDATES_FILENAME
+
+
+def _lock_path(project_path: Path) -> Path:
+    return _metadata_dir(project_path) / (CANDIDATES_FILENAME + LOCK_SUFFIX)
+
+
+def normalize_url(url: str) -> str:
+    """Canonicalize a URL for dedup purposes.
+
+    - Lowercase scheme + host (path case preserved — RFC 3986 §6.2.2.1).
+    - Strip trailing `/` from path unless the path is just `/`.
+    - Drop query params whose name starts with any _STRIP_QUERY_PREFIXES
+      or is in _STRIP_QUERY_EXACT. Remaining params keep their order.
+    - Drop fragment.
+
+    Whitespace-only or empty input returns the input unchanged so callers
+    surface the bad value rather than silently coalescing distinct entries.
+    """
+    if not url or not url.strip():
+        return url
+    parts = urlsplit(url.strip())
+    scheme = parts.scheme.lower()
+    netloc = parts.netloc.lower()
+    path = parts.path
+    if path.endswith("/") and path != "/":
+        path = path.rstrip("/")
+    kept = [
+        (k, v)
+        for k, v in parse_qsl(parts.query, keep_blank_values=True)
+        if not (k.startswith(_STRIP_QUERY_PREFIXES) or k in _STRIP_QUERY_EXACT)
+    ]
+    query = urlencode(kept)
+    return urlunsplit((scheme, netloc, path, query, ""))
+
+
+def _tier_for(score: float) -> str:
+    if score >= TIER_PRIMARY_MIN:
+        return "primary"
+    if score >= TIER_SECONDARY_MIN:
+        return "secondary"
+    return "supporting"
+
+
+def _recompute_priorities(candidates: list[dict]) -> None:
+    """Assign fetch_priority in-place: tier order then score desc within tier.
+
+    fetch_priority is 1-indexed; lower fetches first. Stable on equal score
+    via the candidate's existing list position so the assignment is
+    deterministic across re-merges.
+    """
+    tier_order = {"primary": 0, "secondary": 1, "supporting": 2}
+    indexed = list(enumerate(candidates))
+    indexed.sort(
+        key=lambda pair: (
+            tier_order.get(pair[1].get("tier", "supporting"), 2),
+            -float(pair[1].get("score", 0.0)),
+            pair[0],
+        )
+    )
+    for new_priority, (_orig_idx, entry) in enumerate(indexed, start=1):
+        entry["fetch_priority"] = new_priority
+
+
+def _atomic_write(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, ensure_ascii=False)
+            fh.write("\n")
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def _empty_payload() -> dict:
+    return {"schema_version": SCHEMA_VERSION, "candidates": []}
+
+
+def _validate_candidate(entry: dict) -> str | None:
+    """Return an error string if the entry is malformed; None if valid."""
+    if not isinstance(entry, dict):
+        return f"candidate is not an object: {entry!r}"
+    url = entry.get("url")
+    if not isinstance(url, str) or not url.strip():
+        return "candidate missing non-empty 'url'"
+    score = entry.get("score")
+    if not isinstance(score, (int, float)):
+        return f"candidate {url}: 'score' must be a number, got {type(score).__name__}"
+    if not 0.0 <= float(score) <= 1.0:
+        return f"candidate {url}: 'score' must be in [0.0, 1.0], got {score}"
+    refs = entry.get("sub_question_refs", [])
+    if not isinstance(refs, list) or not all(isinstance(r, str) for r in refs):
+        return f"candidate {url}: 'sub_question_refs' must be a list of strings"
+    return None
+
+
+def _merge_entry(existing: dict, incoming: dict) -> dict:
+    """Merge an incoming candidate into an existing one with the same normalized URL.
+
+    - Higher score wins.
+    - Earlier discovered_at wins (curator emits ISO 8601 UTC).
+    - sub_question_refs are unioned (order: existing first, then new refs).
+    - Other fields from the higher-score entry win.
+    - tier + fetch_priority recomputed by the caller after all merges.
+    """
+    if float(incoming.get("score", 0.0)) > float(existing.get("score", 0.0)):
+        winner, loser = incoming, existing
+    else:
+        winner, loser = existing, incoming
+    merged = dict(winner)
+    existing_at = existing.get("discovered_at") or ""
+    incoming_at = incoming.get("discovered_at") or ""
+    if existing_at and incoming_at:
+        merged["discovered_at"] = min(existing_at, incoming_at)
+    else:
+        merged["discovered_at"] = existing_at or incoming_at
+    union: list[str] = []
+    seen: set[str] = set()
+    for ref in list(existing.get("sub_question_refs", [])) + list(
+        incoming.get("sub_question_refs", [])
+    ):
+        if ref not in seen:
+            seen.add(ref)
+            union.append(ref)
+    merged["sub_question_refs"] = union
+    merged["score"] = float(winner.get("score", 0.0))
+    merged["tier"] = _tier_for(merged["score"])
+    return merged
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    project_path = Path(args.project_path).resolve()
+    if not project_path.is_dir():
+        return _emit(False, error=f"project_path does not exist: {project_path}")
+    _metadata_dir(project_path).mkdir(parents=True, exist_ok=True)
+    target = _candidates_path(project_path)
+    if target.is_file():
+        try:
+            existing = json.loads(target.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            return _emit(False, error=f"existing candidates.json is malformed: {exc}")
+        return _emit(
+            True,
+            data={
+                "path": str(target),
+                "candidates_count": len(existing.get("candidates", [])),
+                "created": False,
+            },
+        )
+    _atomic_write(target, _empty_payload())
+    return _emit(True, data={"path": str(target), "candidates_count": 0, "created": True})
+
+
+def cmd_append_batch(args: argparse.Namespace) -> int:
+    project_path = Path(args.project_path).resolve()
+    if not project_path.is_dir():
+        return _emit(False, error=f"project_path does not exist: {project_path}")
+
+    batch_file = Path(args.batch_file).resolve()
+    if not batch_file.is_file():
+        return _emit(False, error=f"batch_file does not exist: {batch_file}")
+
+    try:
+        batch = json.loads(batch_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return _emit(False, error=f"batch_file is not valid JSON: {exc}")
+
+    if not isinstance(batch, list):
+        return _emit(
+            False,
+            error=f"batch_file must contain a JSON array of candidate objects, got {type(batch).__name__}",
+        )
+
+    for entry in batch:
+        err = _validate_candidate(entry)
+        if err:
+            return _emit(False, error=err)
+
+    # Lock + read-modify-write. Lock file is created lazily and never
+    # deleted — deletion races with the next acquirer's flock-acquire.
+    _metadata_dir(project_path).mkdir(parents=True, exist_ok=True)
+    lock = _lock_path(project_path)
+    target = _candidates_path(project_path)
+
+    with open(lock, "a+", encoding="utf-8") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            if target.is_file():
+                try:
+                    payload = json.loads(target.read_text(encoding="utf-8"))
+                except json.JSONDecodeError as exc:
+                    return _emit(False, error=f"existing candidates.json is malformed: {exc}")
+            else:
+                payload = _empty_payload()
+
+            existing = payload.setdefault("candidates", [])
+            payload.setdefault("schema_version", SCHEMA_VERSION)
+
+            # Build an index by normalized URL for O(1) merge lookup.
+            index: dict[str, int] = {}
+            for idx, entry in enumerate(existing):
+                key = normalize_url(entry.get("url", ""))
+                # Last-writer-wins on a pre-existing duplicate (shouldn't happen,
+                # but tolerate legacy files).
+                index[key] = idx
+
+            added = 0
+            merged = 0
+            for incoming in batch:
+                # Stamp tier from score if absent (curator-side defaults).
+                if "tier" not in incoming:
+                    incoming["tier"] = _tier_for(float(incoming.get("score", 0.0)))
+                key = normalize_url(incoming.get("url", ""))
+                if key in index:
+                    pos = index[key]
+                    existing[pos] = _merge_entry(existing[pos], incoming)
+                    merged += 1
+                else:
+                    new_entry = dict(incoming)
+                    new_entry["url"] = incoming.get("url", "")  # preserve canonical form caller passed
+                    new_entry["tier"] = _tier_for(float(new_entry.get("score", 0.0)))
+                    existing.append(new_entry)
+                    index[key] = len(existing) - 1
+                    added += 1
+
+            _recompute_priorities(existing)
+            _atomic_write(target, payload)
+        finally:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+
+    return _emit(
+        True,
+        data={
+            "path": str(target),
+            "added": added,
+            "merged": merged,
+            "candidates_count": len(existing),
+        },
+    )
+
+
+def cmd_read(args: argparse.Namespace) -> int:
+    project_path = Path(args.project_path).resolve()
+    target = _candidates_path(project_path)
+    if not target.is_file():
+        return _emit(False, data={"path": str(target)}, error="candidates.json does not exist")
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return _emit(False, error=f"candidates.json is not valid JSON: {exc}")
+    return _emit(
+        True,
+        data={
+            "path": str(target),
+            "candidates": payload.get("candidates", []),
+            "schema_version": payload.get("schema_version", ""),
+            "candidates_count": len(payload.get("candidates", [])),
+        },
+    )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="File-locked merge of source-curator output batches into <project>/.metadata/candidates.json",
+        allow_abbrev=False,
+    )
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    p_init = sub.add_parser("init", help="Create empty candidates.json (idempotent)")
+    p_init.add_argument("--project-path", required=True)
+    p_init.set_defaults(func=cmd_init)
+
+    p_append = sub.add_parser("append-batch", help="Merge a curator batch under lock")
+    p_append.add_argument("--project-path", required=True)
+    p_append.add_argument(
+        "--batch-file",
+        required=True,
+        help="Path to a JSON file containing an array of candidate objects",
+    )
+    p_append.set_defaults(func=cmd_append_batch)
+
+    p_read = sub.add_parser("read", help="Emit candidates.json content")
+    p_read.add_argument("--project-path", required=True)
+    p_read.set_defaults(func=cmd_read)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/cogni-knowledge/scripts/fetch-cache.py
+++ b/cogni-knowledge/scripts/fetch-cache.py
@@ -38,6 +38,7 @@ import os
 import sys
 import tempfile
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
 
 SCHEMA_VERSION = "0.1.0"
 FETCH_CACHE_DIRNAME = "fetch-cache"
@@ -48,6 +49,12 @@ BINDING_DIRNAME = ".cogni-knowledge"
 # coordinating an additive change there.
 VALID_FETCH_METHODS = {"webfetch", "cobrowse_interactive"}
 VALID_STATUSES = {"ok", "unavailable"}
+# Kept in sync with candidate-store.py:_STRIP_QUERY_*. Duplicated here so
+# candidates.json dedup and fetch-cache lookup land on the same key for
+# semantically identical URLs. The deferred _knowledge_lib.py extraction
+# will collapse the two copies.
+_STRIP_QUERY_PREFIXES = ("utm_",)
+_STRIP_QUERY_EXACT = frozenset({"ref", "fbclid", "gclid"})
 
 
 def _emit(success: bool, data: dict | None = None, error: str = "") -> int:
@@ -64,8 +71,25 @@ def _cache_dir(knowledge_root: Path) -> Path:
     return knowledge_root / BINDING_DIRNAME / FETCH_CACHE_DIRNAME
 
 
+def normalize_url(url: str) -> str:
+    if not url or not url.strip():
+        return url
+    parts = urlsplit(url.strip())
+    scheme = parts.scheme.lower()
+    netloc = parts.netloc.lower()
+    path = parts.path
+    if path.endswith("/") and path != "/":
+        path = path.rstrip("/")
+    kept = [
+        (k, v)
+        for k, v in parse_qsl(parts.query, keep_blank_values=True)
+        if not (k.startswith(_STRIP_QUERY_PREFIXES) or k in _STRIP_QUERY_EXACT)
+    ]
+    return urlunsplit((scheme, netloc, path, urlencode(kept), ""))
+
+
 def _url_key(url: str) -> str:
-    return hashlib.sha256(url.encode("utf-8")).hexdigest()
+    return hashlib.sha256(normalize_url(url).encode("utf-8")).hexdigest()
 
 
 def _entry_path(knowledge_root: Path, url: str) -> Path:
@@ -117,8 +141,6 @@ def _age_days(stamp: str) -> float | None:
 
 def cmd_store(args: argparse.Namespace) -> int:
     knowledge_root = Path(args.knowledge_root).resolve()
-    if not knowledge_root.is_dir():
-        return _emit(False, error=f"knowledge_root does not exist: {knowledge_root}")
 
     if not args.url or not args.url.strip():
         return _emit(False, error="--url must be a non-empty, non-whitespace string")
@@ -131,7 +153,10 @@ def cmd_store(args: argparse.Namespace) -> int:
     if args.body and args.body_file:
         return _emit(False, error="--body and --body-file are mutually exclusive")
     if args.body_file:
-        body = Path(args.body_file).read_text(encoding="utf-8")
+        try:
+            body = Path(args.body_file).read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return _emit(False, error=f"--body-file does not exist: {args.body_file}")
     else:
         body = args.body or ""
 
@@ -152,7 +177,10 @@ def cmd_store(args: argparse.Namespace) -> int:
         payload["reason"] = args.reason
 
     target = _entry_path(knowledge_root, args.url)
-    _atomic_write(target, payload)
+    try:
+        _atomic_write(target, payload)
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        return _emit(False, error=f"knowledge_root is not a usable directory: {exc}")
     return _emit(
         True,
         data={

--- a/cogni-knowledge/skills/knowledge-curate/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-curate/SKILL.md
@@ -97,7 +97,7 @@ For each sub-question id selected in Step 0:
 
    `source-curator` is invoked as an agent (lives at `${CLAUDE_PLUGIN_ROOT}/agents/source-curator.md`); the `Skill` dispatch convention for agents in cogni-knowledge follows the same pattern cogni-research/cogni-wiki use.
 
-3. Default cadence: dispatch sub-questions in parallel **when 3 or fewer**; otherwise sequential. Parallelism helps wall-clock but each curator does its own WebSearch — three concurrent curators is the rate-limit-friendly ceiling.
+3. Default cadence: dispatch sub-questions in parallel **when 3 or fewer**; otherwise sequential. Parallelism helps wall-clock but each curator does its own WebSearch — three concurrent curators is the rate-limit-friendly ceiling. (Phase 3 / `knowledge-fetch` runs batches strictly sequentially for a related but stricter reason — see that skill's Step 3 for the rationale.)
 
 4. After each curator returns successfully, merge the batch:
    ```

--- a/cogni-knowledge/skills/knowledge-curate/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-curate/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: knowledge-curate
+description: "Phase 2 of the v0.1.0 inverted pipeline. Reads plan.json, dispatches one source-curator agent per sub-question to WebSearch + score candidate sources, merges the per-sub-question batches into candidates.json via candidate-store.py. Does NOT fetch URL bodies — that is Phase 3 (knowledge-fetch). Use this skill whenever the user says 'curate sources for the eu-ai-act plan', 'discover candidates for project X', 'run the curators on plan.json', 'knowledge curate', 'phase 2 of the knowledge pipeline'. After curate, run knowledge-fetch to materialize bodies into the shared fetch-cache."
+allowed-tools: Read, Write, Bash, Glob, Skill
+---
+
+# Knowledge Curate
+
+Phase 2 of the v0.1.0 inverted pipeline. Reads `<project>/.metadata/plan.json`, fans out one `source-curator` dispatch per sub-question (WebSearch + scoring, no fetching), and merges the per-sub-question candidate batches into the canonical `<project>/.metadata/candidates.json` via `candidate-store.py append-batch`.
+
+Read `${CLAUDE_PLUGIN_ROOT}/references/inverted-pipeline.md` §"Phase 2 — `knowledge-curate`" once to anchor on the contract.
+
+## When to run
+
+- `plan.json` exists for the project (Phase 1 has run) AND `candidates.json` does not yet exist (or the user explicitly wants a re-curate)
+- User explicitly invokes `/cogni-knowledge:knowledge-curate`
+
+## Never run when
+
+- No `plan.json` exists at `<project_path>/.metadata/` — offer `knowledge-plan` first.
+- No `binding.json` exists at the resolved knowledge root — offer `knowledge-setup` first.
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--knowledge-slug` | Yes | Slug of the bound knowledge base. |
+| `--project-path` | Yes | Absolute path to the project directory (produced by `knowledge-plan`). |
+| `--knowledge-root` | No | Override the default knowledge-base directory. |
+| `--sub-question-ids` | No | Comma-separated subset of sub-question ids to curate (e.g. `sq-01,sq-03`). Default: all from `plan.json`. Useful for resuming a partial curate. |
+| `--dry-run` | No | Print the dispatch plan without running curators. |
+
+## Workflow
+
+### 0. Pre-flight
+
+**Required plugins.** Probe only `cogni-wiki` (clean-break — no cogni-research dispatch):
+
+```
+probe_plugin() {
+  local plugin="$1" skill="$2"
+  test -f "${CLAUDE_PLUGIN_ROOT}/../${plugin}/skills/${skill}/SKILL.md" && return 0
+  for d in "${CLAUDE_PLUGIN_ROOT}/../../${plugin}/"*/skills/"${skill}"/SKILL.md; do
+    [ -f "$d" ] && return 0
+  done
+  return 1
+}
+probe_plugin cogni-wiki wiki-setup && WIKI_OK=yes || WIKI_OK=no
+```
+
+If `WIKI_OK=no`, abort with the standard missing-plugin message.
+
+**Binding + plan.** Resolve `knowledge_root` (same logic as `knowledge-plan`). Read the binding:
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py read \
+    --knowledge-root <knowledge_root>
+```
+
+On `success: false` → abort, offer `knowledge-setup`.
+
+Read `<project_path>/.metadata/plan.json`. Parse `topic`, `market`, `output_language`, `sub_questions[]`. If `--sub-question-ids` was passed, filter to that subset (reject ids not present).
+
+### 1. Read curator defaults
+
+From the binding envelope above, parse `data.binding.curator_defaults`. Apply per-field fallbacks for legacy bindings (pre-v0.0.3 had no `curator_defaults` block; the consumer-side `.get(..., DEFAULT)` requirement is documented in `CLAUDE.md` §"Data model"):
+
+| Field | Default |
+|---|---|
+| `max_candidates_per_sq` | 12 |
+| `score_threshold` | 0.5 |
+| `fetch_cache_max_age_days` | 30 (not used here; carries through for Phase 3) |
+
+### 2. Initialize candidates.json
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/candidate-store.py init \
+    --project-path <project_path>
+```
+
+Idempotent — safe to re-run after a partial curate.
+
+### 3. Dispatch source-curator per sub-question
+
+For each sub-question id selected in Step 0:
+
+1. Define the batch output path: `<project_path>/.metadata/.candidates.batch.<sq-id>.json` (leading dot keeps it out of casual ls; the file is intermediate state).
+
+2. Dispatch:
+   ```
+   Skill("cogni-knowledge:source-curator",
+         args="PROJECT_PATH=<project_path> SUB_QUESTION_ID=<sq-id> \
+               BATCH_OUTPUT_PATH=<batch_path> MARKET=<market> \
+               MAX_CANDIDATES=<max_candidates_per_sq> \
+               SCORE_THRESHOLD=<score_threshold>")
+   ```
+
+   `source-curator` is invoked as an agent (lives at `${CLAUDE_PLUGIN_ROOT}/agents/source-curator.md`); the `Skill` dispatch convention for agents in cogni-knowledge follows the same pattern cogni-research/cogni-wiki use.
+
+3. Default cadence: dispatch sub-questions in parallel **when 3 or fewer**; otherwise sequential. Parallelism helps wall-clock but each curator does its own WebSearch — three concurrent curators is the rate-limit-friendly ceiling.
+
+4. After each curator returns successfully, merge the batch:
+   ```
+   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/candidate-store.py append-batch \
+       --project-path <project_path> \
+       --batch-file <batch_path>
+   ```
+
+   `append-batch` is file-locked (`fcntl.flock`) so concurrent merges from parallel curators are safe.
+
+5. On a curator failure (`{"ok": false, …}` summary, or a missing batch file), record the sq-id in a `failed_curators[]` collection and continue. Do not abort the skill — partial coverage is better than zero coverage.
+
+### 4. Final read + summary
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/candidate-store.py read \
+    --project-path <project_path>
+```
+
+Parse the result for the final summary. Print ≤ 8 lines:
+
+- Project: `<topic>` at `<project_path>`
+- Curators dispatched: `<count>` (failed: `<failed_count>`)
+- Candidates: `<total>` (`<primary_count>` primary / `<secondary_count>` secondary / `<supporting_count>` supporting)
+- Cost: `$X.XX` (sum of `cost_estimate.estimated_usd` across curator return summaries)
+- Failed sub-questions (if any): `sq-NN, sq-MM` — re-run with `--sub-question-ids sq-NN,sq-MM`
+- Next: run `knowledge-fetch --knowledge-slug <slug> --project-path <project_path>` to materialize bodies
+
+## Edge cases
+
+- **Re-curate of an existing project.** `candidates.json` already exists. `candidate-store.py init` is idempotent (no overwrite). Curators dispatched again will re-emit batches; the merge step dedupes by URL, unions sub-question refs, and keeps the higher score. Pre-existing entries from other sub-questions are preserved.
+- **Curator emits zero candidates.** Either the topic is too obscure for web sources or the score threshold is too high. Surface as a warning; the operator can re-run with `--sub-question-ids <id>` after adjusting `binding.curator_defaults.score_threshold` (manual edit, no skill yet).
+- **Plan has a sub-question id the user did not pass.** Skip — only dispatch the explicitly requested subset. The skipped sq-ids will not appear in `candidates.json`'s `sub_question_refs` until re-run.
+
+## Out of scope
+
+- Does NOT WebFetch (Phase 3 / `source-fetcher`).
+- Does NOT touch the wiki — wiki ingest is Phase 4 (`knowledge-ingest`, not yet shipped).
+- Does NOT modify `plan.json` or `binding.json`.
+- Does NOT support tuning of scoring weights via CLI (forked composite weights are local to `agents/source-curator.md`; edit there).
+
+## Output
+
+- `<project_path>/.metadata/candidates.json` (schema 0.1.0; merged + tier-stamped + priority-assigned)
+- `<project_path>/.metadata/.candidates.batch.<sq-id>.json` for each dispatched sub-question (intermediate; safe to clean up but kept for debugging)
+
+## References
+
+- `${CLAUDE_PLUGIN_ROOT}/references/inverted-pipeline.md` — Phase 2 contract
+- `${CLAUDE_PLUGIN_ROOT}/agents/source-curator.md` — dispatched agent
+- `${CLAUDE_PLUGIN_ROOT}/scripts/candidate-store.py --help`
+- `${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py --help`

--- a/cogni-knowledge/skills/knowledge-curate/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-curate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: knowledge-curate
 description: "Phase 2 of the v0.1.0 inverted pipeline. Reads plan.json, dispatches one source-curator agent per sub-question to WebSearch + score candidate sources, merges the per-sub-question batches into candidates.json via candidate-store.py. Does NOT fetch URL bodies — that is Phase 3 (knowledge-fetch). Use this skill whenever the user says 'curate sources for the eu-ai-act plan', 'discover candidates for project X', 'run the curators on plan.json', 'knowledge curate', 'phase 2 of the knowledge pipeline'. After curate, run knowledge-fetch to materialize bodies into the shared fetch-cache."
-allowed-tools: Read, Write, Bash, Glob, Skill
+allowed-tools: Read, Write, Bash, Glob, Skill, Task
 ---
 
 # Knowledge Curate
@@ -86,16 +86,18 @@ For each sub-question id selected in Step 0:
 
 1. Define the batch output path: `<project_path>/.metadata/.candidates.batch.<sq-id>.json` (leading dot keeps it out of casual ls; the file is intermediate state).
 
-2. Dispatch:
+2. Dispatch via the `Task` tool (matches the upstream `cogni-research/skills/research-report` agent-dispatch convention at lines 408, 559):
    ```
-   Skill("cogni-knowledge:source-curator",
-         args="PROJECT_PATH=<project_path> SUB_QUESTION_ID=<sq-id> \
-               BATCH_OUTPUT_PATH=<batch_path> MARKET=<market> \
-               MAX_CANDIDATES=<max_candidates_per_sq> \
-               SCORE_THRESHOLD=<score_threshold>")
+   Task(source-curator,
+        PROJECT_PATH=<project_path>,
+        SUB_QUESTION_ID=<sq-id>,
+        BATCH_OUTPUT_PATH=<batch_path>,
+        MARKET=<market>,
+        MAX_CANDIDATES=<max_candidates_per_sq>,
+        SCORE_THRESHOLD=<score_threshold>)
    ```
 
-   `source-curator` is invoked as an agent (lives at `${CLAUDE_PLUGIN_ROOT}/agents/source-curator.md`); the `Skill` dispatch convention for agents in cogni-knowledge follows the same pattern cogni-research/cogni-wiki use.
+   `source-curator` lives at `${CLAUDE_PLUGIN_ROOT}/agents/source-curator.md` — agents are dispatched via `Task`, not `Skill` (which is for sibling skills).
 
 3. Default cadence: dispatch sub-questions in parallel **when 3 or fewer**; otherwise sequential. Parallelism helps wall-clock but each curator does its own WebSearch — three concurrent curators is the rate-limit-friendly ceiling. (Phase 3 / `knowledge-fetch` runs batches strictly sequentially for a related but stricter reason — see that skill's Step 3 for the rationale.)
 

--- a/cogni-knowledge/skills/knowledge-fetch/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-fetch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: knowledge-fetch
 description: "Phase 3 of the v0.1.0 inverted pipeline. Reads candidates.json, dispatches source-fetcher agents in batches to WebFetch each URL (with cobrowse fallback) and store bodies through fetch-cache.py. Merges per-batch results into fetch-manifest.json. Cache hits short-circuit; unavailable URLs are negatively cached. Use this skill whenever the user says 'fetch candidates for project X', 'materialize sources for the eu-ai-act plan', 'phase 3 of the knowledge pipeline', 'run the fetchers', 'knowledge fetch'. After fetch, the next slice (M5+M6) will run knowledge-ingest to deposit per-URL wiki pages."
-allowed-tools: Read, Write, Bash, Glob, Skill
+allowed-tools: Read, Write, Bash, Glob, Skill, Task
 ---
 
 # Knowledge Fetch
@@ -91,14 +91,14 @@ For each batch:
 
 1. Define the batch output path: `<project_path>/.metadata/.fetch.batch.<NNN>.json` (e.g., `.fetch.batch.001.json`).
 
-2. Dispatch:
+2. Dispatch via the `Task` tool (matches the upstream `cogni-research/skills/research-report` agent-dispatch convention at lines 408, 559):
    ```
-   Skill("cogni-knowledge:source-fetcher",
-         args="CANDIDATES_PATH=<project_path>/.metadata/candidates.json \
-               KNOWLEDGE_ROOT=<knowledge_root> \
-               BATCH_URLS=<comma-separated URLs from the batch> \
-               MAX_AGE_DAYS=<max_age_days> \
-               BATCH_OUTPUT_PATH=<batch_path>")
+   Task(source-fetcher,
+        CANDIDATES_PATH=<project_path>/.metadata/candidates.json,
+        KNOWLEDGE_ROOT=<knowledge_root>,
+        BATCH_URLS=<comma-separated URLs from the batch>,
+        MAX_AGE_DAYS=<max_age_days>,
+        BATCH_OUTPUT_PATH=<batch_path>)
    ```
 
 3. Default cadence: dispatch batches **sequentially** at v0.0.17 (WebFetch rate-limit awareness, and `fetch-manifest.json` writes happen between batches). Future tuning may parallelize once the rate-limit behaviour is characterised in the alpha re-run (M12).

--- a/cogni-knowledge/skills/knowledge-fetch/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-fetch/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: knowledge-fetch
+description: "Phase 3 of the v0.1.0 inverted pipeline. Reads candidates.json, dispatches source-fetcher agents in batches to WebFetch each URL (with cobrowse fallback) and store bodies through fetch-cache.py. Merges per-batch results into fetch-manifest.json. Cache hits short-circuit; unavailable URLs are negatively cached. Use this skill whenever the user says 'fetch candidates for project X', 'materialize sources for the eu-ai-act plan', 'phase 3 of the knowledge pipeline', 'run the fetchers', 'knowledge fetch'. After fetch, the next slice (M5+M6) will run knowledge-ingest to deposit per-URL wiki pages."
+allowed-tools: Read, Write, Bash, Glob, Skill
+---
+
+# Knowledge Fetch
+
+Phase 3 of the v0.1.0 inverted pipeline. Reads `<project>/.metadata/candidates.json`, fans out `source-fetcher` dispatches over batches of URLs, and merges per-batch results into the canonical `<project>/.metadata/fetch-manifest.json`. Successful fetches land in the shared `<knowledge-root>/.cogni-knowledge/fetch-cache/`; unavailable URLs are negatively cached so a re-run within the freshness window does not re-attempt.
+
+Read `${CLAUDE_PLUGIN_ROOT}/references/inverted-pipeline.md` §"Phase 3 — `knowledge-fetch`" and `references/fetch-cache-design.md` once to anchor on the contract.
+
+## When to run
+
+- `candidates.json` exists for the project (Phase 2 has run) AND either `fetch-manifest.json` does not yet exist OR the user explicitly wants to re-fetch (e.g., after evicting stale cache entries)
+- User explicitly invokes `/cogni-knowledge:knowledge-fetch`
+
+## Never run when
+
+- No `candidates.json` exists at `<project_path>/.metadata/` — offer `knowledge-curate` first.
+- No `binding.json` exists at the resolved knowledge root.
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--knowledge-slug` | Yes | Slug of the bound knowledge base. |
+| `--project-path` | Yes | Absolute path to the project directory. |
+| `--knowledge-root` | No | Override the default knowledge-base directory. |
+| `--max-age-days` | No | Cache freshness window in days. Default: from `binding.curator_defaults.fetch_cache_max_age_days` (30). |
+| `--batch-size` | No | Number of URLs each `source-fetcher` dispatch handles. Default 8. Advisory; the dispatcher controls real concurrency. |
+| `--tier` | No | Restrict fetch to a single tier (`primary`, `secondary`, `supporting`). Default: all tiers. Useful for spending the WebFetch budget on the most authoritative URLs first. |
+| `--dry-run` | No | Print the dispatch plan (batch count, total URLs, cache-hit projection) without running fetchers. |
+
+## Workflow
+
+### 0. Pre-flight
+
+**Required plugins.** Probe only `cogni-wiki` (clean-break):
+
+```
+probe_plugin() {
+  local plugin="$1" skill="$2"
+  test -f "${CLAUDE_PLUGIN_ROOT}/../${plugin}/skills/${skill}/SKILL.md" && return 0
+  for d in "${CLAUDE_PLUGIN_ROOT}/../../${plugin}/"*/skills/"${skill}"/SKILL.md; do
+    [ -f "$d" ] && return 0
+  done
+  return 1
+}
+probe_plugin cogni-wiki wiki-setup && WIKI_OK=yes || WIKI_OK=no
+```
+
+Abort with the standard missing-plugin message on `no`.
+
+**Binding + candidates.** Resolve `knowledge_root`. Read the binding (`knowledge-binding.py read`) and parse `curator_defaults.fetch_cache_max_age_days` (default 30 if absent — legacy bindings).
+
+Read `<project_path>/.metadata/candidates.json` via:
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/candidate-store.py read \
+    --project-path <project_path>
+```
+
+Abort if `success: false` — offer `knowledge-curate` first.
+
+### 1. Build batch plan
+
+1. Apply `--tier` filter (if set) to the candidates list.
+2. Sort by `fetch_priority` ascending (primary tier first, highest score within tier first — see `candidate-store.py _recompute_priorities`).
+3. Split into batches of size `--batch-size` (default 8). Carry the URL list and the candidate metadata (publisher) per batch.
+
+If `--dry-run`: print batch count, total URLs, estimated WebFetch calls (assuming worst case — no cache hits), and stop.
+
+### 2. Initialize fetch-manifest.json
+
+Create `<project_path>/.metadata/fetch-manifest.json` if absent, with the empty payload:
+
+```json
+{
+  "schema_version": "0.1.0",
+  "fetched": [],
+  "unavailable": []
+}
+```
+
+If it exists, leave it — the orchestrator merges into the existing arrays so a re-fetch builds on prior results (cache hits will be marked `from_cache: true`).
+
+### 3. Dispatch source-fetcher per batch
+
+For each batch:
+
+1. Define the batch output path: `<project_path>/.metadata/.fetch.batch.<NNN>.json` (e.g., `.fetch.batch.001.json`).
+
+2. Dispatch:
+   ```
+   Skill("cogni-knowledge:source-fetcher",
+         args="CANDIDATES_PATH=<project_path>/.metadata/candidates.json \
+               KNOWLEDGE_ROOT=<knowledge_root> \
+               BATCH_URLS=<comma-separated URLs from the batch> \
+               MAX_AGE_DAYS=<max_age_days> \
+               BATCH_OUTPUT_PATH=<batch_path>")
+   ```
+
+3. Default cadence: dispatch batches **sequentially** at v0.0.17 (WebFetch rate-limit awareness, and `fetch-manifest.json` writes happen between batches). Future tuning may parallelize once the rate-limit behaviour is characterised in the alpha re-run (M12).
+
+4. After each fetcher returns, merge its batch JSON into `fetch-manifest.json` in the orchestrator:
+   - Read the batch file's `fetched[]` and `unavailable[]`.
+   - Append to the corresponding arrays in `fetch-manifest.json`.
+   - Dedup within each array by URL (in case a re-run hits a URL the prior run also recorded — keep the newer `attempted_at` entry).
+   - Atomic write via `tempfile.mkstemp + os.replace` (mirror the pattern `fetch-cache.py` and `knowledge-binding.py` use). Inline `python3 -c` is fine — this is one short atomic-write helper, no need for a dedicated script yet.
+
+5. On fetcher failure (no batch file written, or summary `ok: false`), record the batch index in `failed_batches[]` and continue. Re-runnable via `--tier` + a manual `candidates.json` slice.
+
+### 4. Final summary
+
+Print ≤ 10 lines:
+
+- Project: `<topic>` at `<project_path>`
+- Batches: `<count>` dispatched (failed: `<failed_count>`)
+- Fetched: `<count>` (`<cache_hits>` from cache, `<fresh_fetches>` new)
+- Unavailable: `<count>` (`<reason_top_3>`)
+- Cost: `$X.XX` (sum of `cost_estimate.estimated_usd` across fetcher return summaries)
+- Cache stats:
+  ```
+  python3 ${CLAUDE_PLUGIN_ROOT}/scripts/fetch-cache.py stat \
+      --knowledge-root <knowledge_root>
+  ```
+  Print `entries`, `total_bytes`.
+- Next: M5+M6 will land `knowledge-ingest`. For v0.0.17, end here — `fetch-manifest.json` + the populated cache are this slice's deliverable.
+
+If `unavailable_count / total_candidates > 0.3`, emit a non-blocking warning: "high unavailable rate (X%) — consider checking network/cobrowse availability or evicting stale negative-cache entries via fetch-cache.py evict".
+
+## Edge cases
+
+- **Empty candidates list.** Nothing to fetch. Skip to summary with a note. Often means `knowledge-curate` failed silently — direct the user to re-run curate.
+- **Cache populated from a prior project.** Cache hits short-circuit. Cache is shared per-knowledge-base; this is the cross-project compounding win.
+- **Re-fetch after eviction.** `fetch-cache.py evict --older-than-days N` removes stale entries. A subsequent `knowledge-fetch` will re-fetch everything that's missing from cache.
+- **Cobrowse unavailable.** `source-fetcher` skips Step 3 silently. The unavailable rate climbs; the orchestrator's warning surfaces it.
+
+## Out of scope
+
+- Does NOT extract claims from fetched bodies — that is Phase 4 (`source-ingester`, M5).
+- Does NOT touch the wiki — Phase 4 (`knowledge-ingest`, M6).
+- Does NOT evict cache entries — that is `fetch-cache.py evict` (manual or via a future `knowledge-refresh --vacuum`).
+
+## Output
+
+- `<project_path>/.metadata/fetch-manifest.json` (schema 0.1.0)
+- `<project_path>/.metadata/.fetch.batch.<NNN>.json` for each dispatched batch (intermediate; kept for debugging)
+- `<knowledge_root>/.cogni-knowledge/fetch-cache/<sha256>.json` for each fetched URL (shared cache; lifecycle per `fetch-cache-design.md`)
+
+## References
+
+- `${CLAUDE_PLUGIN_ROOT}/references/inverted-pipeline.md` — Phase 3 contract
+- `${CLAUDE_PLUGIN_ROOT}/references/fetch-cache-design.md` — cache mechanics
+- `${CLAUDE_PLUGIN_ROOT}/agents/source-fetcher.md` — dispatched agent
+- `${CLAUDE_PLUGIN_ROOT}/scripts/fetch-cache.py --help`
+- `${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py --help`
+- `${CLAUDE_PLUGIN_ROOT}/scripts/candidate-store.py --help`

--- a/cogni-knowledge/skills/knowledge-plan/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-plan/SKILL.md
@@ -87,7 +87,11 @@ Reason about the topic. Decompose it into 3-7 sub-questions that together cover 
 - `id`: `sq-NN` (zero-padded, sequential from `sq-01`).
 - `query`: a concrete, search-engine-friendly phrasing of the sub-question.
 - `search_guidance`: 1-2 sentences telling the Phase 2 source-curator what kinds of sources would best answer this sub-question (regulatory text, industry analysis, court rulings, etc.).
-- `candidate_domains`: a list of 3-8 domain stems where authoritative answers likely live for this market. Examples for `dach`: `eur-lex.europa.eu`, `bfdi.bund.de`, `edpb.europa.eu`, `bitkom.org`. Use the market's authority sources as your starting set — for `dach` see `${CLAUDE_PLUGIN_ROOT}/../cogni-research/references/market-sources.json` (the static reference file is permitted; the clean-break excludes skills + agents, not reference files).
+- `candidate_domains`: a list of 3-8 domain stems where authoritative answers likely live for this market. Examples for `dach`: `eur-lex.europa.eu`, `bfdi.bund.de`, `edpb.europa.eu`, `bitkom.org`. Use the market's authority sources as your starting set — resolved via the canonical workspace helper:
+  ```
+  python3 "${WORKSPACE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/insight-wave/cogni-workspace/*/ | head -1)}/scripts/get-market-config.py" --plugin research --market <market>
+  ```
+  Same path cogni-portfolio's agents use; the helper joins the canonical registry (`cogni-workspace/references/supported-markets-registry.json`) with the research overlay so cogni-knowledge never reaches into cogni-research's filesystem.
 
 If `--sub-question-hints` was passed, ensure each hint maps to at least one sub-question — but you may rephrase, split, or merge as needed for coherence.
 

--- a/cogni-knowledge/skills/knowledge-plan/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-plan/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: knowledge-plan
+description: "Phase 1 of the v0.1.0 inverted pipeline. Decomposes a research topic into 3-7 sub-questions with per-sub-question candidate-domain hints, writes plan.json into a fresh project directory under the bound knowledge base. No web access at this phase — pure decomposition. Use this skill whenever the user says 'plan a new research topic', 'decompose topic X into sub-questions', 'start a knowledge-pipeline run on X', 'knowledge plan for X', 'create sub-questions for X under the eu-ai-act base'. After plan, the user runs knowledge-curate to discover candidate sources."
+allowed-tools: Read, Write, Bash, Glob, AskUserQuestion, Skill
+---
+
+# Knowledge Plan
+
+Phase 1 of the v0.1.0 inverted pipeline (`plan → curate → fetch → ingest → compose → verify → finalize`). This skill decomposes a research topic into a structured plan that downstream phases (`knowledge-curate`, `knowledge-fetch`, …) consume.
+
+Read `${CLAUDE_PLUGIN_ROOT}/references/inverted-pipeline.md` once at the start of a session to anchor on the phase boundaries and the v0.1.0 contract.
+
+## When to run
+
+- User wants to start a new research run on a topic against an existing bound knowledge base
+- User explicitly invokes `/cogni-knowledge:knowledge-plan`
+
+## Never run when
+
+- No `binding.json` exists at the resolved knowledge root — offer `knowledge-setup` first. Plan output lives in a fresh project directory under the bound knowledge root; without a binding there is no anchor.
+- The user wants the legacy v0.0.x research+ingest flow — point at `knowledge-research` (legacy, still wired through `cogni-research`). v0.1.0 is the clean-break path.
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--knowledge-slug` | Yes | Slug of the bound knowledge base. Resolves to `<cwd>/<slug>/` unless `--knowledge-root` overrides. |
+| `--topic` | Yes (prompted) | Free-text research topic, e.g. `"GDPR Article 30 records of processing"`. |
+| `--knowledge-root` | No | Override the default knowledge-base directory. |
+| `--market` | No | Market code (default `dach`). One of: `dach`, `de`, `fr`, `it`, `pl`, `nl`, `es`, `us`, `uk`, `eu`. |
+| `--output-language` | No | Two-letter code, default `en`. |
+| `--sub-question-hints` | No | Pipe-separated list of sub-question seeds the user wants reflected, e.g. `"records of processing scope|controller vs processor obligations"`. |
+| `--dry-run` | No | Print the resolved plan + target paths without writing. |
+
+If `--topic` is missing, ask the user once with AskUserQuestion. Do not invent a topic.
+
+## Workflow
+
+### 0. Pre-flight
+
+**Required plugins.** Probe only `cogni-wiki` — the v0.1.0 inverted pipeline does NOT dispatch cogni-research skills or agents (clean-break commitment, per `references/inverted-pipeline.md` §"What is no longer in the runtime path"). Probe handles both layouts:
+
+```
+probe_plugin() {
+  local plugin="$1" skill="$2"
+  test -f "${CLAUDE_PLUGIN_ROOT}/../${plugin}/skills/${skill}/SKILL.md" && return 0
+  for d in "${CLAUDE_PLUGIN_ROOT}/../../${plugin}/"*/skills/"${skill}"/SKILL.md; do
+    [ -f "$d" ] && return 0
+  done
+  return 1
+}
+probe_plugin cogni-wiki wiki-setup && WIKI_OK=yes || WIKI_OK=no
+```
+
+If `WIKI_OK=no`, abort:
+
+> cogni-knowledge requires `cogni-wiki` to be installed. Install via the marketplace, then retry.
+
+**Binding.** Resolve `knowledge_root`:
+1. If `--knowledge-root` is set, use it.
+2. Otherwise, `knowledge_root = <cwd>/<knowledge-slug>/`.
+
+Read the binding:
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py read \
+    --knowledge-root <knowledge_root>
+```
+
+On `success: false` — abort and offer `knowledge-setup`. Do not auto-create.
+
+Verify the binding's `knowledge_slug` matches `--knowledge-slug` — mismatch means the user is pointing at the wrong directory.
+
+### 1. Slugify topic + resolve project root
+
+- `topic_slug = kebab-case of --topic` (lowercase, alphanumerics + dashes; collapse runs of dashes; strip leading/trailing dashes; cap at 60 chars). Use `sed`/`python3` — no external slugify dep.
+- `date_stamp = $(date -u +%F)` (e.g. `2026-05-20`).
+- `project_path = <knowledge_root>/<topic_slug>-<date_stamp>/`
+- If `project_path` already exists, abort with a clear message — do not overwrite (`plan.json` is the project's anchor; re-planning the same topic on the same day means the user wants a different slug or a different date in the dir name).
+
+If `--dry-run`, print the resolved knowledge_root, project_path, sub-question count target (3-7), and stop here.
+
+### 2. Decompose topic into sub-questions (no web)
+
+Reason about the topic. Decompose it into 3-7 sub-questions that together cover the topic with minimal overlap. For each sub-question:
+
+- `id`: `sq-NN` (zero-padded, sequential from `sq-01`).
+- `query`: a concrete, search-engine-friendly phrasing of the sub-question.
+- `search_guidance`: 1-2 sentences telling the Phase 2 source-curator what kinds of sources would best answer this sub-question (regulatory text, industry analysis, court rulings, etc.).
+- `candidate_domains`: a list of 3-8 domain stems where authoritative answers likely live for this market. Examples for `dach`: `eur-lex.europa.eu`, `bfdi.bund.de`, `edpb.europa.eu`, `bitkom.org`. Use the market's authority sources as your starting set — for `dach` see `${CLAUDE_PLUGIN_ROOT}/../cogni-research/references/market-sources.json` (the static reference file is permitted; the clean-break excludes skills + agents, not reference files).
+
+If `--sub-question-hints` was passed, ensure each hint maps to at least one sub-question — but you may rephrase, split, or merge as needed for coherence.
+
+### 3. Write plan.json
+
+Create `<project_path>/.metadata/` (using `mkdir -p`).
+
+Write `<project_path>/.metadata/plan.json` with the schema below (per `references/inverted-pipeline.md:41-57`):
+
+```json
+{
+  "schema_version": "0.1.0",
+  "topic": "<--topic verbatim>",
+  "sub_questions": [
+    {
+      "id": "sq-01",
+      "query": "...",
+      "search_guidance": "...",
+      "candidate_domains": ["europa.eu", "..."]
+    }
+  ],
+  "market": "<resolved market>",
+  "output_language": "<resolved language>",
+  "cost_estimate_usd": 0.0,
+  "created": "<ISO 8601 UTC, e.g. 2026-05-20T14:31:02Z>"
+}
+```
+
+Use the Write tool. JSON must be valid (no trailing commas, double quotes).
+
+`cost_estimate_usd` is 0.0 at Phase 1 since this skill does not call WebSearch/WebFetch. Downstream phases accumulate cost into their own manifests.
+
+### 4. Binding is NOT touched
+
+Phase 1 is project-local. Do not call `knowledge-binding.py append-project`. The binding append happens at M9 (`knowledge-finalize`), after verification completes.
+
+### 5. Final summary
+
+Print ≤ 6 lines:
+
+- Knowledge base: `<knowledge_slug>` at `<knowledge_root>`
+- New project: `<topic_slug>-<date_stamp>` (topic: `<topic>`)
+- Plan: `<sub_questions_count>` sub-questions, market `<market>`, language `<output_language>`
+- Plan path: `<project_path>/.metadata/plan.json`
+- Next: run `knowledge-curate --knowledge-slug <slug> --project-path <project_path>` to discover candidate sources
+
+## Edge cases
+
+- **Topic resolves to the same slug as an existing project on the same day.** Step 1 aborts. The user can rephrase the topic or wait until tomorrow — multi-run-per-day on the same topic is not a v0.1.0 use case.
+- **Sub-question count outside 3-7.** Re-decompose. Too few (1-2) usually means the topic is too narrow for sub-questions; suggest the user research the question directly via WebSearch. Too many (8+) means the topic is too broad; suggest a knowledge-plan per major theme.
+- **Binding pre-dates v0.0.3** (no `curator_defaults`). No problem — `knowledge-plan` does not read `curator_defaults`. Downstream `knowledge-curate` falls back to `DEFAULT_CURATOR_DEFAULTS` for legacy bindings.
+
+## Out of scope
+
+- Does NOT call WebSearch or WebFetch (Phase 1 is decomposition only).
+- Does NOT touch the wiki — wiki ingest is Phase 4 (`knowledge-ingest`, M5+M6, not yet shipped).
+- Does NOT modify `binding.json` — Phase 7 (`knowledge-finalize`) appends.
+- Does NOT support `--source-mode local|hybrid|wiki` — v0.1.0 is web-only per `references/absorption-roadmap.md` Phase 5 "Out of scope".
+
+## Output
+
+- `<project_path>/.metadata/plan.json` (schema 0.1.0)
+
+No other files written.
+
+## References
+
+- `${CLAUDE_PLUGIN_ROOT}/references/inverted-pipeline.md` — Phase 1 contract
+- `${CLAUDE_PLUGIN_ROOT}/references/absorption-roadmap.md` — M-table progress
+- `${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py --help`

--- a/cogni-knowledge/tests/fixtures/test_helpers.sh
+++ b/cogni-knowledge/tests/fixtures/test_helpers.sh
@@ -1,0 +1,44 @@
+# test_helpers.sh — shared bash helpers sourced by cogni-knowledge/tests/*.
+#
+# Before this file landed at v0.0.17, every test file inlined `red()` /
+# `green()` (byte-identical) and re-implemented `assert_grep` with two
+# divergent signatures across plugins. The cogni-wiki form took (pattern,
+# description) with a $SKILL global; the cogni-knowledge form added the
+# file as an explicit first argument. The 3-arg form is the more general
+# of the two and is the convention adopted here.
+#
+# Source via:
+#   . "$(dirname "$0")/fixtures/test_helpers.sh"
+#
+# Bash 3.2 compatible.
+
+red()   { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+
+# assert_grep PATTERN FILE DESCRIPTION
+#   Increments the caller's `errors` variable on failure.
+assert_grep() {
+  local pattern="$1" file="$2" description="$3"
+  if grep -q -- "$pattern" "$file" 2>/dev/null; then
+    green "PASS: $description"
+  else
+    red "FAIL: $description"
+    red "  pattern: $pattern"
+    red "  file:    $file"
+    errors=$((errors + 1))
+  fi
+}
+
+# assert_not_grep PATTERN FILE DESCRIPTION
+#   Symmetric counterpart — fails if PATTERN is present.
+assert_not_grep() {
+  local pattern="$1" file="$2" description="$3"
+  if grep -q -- "$pattern" "$file" 2>/dev/null; then
+    red "FAIL: $description"
+    red "  pattern (should NOT appear): $pattern"
+    red "  file: $file"
+    errors=$((errors + 1))
+  else
+    green "PASS: $description"
+  fi
+}

--- a/cogni-knowledge/tests/test_candidate_store.sh
+++ b/cogni-knowledge/tests/test_candidate_store.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# test_candidate_store.sh - smoke test for candidate-store.py.
+#
+# Asserts:
+#   1. init creates an empty candidates.json with schema 0.1.0 and is idempotent
+#      across re-runs.
+#   2. append-batch merges two batches with an overlapping URL; the overlap
+#      is deduped, the higher score wins, sub_question_refs are unioned,
+#      earliest discovered_at wins, fetch_priority is re-assigned.
+#   3. Two concurrent append-batch subshells racing on the same project end
+#      with all batch entries present and a valid JSON file (file-lock works).
+#   4. Malformed inputs are rejected with success:false and a clear error:
+#      - non-array batch
+#      - candidate missing url
+#      - candidate with out-of-range score
+#   5. URL normalization collapses scheme/host case, trailing slash, and
+#      tracking query params to a single entry.
+#
+# bash 3.2 + stdlib python3 only. Posix only (uses fcntl.flock).
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$PLUGIN_ROOT/scripts/candidate-store.py"
+
+red()   { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+
+if [ ! -f "$SCRIPT" ]; then
+  red "FAIL: candidate-store.py not found at $SCRIPT"
+  exit 1
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+errors=0
+
+PROJ="$WORK/project"
+mkdir -p "$PROJ"
+
+# 1. init creates empty candidates.json + idempotent.
+python3 "$SCRIPT" init --project-path "$PROJ" >/dev/null
+INIT_AGAIN=$(python3 "$SCRIPT" init --project-path "$PROJ")
+if echo "$INIT_AGAIN" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d['success'] is True, d
+assert d['data']['created'] is False, d
+assert d['data']['candidates_count'] == 0, d
+print('OK')
+" | grep -q OK; then
+  green "PASS: init creates empty candidates.json and is idempotent"
+else
+  red "FAIL: init not idempotent"
+  red "  got: $INIT_AGAIN"
+  errors=$((errors + 1))
+fi
+
+SCHEMA=$(python3 -c "import json; print(json.load(open('$PROJ/.metadata/candidates.json'))['schema_version'])")
+if [ "$SCHEMA" = "0.1.0" ]; then
+  green "PASS: init writes schema_version 0.1.0"
+else
+  red "FAIL: schema_version expected 0.1.0, got '$SCHEMA'"
+  errors=$((errors + 1))
+fi
+
+# 2. append-batch dedup + merge semantics.
+BATCH_A="$WORK/batch-a.json"
+cat > "$BATCH_A" <<'JSON'
+[
+  {"url": "https://europa.eu/article-6", "title": "Article 6", "score": 0.85,
+   "sub_question_refs": ["sq-01"], "publisher": "europa.eu",
+   "discovered_at": "2026-05-20T10:00:00Z"},
+  {"url": "https://example.org/gdpr-art-30", "title": "Art 30 GDPR", "score": 0.71,
+   "sub_question_refs": ["sq-02"], "publisher": "example.org",
+   "discovered_at": "2026-05-20T10:00:01Z"}
+]
+JSON
+
+BATCH_B="$WORK/batch-b.json"
+cat > "$BATCH_B" <<'JSON'
+[
+  {"url": "https://europa.eu/article-6", "title": "Article 6 (alt)", "score": 0.92,
+   "sub_question_refs": ["sq-03"], "publisher": "europa.eu",
+   "discovered_at": "2026-05-20T11:00:00Z"},
+  {"url": "https://acme.io/new-source", "title": "Acme", "score": 0.42,
+   "sub_question_refs": ["sq-02"], "publisher": "acme.io",
+   "discovered_at": "2026-05-20T11:00:01Z"}
+]
+JSON
+
+python3 "$SCRIPT" append-batch --project-path "$PROJ" --batch-file "$BATCH_A" >/dev/null
+python3 "$SCRIPT" append-batch --project-path "$PROJ" --batch-file "$BATCH_B" >/dev/null
+
+if python3 - <<PY > /dev/null
+import json
+data = json.load(open('$PROJ/.metadata/candidates.json'))
+cands = data['candidates']
+assert len(cands) == 3, cands  # europa deduped, example + acme added
+by_url = {c['url']: c for c in cands}
+ea = by_url['https://europa.eu/article-6']
+assert ea['score'] == 0.92, ea  # higher score wins
+assert ea['title'] == 'Article 6 (alt)', ea  # higher-score entry's fields win
+assert ea['tier'] == 'primary', ea  # >= 0.80
+assert ea['discovered_at'] == '2026-05-20T10:00:00Z', ea  # earliest wins
+assert sorted(ea['sub_question_refs']) == ['sq-01', 'sq-03'], ea  # unioned
+# fetch_priority deterministic: europa (primary, 0.92) → 1, example (secondary, 0.71) → 2,
+# acme (supporting, 0.42) → 3.
+prios = {c['url']: c['fetch_priority'] for c in cands}
+assert prios['https://europa.eu/article-6'] == 1, prios
+assert prios['https://example.org/gdpr-art-30'] == 2, prios
+assert prios['https://acme.io/new-source'] == 3, prios
+PY
+then
+  green "PASS: append-batch dedup, score-win, ref-union, fetch_priority assignment"
+else
+  red "FAIL: dedup/merge semantics broken"
+  errors=$((errors + 1))
+fi
+
+# 3. Concurrent append (two subshells racing).
+PROJ2="$WORK/project2"
+mkdir -p "$PROJ2"
+python3 "$SCRIPT" init --project-path "$PROJ2" >/dev/null
+
+BATCH_C="$WORK/batch-c.json"
+BATCH_D="$WORK/batch-d.json"
+python3 - <<PY
+import json
+batch_c = [{"url": f"https://race.test/c-{i}", "title": f"C-{i}", "score": 0.7,
+            "sub_question_refs": ["sq-A"], "publisher": "race.test",
+            "discovered_at": "2026-05-20T12:00:00Z"} for i in range(20)]
+batch_d = [{"url": f"https://race.test/d-{i}", "title": f"D-{i}", "score": 0.6,
+            "sub_question_refs": ["sq-B"], "publisher": "race.test",
+            "discovered_at": "2026-05-20T12:00:01Z"} for i in range(20)]
+open("$BATCH_C", "w").write(json.dumps(batch_c))
+open("$BATCH_D", "w").write(json.dumps(batch_d))
+PY
+
+(python3 "$SCRIPT" append-batch --project-path "$PROJ2" --batch-file "$BATCH_C" >/dev/null) &
+PID_C=$!
+(python3 "$SCRIPT" append-batch --project-path "$PROJ2" --batch-file "$BATCH_D" >/dev/null) &
+PID_D=$!
+wait $PID_C
+wait $PID_D
+
+if python3 - <<PY > /dev/null
+import json
+data = json.load(open('$PROJ2/.metadata/candidates.json'))
+cands = data['candidates']
+assert len(cands) == 40, f"expected 40, got {len(cands)}"
+urls = {c['url'] for c in cands}
+expected = {f"https://race.test/c-{i}" for i in range(20)} | {f"https://race.test/d-{i}" for i in range(20)}
+assert urls == expected, urls.symmetric_difference(expected)
+PY
+then
+  green "PASS: concurrent append-batch — file lock preserves both batches' content"
+else
+  red "FAIL: concurrent append lost data"
+  errors=$((errors + 1))
+fi
+
+# 4a. Non-array batch → reject.
+BAD_BATCH="$WORK/bad-not-array.json"
+echo '{"not": "an array"}' > "$BAD_BATCH"
+OUT=$(python3 "$SCRIPT" append-batch --project-path "$PROJ" --batch-file "$BAD_BATCH" 2>&1 || true)
+if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'array' in d['error'].lower()" 2>/dev/null; then
+  green "PASS: non-array batch rejected"
+else
+  red "FAIL: non-array batch not rejected"
+  red "  got: $OUT"
+  errors=$((errors + 1))
+fi
+
+# 4b. Missing url → reject.
+BAD_URL="$WORK/bad-url.json"
+echo '[{"score": 0.5, "sub_question_refs": []}]' > "$BAD_URL"
+OUT=$(python3 "$SCRIPT" append-batch --project-path "$PROJ" --batch-file "$BAD_URL" 2>&1 || true)
+if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'url' in d['error'].lower()" 2>/dev/null; then
+  green "PASS: missing-url candidate rejected"
+else
+  red "FAIL: missing-url candidate not rejected"
+  red "  got: $OUT"
+  errors=$((errors + 1))
+fi
+
+# 4c. Out-of-range score → reject.
+BAD_SCORE="$WORK/bad-score.json"
+echo '[{"url": "https://x.io/y", "score": 1.5, "sub_question_refs": []}]' > "$BAD_SCORE"
+OUT=$(python3 "$SCRIPT" append-batch --project-path "$PROJ" --batch-file "$BAD_SCORE" 2>&1 || true)
+if echo "$OUT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['success'] is False and 'score' in d['error'].lower()" 2>/dev/null; then
+  green "PASS: out-of-range score rejected"
+else
+  red "FAIL: out-of-range score not rejected"
+  red "  got: $OUT"
+  errors=$((errors + 1))
+fi
+
+# 5. URL normalization: scheme/host case + trailing slash + tracking params
+# collapse to one entry.
+PROJ3="$WORK/project3"
+mkdir -p "$PROJ3"
+python3 "$SCRIPT" init --project-path "$PROJ3" >/dev/null
+
+NORM_BATCH="$WORK/norm-batch.json"
+cat > "$NORM_BATCH" <<'JSON'
+[
+  {"url": "https://Foo.COM/Article/?utm_source=a&utm_medium=b",
+   "title": "v1", "score": 0.7, "sub_question_refs": ["sq-1"],
+   "discovered_at": "2026-05-20T10:00:00Z"},
+  {"url": "HTTPS://foo.com/Article?fbclid=xyz",
+   "title": "v2", "score": 0.8, "sub_question_refs": ["sq-2"],
+   "discovered_at": "2026-05-20T10:00:01Z"}
+]
+JSON
+
+python3 "$SCRIPT" append-batch --project-path "$PROJ3" --batch-file "$NORM_BATCH" >/dev/null
+if python3 - <<PY > /dev/null
+import json
+data = json.load(open('$PROJ3/.metadata/candidates.json'))
+cands = data['candidates']
+assert len(cands) == 1, f"expected 1 deduped entry, got {len(cands)}: {[c['url'] for c in cands]}"
+c = cands[0]
+assert c['score'] == 0.8, c  # higher score wins
+assert sorted(c['sub_question_refs']) == ['sq-1', 'sq-2'], c
+PY
+then
+  green "PASS: URL normalization collapses scheme-case, trailing slash, and tracking params"
+else
+  red "FAIL: URL normalization broken"
+  errors=$((errors + 1))
+fi
+
+if [ $errors -eq 0 ]; then
+  green "ALL PASS"
+  exit 0
+else
+  red "$errors test(s) failed"
+  exit 1
+fi

--- a/cogni-knowledge/tests/test_candidate_store.sh
+++ b/cogni-knowledge/tests/test_candidate_store.sh
@@ -23,8 +23,7 @@ set -eu
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/scripts/candidate-store.py"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 
 if [ ! -f "$SCRIPT" ]; then
   red "FAIL: candidate-store.py not found at $SCRIPT"
@@ -229,6 +228,31 @@ then
   green "PASS: URL normalization collapses scheme-case, trailing slash, and tracking params"
 else
   red "FAIL: URL normalization broken"
+  errors=$((errors + 1))
+fi
+
+# 6. Empty batch is a no-op — does not rewrite candidates.json on disk
+# (early-return optimisation; verified via mtime).
+PROJ4="$WORK/project4"
+mkdir -p "$PROJ4"
+python3 "$SCRIPT" init --project-path "$PROJ4" >/dev/null
+EMPTY_BATCH="$WORK/empty-batch.json"
+echo '[]' > "$EMPTY_BATCH"
+BEFORE_MTIME=$(python3 -c "import os; print(int(os.stat('$PROJ4/.metadata/candidates.json').st_mtime_ns))")
+# Sleep just enough to make a mtime-change observable if the file is rewritten.
+sleep 0.05
+EMPTY_OUT=$(python3 "$SCRIPT" append-batch --project-path "$PROJ4" --batch-file "$EMPTY_BATCH")
+AFTER_MTIME=$(python3 -c "import os; print(int(os.stat('$PROJ4/.metadata/candidates.json').st_mtime_ns))")
+if [ "$BEFORE_MTIME" = "$AFTER_MTIME" ] && echo "$EMPTY_OUT" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d['success'] is True and d['data']['added'] == 0 and d['data']['merged'] == 0, d
+"; then
+  green "PASS: empty batch short-circuits — no rewrite, added=merged=0"
+else
+  red "FAIL: empty batch triggered a rewrite or wrong envelope"
+  red "  before: $BEFORE_MTIME, after: $AFTER_MTIME"
+  red "  got:    $EMPTY_OUT"
   errors=$((errors + 1))
 fi
 

--- a/cogni-knowledge/tests/test_fetch_cache.sh
+++ b/cogni-knowledge/tests/test_fetch_cache.sh
@@ -328,6 +328,46 @@ else
   errors=$((errors + 1))
 fi
 
+# 9. URL normalization at key — semantically identical URLs (case, trailing
+# slash, tracking params) must produce the SAME cache key so that the
+# curator's dedup (candidate-store.normalize_url) and the cache lookup
+# agree. Regression guard for the bug fixed in v0.0.17.
+KEY_RAW=$(python3 "$SCRIPT" key --url "https://Example.ORG/Article/?utm_source=x&ref=y" --bare)
+KEY_NORM=$(python3 "$SCRIPT" key --url "https://example.org/Article" --bare)
+if [ "$KEY_RAW" = "$KEY_NORM" ]; then
+  green "PASS: cache key normalizes scheme/host case, trailing slash, tracking params"
+else
+  red "FAIL: cache keys diverge for semantically identical URLs"
+  red "  raw  : $KEY_RAW"
+  red "  norm : $KEY_NORM"
+  errors=$((errors + 1))
+fi
+
+# 10. store + fetch via two equivalent URL forms — body round-trips.
+KB2="$WORK/kb2"
+mkdir -p "$KB2/.cogni-knowledge"
+python3 "$SCRIPT" store \
+  --knowledge-root "$KB2" \
+  --url "https://EXAMPLE.com/Doc/?utm_source=foo" \
+  --fetch-method webfetch \
+  --status ok \
+  --body "the doc body" \
+  --http-status 200 >/dev/null
+FETCH_NORM=$(python3 "$SCRIPT" fetch --knowledge-root "$KB2" --url "https://example.com/Doc")
+if echo "$FETCH_NORM" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d['success'] is True, d
+assert d['data']['entry']['body'] == 'the doc body', d
+print('OK')
+" | grep -q OK; then
+  green "PASS: store + fetch round-trip across equivalent URL forms"
+else
+  red "FAIL: cross-form fetch missed the entry"
+  red "  got: $FETCH_NORM"
+  errors=$((errors + 1))
+fi
+
 if [ $errors -gt 0 ]; then
   red "$errors case(s) failed."
   exit 1

--- a/cogni-knowledge/tests/test_skill_contracts.sh
+++ b/cogni-knowledge/tests/test_skill_contracts.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# test_skill_contracts.sh - grep-based contract assertions for the v0.0.17
+# Phase 1/2/3 skills + agents.
+#
+# Per the convention at tests/README.md §"Contract tests": for pure LLM
+# skills, regression coverage is SKILL.md content invariants. These checks
+# catch the most likely failure mode — a path, flag, or step silently
+# disappearing from the contract. They do NOT assert LLM behaviour.
+#
+# Covers:
+#   - knowledge-plan: writes plan.json schema 0.1.0, probes only cogni-wiki,
+#     does not append binding.
+#   - knowledge-curate: reads plan.json, dispatches source-curator, merges
+#     through candidate-store.py append-batch, reads curator_defaults from
+#     binding.
+#   - knowledge-fetch: reads candidates.json, dispatches source-fetcher,
+#     reads fetch_cache_max_age_days from binding, calls fetch-cache.py stat.
+#   - source-curator agent: forked header, candidates.json output, drops
+#     dimensions/annotation emission.
+#   - source-fetcher agent: webfetch + cobrowse_interactive enum,
+#     fetch-cache.py store/fetch contract.
+#   - Clean-break invariant: no `cogni-research:` or `cogni-claims:` skill
+#     dispatch references in any of the new files.
+#
+# bash 3.2 + grep only.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+red()   { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+
+errors=0
+
+assert_grep() {
+  local pattern="$1" file="$2" description="$3"
+  if grep -q -- "$pattern" "$file" 2>/dev/null; then
+    green "PASS: $description"
+  else
+    red "FAIL: $description"
+    red "  pattern: $pattern"
+    red "  file:    $file"
+    errors=$((errors + 1))
+  fi
+}
+
+assert_not_grep() {
+  local pattern="$1" file="$2" description="$3"
+  if grep -q -- "$pattern" "$file" 2>/dev/null; then
+    red "FAIL: $description"
+    red "  pattern (should NOT appear): $pattern"
+    red "  file: $file"
+    errors=$((errors + 1))
+  else
+    green "PASS: $description"
+  fi
+}
+
+# --- knowledge-plan SKILL.md ---------------------------------------------
+PLAN="$PLUGIN_ROOT/skills/knowledge-plan/SKILL.md"
+if [ ! -f "$PLAN" ]; then
+  red "FAIL: knowledge-plan/SKILL.md not found"
+  exit 1
+fi
+assert_grep 'name: knowledge-plan' "$PLAN" "knowledge-plan: frontmatter name"
+assert_grep '"schema_version": "0.1.0"' "$PLAN" "knowledge-plan: plan.json schema 0.1.0 in spec"
+assert_grep '3-7 sub-questions' "$PLAN" "knowledge-plan: 3-7 sub-question contract"
+assert_grep 'probe_plugin cogni-wiki wiki-setup' "$PLAN" "knowledge-plan: probes cogni-wiki"
+assert_grep 'knowledge-finalize' "$PLAN" "knowledge-plan: defers binding append to M9 knowledge-finalize"
+assert_not_grep 'probe_plugin cogni-research' "$PLAN" "knowledge-plan: does NOT probe cogni-research (clean break)"
+
+# --- knowledge-curate SKILL.md -------------------------------------------
+CURATE="$PLUGIN_ROOT/skills/knowledge-curate/SKILL.md"
+if [ ! -f "$CURATE" ]; then
+  red "FAIL: knowledge-curate/SKILL.md not found"
+  exit 1
+fi
+assert_grep 'name: knowledge-curate' "$CURATE" "knowledge-curate: frontmatter name"
+assert_grep 'candidate-store.py init' "$CURATE" "knowledge-curate: calls candidate-store.py init"
+assert_grep 'candidate-store.py append-batch' "$CURATE" "knowledge-curate: calls candidate-store.py append-batch"
+assert_grep 'curator_defaults' "$CURATE" "knowledge-curate: reads curator_defaults from binding"
+assert_grep 'max_candidates_per_sq' "$CURATE" "knowledge-curate: reads max_candidates_per_sq"
+assert_grep 'score_threshold' "$CURATE" "knowledge-curate: reads score_threshold"
+assert_grep 'source-curator' "$CURATE" "knowledge-curate: dispatches source-curator agent"
+assert_grep 'cogni-knowledge:source-curator' "$CURATE" "knowledge-curate: uses cogni-knowledge:source-curator skill-namespace"
+
+# --- knowledge-fetch SKILL.md --------------------------------------------
+FETCH="$PLUGIN_ROOT/skills/knowledge-fetch/SKILL.md"
+if [ ! -f "$FETCH" ]; then
+  red "FAIL: knowledge-fetch/SKILL.md not found"
+  exit 1
+fi
+assert_grep 'name: knowledge-fetch' "$FETCH" "knowledge-fetch: frontmatter name"
+assert_grep 'fetch_cache_max_age_days' "$FETCH" "knowledge-fetch: reads fetch_cache_max_age_days"
+assert_grep 'fetch-cache.py stat' "$FETCH" "knowledge-fetch: calls fetch-cache.py stat in summary"
+assert_grep 'source-fetcher' "$FETCH" "knowledge-fetch: dispatches source-fetcher agent"
+assert_grep 'fetch-manifest.json' "$FETCH" "knowledge-fetch: writes fetch-manifest.json"
+assert_grep 'cogni-knowledge:source-fetcher' "$FETCH" "knowledge-fetch: uses cogni-knowledge:source-fetcher namespace"
+
+# --- source-curator agent ------------------------------------------------
+CURATOR="$PLUGIN_ROOT/agents/source-curator.md"
+if [ ! -f "$CURATOR" ]; then
+  red "FAIL: agents/source-curator.md not found"
+  exit 1
+fi
+assert_grep 'name: source-curator' "$CURATOR" "source-curator: frontmatter name"
+assert_grep 'Forked from cogni-research/agents/source-curator.md at SHA' "$CURATOR" "source-curator: declares fork SHA in header"
+assert_grep 'candidates.json' "$CURATOR" "source-curator: emits to candidates.json contract"
+assert_grep 'sub_question_refs' "$CURATOR" "source-curator: emits sub_question_refs[]"
+assert_grep 'Do not emit' "$CURATOR" "source-curator: documents the drop-emission discipline"
+assert_grep 'WebSearch' "$CURATOR" "source-curator: uses WebSearch"
+# Negative assertion targets the frontmatter tools: line only — the body
+# legitimately mentions WebFetch to document the boundary.
+CURATOR_TOOLS_LINE=$(grep '^tools:' "$CURATOR" || true)
+if ! echo "$CURATOR_TOOLS_LINE" | grep -q WebFetch; then
+  green "PASS: source-curator: frontmatter tools: does NOT include WebFetch (Phase 3's job)"
+else
+  red "FAIL: source-curator: frontmatter tools: must not include WebFetch"
+  red "  got: $CURATOR_TOOLS_LINE"
+  errors=$((errors + 1))
+fi
+
+# --- source-fetcher agent ------------------------------------------------
+FETCHER="$PLUGIN_ROOT/agents/source-fetcher.md"
+if [ ! -f "$FETCHER" ]; then
+  red "FAIL: agents/source-fetcher.md not found"
+  exit 1
+fi
+assert_grep 'name: source-fetcher' "$FETCHER" "source-fetcher: frontmatter name"
+assert_grep 'fetch-cache.py store' "$FETCHER" "source-fetcher: calls fetch-cache.py store"
+assert_grep 'fetch-cache.py fetch' "$FETCHER" "source-fetcher: calls fetch-cache.py fetch (cache lookup)"
+assert_grep 'webfetch' "$FETCHER" "source-fetcher: uses webfetch enum (matches cogni-claims)"
+assert_grep 'cobrowse_interactive' "$FETCHER" "source-fetcher: uses cobrowse_interactive enum (matches cogni-claims)"
+assert_grep 'fallback_attempted' "$FETCHER" "source-fetcher: emits fallback_attempted in unavailable[]"
+assert_grep 'WebFetch' "$FETCHER" "source-fetcher: uses WebFetch tool"
+# Frontmatter-tools-only check (body mentions WebSearch to document the boundary).
+FETCHER_TOOLS_LINE=$(grep '^tools:' "$FETCHER" || true)
+if ! echo "$FETCHER_TOOLS_LINE" | grep -q WebSearch; then
+  green "PASS: source-fetcher: frontmatter tools: does NOT include WebSearch (curator's job)"
+else
+  red "FAIL: source-fetcher: frontmatter tools: must not include WebSearch"
+  red "  got: $FETCHER_TOOLS_LINE"
+  errors=$((errors + 1))
+fi
+
+# --- Clean-break invariant ------------------------------------------------
+# v0.1.0 forbids dispatching cogni-research or cogni-claims skills/agents
+# from the new runtime path. Static references to documentation files (e.g.,
+# cogni-research/references/market-sources.json) are permitted; skill/agent
+# DISPATCH is not.
+for f in "$PLAN" "$CURATE" "$FETCH" "$CURATOR" "$FETCHER"; do
+  # The forbidden patterns are 'Skill("cogni-research:' and 'Skill("cogni-claims:'.
+  # Also catch loose `cogni-research:` skill-namespace references.
+  if grep -qE 'Skill\("?cogni-(research|claims):' "$f" 2>/dev/null; then
+    red "FAIL: clean-break: $f dispatches a cogni-research/cogni-claims skill"
+    grep -nE 'Skill\("?cogni-(research|claims):' "$f"
+    errors=$((errors + 1))
+  fi
+done
+if [ $errors -eq 0 ]; then
+  green "PASS: clean-break — no cogni-research/cogni-claims skill dispatch in new files"
+fi
+
+if [ $errors -eq 0 ]; then
+  green "ALL PASS"
+  exit 0
+else
+  red "$errors test(s) failed"
+  exit 1
+fi

--- a/cogni-knowledge/tests/test_skill_contracts.sh
+++ b/cogni-knowledge/tests/test_skill_contracts.sh
@@ -28,34 +28,9 @@ set -eu
 
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-red()   { printf '\033[31m%s\033[0m\n' "$1"; }
-green() { printf '\033[32m%s\033[0m\n' "$1"; }
+. "$(dirname "$0")/fixtures/test_helpers.sh"
 
 errors=0
-
-assert_grep() {
-  local pattern="$1" file="$2" description="$3"
-  if grep -q -- "$pattern" "$file" 2>/dev/null; then
-    green "PASS: $description"
-  else
-    red "FAIL: $description"
-    red "  pattern: $pattern"
-    red "  file:    $file"
-    errors=$((errors + 1))
-  fi
-}
-
-assert_not_grep() {
-  local pattern="$1" file="$2" description="$3"
-  if grep -q -- "$pattern" "$file" 2>/dev/null; then
-    red "FAIL: $description"
-    red "  pattern (should NOT appear): $pattern"
-    red "  file: $file"
-    errors=$((errors + 1))
-  else
-    green "PASS: $description"
-  fi
-}
 
 # --- knowledge-plan SKILL.md ---------------------------------------------
 PLAN="$PLUGIN_ROOT/skills/knowledge-plan/SKILL.md"

--- a/cogni-knowledge/tests/test_skill_contracts.sh
+++ b/cogni-knowledge/tests/test_skill_contracts.sh
@@ -57,8 +57,11 @@ assert_grep 'candidate-store.py append-batch' "$CURATE" "knowledge-curate: calls
 assert_grep 'curator_defaults' "$CURATE" "knowledge-curate: reads curator_defaults from binding"
 assert_grep 'max_candidates_per_sq' "$CURATE" "knowledge-curate: reads max_candidates_per_sq"
 assert_grep 'score_threshold' "$CURATE" "knowledge-curate: reads score_threshold"
-assert_grep 'source-curator' "$CURATE" "knowledge-curate: dispatches source-curator agent"
-assert_grep 'cogni-knowledge:source-curator' "$CURATE" "knowledge-curate: uses cogni-knowledge:source-curator skill-namespace"
+assert_grep 'Task(source-curator' "$CURATE" "knowledge-curate: dispatches source-curator via Task (matches cogni-research convention)"
+# Belt-and-braces: confirm the obsolete Skill(\"cogni-knowledge:source-curator\")
+# dispatch is not lingering. Agents live at agents/, not skills/.
+assert_not_grep 'Skill("cogni-knowledge:source-curator' "$CURATE" "knowledge-curate: no Skill('cogni-knowledge:source-curator) — agents go through Task"
+assert_grep 'Task' "$CURATE" "knowledge-curate: Task listed in allowed-tools"
 
 # --- knowledge-fetch SKILL.md --------------------------------------------
 FETCH="$PLUGIN_ROOT/skills/knowledge-fetch/SKILL.md"
@@ -69,9 +72,10 @@ fi
 assert_grep 'name: knowledge-fetch' "$FETCH" "knowledge-fetch: frontmatter name"
 assert_grep 'fetch_cache_max_age_days' "$FETCH" "knowledge-fetch: reads fetch_cache_max_age_days"
 assert_grep 'fetch-cache.py stat' "$FETCH" "knowledge-fetch: calls fetch-cache.py stat in summary"
-assert_grep 'source-fetcher' "$FETCH" "knowledge-fetch: dispatches source-fetcher agent"
+assert_grep 'Task(source-fetcher' "$FETCH" "knowledge-fetch: dispatches source-fetcher via Task"
 assert_grep 'fetch-manifest.json' "$FETCH" "knowledge-fetch: writes fetch-manifest.json"
-assert_grep 'cogni-knowledge:source-fetcher' "$FETCH" "knowledge-fetch: uses cogni-knowledge:source-fetcher namespace"
+assert_not_grep 'Skill("cogni-knowledge:source-fetcher' "$FETCH" "knowledge-fetch: no Skill('cogni-knowledge:source-fetcher) — agents go through Task"
+assert_grep 'Task' "$FETCH" "knowledge-fetch: Task listed in allowed-tools"
 
 # --- source-curator agent ------------------------------------------------
 CURATOR="$PLUGIN_ROOT/agents/source-curator.md"
@@ -81,6 +85,11 @@ if [ ! -f "$CURATOR" ]; then
 fi
 assert_grep 'name: source-curator' "$CURATOR" "source-curator: frontmatter name"
 assert_grep 'Forked from cogni-research/agents/source-curator.md at SHA' "$CURATOR" "source-curator: declares fork SHA in header"
+# Market config must route through the canonical workspace helper, NOT a
+# direct read of cogni-research/references/market-sources.json (preserves
+# the clean-break commitment past M11+ when cogni-research is archived).
+assert_grep 'get-market-config.py' "$CURATOR" "source-curator: routes market config through cogni-workspace helper"
+assert_not_grep 'cogni-research/references/market-sources.json' "$CURATOR" "source-curator: no direct read of cogni-research/references/market-sources.json"
 assert_grep 'candidates.json' "$CURATOR" "source-curator: emits to candidates.json contract"
 assert_grep 'sub_question_refs' "$CURATOR" "source-curator: emits sub_question_refs[]"
 assert_grep 'Do not emit' "$CURATOR" "source-curator: documents the drop-emission discipline"
@@ -115,6 +124,17 @@ if ! echo "$FETCHER_TOOLS_LINE" | grep -q WebSearch; then
   green "PASS: source-fetcher: frontmatter tools: does NOT include WebSearch (curator's job)"
 else
   red "FAIL: source-fetcher: frontmatter tools: must not include WebSearch"
+  red "  got: $FETCHER_TOOLS_LINE"
+  errors=$((errors + 1))
+fi
+# MCP cobrowse tools must be enumerated so the fallback path actually works
+# (plugin agents do not auto-inherit MCP tools when a tools: array is set —
+# confirmed against cogni-claims/agents/source-inspector which uses the same
+# mcp__claude-in-chrome__* names).
+if echo "$FETCHER_TOOLS_LINE" | grep -q 'mcp__claude-in-chrome__'; then
+  green "PASS: source-fetcher: frontmatter tools: enumerates claude-in-chrome MCP tools for cobrowse fallback"
+else
+  red "FAIL: source-fetcher: cobrowse fallback unreachable without MCP tools in tools: array"
   red "  got: $FETCHER_TOOLS_LINE"
   errors=$((errors + 1))
 fi


### PR DESCRIPTION
## Summary

- Lands milestones **M2-finish + M3 + M4** of the v0.1.0 inverted-pipeline clean break on top of PR #269's M1 + M2-script foundation. Plugin stays at `0.0.x` / maturity `incubating`; the maturity flip to Preview ships at M12 alongside the alpha re-run + 0.1.0 bump.
- New runtime path: `knowledge-plan` → `knowledge-curate` (dispatches `source-curator` × N) → `knowledge-fetch` (dispatches `source-fetcher` × N, writes through `fetch-cache.py`). Project-local at every phase — `binding.json` append still happens at M9 (`knowledge-finalize`).
- Clean-break invariant enforced: zero `cogni-research:` or `cogni-claims:` skill/agent dispatch in any new file (asserted by `tests/test_skill_contracts.sh`).
- `0.0.16` slot reserved for the alpha-re-run identifier; no released artefact ships under that tag.

## What landed

**M2-finish — `agents/source-fetcher.md`** (NEW; no upstream). Per-URL loop: `fetch-cache.py fetch` → WebFetch → cobrowse fallback (`claude-in-chrome` MCP) → `fetch-cache.py store` for both `ok` and `unavailable`. Closed `webfetch_error_class` vocabulary. Never decides to drop a URL — only records availability.

**M3 — `agents/source-curator.md`** (point-in-time fork of `cogni-research/agents/source-curator.md` at SHA `d2ee309`). Reshape: writes `candidates.json` (not `curated-sources.json`), `composite_score → score`, adds `tier` + `sub_question_refs[]`, drops emission of `dimensions{}` / `annotation` / `diversity{}`. Composite scoring weights `0.30/0.25/0.15/0.15/0.15` unchanged at fork time. WebSearch only — no WebFetch.

**M4 — three skills + one script**:
- `skills/knowledge-plan/SKILL.md` — Phase 1. Topic → 3-7 sub-questions + per-sub-question `candidate_domains[]` (no web). Creates `<knowledge-root>/<topic-slug>-<YYYY-MM-DD>/.metadata/plan.json` schema `0.1.0`.
- `skills/knowledge-curate/SKILL.md` — Phase 2 orchestrator. Reads `plan.json` + `binding.curator_defaults`, fans out one `source-curator` per sub-question (parallel ≤3, sequential otherwise), merges through `candidate-store.py append-batch`.
- `skills/knowledge-fetch/SKILL.md` — Phase 3 orchestrator. Reads `candidates.json` + `binding.curator_defaults.fetch_cache_max_age_days`, builds batches (default 8 URLs sorted by `fetch_priority`), dispatches `source-fetcher` per batch. `--tier` flag scopes by priority. Non-blocking warning when unavailable rate > 30%.
- `scripts/candidate-store.py` — stdlib, file-locked (`fcntl.flock`) merge of parallel curator batches. Subcommands `init` / `append-batch` / `read`. Dedup by URL-normalized form (lowercase scheme+host, trailing-slash-stripped, `utm_*` / `ref` / `fbclid` / `gclid` params dropped). On collision: higher score wins, earliest `discovered_at` wins, `sub_question_refs[]` unioned, `tier` + `fetch_priority` recomputed.

**Tests** (2 new files, 12 total in `cogni-knowledge/tests/`):
- `test_candidate_store.sh` — 8 assertions including concurrent-append correctness.
- `test_skill_contracts.sh` — grep-based contract assertions for the 6 new SKILL.md/agent.md files + clean-break invariant.

**Docs**:
- `CLAUDE.md` — Skills table (+3 rows), new **Agents** section (cogni-knowledge has an `agents/` dir for the first time at v0.0.17), Scripts table (+`fetch-cache.py`, +`candidate-store.py`), "Future phases" rewritten to delegate the milestone narrative to `references/absorption-roadmap.md` with a current progress pointer.
- `CHANGELOG.md` — `0.0.17` entry; explains the `0.0.16` slot reservation.

## Out of scope (deferred to next slice)

- **M5** — `claim-extractor` fork + `source-ingester` agent.
- **M6** — `knowledge-ingest` skill (now unblocked by cogni-wiki 0.0.44's `type: source` allowlist).
- **M7-M12** — composer, verifier (+ `revisor` fork per PR #269 review), finalize, query/dashboard/refresh rebuild on new manifests, archive of legacy skills, alpha re-run, version bump to 0.1.0, maturity flip.
- doc-audit sweep (M11).

## Test plan

- [x] `for t in cogni-knowledge/tests/test_*.sh; do bash "$t" || exit 1; done` — all 12 pass (10 existing + 2 new).
- [x] `bash cogni-workspace/scripts/check-skill-names.sh` — OK.
- [x] Clean-break invariant: `grep -E 'Skill\("?cogni-(research|claims):' agents/*.md skills/knowledge-{plan,curate,fetch}/SKILL.md` returns no matches (also asserted by `test_skill_contracts.sh`).
- [ ] **Manual end-to-end smoke** (recommended before merge; see plan file `/root/.claude/plans/here-is-a-draft-moonlit-goose.md` §Verification for the 7-step recipe — `knowledge-setup` → `knowledge-plan` on a GDPR topic → `knowledge-curate` → `knowledge-fetch` → re-run for cache-hit verification → inject 404 for unavailable-handling → confirm cache stats).

https://claude.ai/code/session_012mpGbRjN8S59hKBV1q2THh

---
_Generated by [Claude Code](https://claude.ai/code/session_012mpGbRjN8S59hKBV1q2THh)_