### PR TITLE
cogni-knowledge 0.0.18: extract _knowledge_lib.py (closes #272, #273)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -277,7 +277,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "maturity": "incubating",
       "description": "Wiki-first research that compounds. Binds a cogni-research project to a cogni-wiki knowledge base so every research run deposits into the same persistent, queryable, interlinked markdown wiki — and so future runs read what previous runs filed instead of starting from zero. Thin orchestrator over cogni-research and cogni-wiki; no forked agents, no duplicated scripts. The differentiator vs. one-shot deep-research tools (OpenAI Deep Research, Perplexity Spaces, GPT Researcher) is the binding: knowledge accumulates across projects instead of dying in chat history.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Wiki-first research that compounds. Binds a cogni-research project to a cogni-wiki knowledge base so every research run deposits into the same persistent, queryable, interlinked markdown wiki — and so future runs read what previous runs filed instead of starting from zero. Thin orchestrator over cogni-research and cogni-wiki; no forked agents, no duplicated scripts. The differentiator vs. one-shot deep-research tools (OpenAI Deep Research, Perplexity Spaces, GPT Researcher) is the binding: knowledge accumulates across projects instead of dying in chat history.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/CHANGELOG.md
+++ b/cogni-knowledge/CHANGELOG.md
@@ -1,8 +1,35 @@
 # cogni-knowledge changelog
 
+## 0.0.18 — 2026-05-21
+
+### Changed
+
+- `scripts/_knowledge_lib.py` — NEW. Extracts the `normalize_url` +
+  `_STRIP_QUERY_*` + `atomic_write` helpers previously duplicated across
+  `candidate-store.py` and `fetch-cache.py`. Closes #272. The extraction was
+  scheduled for M5 (`source-ingester` as the third caller); landed early
+  because the two existing callers had already started style-drifting on
+  `normalize_url`. Single source of truth for URL identity in the inverted
+  pipeline — the dedup-key contract between curator-side merge and
+  fetcher-side cache lookup is now structural rather than convention.
+- `scripts/candidate-store.py`, `scripts/fetch-cache.py` — now import the
+  shared helpers from `_knowledge_lib`; `_atomic_write` call sites renamed
+  in-place to the public `atomic_write`. No behavioural change.
+- `tests/test_knowledge_lib.sh` — NEW. Three-way `is`-identity assertion
+  between `candidate-store`, `fetch-cache`, and `_knowledge_lib`
+  `normalize_url` / `atomic_write`; behavioural canonicalization sanity
+  check across a representative URL; `atomic_write` round-trip plus
+  no-leftover-`.tmp` assertion.
+
+### Notes
+
+- `knowledge-binding.py:_write_binding` shares the same atomic-write pattern
+  but a different signature (takes `knowledge_root`, resolves the binding
+  path internally). Not extracted in this slice — possible follow-up.
+
 ## 0.0.17 — 2026-05-20
 
-Phase 5 milestones M2-finish + M3 + M4 — the `plan → curate → fetch` chain of the v0.1.0 inverted pipeline. PR #269 (M1 + M2-script) shipped the foundation without a version bump; this release surfaces the first user-visible inverted-pipeline skills. Plugin stays at `0.0.x`/maturity `incubating` per the absorption-roadmap M-table — the maturity flip to Preview ships at M12 alongside the alpha re-run + 0.1.0 bump. The `0.0.16` slot is reserved for the alpha-re-run measurement record referenced in `references/alpha-findings.md` and the `knowledge-binding.py` comment block; no released artefact ships under that tag.
+Phase 5 milestones M2-finish + M3 + M4 — the `plan → curate → fetch` chain of the v0.1.0 inverted pipeline. PR #269 (M1 + M2-script) shipped the foundation without a version bump; this release surfaces the first user-visible inverted-pipeline skills. Plugin stays at `0.0.x`/maturity `incubating` per the absorption-roadmap M-table — the maturity flip to Preview ships at M12 alongside the alpha re-run + 0.1.0 bump. The `0.0.16` slot is reserved for the alpha-re-run measurement record referenced in `references/alpha-findings.md` and the `knowledge-binding.py` comment block; no source code shipped under that version. The annotated git tag `cogni-knowledge-v0.0.16-alpha-measurement` at commit `f6c9d24e` marks the measurement record so the version timeline reads linearly. Closes #273.
 
 ### Added
 

--- a/cogni-knowledge/scripts/_knowledge_lib.py
+++ b/cogni-knowledge/scripts/_knowledge_lib.py
@@ -9,17 +9,6 @@ must agree byte-for-byte on the canonical form of any URL — otherwise the
 curator-side dedup and the fetch-cache hit/miss decision drift, and a URL
 present in `candidates.json` can silently miss in the cache (or vice versa).
 
-Before this module existed, `normalize_url` + the `_STRIP_QUERY_*` constants
-+ the `tempfile.mkstemp + os.replace` atomic-write pattern were duplicated
-across both scripts. The copies had already started style-drifting on
-`normalize_url`. The deferred extraction was originally scheduled for M5
-(`source-ingester` as a third caller); landed early at v0.0.18 to close
-the divergence before it became behavioural.
-
-`knowledge-binding.py:_write_binding` shares the same atomic-write pattern
-but a different signature (takes `knowledge_root`, resolves the binding
-path internally). Not extracted here — possible follow-up.
-
 stdlib-only. Python 3.8+.
 """
 

--- a/cogni-knowledge/scripts/_knowledge_lib.py
+++ b/cogni-knowledge/scripts/_knowledge_lib.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+_knowledge_lib.py — shared primitives for cogni-knowledge scripts.
+
+Single source of truth for URL identity in the v0.1.0 inverted pipeline.
+`candidate-store.py` (curator-side merge into `candidates.json`) and
+`fetch-cache.py` (fetcher-side cache lookup keyed by `sha256(normalize_url(url))`)
+must agree byte-for-byte on the canonical form of any URL — otherwise the
+curator-side dedup and the fetch-cache hit/miss decision drift, and a URL
+present in `candidates.json` can silently miss in the cache (or vice versa).
+
+Before this module existed, `normalize_url` + the `_STRIP_QUERY_*` constants
++ the `tempfile.mkstemp + os.replace` atomic-write pattern were duplicated
+across both scripts. The copies had already started style-drifting on
+`normalize_url`. The deferred extraction was originally scheduled for M5
+(`source-ingester` as a third caller); landed early at v0.0.18 to close
+the divergence before it became behavioural.
+
+`knowledge-binding.py:_write_binding` shares the same atomic-write pattern
+but a different signature (takes `knowledge_root`, resolves the binding
+path internally). Not extracted here — possible follow-up.
+
+stdlib-only. Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
+
+# Tracking-param prefixes/names stripped during URL normalization. Covers
+# the common cases seen in EU regulatory crawls; conservative on purpose —
+# only well-known tracking params are dropped to avoid breaking URLs that
+# rely on a query string for content identity.
+_STRIP_QUERY_PREFIXES = ("utm_",)
+_STRIP_QUERY_EXACT = frozenset({"ref", "fbclid", "gclid"})
+
+
+def normalize_url(url: str) -> str:
+    """Canonicalize a URL for dedup purposes.
+
+    - Lowercase scheme + host (path case preserved — RFC 3986 §6.2.2.1).
+    - Strip trailing `/` from path unless the path is just `/`.
+    - Drop query params whose name starts with any _STRIP_QUERY_PREFIXES
+      or is in _STRIP_QUERY_EXACT. Remaining params keep their order.
+    - Drop fragment.
+
+    Whitespace-only or empty input returns the input unchanged so callers
+    surface the bad value rather than silently coalescing distinct entries.
+    """
+    if not url or not url.strip():
+        return url
+    parts = urlsplit(url.strip())
+    scheme = parts.scheme.lower()
+    netloc = parts.netloc.lower()
+    path = parts.path
+    if path.endswith("/") and path != "/":
+        path = path.rstrip("/")
+    kept = [
+        (k, v)
+        for k, v in parse_qsl(parts.query, keep_blank_values=True)
+        if not (k.startswith(_STRIP_QUERY_PREFIXES) or k in _STRIP_QUERY_EXACT)
+    ]
+    query = urlencode(kept)
+    return urlunsplit((scheme, netloc, path, query, ""))
+
+
+def atomic_write(path: Path, payload: dict) -> Path:
+    """Atomically write `payload` as pretty-printed JSON to `path`.
+
+    `tempfile.mkstemp` so two concurrent writers to the same target cannot
+    collide on a predictable `.tmp` suffix; `os.replace` for the atomic
+    swap; tmp-file unlink on exception so failures don't leave debris.
+    The temp file lives in the same directory as the target so the
+    `os.replace` cannot cross devices.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, ensure_ascii=False)
+            fh.write("\n")
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    return path

--- a/cogni-knowledge/scripts/candidate-store.py
+++ b/cogni-knowledge/scripts/candidate-store.py
@@ -45,8 +45,6 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _knowledge_lib import (  # noqa: E402
-    _STRIP_QUERY_EXACT,
-    _STRIP_QUERY_PREFIXES,
     atomic_write,
     normalize_url,
 )

--- a/cogni-knowledge/scripts/candidate-store.py
+++ b/cogni-knowledge/scripts/candidate-store.py
@@ -40,12 +40,16 @@ import argparse
 import datetime as _dt
 import fcntl
 import json
-import os
-import re
 import sys
-import tempfile
 from pathlib import Path
-from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _knowledge_lib import (  # noqa: E402
+    _STRIP_QUERY_EXACT,
+    _STRIP_QUERY_PREFIXES,
+    atomic_write,
+    normalize_url,
+)
 
 SCHEMA_VERSION = "0.1.0"
 CANDIDATES_FILENAME = "candidates.json"
@@ -57,13 +61,6 @@ METADATA_DIRNAME = ".metadata"
 # `cogni-knowledge/agents/source-curator.md` Phase 3.
 TIER_PRIMARY_MIN = 0.80
 TIER_SECONDARY_MIN = 0.50
-
-# Tracking-param prefixes/names stripped during URL normalization. Covers
-# the common cases seen in EU regulatory crawls; conservative on purpose —
-# only well-known tracking params are dropped to avoid breaking URLs that
-# rely on a query string for content identity.
-_STRIP_QUERY_PREFIXES = ("utm_",)
-_STRIP_QUERY_EXACT = frozenset({"ref", "fbclid", "gclid"})
 
 
 def _emit(success: bool, data: dict | None = None, error: str = "") -> int:
@@ -88,35 +85,6 @@ def _lock_path(project_path: Path) -> Path:
     return _metadata_dir(project_path) / (CANDIDATES_FILENAME + LOCK_SUFFIX)
 
 
-def normalize_url(url: str) -> str:
-    """Canonicalize a URL for dedup purposes.
-
-    - Lowercase scheme + host (path case preserved — RFC 3986 §6.2.2.1).
-    - Strip trailing `/` from path unless the path is just `/`.
-    - Drop query params whose name starts with any _STRIP_QUERY_PREFIXES
-      or is in _STRIP_QUERY_EXACT. Remaining params keep their order.
-    - Drop fragment.
-
-    Whitespace-only or empty input returns the input unchanged so callers
-    surface the bad value rather than silently coalescing distinct entries.
-    """
-    if not url or not url.strip():
-        return url
-    parts = urlsplit(url.strip())
-    scheme = parts.scheme.lower()
-    netloc = parts.netloc.lower()
-    path = parts.path
-    if path.endswith("/") and path != "/":
-        path = path.rstrip("/")
-    kept = [
-        (k, v)
-        for k, v in parse_qsl(parts.query, keep_blank_values=True)
-        if not (k.startswith(_STRIP_QUERY_PREFIXES) or k in _STRIP_QUERY_EXACT)
-    ]
-    query = urlencode(kept)
-    return urlunsplit((scheme, netloc, path, query, ""))
-
-
 def _tier_for(score: float) -> str:
     if score >= TIER_PRIMARY_MIN:
         return "primary"
@@ -139,23 +107,6 @@ def _recompute_priorities(candidates: list[dict]) -> None:
     )
     for new_priority, (_orig_idx, entry) in enumerate(indexed, start=1):
         entry["fetch_priority"] = new_priority
-
-
-def _atomic_write(path: Path, payload: dict) -> Path:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump(payload, fh, indent=2, ensure_ascii=False)
-            fh.write("\n")
-        os.replace(tmp, path)
-    except Exception:
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
-    return path
 
 
 def _empty_payload() -> dict:
@@ -222,7 +173,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     try:
         existing = json.loads(target.read_text(encoding="utf-8"))
     except FileNotFoundError:
-        _atomic_write(target, _empty_payload())
+        atomic_write(target, _empty_payload())
         return _emit(True, data={"path": str(target), "candidates_count": 0, "created": True})
     except json.JSONDecodeError as exc:
         return _emit(False, error=f"existing candidates.json is malformed: {exc}")
@@ -315,7 +266,7 @@ def cmd_append_batch(args: argparse.Namespace) -> int:
                     added += 1
 
             _recompute_priorities(existing)
-            _atomic_write(target, payload)
+            atomic_write(target, payload)
         finally:
             fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
 

--- a/cogni-knowledge/scripts/fetch-cache.py
+++ b/cogni-knowledge/scripts/fetch-cache.py
@@ -34,11 +34,14 @@ import argparse
 import datetime as _dt
 import hashlib
 import json
-import os
 import sys
-import tempfile
 from pathlib import Path
-from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _knowledge_lib import (  # noqa: E402
+    atomic_write,
+    normalize_url,
+)
 
 SCHEMA_VERSION = "0.1.0"
 FETCH_CACHE_DIRNAME = "fetch-cache"
@@ -49,12 +52,6 @@ BINDING_DIRNAME = ".cogni-knowledge"
 # coordinating an additive change there.
 VALID_FETCH_METHODS = {"webfetch", "cobrowse_interactive"}
 VALID_STATUSES = {"ok", "unavailable"}
-# Kept in sync with candidate-store.py:_STRIP_QUERY_*. Duplicated here so
-# candidates.json dedup and fetch-cache lookup land on the same key for
-# semantically identical URLs. The deferred _knowledge_lib.py extraction
-# will collapse the two copies.
-_STRIP_QUERY_PREFIXES = ("utm_",)
-_STRIP_QUERY_EXACT = frozenset({"ref", "fbclid", "gclid"})
 
 
 def _emit(success: bool, data: dict | None = None, error: str = "") -> int:
@@ -71,23 +68,6 @@ def _cache_dir(knowledge_root: Path) -> Path:
     return knowledge_root / BINDING_DIRNAME / FETCH_CACHE_DIRNAME
 
 
-def normalize_url(url: str) -> str:
-    if not url or not url.strip():
-        return url
-    parts = urlsplit(url.strip())
-    scheme = parts.scheme.lower()
-    netloc = parts.netloc.lower()
-    path = parts.path
-    if path.endswith("/") and path != "/":
-        path = path.rstrip("/")
-    kept = [
-        (k, v)
-        for k, v in parse_qsl(parts.query, keep_blank_values=True)
-        if not (k.startswith(_STRIP_QUERY_PREFIXES) or k in _STRIP_QUERY_EXACT)
-    ]
-    return urlunsplit((scheme, netloc, path, urlencode(kept), ""))
-
-
 def _url_key(url: str) -> str:
     return hashlib.sha256(normalize_url(url).encode("utf-8")).hexdigest()
 
@@ -98,26 +78,6 @@ def _entry_path(knowledge_root: Path, url: str) -> Path:
 
 def _content_hash(body: str) -> str:
     return "sha256:" + hashlib.sha256(body.encode("utf-8")).hexdigest()
-
-
-def _atomic_write(path: Path, payload: dict) -> Path:
-    # Mirrors cogni-wiki/_wikilib.atomic_write semantics — tempfile.mkstemp
-    # so two concurrent writers to the same URL cannot collide on a
-    # predictable `.tmp` suffix, and the temp file is unlinked on exception.
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump(payload, fh, indent=2, ensure_ascii=False)
-            fh.write("\n")
-        os.replace(tmp, path)
-    except Exception:
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
-    return path
 
 
 def _parse_iso(stamp: str) -> _dt.datetime | None:
@@ -178,7 +138,7 @@ def cmd_store(args: argparse.Namespace) -> int:
 
     target = _entry_path(knowledge_root, args.url)
     try:
-        _atomic_write(target, payload)
+        atomic_write(target, payload)
     except (FileNotFoundError, NotADirectoryError) as exc:
         return _emit(False, error=f"knowledge_root is not a usable directory: {exc}")
     return _emit(

--- a/cogni-knowledge/tests/test_knowledge_lib.sh
+++ b/cogni-knowledge/tests/test_knowledge_lib.sh
@@ -38,85 +38,10 @@ done
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 
-errors=0
-
-# 1. Three-way identity of the shared symbols.
-if python3 - "$SCRIPTS_DIR" <<'PY'
-import importlib.util
-import sys
-from pathlib import Path
-
-scripts = Path(sys.argv[1])
-
-def load(name, fname):
-    spec = importlib.util.spec_from_file_location(name, scripts / fname)
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[name] = mod
-    spec.loader.exec_module(mod)
-    return mod
-
-kl = load("_knowledge_lib", "_knowledge_lib.py")
-cs = load("candidate_store", "candidate-store.py")
-fc = load("fetch_cache", "fetch-cache.py")
-
-assert cs.normalize_url is fc.normalize_url is kl.normalize_url, (
-    "normalize_url identities diverge: cs=%r fc=%r kl=%r"
-    % (cs.normalize_url, fc.normalize_url, kl.normalize_url)
-)
-assert cs.atomic_write is fc.atomic_write is kl.atomic_write, (
-    "atomic_write identities diverge: cs=%r fc=%r kl=%r"
-    % (cs.atomic_write, fc.atomic_write, kl.atomic_write)
-)
-print("OK")
-PY
-then
-  green "PASS: three-way identity — normalize_url and atomic_write are the same objects in candidate-store, fetch-cache, _knowledge_lib"
-else
-  red "FAIL: identity check broke"
-  errors=$((errors + 1))
-fi
-
-# 2. Behavioural canonicalization: a URL exercising every transformation
-#    must produce the same canonical form from all three callers.
-if python3 - "$SCRIPTS_DIR" <<'PY'
-import importlib.util
-import sys
-from pathlib import Path
-
-scripts = Path(sys.argv[1])
-
-def load(name, fname):
-    spec = importlib.util.spec_from_file_location(name, scripts / fname)
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[name] = mod
-    spec.loader.exec_module(mod)
-    return mod
-
-kl = load("_knowledge_lib", "_knowledge_lib.py")
-cs = load("candidate_store", "candidate-store.py")
-fc = load("fetch_cache", "fetch-cache.py")
-
-url = "https://EXAMPLE.org/Foo/?utm_source=x&ref=y&keep=1#frag"
-expected = "https://example.org/Foo?keep=1"
-
-got_kl = kl.normalize_url(url)
-got_cs = cs.normalize_url(url)
-got_fc = fc.normalize_url(url)
-
-assert got_kl == expected, ("_knowledge_lib", got_kl, expected)
-assert got_cs == expected, ("candidate-store", got_cs, expected)
-assert got_fc == expected, ("fetch-cache", got_fc, expected)
-print("OK")
-PY
-then
-  green "PASS: canonicalization — scheme/host lowercased, trailing slash stripped, utm_+ref dropped, fragment removed, path case preserved"
-else
-  red "FAIL: canonicalization mismatch"
-  errors=$((errors + 1))
-fi
-
-# 3. atomic_write round-trip + no `.tmp` debris on success.
-if python3 - "$SCRIPTS_DIR" "$WORK" <<'PY'
+# Run all three assertions in one python3 subprocess; emit a tagged status
+# line per assertion so bash can grade each independently. Splitting into
+# three subprocesses would re-import the same three modules each time.
+OUT=$(python3 - "$SCRIPTS_DIR" "$WORK" <<'PY'
 import importlib.util
 import json
 import sys
@@ -125,31 +50,85 @@ from pathlib import Path
 scripts = Path(sys.argv[1])
 work = Path(sys.argv[2])
 
-spec = importlib.util.spec_from_file_location("_knowledge_lib", scripts / "_knowledge_lib.py")
-kl = importlib.util.module_from_spec(spec)
-sys.modules["_knowledge_lib"] = kl
-spec.loader.exec_module(kl)
 
-target = work / "out" / "payload.json"
-payload = {"schema_version": "0.1.0", "candidates": [{"url": "https://example.org/a", "score": 0.42}]}
-returned = kl.atomic_write(target, payload)
+def load(name, fname):
+    spec = importlib.util.spec_from_file_location(name, scripts / fname)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
 
-assert returned == target, (returned, target)
-assert target.is_file(), target
 
-readback = json.loads(target.read_text(encoding="utf-8"))
-assert readback == payload, (readback, payload)
+def check(tag, fn):
+    try:
+        fn()
+        print(f"{tag}: OK")
+    except AssertionError as exc:
+        print(f"{tag}: FAIL {exc}")
 
-leftover = [p.name for p in target.parent.iterdir() if p.name.startswith(".payload.json.") and p.name.endswith(".tmp")]
-assert leftover == [], leftover
-print("OK")
+
+kl = load("_knowledge_lib", "_knowledge_lib.py")
+cs = load("candidate_store", "candidate-store.py")
+fc = load("fetch_cache", "fetch-cache.py")
+
+
+def assert_identity():
+    assert cs.normalize_url is fc.normalize_url is kl.normalize_url, (
+        f"normalize_url identities diverge: cs={cs.normalize_url!r} "
+        f"fc={fc.normalize_url!r} kl={kl.normalize_url!r}"
+    )
+    assert cs.atomic_write is fc.atomic_write is kl.atomic_write, (
+        f"atomic_write identities diverge: cs={cs.atomic_write!r} "
+        f"fc={fc.atomic_write!r} kl={kl.atomic_write!r}"
+    )
+
+
+def assert_canonicalization():
+    url = "https://EXAMPLE.org/Foo/?utm_source=x&ref=y&keep=1#frag"
+    expected = "https://example.org/Foo?keep=1"
+    for tag, mod in (("_knowledge_lib", kl), ("candidate-store", cs), ("fetch-cache", fc)):
+        got = mod.normalize_url(url)
+        assert got == expected, f"{tag}: got={got!r} expected={expected!r}"
+
+
+def assert_atomic_write_roundtrip():
+    target = work / "out" / "payload.json"
+    payload = {"schema_version": "0.1.0", "candidates": [{"url": "https://example.org/a", "score": 0.42}]}
+    returned = kl.atomic_write(target, payload)
+    assert returned == target, (returned, target)
+    assert target.is_file(), target
+    readback = json.loads(target.read_text(encoding="utf-8"))
+    assert readback == payload, (readback, payload)
+    leftover = [
+        p.name for p in target.parent.iterdir()
+        if p.name.startswith(".payload.json.") and p.name.endswith(".tmp")
+    ]
+    assert leftover == [], leftover
+
+
+check("identity", assert_identity)
+check("canonicalization", assert_canonicalization)
+check("atomic_write_roundtrip", assert_atomic_write_roundtrip)
 PY
-then
-  green "PASS: atomic_write round-trips payload and leaves no .tmp debris"
-else
-  red "FAIL: atomic_write round-trip"
-  errors=$((errors + 1))
-fi
+)
+
+errors=0
+
+grade() {
+  local tag="$1" description="$2"
+  local line
+  line=$(printf '%s\n' "$OUT" | grep "^${tag}:" || true)
+  case "$line" in
+    "${tag}: OK")     green "PASS: $description" ;;
+    "${tag}: FAIL "*) red   "FAIL: $description"; red "  ${line#${tag}: FAIL }"; errors=$((errors + 1)) ;;
+    *)                red   "FAIL: $description (no result line for '$tag' — python subprocess crashed?)"
+                      red   "  output: $OUT"; errors=$((errors + 1)) ;;
+  esac
+}
+
+grade identity                "three-way identity — normalize_url and atomic_write are the same objects in candidate-store, fetch-cache, _knowledge_lib"
+grade canonicalization        "canonicalization — scheme/host lowercased, trailing slash stripped, utm_+ref dropped, fragment removed, path case preserved"
+grade atomic_write_roundtrip  "atomic_write round-trips payload and leaves no .tmp debris"
 
 if [ $errors -gt 0 ]; then
   red "$errors case(s) failed."

--- a/cogni-knowledge/tests/test_knowledge_lib.sh
+++ b/cogni-knowledge/tests/test_knowledge_lib.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# test_knowledge_lib.sh — contract test for the shared _knowledge_lib.py.
+#
+# Asserts:
+#   1. Three-way `is`-identity: candidate-store.normalize_url,
+#      fetch-cache.normalize_url, and _knowledge_lib.normalize_url are the
+#      same function object. Same for atomic_write. This is the structural
+#      guarantee that the dedup-key contract between the curator-side merge
+#      (candidates.json) and the fetcher-side cache lookup (fetch-cache)
+#      cannot drift — it isn't a convention, it's the same function.
+#   2. Behavioural canonicalization: a representative URL exercising every
+#      transformation (mixed-case scheme/host, trailing slash, utm_/ref
+#      stripping, fragment removal) yields the same canonical form across
+#      all three callers.
+#   3. atomic_write round-trip: a payload writes, reads back equal, and
+#      leaves no `.tmp` debris in the parent directory on success.
+#
+# Script names contain hyphens (candidate-store, fetch-cache), which means
+# plain `import candidate-store` is invalid Python. Tests load the modules
+# by path via importlib.util.spec_from_file_location.
+#
+# bash 3.2 + stdlib python3 only.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPTS_DIR="$PLUGIN_ROOT/scripts"
+
+. "$(dirname "$0")/fixtures/test_helpers.sh"
+
+for f in _knowledge_lib.py candidate-store.py fetch-cache.py; do
+  if [ ! -f "$SCRIPTS_DIR/$f" ]; then
+    red "FAIL: $f not found at $SCRIPTS_DIR/$f"
+    exit 1
+  fi
+done
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+errors=0
+
+# 1. Three-way identity of the shared symbols.
+if python3 - "$SCRIPTS_DIR" <<'PY'
+import importlib.util
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+
+def load(name, fname):
+    spec = importlib.util.spec_from_file_location(name, scripts / fname)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+kl = load("_knowledge_lib", "_knowledge_lib.py")
+cs = load("candidate_store", "candidate-store.py")
+fc = load("fetch_cache", "fetch-cache.py")
+
+assert cs.normalize_url is fc.normalize_url is kl.normalize_url, (
+    "normalize_url identities diverge: cs=%r fc=%r kl=%r"
+    % (cs.normalize_url, fc.normalize_url, kl.normalize_url)
+)
+assert cs.atomic_write is fc.atomic_write is kl.atomic_write, (
+    "atomic_write identities diverge: cs=%r fc=%r kl=%r"
+    % (cs.atomic_write, fc.atomic_write, kl.atomic_write)
+)
+print("OK")
+PY
+then
+  green "PASS: three-way identity — normalize_url and atomic_write are the same objects in candidate-store, fetch-cache, _knowledge_lib"
+else
+  red "FAIL: identity check broke"
+  errors=$((errors + 1))
+fi
+
+# 2. Behavioural canonicalization: a URL exercising every transformation
+#    must produce the same canonical form from all three callers.
+if python3 - "$SCRIPTS_DIR" <<'PY'
+import importlib.util
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+
+def load(name, fname):
+    spec = importlib.util.spec_from_file_location(name, scripts / fname)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+kl = load("_knowledge_lib", "_knowledge_lib.py")
+cs = load("candidate_store", "candidate-store.py")
+fc = load("fetch_cache", "fetch-cache.py")
+
+url = "https://EXAMPLE.org/Foo/?utm_source=x&ref=y&keep=1#frag"
+expected = "https://example.org/Foo?keep=1"
+
+got_kl = kl.normalize_url(url)
+got_cs = cs.normalize_url(url)
+got_fc = fc.normalize_url(url)
+
+assert got_kl == expected, ("_knowledge_lib", got_kl, expected)
+assert got_cs == expected, ("candidate-store", got_cs, expected)
+assert got_fc == expected, ("fetch-cache", got_fc, expected)
+print("OK")
+PY
+then
+  green "PASS: canonicalization — scheme/host lowercased, trailing slash stripped, utm_+ref dropped, fragment removed, path case preserved"
+else
+  red "FAIL: canonicalization mismatch"
+  errors=$((errors + 1))
+fi
+
+# 3. atomic_write round-trip + no `.tmp` debris on success.
+if python3 - "$SCRIPTS_DIR" "$WORK" <<'PY'
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+work = Path(sys.argv[2])
+
+spec = importlib.util.spec_from_file_location("_knowledge_lib", scripts / "_knowledge_lib.py")
+kl = importlib.util.module_from_spec(spec)
+sys.modules["_knowledge_lib"] = kl
+spec.loader.exec_module(kl)
+
+target = work / "out" / "payload.json"
+payload = {"schema_version": "0.1.0", "candidates": [{"url": "https://example.org/a", "score": 0.42}]}
+returned = kl.atomic_write(target, payload)
+
+assert returned == target, (returned, target)
+assert target.is_file(), target
+
+readback = json.loads(target.read_text(encoding="utf-8"))
+assert readback == payload, (readback, payload)
+
+leftover = [p.name for p in target.parent.iterdir() if p.name.startswith(".payload.json.") and p.name.endswith(".tmp")]
+assert leftover == [], leftover
+print("OK")
+PY
+then
+  green "PASS: atomic_write round-trips payload and leaves no .tmp debris"
+else
+  red "FAIL: atomic_write round-trip"
+  errors=$((errors + 1))
+fi
+
+if [ $errors -gt 0 ]; then
+  red "$errors case(s) failed."
+  exit 1
+fi
+
+green ""
+green "All _knowledge_lib.py cases pass."


### PR DESCRIPTION
## Summary

- **#272** — Extract the duplicated `normalize_url` + `_STRIP_QUERY_*` + atomic-write helpers from `candidate-store.py` and `fetch-cache.py` into a new `cogni-knowledge/scripts/_knowledge_lib.py`. The two `normalize_url` bodies had already started style-drifting (one binds `query = urlencode(kept)`, the other inlines it); the dedup-key contract between the curator-side merge into `candidates.json` and the fetch-cache lookup key depends on byte-for-byte identity, so extraction is now structural rather than convention. New `tests/test_knowledge_lib.sh` asserts three-way `is`-identity of the shared symbols, behavioural canonicalization, and `atomic_write` round-trip.
- **#273** — Annotated tag `cogni-knowledge-v0.0.16-alpha-measurement` created locally at commit `f6c9d24e` (Phase 4 alpha re-run GO decision). Remote tag push returned HTTP 403 from this environment's proxy — **the tag needs to be pushed from a local terminal**: `git fetch && git push origin cogni-knowledge-v0.0.16-alpha-measurement` (or recreate the tag locally at `f6c9d24e` if the local clone doesn't have it). CHANGELOG sentence in the v0.0.17 entry already updated to reference the tag.
- Version bumps: `0.0.17 → 0.0.18` in both `cogni-knowledge/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.

Net diff: +268 / −109 across 7 files; the script changes are a net deletion because the duplicated helpers collapse to one shared module.

Two commits:
1. `7fe78e1` — the extraction, callers, contract test, CHANGELOG, version bumps.
2. `aa7c26b` — `/code-review` follow-ups: trimmed extraction-history narrative from the new module's docstring (belongs in CHANGELOG); consolidated the contract test's 3 subprocesses into 1 with a per-assertion grading helper (3× faster, surfaces failure detail).

`knowledge-binding.py:_write_binding` shares the same atomic-write pattern but takes `knowledge_root` (different signature) — deliberately left untouched this round; flagged in CHANGELOG Notes as a possible follow-up.

## Test plan

- [x] `bash cogni-knowledge/tests/test_candidate_store.sh` — all pass (regression)
- [x] `bash cogni-knowledge/tests/test_fetch_cache.sh` — all pass (regression, including the cross-caller key-equality assertion at line 335 that this change makes structural)
- [x] `bash cogni-knowledge/tests/test_knowledge_lib.sh` — 3/3 pass in ~75ms
- [x] Full suite: `for t in cogni-knowledge/tests/test_*.sh; do bash "$t"; done` — 13/13 pass
- [x] Smoke: `python3 cogni-knowledge/scripts/candidate-store.py init --project-path /tmp/_kn_smoke` returns `success: true`; catches sys.path import-shim regressions
- [x] Smoke: `python3 cogni-knowledge/scripts/fetch-cache.py key --url "https://EXAMPLE.org/foo/?utm_source=x" --bare` returns the sha256 of the normalized URL
- [x] CHANGELOG sanity: v0.0.17 paragraph no longer says "no released artefact ships under that tag"; v0.0.18 entry closes #272
- [ ] **Maintainer action required:** push `cogni-knowledge-v0.0.16-alpha-measurement` to origin from a local terminal (remote push blocked from this environment)

https://claude.ai/code/session_017vf7NSWRBfbaGjx9sJzDqo

---
_Generated by [Claude Code](https://claude.ai/code/session_017vf7NSWRBfbaGjx9sJzDqo)_