### PR TITLE
cogni-knowledge 0.0.21: source-fetcher PDF Read-loop past page 20 (closes #278)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -277,7 +277,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "maturity": "incubating",
       "description": "Wiki-first research that compounds. Binds a cogni-research project to a cogni-wiki knowledge base so every research run deposits into the same persistent, queryable, interlinked markdown wiki — and so future runs read what previous runs filed instead of starting from zero. Thin orchestrator over cogni-research and cogni-wiki; no forked agents, no duplicated scripts. The differentiator vs. one-shot deep-research tools (OpenAI Deep Research, Perplexity Spaces, GPT Researcher) is the binding: knowledge accumulates across projects instead of dying in chat history.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Wiki-first research that compounds. Binds a cogni-research project to a cogni-wiki knowledge base so every research run deposits into the same persistent, queryable, interlinked markdown wiki — and so future runs read what previous runs filed instead of starting from zero. Thin orchestrator over cogni-research and cogni-wiki; no forked agents, no duplicated scripts. The differentiator vs. one-shot deep-research tools (OpenAI Deep Research, Perplexity Spaces, GPT Researcher) is the binding: knowledge accumulates across projects instead of dying in chat history.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/CHANGELOG.md
+++ b/cogni-knowledge/CHANGELOG.md
@@ -1,5 +1,19 @@
 # cogni-knowledge changelog
 
+## 0.0.21 — 2026-05-21
+
+`source-fetcher` Step 2 PDF branch now reads PDFs past page 20. Resolves F18 from the v0.0.20 M5+M6 smoke (issue #278). Single-file behaviour change in the agent contract plus a contract-test assertion; no script or schema changes.
+
+### Changed
+
+- `agents/source-fetcher.md` — Step 2 PDF branch loops `Read` over the saved PDF in 20-page windows (`"1-20"`, `"21-40"`, `"41-60"`, …) until either an empty page range is returned (end of PDF) or a 200-page hard cap fires (cost guard — Read transcribes PDFs via vision-rendered images, scaling linearly with pages). Concatenates per-window text into one body before `fetch-cache.py store`. The per-batch `fetched[]` entry now records `pdf_pages_read: <N>` so the orchestrator and a future operator can see exactly how much of the PDF landed; `pdf_truncated: true` is reserved for the 200-page hard-cap case. Phase 2 batch-output example extended to show the PDF row shape. Pre-v0.0.21 behaviour silently lost 60%+ of EUR-Lex consolidated annexes, EP think-tank ATAGs, and 30+ page arxiv papers; `claim-extractor` could not reach claims past page 20.
+- `tests/test_ingest_contract.sh` — adds `assert_grep 'pdf_pages_read' "$FETCHER" ...` alongside the existing `pdf_truncated` assertion. Both tokens are now greppable: `pdf_pages_read` for the normal-loop case, `pdf_truncated` for the hard-cap case.
+
+### Notes
+
+- **Per-batch sink, not cache-entry schema.** Issue #278's acceptance criterion #2 originally proposed `pdf_pages_read` in the cache entry. This release surfaces the field in the agent-emitted per-batch `fetched[]` instead, keeping `fetch-cache.py`'s persisted schema frozen — strictly within the issue's "single agent file edit + test extension" scope.
+- **No re-fetch of existing cache.** The EP ATAG PDF in `.alpha/eu-ai-act-gpai/`'s cache was captured at 1-2 pages pre-fix during the M5+M6 smoke. A re-fetch under the new loop is a manual smoke step (`fetch-cache.py evict` then re-run `source-fetcher`); not part of this release.
+
 ## 0.0.20 — 2026-05-21
 
 Slice 2 of the absorption-roadmap Current sprint — Phase 5 M5 + M6. Lands the Phase-4 ingest step of the v0.1.0 inverted pipeline (`plan → curate → fetch → **ingest** → compose → verify → finalize`): claim extraction now happens at ingest time (per `references/claim-at-ingest.md`), populating each `wiki/sources/<slug>.md` page's `pre_extracted_claims:` frontmatter so future verification at draft time becomes a zero-network string match. Bundles two Slice-1 follow-up issues: #275 (PDF detection in source-fetcher, via shared `_knowledge_lib.is_pdf_response`) and #276 (`cobrowse_unavailable` reason promoted to documented vocabulary). Closes #275 Closes #276.

--- a/cogni-knowledge/agents/source-fetcher.md
+++ b/cogni-knowledge/agents/source-fetcher.md
@@ -84,8 +84,12 @@ If either is true, WebFetch will typically have saved the binary body to a sessi
 
 This line is an **undocumented tool-output convention** — parse defensively. The acceptable patterns are the literal `also saved to ` substring followed by an absolute path ending in `.pdf` on the same line. If a saved-file path is found:
 
-1. `Read` the PDF with `pages: "1-20"` (the Read tool caps at 20 pages per call). For PDFs longer than 20 pages, read pages 1-20 only and record `pdf_truncated: true` in the cache entry's `notes` field below.
-2. Concatenate the per-page text into a single body string.
+1. Loop `Read` over the saved PDF in 20-page windows (`pages: "1-20"`, then `"21-40"`, then `"41-60"`, …) until either:
+   - the next window returns an empty page range (end of PDF — Read surfaces no further page content), **or**
+   - the cumulative page count reaches a **200-page hard cap** (cost guard — Read transcribes PDFs via vision-rendered images, so cost scales linearly with pages; #278).
+
+   Track the final `<N>` pages successfully read across all windows.
+2. Concatenate the per-window text into a single body string in window order.
 3. Write the transcribed text to a temp file (`mktemp`).
 4. Store via:
    ```
@@ -99,7 +103,7 @@ This line is an **undocumented tool-output convention** — parse defensively. T
        --http-status 200
    ```
    The body is text; `fetch_method` stays `webfetch` (the cache entry records that the original response was a PDF in spirit via the URL — `fetch_method` describes the transport, not the MIME).
-5. Emit `fetched[]` entry with the returned `cache_key` and `content_hash`.
+5. Emit `fetched[]` entry with the returned `cache_key` and `content_hash`, and include `pdf_pages_read: <N>` so the orchestrator (and a future operator) can see exactly how much of the PDF landed. Set `pdf_truncated: true` **only** when the 200-page hard cap fired before the PDF ended; otherwise omit it (`<N>` alone conveys completeness for PDFs that fit under the cap). The field lives in the per-batch `fetched[]` sink — `fetch-cache.py`'s cache-entry schema is unchanged (#278).
 
 If no saved-file path is found in the WebFetch output (the EUR-Lex case empirically observed during the M4 smoke) → proceed to Step 4 with `reason: pdf_extraction_failed`. Do NOT fall through to Step 3 — cobrowse downloads PDFs rather than rendering their text, so it is not a usable fallback for the PDF branch.
 
@@ -165,7 +169,11 @@ Write a top-level JSON object to `BATCH_OUTPUT_PATH`:
   "schema_version": "0.1.0",
   "fetched": [
     {"url": "...", "cache_key": "<sha256>", "content_hash": "sha256:...",
-     "fetch_method": "webfetch", "fetched_at": "...", "from_cache": false}
+     "fetch_method": "webfetch", "fetched_at": "...", "from_cache": false},
+    {"url": "https://www.europarl.europa.eu/.../ATAG.pdf",
+     "cache_key": "<sha256>", "content_hash": "sha256:...",
+     "fetch_method": "webfetch", "fetched_at": "...", "from_cache": false,
+     "pdf_pages_read": 13}
   ],
   "unavailable": [
     {"url": "...", "reason": "webfetch_timeout", "attempted_at": "...",

--- a/cogni-knowledge/agents/source-fetcher.md
+++ b/cogni-knowledge/agents/source-fetcher.md
@@ -63,7 +63,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/fetch-cache.py fetch \
 ```
 
 - `success: true` → cache hit. Inspect `data.entry.status`:
-  - `ok` → emit a `fetched[]` entry referencing `data.cache_key` + `data.entry.content_hash` + `data.entry.fetch_method`. Skip to next URL.
+  - `ok` → emit a `fetched[]` entry referencing `data.cache_key` + `data.entry.content_hash` + `data.entry.fetch_method`. Skip to next URL. (Note: `pdf_pages_read` is only emitted on fresh PDF fetches in Step 2; cache-hit PDF rows omit it because the page count is not part of the cache entry's persisted schema — #278.)
   - `unavailable` → negative-cache hit. Emit an `unavailable[]` entry with `reason: <data.entry.reason>` + `fallback_attempted: false` + `attempted_at: <now>` + `from_cache: true`. Skip to next URL.
 - `success: false` with `data.reason == "miss"` or `"stale"` → proceed to Step 2.
 
@@ -85,7 +85,7 @@ If either is true, WebFetch will typically have saved the binary body to a sessi
 This line is an **undocumented tool-output convention** — parse defensively. The acceptable patterns are the literal `also saved to ` substring followed by an absolute path ending in `.pdf` on the same line. If a saved-file path is found:
 
 1. Loop `Read` over the saved PDF in 20-page windows (`pages: "1-20"`, then `"21-40"`, then `"41-60"`, …) until either:
-   - the next window returns an empty page range (end of PDF — Read surfaces no further page content), **or**
+   - the next window returns no transcribed page content **or** Read surfaces an out-of-range page indication (end of PDF), **or**
    - the cumulative page count reaches a **200-page hard cap** (cost guard — Read transcribes PDFs via vision-rendered images, so cost scales linearly with pages; #278).
 
    Track the final `<N>` pages successfully read across all windows.

--- a/cogni-knowledge/references/inverted-pipeline.md
+++ b/cogni-knowledge/references/inverted-pipeline.md
@@ -98,13 +98,16 @@ Output: `<project>/.metadata/fetch-manifest.json`:
 {
   "schema_version": "0.1.0",
   "fetched": [
-    {"url": "...", "cache_key": "<sha256>", "content_hash": "<sha256-of-body>", "fetch_method": "webfetch", "fetched_at": "..."}
+    {"url": "...", "cache_key": "<sha256>", "content_hash": "<sha256-of-body>", "fetch_method": "webfetch", "fetched_at": "..."},
+    {"url": "https://example.org/paper.pdf", "cache_key": "<sha256>", "content_hash": "<sha256-of-body>", "fetch_method": "webfetch", "fetched_at": "...", "pdf_pages_read": 13}
   ],
   "unavailable": [
     {"url": "...", "reason": "webfetch_timeout", "attempted_at": "...", "fallback_attempted": false}
   ]
 }
 ```
+
+`pdf_pages_read` (added v0.0.21, #278) is **PDF-only and optional**: it carries the cumulative page count successfully read by `source-fetcher`'s 20-page-window Read-loop. Non-PDF rows omit it. `pdf_truncated: true` (also optional, PDF-only) is set only when the agent's 200-page hard cap fired before the PDF ended — for PDFs that fit under the cap, `pdf_pages_read` alone conveys completeness.
 
 Cache hit semantics: if a cache file exists for the URL and `fetched_at` is within the freshness window (default 30 days, configurable in `binding.curator_defaults`), reuse without re-fetching. The fetch-cache is content-addressed by URL, not by content — so the same URL fetched twice produces one cache file with the latest body.
 

--- a/cogni-knowledge/tests/test_ingest_contract.sh
+++ b/cogni-knowledge/tests/test_ingest_contract.sh
@@ -117,7 +117,8 @@ FETCHER="$PLUGIN_ROOT/agents/source-fetcher.md"
 assert_grep 'is_pdf_response' "$FETCHER" "source-fetcher: uses is_pdf_response helper (#275)"
 assert_grep 'pdf_extraction_failed' "$FETCHER" "source-fetcher: closed vocab includes pdf_extraction_failed (#275)"
 assert_grep 'cobrowse_unavailable' "$FETCHER" "source-fetcher: closed vocab includes cobrowse_unavailable (#276)"
-assert_grep 'pdf_truncated' "$FETCHER" "source-fetcher: documents pdf_truncated note for PDFs >20 pages"
+assert_grep 'pdf_truncated' "$FETCHER" "source-fetcher: documents pdf_truncated for the 200-page hard-cap case (#278)"
+assert_grep 'pdf_pages_read' "$FETCHER" "source-fetcher: records pdf_pages_read in per-batch fetched[] entry (#278)"
 # Regression guard for the #277 review-blocker: the PDF branch instructs
 # the agent to `Read pages: "1-20"` the saved binary; the Read tool MUST
 # be in the frontmatter tools list or the PDF rail fails at runtime with


### PR DESCRIPTION
## Summary

- Step 2's PDF branch in `agents/source-fetcher.md` now **loops `Read` across 20-page windows** (`"1-20"`, `"21-40"`, …) until an empty page range is returned or a **200-page hard cap** fires (cost guard — Read transcribes PDFs via vision-rendered images, scaling linearly with pages). Pre-v0.0.21 silently lost 60%+ of EUR-Lex consolidated annexes, EP think-tank ATAGs, and 30+ page arxiv papers; `claim-extractor` could not reach claims past page 20.
- The per-batch `fetched[]` entry now carries `pdf_pages_read: <N>` so the orchestrator and a future operator can see exactly how much of the PDF landed. `pdf_truncated: true` is reserved for the 200-page hard-cap case.
- Mirrored into `references/inverted-pipeline.md` Phase 3 (the v0.1.0 canonical contract) so the schema example matches the agent prose.

## Scope notes

- **Per-batch sink, not cache-entry schema.** Issue #278's acceptance criterion #2 originally proposed `pdf_pages_read` in the cache entry. Per the issue author's direction, this PR surfaces the field in the agent-emitted per-batch `fetched[]` instead, keeping `fetch-cache.py`'s persisted schema frozen — strictly within the issue's "single agent file edit + test extension" scope.
- **No re-fetch of existing cache.** The EP ATAG PDF in `.alpha/eu-ai-act-gpai/`'s cache was captured at 1-2 pages pre-fix during the M5+M6 smoke. A re-fetch under the new loop is a manual operator step (`fetch-cache.py evict` then re-run `source-fetcher`); not part of this release.

## Files changed

| File | Change |
|---|---|
| `cogni-knowledge/agents/source-fetcher.md` | Step 2 PDF branch: single Read → 20-page-window loop with 200-page cap. Emits `pdf_pages_read: <N>` in `fetched[]`. Phase 2 example extended with a PDF row. |
| `cogni-knowledge/references/inverted-pipeline.md` | Phase 3 `fetched[]` schema example + one-line note explaining `pdf_pages_read` is PDF-only / optional and `pdf_truncated` is hard-cap-only. |
| `cogni-knowledge/tests/test_ingest_contract.sh` | New `assert_grep 'pdf_pages_read' "$FETCHER" …` alongside existing `pdf_truncated` assertion. |
| `cogni-knowledge/CHANGELOG.md` | `## 0.0.21 — 2026-05-21` entry. |
| `cogni-knowledge/.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` | Version bump `0.0.20` → `0.0.21`. |

## Test plan

- [x] `bash cogni-knowledge/tests/test_ingest_contract.sh` — ALL PASS (40 → 41 assertions; new `pdf_pages_read` row green; existing `pdf_truncated` assertion still green for the hard-cap case)
- [x] `bash cogni-knowledge/tests/test_skill_contracts.sh` — ALL PASS (no clean-break regression; no new `cogni-(research|claims|wiki):*` skill dispatch)
- [x] `grep -n 'pdf_pages_read\|pdf_truncated' cogni-knowledge/agents/source-fetcher.md` — both tokens present with distinct semantics in the prose
- [x] Version mirror: `cogni-knowledge/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` both at `0.0.21`
- [ ] Optional manual smoke (not blocking merge): `fetch-cache.py evict` the EP ATAG entry, re-run `source-fetcher`, expect `pdf_pages_read: <real-page-count>` in the per-batch manifest and a substantially larger cached body

Closes #278.

https://claude.ai/code/session_01LKn1Ua1NbTqnUCGPUJGkuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKn1Ua1NbTqnUCGPUJGkuZ)_