### PR TITLE
docs: sync 12 plugins with code reality + add cogni-knowledge to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 ## What the plugins do
 
-14 plugins organized around ten capability areas. Each area handles a distinct part of the consulting-to-delivery workflow; plugins within an area share data formats and can be used independently or together.
+15 plugins organized around ten capability areas. Each area handles a distinct part of the consulting-to-delivery workflow; plugins within an area share data formats and can be used independently or together.
 
 ### Research
 
@@ -103,11 +103,17 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 #### Knowledge Management
 
-[cogni-wiki](cogni-wiki/README.md) maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Based on Andrej Karpathy's LLM Wiki pattern: answers come from the wiki (not model memory), contradictions are surfaced at ingest, and knowledge compounds instead of starting from zero. 7 skills.
+[cogni-wiki](cogni-wiki/README.md) maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Based on Andrej Karpathy's LLM Wiki pattern: answers come from the wiki (not model memory), contradictions are surfaced at ingest, and knowledge compounds instead of starting from zero. 12 skills.
 
 > "Ingest this research paper into my wiki and show me what changed"
 
 → [Plugin guide](docs/plugin-guide/cogni-wiki.md)
+
+[cogni-knowledge](cogni-knowledge/README.md) is the wiki-first research orchestrator — it binds a cogni-wiki knowledge base to any number of research projects so findings compound across runs instead of dying in chat history. Its zero-network inverted pipeline (plan → curate → fetch → ingest → compose → verify → finalize) deposits verified syntheses straight into the wiki, where future questions read them as prior framing. 12 skills.
+
+> "Set up a knowledge base on the EU AI Act and deposit my first research synthesis"
+
+→ [Plugin guide](docs/plugin-guide/cogni-knowledge.md)
 
 Beyond the open-source plugins, cogni-works offers consulting services — plugin engineering for domain-specific workflows, managed deployment, and a partner certification program — through [cogni-work.ai](https://cogni-work.ai). Whether you run a consulting practice, a sales organization, or a marketing team, the site shows how these capabilities translate into managed workflows and onboarding for your team.
 
@@ -195,7 +201,7 @@ The workplace combines Claude Code with [Obsidian](https://obsidian.md/) for per
 ```
 insight-wave/
 ├── .claude-plugin/
-│   └── marketplace.json                    # Marketplace manifest (14 plugins)
+│   └── marketplace.json                    # Marketplace manifest (15 plugins)
 ├── docs/                                   # User documentation
 │   ├── getting-started.md                  # Forwarder → workflows/install-to-infographic.md
 │   ├── ecosystem-overview.md               # Plugin landscape and data flow
@@ -207,6 +213,7 @@ insight-wave/
 ├── cogni-consulting/                       # Double Diamond orchestrator
 ├── cogni-copywriting/                      # Copywriting toolkit
 ├── cogni-help/                             # Help hub: courses, guide, workflows, troubleshoot
+├── cogni-knowledge/                        # Wiki-first research orchestrator
 ├── cogni-marketing/                        # B2B marketing content engine
 ├── cogni-narrative/                        # Story arc narrative transformation
 ├── cogni-portfolio/                        # Portfolio messaging & planning
@@ -234,22 +241,23 @@ Plugins follow the [Claude Code plugin standard](https://code.claude.com/docs/en
 
 | Plugin | Capability | Skills | Agents | What it does |
 |--------|-----------|--------|--------|--------------|
-| [cogni-research](cogni-research/README.md) | Research | 5 | 9 | Multi-agent web research with parallel section researchers, five report types, and claims-verified review loops |
-| [cogni-trends](cogni-trends/README.md) | Trend Intelligence | 6 | 9 | TIPS trend scouting with bilingual DE/EN research, investment theme modeling, and reusable industry catalogs |
-| [cogni-portfolio](cogni-portfolio/README.md) | Portfolio | 19 | 20 | IS/DOES/MEANS portfolio positioning with eight industry taxonomies, competitive analysis, and market sizing |
+| [cogni-research](cogni-research/README.md) | Research | 6 | 9 | Multi-agent web research with parallel section researchers, five report types, and claims-verified review loops |
+| [cogni-trends](cogni-trends/README.md) | Trend Intelligence | 9 | 12 | TIPS trend scouting with bilingual DE/EN research, investment theme modeling, and reusable industry catalogs |
+| [cogni-portfolio](cogni-portfolio/README.md) | Portfolio | 21 | 20 | IS/DOES/MEANS portfolio positioning with eight industry taxonomies, competitive analysis, and market sizing |
 | [cogni-marketing](cogni-marketing/README.md) | Content | 11 | 3 | B2B marketing content engine — 16 formats across thought leadership, demand gen, lead gen, sales enablement, ABM |
 | [cogni-copywriting](cogni-copywriting/README.md) | Content | 4 | 2 | Professional copywriting with 7 messaging frameworks, 5 stakeholder personas, and arc-aware polishing |
-| [cogni-narrative](cogni-narrative/README.md) | Content | 3 | 3 | Story arc narrative transformation using 10 frameworks with quality scoring and derivative format adaptation |
+| [cogni-narrative](cogni-narrative/README.md) | Content | 3 | 3 | Story arc narrative transformation using 11 frameworks with quality scoring and derivative format adaptation |
 | [cogni-sales](cogni-sales/README.md) | Sales | 1 | 4 | Corporate Visions Why Change pitch generation for named customers or market segments |
 | [cogni-consulting](cogni-consulting/README.md) | Consulting | 7 | 1 | Double Diamond consulting orchestrator with 8 vision classes and Lean Canvas authoring |
-| [cogni-visual](cogni-visual/README.md) | Visual | 8 | 17 | Slide decks, infographics, web narratives, poster storyboards, and report enrichment from narratives |
+| [cogni-visual](cogni-visual/README.md) | Visual | 8 | 19 | Slide decks, infographics, web narratives, poster storyboards, and report enrichment from narratives |
 | [cogni-website](cogni-website/README.md) | Website | 6 | 3 | Multi-page customer websites from portfolio, marketing, and research content with shared navigation and theming |
 | [cogni-claims](cogni-claims/README.md) | Quality | 2 | 2 | Source verification — catches misquotations, unsupported conclusions, and stale data in sourced claims |
 | [cogni-help](cogni-help/README.md) | Platform | 7 | 1 | 12-course curriculum, plugin discovery, workflow templates, troubleshooting, and cheatsheets |
-| [cogni-wiki](cogni-wiki/README.md) | Platform | 7 | 0 | Persistent interlinked markdown wiki — compile-time knowledge from sources, wiki-grounded answers, backlink audit, health lint |
-| [cogni-workspace](cogni-workspace/README.md) | Platform | 6 | 0 | Shared foundation — env vars, MCP installation, theme management, plugin discovery, workspace health, Obsidian integration, bundled wiki |
+| [cogni-knowledge](cogni-knowledge/README.md) | Platform | 12 | 7 | Wiki-first research orchestrator — binds a cogni-wiki base to N research projects so findings compound across runs via a zero-network inverted pipeline |
+| [cogni-wiki](cogni-wiki/README.md) | Platform | 12 | 0 | Persistent interlinked markdown wiki — compile-time knowledge from sources, wiki-grounded answers, backlink audit, health lint |
+| [cogni-workspace](cogni-workspace/README.md) | Platform | 9 | 0 | Shared foundation — env vars, MCP installation, theme management, plugin discovery, workspace health, Obsidian integration, bundled wiki |
 
-**92 skills, 74 agents** across the ecosystem.
+**118 skills, 86 agents** across the ecosystem.
 
 See [Cross-Plugin Data Flow](docs/er-diagram.md) for how data flows between plugins, or browse the [full documentation](docs/ecosystem-overview.md).
 

--- a/cogni-claims/README.md
+++ b/cogni-claims/README.md
@@ -21,7 +21,7 @@ Every claim above has been verified against its source using this plugin. This p
 
 ## What it is
 
-A systematic claim-verification workflow for Claude Cowork. Other plugins generate sourced content — this one checks whether the sources actually say what's claimed. It detects five deviation types — misquotation, unsupported conclusions, selective omission, data staleness, and source contradiction — and routes each finding through explicit human resolution before publish. It's designed for cross-plugin use: submit claims from anywhere, verify and resolve them here.
+A systematic claim-verification workflow for Claude Code / Claude Cowork. Other plugins generate sourced content — this one checks whether the sources actually say what's claimed. It detects five deviation types — misquotation, unsupported conclusions, selective omission, data staleness, and source contradiction — and routes each finding through explicit human resolution before publish. It's designed for cross-plugin use: submit claims from anywhere, verify and resolve them here.
 
 ## What it does
 

--- a/cogni-consulting/README.md
+++ b/cogni-consulting/README.md
@@ -4,6 +4,8 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
+> **Start here.** Run `/cogni-consulting:consulting-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
+
 A [Claude Cowork](https://claude.ai/cowork) plugin for structured consulting engagements built on the Double Diamond framework (UK Design Council, 2005). Diverge to explore, converge to decide, twice. Four gated phases coordinate six insight-wave plugins under a Diamond Coach that opens with intent and closes with accomplishments. Lean Canvas authoring and lightweight how-might-we engagements ship in the same workflow.
 
 ## Why this exists
@@ -48,6 +50,7 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 ## Quick start
 
 ```
+/cogni-consulting:consulting-resume   # ← entry point: status + next step
 /consulting-setup         # frame the vision and scaffold the engagement
 /consulting-discover      # D1 diverge: research, trends, competitive baseline
 /consulting-define        # D1 converge: assumption verification, problem synthesis
@@ -92,12 +95,12 @@ Each engagement lives in `cogni-consulting/{slug}/` with phase output directorie
 
 | Component | Type | What it does |
 |-----------|------|--------------|
+| `consulting-resume` | skill | Resume, continue, or check status of a Double Diamond consulting engagement. |
 | `consulting-setup` | skill | Initialize a new Double Diamond consulting engagement with vision framing and project scaffolding. |
 | `consulting-discover` | skill | Execute the Discover phase of a Double Diamond engagement — diverge to build a rich understanding of the problem landscape. |
 | `consulting-define` | skill | Execute the Define phase of a Double Diamond engagement — converge from discovery insights to a clear problem statement. |
 | `consulting-develop` | skill | Execute the Develop phase of a Double Diamond engagement — diverge to generate and explore solution options. |
 | `consulting-deliver` | skill | Execute the Deliver phase of a Double Diamond engagement — converge on validated, actionable outcomes. |
-| `consulting-resume` | skill | Resume, continue, or check status of a Double Diamond consulting engagement. |
 | `consulting-export` | skill | Generate the final deliverable package for a Double Diamond engagement. |
 | `phase-analyst` | agent | Analyze diamond engagement state and assess phase readiness. |
 | `phase-gate-guard` | hook (PreToolUse) | Warns if consulting phase prerequisites are incomplete before allowing phase skills to execute. |
@@ -157,7 +160,9 @@ cogni-consulting/
 └── scripts/                      Engagement management scripts
     ├── engagement-init.sh
     ├── engagement-status.sh
-    └── update-phase.sh
+    ├── update-phase.sh
+    ├── discover-projects.sh      Wrapper delegating to cogni-workspace project discovery
+    └── _discover_extractor.py    Per-engagement JSON field extractor
 ```
 
 ## Dependencies

--- a/cogni-consulting/README.md
+++ b/cogni-consulting/README.md
@@ -6,7 +6,7 @@
 
 > **Start here.** Run `/cogni-consulting:consulting-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
 
-A [Claude Cowork](https://claude.ai/cowork) plugin for structured consulting engagements built on the Double Diamond framework (UK Design Council, 2005). Diverge to explore, converge to decide, twice. Four gated phases coordinate six insight-wave plugins under a Diamond Coach that opens with intent and closes with accomplishments. Lean Canvas authoring and lightweight how-might-we engagements ship in the same workflow.
+A [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai/cowork) plugin for structured consulting engagements built on the Double Diamond framework (UK Design Council, 2005). Diverge to explore, converge to decide, twice. Four gated phases coordinate six insight-wave plugins under a Diamond Coach that opens with intent and closes with accomplishments. Lean Canvas authoring and lightweight how-might-we engagements ship in the same workflow.
 
 ## Why this exists
 

--- a/cogni-copywriting/README.md
+++ b/cogni-copywriting/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-A [Claude Cowork](https://claude.ai/cowork) plugin that turns AI-generated drafts into executive-ready documents. Seven messaging frameworks, five parallel stakeholder personas for blind-spot review, bilingual readability validation (English Flesch, German Amstad + Wolf Schneider), and Power Positions sales enhancement — while preserving upstream story arc structure from cogni-narrative. A `copy-json` adapter polishes text fields inside JSON files, and `audit-copywriter` verifies arc contracts stay in sync with cogni-narrative upstream.
+A [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai/cowork) plugin that turns AI-generated drafts into executive-ready documents. Seven messaging frameworks, five parallel stakeholder personas for blind-spot review, bilingual readability validation (English Flesch, German Amstad + Wolf Schneider), and Power Positions sales enhancement — while preserving upstream story arc structure from cogni-narrative. A `copy-json` adapter polishes text fields inside JSON files, and `audit-copywriter` verifies arc contracts stay in sync with cogni-narrative upstream.
 
 ## Why this exists
 

--- a/cogni-help/README.md
+++ b/cogni-help/README.md
@@ -123,7 +123,7 @@ Exercise artifacts are written to `_teacher-exercises/`.
 
 ```
 cogni-help/
-├── .claude-plugin/plugin.json    Plugin manifest (v0.0.6)
+├── .claude-plugin/plugin.json    Plugin manifest (v0.0.7)
 ├── agents/                       1 delegation agent
 │   └── course-deck-generator.md
 ├── skills/                       7 skills

--- a/cogni-knowledge/README.md
+++ b/cogni-knowledge/README.md
@@ -176,6 +176,7 @@ The plugin sits between the user and `cogni-wiki`. On the v0.1.0 inverted pipeli
 ## Dependencies
 
 - `cogni-wiki` ≥ 0.0.44 (Phase 4 `knowledge-ingest` needs the `type: source` allowlist added to `wiki-lint` / `wiki-health` at 0.0.44; `knowledge-query` uses the `--wiki-root` flag from 0.0.41)
+- `cogni-workspace` — optional. `knowledge-plan` and the `source-curator` agent call `cogni-workspace/scripts/get-market-config.py` at runtime when a market is configured for localized (bilingual + per-market authority) search. Without it, search falls back to the unlocalized default.
 - `cogni-research` — **not a runtime dependency** of the v0.1.0 inverted pipeline (forked agents are local point-in-time copies). The archived v0.0.x chain under `_archive/` delegated to it; it remains available as a sibling plugin for one-shot reports.
 
 ## Custom development

--- a/cogni-marketing/README.md
+++ b/cogni-marketing/README.md
@@ -4,6 +4,8 @@
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
+> **Start here.** Run `/cogni-marketing:marketing-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
+
 B2B marketing content engine for the insight-wave ecosystem. Bridges cogni-trends strategic themes and cogni-portfolio propositions into channel-ready content. Supports thought leadership, demand generation, lead generation, sales enablement, and ABM across markets with configurable brand voice. Bilingual DE/EN.
 
 ## Why this exists
@@ -53,6 +55,7 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 ## Quick start
 
 ```
+/cogni-marketing:marketing-resume   # ← entry point: status + next step
 /marketing-setup                # initialize project from portfolio + TIPS data
 /content-strategy               # build the content matrix
 /thought-leadership             # generate awareness-stage content
@@ -108,6 +111,7 @@ Content pieces are markdown files with YAML frontmatter tracking type, format, m
 
 | Component | Type | What it does |
 |-----------|------|--------------|
+| `marketing-resume` | skill | Resume a session — show status, gaps, and recommended next actions |
 | `marketing-setup` | skill | Initialize project from portfolio + TIPS data, configure brand voice and markets |
 | `content-strategy` | skill | Build 3D content matrix with gap detection and priority sequencing |
 | `thought-leadership` | skill | Generate awareness-stage content (blogs, keynotes, op-eds, podcasts) |
@@ -118,7 +122,6 @@ Content pieces are markdown files with YAML frontmatter tracking type, format, m
 | `campaign-builder` | skill | Orchestrate content into multi-channel campaigns with phased funnel progression |
 | `content-calendar` | skill | Generate and manage editorial calendar with cadence tracking |
 | `marketing-dashboard` | skill | Interactive HTML dashboard for coverage and progress visualization |
-| `marketing-resume` | skill | Resume a session — show status, gaps, and recommended next actions |
 | `content-writer` | agent (sonnet) | Generates individual content pieces per format spec, brand voice, and source data |
 | `channel-adapter` | agent (haiku) | Adapts existing content to different channels while preserving core message |
 | `seo-researcher` | agent (sonnet) | Researches SEO keywords and competitor content for GTM path/market combinations |

--- a/cogni-narrative/README.md
+++ b/cogni-narrative/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-The story arc engine for the insight-wave ecosystem — transforms structured research and portfolio output into executive-grade narratives using 10 arc frameworks (Corporate Visions, JTBD Portfolio, Strategic Foresight, Trend Panorama, and six more) and 8 narrative techniques, sitting between cogni-research and cogni-copywriting in the pipeline and feeding cogni-visual, cogni-sales, and cogni-marketing downstream. Bilingual EN/DE.
+The story arc engine for the insight-wave ecosystem — transforms structured research and portfolio output into executive-grade narratives using 11 arc frameworks (Corporate Visions, JTBD Portfolio, Strategic Foresight, Trend Panorama, and seven more) and 8 narrative techniques, sitting between cogni-research and cogni-copywriting in the pipeline and feeding cogni-visual, cogni-sales, and cogni-marketing downstream. Bilingual EN/DE.
 
 ## Why this exists
 
@@ -23,7 +23,7 @@ This plugin applies structured story arc frameworks — each with defined sectio
 
 ## What it is
 
-A story arc engine for the insight-wave ecosystem. Ten named arc frameworks — covering sales, innovation, competitive intelligence, investment themes, portfolio introductions, and company pages — impose rhetorical discipline on structured content, mapping evidence to arc elements, transitions, and quality gates. Other plugins produce research and data; cogni-narrative shapes it into executive-grade stories that drive decisions.
+A story arc engine for the insight-wave ecosystem. Eleven named arc frameworks — covering sales, innovation, competitive intelligence, investment themes, portfolio introductions, and company pages — impose rhetorical discipline on structured content, mapping evidence to arc elements, transitions, and quality gates. Other plugins produce research and data; cogni-narrative shapes it into executive-grade stories that drive decisions.
 
 ## What it does
 

--- a/cogni-narrative/README.md
+++ b/cogni-narrative/README.md
@@ -34,7 +34,7 @@ A story arc engine for the insight-wave ecosystem. Eleven named arc frameworks �
 ## What it means for you
 
 - **Arc-disciplined, not improvised.** Every narrative follows one of 10 proven story arc structures — cutting first-draft time from hours to under 15 minutes while maintaining consistent quality across documents and authors.
-- **Match the arc to the audience before you write.** Ten frameworks cover every consulting output type — from sales enablement to board-ready investment themes to company pages — so structure decisions are made by context, not guesswork.
+- **Match the arc to the audience before you write.** Eleven frameworks cover every consulting output type — from sales enablement to board-ready investment themes to company pages — so structure decisions are made by context, not guesswork.
 - **Quality-gated.** Automated scoring (0-100, A-F grades) on structural compliance, critical accuracy, evidence density, and language — with improvement suggestions per dimension.
 - **One narrative, three derivative formats.** Executive briefs, talking points, and one-pagers — adapted from the source narrative without rewriting.
 - **Ship in the reader's language.** Full EN/DE support with localized arc headers and proper Unicode — no post-processing needed for German-language clients or DACH reports.

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -6,7 +6,9 @@
 
 > **Markets covered.** 25 pluggable regions — single-country (DE, FR, IT, ES, NL, PL, AT, CZ, SK, HU, RO, HR, GR, MK), composite (DACH, EU, Nordics, US/NA, APAC, LATAM, MEA), extended (CN, JP), and global (UK, Global) — market-segmented propositions, competitors, and customer personas — not one-size-fits-all.
 
-A [Claude Cowork](https://claude.ai/cowork) plugin for portfolio messaging and proposition planning. Helps SMEs build structured, market-specific value propositions using the IS/DOES/MEANS (FAB) framework — from product definition through competitive analysis and customer profiling to export-ready deliverables, across eight pluggable industry taxonomies (B2B SaaS, FinTech, HealthTech, MarTech, Industrial Tech, ICT, Professional Services, Commercial Open Source).
+> **Start here.** Run `/cogni-portfolio:portfolio-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
+
+A [Claude Cowork](https://claude.ai/cowork) plugin for portfolio messaging and proposition planning. Helps SMEs build structured, market-specific value propositions using the IS/DOES/MEANS (FAB) framework — from product definition through competitive analysis and customer profiling to export-ready deliverables, across eight pluggable industry taxonomies (B2B SaaS, FinTech, HealthTech, MarTech, Industrial Tech, ICT, Professional Services, Commercial Open Source) and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).
 
 ## Why this exists
 
@@ -62,6 +64,7 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 ## Quick start
 
 ```
+/cogni-portfolio:portfolio-resume          # ← entry point: status + next step
 /portfolio-setup                           # create project, capture company context
 /products                                  # define named offerings
 /features                                  # add capabilities per product (IS layer)
@@ -123,6 +126,7 @@ Each portfolio project lives in `cogni-portfolio/{slug}/` with typed JSON files 
 
 | Component | Type | What it does |
 |-----------|------|--------------|
+| `portfolio-resume` | skill | Resume, continue, or check status of a portfolio project |
 | `portfolio-setup` | skill | Initialize a new portfolio project with company context and directory structure |
 | `portfolio-canvas` | skill | Bootstrap a portfolio project from a Lean Canvas or Business Model Canvas |
 | `portfolio-scan` | skill | Discover offerings via website scanning and classify against taxonomy |
@@ -143,7 +147,6 @@ Each portfolio project lives in `cogni-portfolio/{slug}/` with typed JSON files 
 | `portfolio-lineage` | skill | Track source documents and URLs, detect changes, cascade refresh through features → propositions → solutions |
 | `portfolio-consolidate` | skill | Roll up N research-only scan outputs into a taxonomy-shaped coverage matrix across providers |
 | `trends-bridge` | skill | Bidirectional integration between cogni-trends TIPS analysis and the portfolio |
-| `portfolio-resume` | skill | Resume, continue, or check status of a portfolio project |
 | `market-researcher` | agent | Web research for TAM/SAM/SOM with claim submission |
 | `competitor-researcher` | agent | Web research for competitive intelligence per proposition |
 | `customer-researcher` | agent | Web research for named company profiling per target market |
@@ -186,7 +189,7 @@ cogni-portfolio/
 ├── hooks/                        1 guardrail hook (Excalidraw canvas auto-start)
 ├── references/
 │   └── data-model.md             Full entity schema and project structure reference
-└── scripts/                      13 utility scripts
+└── scripts/                      18 utility scripts
 ```
 
 ## Dependencies
@@ -198,6 +201,7 @@ cogni-portfolio/
 | cogni-marketing | No | Customer narratives from portfolio-communicate are auto-discovered by marketing-setup for voice/messaging enrichment |
 | cogni-claims | No | Claim verification for research-backed assertions via portfolio-verify |
 | cogni-trends | No | Bidirectional TIPS integration via trends-bridge |
+| cogni-research | No | Pitch arcs (technology-futures, strategic-foresight, trend-panorama, theme-thesis) in portfolio-communicate draw on cogni-research output for evidence |
 | cogni-workspace | No | Theme selection for portfolio-dashboard via pick-theme |
 | cogni-consulting | No | Lean Canvas extraction via portfolio-canvas (canvases from business-model-hypothesis vision class) |
 | cogni-sales | No | Downstream consumer — why-change pitch builds on portfolio features and propositions |

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -8,7 +8,7 @@
 
 > **Start here.** Run `/cogni-portfolio:portfolio-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
 
-A [Claude Cowork](https://claude.ai/cowork) plugin for portfolio messaging and proposition planning. Helps SMEs build structured, market-specific value propositions using the IS/DOES/MEANS (FAB) framework — from product definition through competitive analysis and customer profiling to export-ready deliverables, across eight pluggable industry taxonomies (B2B SaaS, FinTech, HealthTech, MarTech, Industrial Tech, ICT, Professional Services, Commercial Open Source) and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).
+A [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai/cowork) plugin for portfolio messaging and proposition planning. Helps SMEs build structured, market-specific value propositions using the IS/DOES/MEANS (FAB) framework — from product definition through competitive analysis and customer profiling to export-ready deliverables, across eight pluggable industry taxonomies (B2B SaaS, FinTech, HealthTech, MarTech, Industrial Tech, ICT, Professional Services, Commercial Open Source) and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).
 
 ## Why this exists
 
@@ -23,7 +23,7 @@ B2B companies know what they sell — but struggle to articulate why each market
 
 ## What it is
 
-A structured portfolio messaging workflow for Claude Cowork. Eight pluggable taxonomy templates (B2B ICT, SaaS, FinTech, HealthTech, etc.) provide industry-standard classification. The IS/DOES/MEANS framework ensures every proposition answers: what IS the capability, what DOES it do for the buyer, and what does it MEAN for their business.
+A structured portfolio messaging workflow for Claude Code / Claude Cowork. Eight pluggable taxonomy templates (B2B ICT, SaaS, FinTech, HealthTech, etc.) provide industry-standard classification. The IS/DOES/MEANS framework ensures every proposition answers: what IS the capability, what DOES it do for the buyer, and what does it MEAN for their business.
 
 ## What it does
 

--- a/cogni-research/README.md
+++ b/cogni-research/README.md
@@ -4,7 +4,9 @@
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-> **Markets covered.** 21 localized European, Anglo, LATAM, and APAC markets — DACH (VDMA, BITKOM, Fraunhofer), FR (INRIA, ARCEP, Les Echos), IT (CNR, AGCOM, ASI), PL (UKE, POLSA, GUS), NL (TNO, ACM), ES (CNMC, INTA, CDTI), MX (INEGI, CONACYT, IFT), BR (IBGE, CNPq, FAPESP), CN (CAICT, MIIT, Xinhua), plus US, UK, and EU — bilingual queries, per-market authority sources, output in your chosen language.
+> **Markets covered.** 21 localized European, Anglo, LATAM, and APAC markets — DACH (VDMA, BITKOM, Fraunhofer), FR (INRIA, ARCEP, Les Echos), IT (CNR, AGCOM, ASI), PL (UKE, POLSA, GUS), NL (TNO, ACM), ES (CNMC, INTA, CDTI), MX (INEGI, Conahcyt, IFT), BR (IBGE, CNPq, FAPESP), CN (CAICT, MIIT, Caixin), plus US, UK, and EU — bilingual queries, per-market authority sources, output in your chosen language.
+
+> **Start here.** Run `/cogni-research:research-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
 
 Multi-agent research report generator for the insight-wave ecosystem. STORM-inspired editorial workflow with parallel section research and claims-verified review loops. Five report types (basic, detailed, deep, outline, resource) and four source modes (web, local documents, wiki, hybrid) — from quick overviews to deep recursive explorations. Research runs localized across 21 European, Anglo, LATAM, and APAC markets (DACH, DE, AT, FR, IT, ES, NL, PL, CZ, SK, HU, RO, HR, GR, MK, UK, US, EU, MX, BR, CN) with intent-based bilingual search and per-market authority sources.
 
@@ -59,7 +61,14 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 
 ## Quick start
 
-Describe what you want in natural language — no slash commands needed. Claude detects the request and loads the skill automatically:
+```
+/cogni-research:research-resume   # ← entry point: status + next step
+/research-setup      # configure report type, market, source mode
+/research-report     # run the multi-agent research pipeline
+/verify-report       # verify every claim against its cited source
+```
+
+Or describe what you want in natural language — no slash commands needed. Claude detects the request and loads the skill automatically:
 
 - "Write a research report on quantum computing's impact on cryptography"
 - "Write a detailed research report on AI adoption in healthcare"
@@ -129,10 +138,11 @@ The pipeline uses two skills that split the work across separate context windows
 
 | Component | Type | What it does |
 |-----------|------|--------------|
-| `research-report` | skill | Generate a multi-agent research report using parallel web research with structural review |
 | `research-resume` | skill | Resume, continue, or check status of a cogni-research project across sessions |
+| `research-report` | skill | Generate a multi-agent research report using parallel web research with structural review |
 | `research-setup` | skill | Configure and initialize a cogni-research project via interactive Configuration Menu |
 | `verify-report` | skill | Verify claims in a research report against cited sources using cogni-claims |
+| `audit-arcs` | skill | Audit the story-arc registry against cogni-narrative upstream definitions and report drift |
 | `section-researcher` | agent (sonnet) | Parallel web researcher for a single sub-question or report section |
 | `local-researcher` | agent (sonnet) | Parallel document analyst for a single sub-question from local files (PDF, DOCX, TXT, MD, CSV) |
 | `wiki-researcher` | agent (sonnet) | Parallel wiki researcher querying cogni-wiki instances for a single sub-question using index-first page discovery |
@@ -150,7 +160,7 @@ The pipeline uses two skills that split the work across separate context windows
 ```
 cogni-research/
 ├── .claude-plugin/               Plugin manifest
-├── skills/                       4 skills (research-report, research-resume, research-setup, verify-report)
+├── skills/                       5 skills (research-report, research-resume, research-setup, verify-report, audit-arcs)
 │   ├── research-report/
 │   │   ├── SKILL.md
 │   │   └── references/           Report types, sub-questions, review criteria, agent roles
@@ -159,9 +169,11 @@ cogni-research/
 │   │   └── SKILL.md
 │   ├── research-setup/
 │   │   └── SKILL.md
-│   └── verify-report/
-│       ├── SKILL.md
-│       └── references/           Claims integration, standalone mode, review criteria
+│   ├── verify-report/
+│   │   ├── SKILL.md
+│   │   └── references/           Claims integration, standalone mode, review criteria
+│   └── audit-arcs/
+│       └── SKILL.md              Story-arc registry sync audit against cogni-narrative
 ├── agents/                       9 research agents
 │   ├── section-researcher.md
 │   ├── local-researcher.md

--- a/cogni-trends/README.md
+++ b/cogni-trends/README.md
@@ -8,7 +8,7 @@
 
 > **Start here.** Run `/cogni-trends:trends-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
 
-A [Claude Cowork](https://claude.ai/cowork) plugin for scouting, selecting, and reporting on strategic industry trends — **rooted in the German Mittelstand, covering European markets (DE/FR/IT/PL/NL/ES) and US/UK**. Combines the [Smarter Service Trendradar](https://www.smarter-service.com/2023/01/31/trendradar-fuer-die-multikrise-und-neue-geooekonomie/) (4-dimension structure by Bernhard Steimel) with the TIPS content framework (Trends, Implications, Possibilities, Solutions — a B2B consulting methodology widely used since the early 2000s; see [WO2018046399A1](https://patents.google.com/patent/WO2018046399A1/en) for a detailed treatment, filed by Siemens 2017, ceased 2019).
+A [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai/cowork) plugin for scouting, selecting, and reporting on strategic industry trends — **rooted in the German Mittelstand, covering European markets (DE/FR/IT/PL/NL/ES) and US/UK**. Combines the [Smarter Service Trendradar](https://www.smarter-service.com/2023/01/31/trendradar-fuer-die-multikrise-und-neue-geooekonomie/) (4-dimension structure by Bernhard Steimel) with the TIPS content framework (Trends, Implications, Possibilities, Solutions — a B2B consulting methodology widely used since the early 2000s; see [WO2018046399A1](https://patents.google.com/patent/WO2018046399A1/en) for a detailed treatment, filed by Siemens 2017, ceased 2019).
 
 ## Frameworks
 

--- a/cogni-trends/README.md
+++ b/cogni-trends/README.md
@@ -6,6 +6,8 @@
 
 > **Markets covered.** 8 European and Anglo markets with per-region trend authorities — DACH (VDMA, BITKOM, Fraunhofer), FR (INRIA, ARCEP, Les Echos), IT (CNR, AGCOM, ASI), PL (UKE, POLSA, GUS), NL (TNO, ACM), ES (CNMC, INTA, CDTI), plus US and UK — DE/EN bilingual research against regional authorities — no generic US-centric datasets.
 
+> **Start here.** Run `/cogni-trends:trends-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
+
 A [Claude Cowork](https://claude.ai/cowork) plugin for scouting, selecting, and reporting on strategic industry trends — **rooted in the German Mittelstand, covering European markets (DE/FR/IT/PL/NL/ES) and US/UK**. Combines the [Smarter Service Trendradar](https://www.smarter-service.com/2023/01/31/trendradar-fuer-die-multikrise-und-neue-geooekonomie/) (4-dimension structure by Bernhard Steimel) with the TIPS content framework (Trends, Implications, Possibilities, Solutions — a B2B consulting methodology widely used since the early 2000s; see [WO2018046399A1](https://patents.google.com/patent/WO2018046399A1/en) for a detailed treatment, filed by Siemens 2017, ceased 2019).
 
 ## Frameworks
@@ -101,6 +103,7 @@ Describe what you want in natural language:
 Or invoke skills directly:
 
 ```
+/cogni-trends:trends-resume   # ← entry point: status + next step
 /trend-scout         → interactive industry selection + bilingual trend scouting
 /value-modeler       → investment themes, solution blueprints, portfolio anchoring
 /trend-research      → enrich every candidate with quantitative evidence; emit research manifest
@@ -209,7 +212,7 @@ cogni-trends/
 │   ├── verify-trend-report/  Claim verification + structural review + revision pipeline
 │   ├── trends-catalog/     Persistent industry knowledge base
 │   └── trends-dashboard/   Interactive HTML visualization
-├── agents/              11 research agents
+├── agents/              12 research agents
 │   ├── trend-web-researcher.md          Persona-shaped bilingual research (haiku)
 │   ├── trend-generator.md               60 scored candidates with persona reasoning (opus)
 │   ├── trend-candidate-reviewer.md      3-perspective stakeholder review (sonnet)
@@ -227,7 +230,8 @@ cogni-trends/
 ├── references/          Framework documentation
 │   ├── research-types/  Research type specifications
 │   └── taxonomies/      Taxonomy definitions
-└── scripts/             5 utility scripts
+├── scripts/             6 utility scripts
+└── tests/               Project-status test + fixtures
 ```
 
 ## Dependencies

--- a/cogni-visual/README.md
+++ b/cogni-visual/README.md
@@ -128,7 +128,7 @@ The pipeline follows a compose-polish-visualize flow: narratives from cogni-narr
 
 ```
 cogni-visual/                              # 7 skills · 19 agents · 6 commands · 1 hook
-├── .claude-plugin/                        Plugin manifest (v0.16.20)
+├── .claude-plugin/                        Plugin manifest (v0.16.22)
 ├── skills/                               7 visual skills (4 brief generators · 1 renderer · 1 enricher · 1 reviewer)
 │   ├── story-to-slides/
 │   ├── story-to-web/

--- a/cogni-visual/README.md
+++ b/cogni-visual/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-A [Claude Cowork](https://claude.ai/cowork) plugin for brief-based visual production — skills distill polished narratives and structured data into YAML+Markdown briefs (slides, infographics, storyboards, web narratives, enriched reports), then rendering agents hand those briefs to PPTX, Excalidraw, Pencil MCP, and HTML backends. Every output inherits brand identity from your cogni-workspace theme instead of generic templates.
+A [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai/cowork) plugin for brief-based visual production — skills distill polished narratives and structured data into YAML+Markdown briefs (slides, infographics, storyboards, web narratives, enriched reports), then rendering agents hand those briefs to PPTX, Excalidraw, Pencil MCP, and HTML backends. Every output inherits brand identity from your cogni-workspace theme instead of generic templates.
 
 ## Why this exists
 

--- a/cogni-website/README.md
+++ b/cogni-website/README.md
@@ -4,6 +4,8 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
+> **Start here.** Run `/cogni-website:website-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
+
 Assembles multi-page customer websites from portfolio, marketing, trend, and research content produced by other insight-wave plugins — outputting a deployable static site with shared navigation, theming, and responsive HTML.
 
 ## Why this exists
@@ -56,6 +58,7 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 ## Quick start
 
 ```
+/cogni-website:website-resume   # ← entry point: status + next step
 /website-setup     # Discover sources, select theme, configure the project, capture legal foundation
 /website-plan      # Plan site structure and map content to pages
 /website-legal     # Generate Impressum, Datenschutz, Cookie-Hinweis for DE/AT/CH/EU
@@ -100,12 +103,12 @@ Run `/website-setup` in any Claude Code session where cogni-portfolio is install
 
 | Component | Type | What it does |
 |-----------|------|--------------|
+| `website-resume` | skill | Detect project phase, check for source changes and new upstream plugins, route to the correct next skill |
 | `website-setup` | skill | Discover content sources, validate requirements, select theme, scaffold project, write `website-project.json` |
 | `website-plan` | skill | Deep-scan content, propose page structure, map content to page sections, write `website-plan.json` |
 | `website-legal` | skill | Generate Impressum/Datenschutz/Cookies from jurisdiction-specific templates (DE/AT/CH/EU), patch `website-plan.json` with footer-only legal entries and `legal_links` |
 | `website-build` | skill | Orchestrate CSS generation, hero rendering, and parallel page generation from the plan |
 | `website-preview` | skill | Validate built site file completeness and internal links; open in browser |
-| `website-resume` | skill | Detect project phase, check for source changes and new upstream plugins, route to the correct next skill |
 | `site-assembler` | agent (sonnet) | Generate `style.css` from design variables and navigation partials (`header.html`, `footer.html`, `sitemap.xml`) |
 | `page-generator` | agent (sonnet) | Generate a single HTML page from source content and a page-type template specification |
 | `hero-renderer` | agent (sonnet) | Render the homepage hero section using Pencil MCP for AI-generated imagery; falls back to CSS gradient |

--- a/cogni-wiki/README.md
+++ b/cogni-wiki/README.md
@@ -4,6 +4,8 @@
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
+> **Start here.** Run `/cogni-wiki:wiki-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
+
 **A better RAG for personal and small-team knowledge work.** Instead of re-discovering the same information every query through embedding similarity, cogni-wiki has Claude compile sources once into a persistent, interlinked markdown wiki — no vector store, no chunking heuristics, no opaque retrieval. Knowledge compounds with every ingest; answers trace to readable markdown files, not vector math. Plain files, plain backlinks, plain Unix tools.
 
 Based on [Andrej Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) and the reference implementation by [kfchou/wiki-skills](https://github.com/kfchou/wiki-skills).
@@ -101,6 +103,7 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 ## Quick start
 
 ```
+/cogni-wiki:wiki-resume                                        # ← entry point: status + next step
 /cogni-wiki:wiki-setup                                         # Bootstrap a new wiki
 # (drop a paper in cogni-wiki/primary/raw/)
 /cogni-wiki:wiki-ingest                                        # Summarise + cross-link
@@ -109,7 +112,6 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 /cogni-wiki:wiki-lint                                          # Tokenful semantic pass after every 5–10 ingests
 /cogni-wiki:wiki-update --page <slug>                          # Revise a page with new evidence
 /cogni-wiki:wiki-dashboard                                     # Visual HTML overview (incl. synthesis bucket)
-/cogni-wiki:wiki-resume                                        # "Where was I?" (with health snapshot + synthesis_count_30d)
 /cogni-wiki:wiki-from-research                                 # Cold-start: research → wiki in one dispatch
 /cogni-wiki:wiki-refresh --from-research <slug>                # Refresh stale pages from a research project
 /cogni-wiki:wiki-claims-resweep                                # Re-verify cited URLs against current source content
@@ -138,13 +140,13 @@ Claude Code already has an auto-memory system at `~/.claude/projects/.../memory/
 
 | Component | Type | Description |
 |-----------|------|-------------|
+| wiki-resume | Skill | Show status, activity (incl. synthesis count + health snapshot), and recommended next action for the wiki |
 | wiki-setup | Skill | Bootstrap a new Karpathy-style LLM wiki at a user-chosen directory |
 | wiki-ingest | Skill | Ingest a source document into the wiki with summary, frontmatter, and backlink audit; also operates the persistent ingest queue (Mode D, v0.0.35+) for deferred draining via `--enqueue` / `--next` / `--queue-status` / `--queue-retry` |
 | wiki-query | Skill | Answer a question by reading the wiki — never from memory; optionally files the answer back as a `type: synthesis` page |
 | wiki-health | Skill | Zero-LLM structural integrity preflight — broken wikilinks, missing frontmatter, broken raw/`wiki://` sources, id mismatch, invalid type, stub pages, `entries_count` drift, index/filesystem drift, claim_drift count. Runs automatically every session via wiki-resume (v0.0.27) |
 | wiki-lint | Skill | Tokenful semantic audit — contradictions, type drift, undercited claims, missing concept pages, plus deterministic warnings that need narrative (orphans, stale, tag typos, reverse links, claim_drift severity). Refuses to run while wiki-health reports errors |
 | wiki-update | Skill | Revise an existing wiki page with diff-before-write discipline and source citations |
-| wiki-resume | Skill | Show status, activity (incl. synthesis count + health snapshot), and recommended next action for the wiki |
 | wiki-dashboard | Skill | Generate a self-contained HTML dashboard with tag cloud, backlink graph, type bars (incl. synthesis), and histograms |
 | wiki-from-research | Skill | Cold-start orchestrator: chains cogni-research's setup + report into wiki-setup + wiki-ingest in one dispatch (Mode A from a topic, Mode B from an existing research slug) |
 | wiki-refresh | Skill | Refresh stale wiki pages with fresh evidence from a completed cogni-research project; Jaccard match, batch-confirmed, sequential wiki-update dispatch |

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -23,7 +23,7 @@ This plugin provides the infrastructure layer — workspace initialization, them
 
 cogni-workspace implements the **infrastructure-as-plugin pattern**: a dedicated plugin whose sole job is to own the shared state that all other plugins consume — environment variables, plugin registry, theme storage, and tool configuration. It is the only plugin in the ecosystem with no upward dependencies; every other cogni-x plugin depends on it, and none of them duplicate what it provides.
 
-In the Claude Cowork plugin model, workspace-level state (paths, env vars, installed MCPs) cannot be assumed — it must be actively initialized and maintained. cogni-workspace does this in one command and keeps it consistent across plugin updates. Health diagnostics run a five-tier check (foundation, env vars, plugin registry, themes, dependencies) so drift is caught before downstream skills break, not after.
+In the Claude Code / Claude Cowork plugin model, workspace-level state (paths, env vars, installed MCPs) cannot be assumed — it must be actively initialized and maintained. cogni-workspace does this in one command and keeps it consistent across plugin updates. Health diagnostics run a five-tier check (foundation, env vars, plugin registry, themes, dependencies) so drift is caught before downstream skills break, not after.
 
 ## What it does
 

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -92,6 +92,9 @@ Claude checks dependencies, discovers installed plugins, asks for your language 
 | `workspace-status` | skill | Five-tier diagnostic: foundation, env vars, plugin registry, themes, dependencies |
 | `install-mcp` | skill | End-to-end MCP server installation — clone and build git-based MCPs, configure native app MCPs, and patch Claude Desktop config |
 | `ask` | skill | Answer questions about the insight-wave ecosystem by reading the bundled wiki — grounded, cited, never from memory |
+| `manage-markets` | skill | Write path for the canonical supported-markets registry — show status and add markets (codes, locales, authorities) |
+| `audit-region-sources` | skill | Read-only sibling of manage-markets — audit per-plugin region-source overlays against the canonical registry for orphans and drift |
+| `workspace-dashboard` | skill | Interactive HTML dashboard of workspace foundation, env vars, plugin registry, themes, and dependencies |
 | `on-session-start.sh` | hook (SessionStart) | Sources workspace environment and validates plugin availability at session start |
 | `check-dependencies.sh` | script | Returns JSON with availability/version of required and optional dependencies |
 | `check-skill-names.sh` | script | Validates skill directory names against plugin.json manifest for consistency |
@@ -108,12 +111,15 @@ Claude checks dependencies, discovers installed plugins, asks for your language 
 ```
 cogni-workspace/
 ├── .claude-plugin/plugin.json    Plugin manifest
-├── skills/                       6 workspace management skills
+├── skills/                       9 workspace management skills
 │   ├── ask/                      Query the bundled insight-wave wiki for grounded answers
+│   ├── audit-region-sources/     Audit per-plugin region-source overlays against the registry
 │   ├── install-mcp/              MCP server installation and Desktop config patching
+│   ├── manage-markets/           Write path for the canonical supported-markets registry
 │   ├── manage-workspace/         Init or update workspace (includes Obsidian integration)
 │   ├── manage-themes/
 │   ├── pick-theme/
+│   ├── workspace-dashboard/      Interactive HTML workspace status dashboard
 │   └── workspace-status/
 ├── wiki/                         Bundled vendor-curated insight-wave reference wiki (read by ask)
 │   ├── .cogni-wiki/              Wiki config + lockfile

--- a/docs/plugin-guide/cogni-knowledge.md
+++ b/docs/plugin-guide/cogni-knowledge.md
@@ -1,0 +1,267 @@
+# cogni-knowledge
+
+Wiki-first research orchestrator that binds a persistent knowledge base to N research projects so findings compound across runs instead of dying in chat history.
+
+For the canonical IS/DOES/MEANS positioning of this plugin, see the [cogni-knowledge README](../../cogni-knowledge/README.md).
+
+---
+
+## Overview
+
+cogni-knowledge solves a gap that every other deep-research tool leaves open: where do the findings go after the report ships? `research-report` produces a document and loses the underlying knowledge to context history. cogni-knowledge inverts that posture — a research run binds to a named knowledge base, deposits its verified synthesis into a persistent [cogni-wiki](cogni-wiki.md), and the next run reads from that wiki before going to the web.
+
+The plugin is a thin orchestrator over `cogni-wiki`. It owns exactly one new artifact — a `binding.json` manifest that records "this wiki is the knowledge base for topic area X, and these research projects have contributed to it." All other state lives upstream: wiki pages in `cogni-wiki`, fetch bodies in the content-addressed fetch-cache, research project files in `cogni-research-<slug>/`.
+
+The v0.1.0 inverted pipeline (Phases 1–7: plan → curate → fetch → ingest → compose → verify → finalize) forks dedicated agents locally and runs zero-network claim verification. The runtime path is 0% cogni-research — the bound wiki is the only evidence source for composition, verification, and finalization. A legacy v0.0.x chain that delegated to cogni-research is archived under `_archive/`.
+
+> **Preview** (v0.1.x) — core skills defined but may change. Feedback welcome.
+
+---
+
+## Key Concepts
+
+### The Inverted Pipeline (Phases 1–7)
+
+The pipeline runs in sequence. Each phase writes to disk so interrupted runs resume from the first incomplete phase.
+
+| Phase | Skill | What happens |
+|-------|-------|--------------|
+| 1 | `knowledge-plan` | Decomposes topic into 3–7 sub-questions with per-sub-question candidate domains (no web yet) |
+| 2 | `knowledge-curate` | Fans out one `source-curator` per sub-question — WebSearch + score + WebFetch bodies into the shared fetch-cache in parallel |
+| 3 | `knowledge-fetch` | Assembles `fetch-manifest.json` from curators' results; opt-in cobrowse recovery of misses (`--cobrowse`) |
+| 4 | `knowledge-ingest` | Writes `wiki/sources/<slug>.md` per fetched URL with `type: source` + `pre_extracted_claims:` frontmatter — the wiki is populated before any draft runs |
+| 5 | `knowledge-compose` | Reads the populated wiki and prior syntheses, emits `draft-vN.md` with `[[sources/<slug>]]` wikilink citations + `citation-manifest.json` |
+| 6 | `knowledge-verify` | Scores every cited claim against the cited page's `pre_extracted_claims` — zero network; runs a revisor loop on `unsupported` deviations, capped at 2 iterations |
+| 7 | `knowledge-finalize` | Deposits verified draft as `wiki/syntheses/<slug>.md` with `derived_from_research:` lineage; updates wiki index; appends project to `binding.json` — closes the compounding loop |
+
+The loop closes at Phase 7: every `knowledge-compose` run reads `wiki/syntheses/*.md` as prior cross-source framing, so each successive project starts from a richer base.
+
+### The Binding Manifest
+
+`.cogni-knowledge/binding.json` is the only new state this plugin owns. It sits as a sibling to the wiki's `.cogni-wiki/config.json` and records:
+
+- which cogni-wiki is the substrate (`wiki_path`)
+- which research projects have been deposited (`research_projects[]`)
+- topic lineage — covered themes and open themes (`topic_lineage`)
+- curator defaults — score threshold, max candidates per sub-question, fetch-cache max age (`curator_defaults`)
+
+Every skill that needs to know "where is the wiki?" or "what has been deposited?" reads `binding.json` rather than any external config.
+
+### Wiki-First vs. One-Shot Research
+
+One-shot tools (cogni-research in standalone mode, OpenAI Deep Research, Perplexity Spaces) produce a report and stop. Every subsequent run on a related topic starts from zero web.
+
+Wiki-first means: run research on EU AI Act Article 6 today; tomorrow's run on foundation-model obligations reads what you already filed — source pages, pre-extracted claims, and the synthesized `wiki/syntheses/<slug>.md` deposit — before issuing a single new web search. Knowledge gets denser with every project.
+
+### Zero-Network Claim Verification
+
+`knowledge-verify` scores citations against the `pre_extracted_claims:` frontmatter that `knowledge-ingest` wrote into each source page during Phase 4. It never re-fetches a URL. The verifier fans out across parallel shards (default 40 citations per shard), runs a revisor loop on `unsupported` deviations, and converges in under 5 minutes per shard. The contrast with cogni-claims' URL re-verification approach (20–30 min baseline) is structural: the claims were extracted at ingest time and are already on disk.
+
+### The Delegation Contract
+
+cogni-knowledge adds no logic that already exists upstream. `knowledge-setup` does not re-implement `wiki-setup` — it only handles the `binding.json` half. `knowledge-query` does not re-implement search — it resolves the wiki path from `binding.json` and delegates to `cogni-wiki:wiki-query`. If you find yourself writing a new agent or duplicating a cogni-wiki script, the right answer is almost always to push the change upstream and re-delegate. See `cogni-knowledge/references/delegation-contract.md`.
+
+---
+
+## Getting Started
+
+Bootstrap a knowledge base with `knowledge-setup`, then run the pipeline phase by phase. The `knowledge-resume` skill is the entry point — it reads current state and tells you the next step whether you are starting fresh or returning to an in-progress base.
+
+```
+# Entry point: check status or start fresh
+/cogni-knowledge:knowledge-resume --knowledge-slug eu-ai-act
+
+# Bootstrap (first time only)
+/cogni-knowledge:knowledge-setup --knowledge-slug eu-ai-act --knowledge-title "EU AI Act knowledge base"
+
+# Inverted pipeline — run in order
+/cogni-knowledge:knowledge-plan     --knowledge-slug eu-ai-act --topic "EU AI Act Article 6 high-risk systems"
+/cogni-knowledge:knowledge-curate   --knowledge-slug eu-ai-act --project-path ./eu-ai-act-article-6/
+/cogni-knowledge:knowledge-fetch    --knowledge-slug eu-ai-act --project-path ./eu-ai-act-article-6/
+/cogni-knowledge:knowledge-ingest   --knowledge-slug eu-ai-act --project-path ./eu-ai-act-article-6/
+/cogni-knowledge:knowledge-compose  --knowledge-slug eu-ai-act --project-path ./eu-ai-act-article-6/
+/cogni-knowledge:knowledge-verify   --knowledge-slug eu-ai-act --project-path ./eu-ai-act-article-6/
+/cogni-knowledge:knowledge-finalize --knowledge-slug eu-ai-act --project-path ./eu-ai-act-article-6/
+
+# Inspect and query the accumulated base
+/cogni-knowledge:knowledge-dashboard --knowledge-slug eu-ai-act --open yes
+/cogni-knowledge:knowledge-query     --knowledge-slug eu-ai-act --question "what does the wiki say about foundation models?"
+```
+
+The second project reads the wiki the first one deposited. The compounding loop begins after the first `knowledge-finalize`.
+
+---
+
+## Capabilities
+
+### knowledge-resume
+
+Status skill and session entry point. Reads `binding.json` and delegates to `cogni-wiki:wiki-resume` (which runs `wiki-health` automatically). Adds a per-project inverted-pipeline depth column — sub-questions planned, sources curated/fetched/ingested, citations verified, phase reached — via `pipeline-summary.py`. Returns a suggested next action for the current state.
+
+### knowledge-setup
+
+Bootstraps a knowledge base. Dispatches `cogni-wiki:wiki-setup` to create the wiki if it does not exist, then writes `binding.json`. The only setup work this skill does beyond wiki creation is initializing the binding manifest; all wiki structure is owned by cogni-wiki.
+
+### knowledge-plan
+
+Phase 1 of the inverted pipeline. Decomposes a topic into 3–7 sub-questions with per-sub-question `candidate_domains[]`, using no web access. Writes `<project>/.metadata/plan.json`. When a market is configured, reads `cogni-workspace/scripts/get-market-config.py` to seed bilingual domain candidates for localized search in Phase 2.
+
+### knowledge-curate
+
+Phase 2. Fans out one `source-curator` agent per sub-question in parallel — each runs WebSearch + scoring + WebFetch body-pull for every surviving candidate into the shared fetch-cache. Merges per-sub-question batches into `candidates.json` via `candidate-store.py` (file-locked, URL-dedup, score-wins on collision). Each candidate carries a `fetch` sub-object so Phase 3 never has to re-fetch.
+
+### knowledge-fetch
+
+Phase 3. Builds `fetch-manifest.json` from the curators' existing `fetch` sub-objects — no additional WebFetch calls by default. If `--cobrowse` is passed (or confirmed interactively), dispatches `source-fetcher` to recover WebFetch misses via the `claude-in-chrome` extension. Cobrowse is off by default so unattended runs stay browser-free.
+
+### knowledge-ingest
+
+Phase 4. Reads `fetch-manifest.json`, dispatches one `source-ingester` per fetched source (which dispatches `claim-extractor` per body), and writes `wiki/sources/<slug>.md` with `type: source` and populated `pre_extracted_claims:` frontmatter. The wiki is populated before any draft runs — this is the structural precondition for zero-network verification in Phase 6.
+
+### knowledge-compose
+
+Phase 5. Dispatches `wiki-composer`, which reads `wiki/index.md` + selected `wiki/sources/*.md` + prior `wiki/syntheses/*.md`, and writes `draft-vN.md` with `[[sources/<slug>]]` wikilink citations plus `citation-manifest.json`. A leftover `writer-outline-vN.json` from a crashed prior run triggers outline-recovery so only Phase 2 of the composer reruns.
+
+### knowledge-verify
+
+Phase 6. Shards `citation-manifest.json` via `verify-store.py`, dispatches `wiki-verifier` agents in parallel across shards (each shard target: under 5 minutes), then merges into `verify-vN.json`. Each verifier scores `draft_sentence` against `pre_extracted_claims` as `verbatim` / `paraphrase` / `unsupported` / `synthesis` — no network calls, no URL re-fetch. Loops with `revisor` on `unsupported` deviations (max 2 iterations); the revisor re-points to a covering on-page claim before dropping a citation.
+
+### knowledge-finalize
+
+Phase 7. Runs `cycle-guard.py` to refuse self-citing loops, then atomically writes `wiki/syntheses/<slug>.md` with `type: synthesis`, `derived_from_research: <project-slug>`, and a reconstructed `## References` list. Updates the wiki index, bumps `entries_count`, rebuilds `context_brief`, and appends the project to `binding.json`. Writes a datestamped line to `wiki/log.md`. Future `knowledge-compose` runs read the deposited synthesis as prior framing.
+
+### knowledge-query
+
+Read-only. Resolves the wiki path from `binding.json`, delegates to `cogni-wiki:wiki-query` with the question, and appends a one-line footer showing the knowledge base slug and deposit count. Use this to ask natural-language questions against everything the base has accumulated.
+
+### knowledge-dashboard
+
+Renders the wiki's HTML dashboard via `cogni-wiki:wiki-dashboard`, then writes a `knowledge-overlay.md` sidecar: per-project inverted-pipeline columns, a global pipeline-health block from `pipeline-summary.py cache-health`, and the latest `claim_drift` count from a lint audit.
+
+### knowledge-refresh
+
+Self-healing skill with two modes. Pull-mode (`--mode pull --from-research <slug>`) delegates to `cogni-wiki:wiki-refresh` to deposit an externally produced research project. Push-mode (`--mode push`) lints the wiki to find stale pages, prompts you to select which topics to refresh, and runs the full seven-phase pipeline per selected topic — sequentially, fail-soft, idempotent.
+
+---
+
+## Integration Points
+
+### Upstream (what cogni-knowledge consumes)
+
+| Plugin | What is consumed |
+|--------|-----------------|
+| cogni-wiki | The substrate — wiki-setup, wiki-query, wiki-dashboard, wiki-refresh, wiki-lint, wiki-resume, wiki-health |
+| cogni-workspace | Optional — `get-market-config.py` for bilingual, per-market authority search when a market is configured |
+
+cogni-wiki is a hard dependency (requires v0.0.44+). cogni-workspace is optional — without it, search falls back to unlocalized defaults.
+
+cogni-research is not a runtime dependency of the v0.1.0 inverted pipeline. The archived v0.0.x chain under `_archive/` delegated to it; it remains available as a sibling plugin for one-shot reports. For details on the one-shot pipeline, see [cogni-research](cogni-research.md).
+
+### Downstream (what cogni-knowledge produces)
+
+cogni-knowledge deposits into the bound cogni-wiki. Everything it writes — source pages (`wiki/sources/<slug>.md`), synthesis pages (`wiki/syntheses/<slug>.md`), log entries, and index updates — is owned by the wiki and browsable via Obsidian or any Markdown reader. The wiki itself can then feed [cogni-research](cogni-research.md) in `wiki` or `hybrid` source mode, or be queried directly via `knowledge-query`.
+
+---
+
+## Common Workflows
+
+### Workflow 1: Bootstrap + First Deposit
+
+Start here for a new topic area.
+
+1. `/knowledge-resume --knowledge-slug <slug>` — check whether the base exists; if not, proceed to setup
+2. `/knowledge-setup --knowledge-slug <slug> --knowledge-title "<title>"`
+3. Run the seven-phase pipeline: `knowledge-plan` → `knowledge-curate` → `knowledge-fetch` → `knowledge-ingest` → `knowledge-compose` → `knowledge-verify` → `knowledge-finalize`
+4. `/knowledge-dashboard --knowledge-slug <slug> --open yes` — inspect what was deposited
+
+After `knowledge-finalize` completes, the first synthesis lives in `wiki/syntheses/`. The compounding base has begun.
+
+### Workflow 2: Query the Compounding Base
+
+After two or more projects have been deposited, the base has cross-project framing.
+
+1. `/knowledge-query --knowledge-slug <slug> --question "<natural language question>"` — ask against everything filed
+2. If the answer is thin, check `knowledge-dashboard` for which topics are covered and which are open
+3. Run the pipeline on an open theme to fill the gap
+
+### Workflow 3: Refresh Stale Topics
+
+Use this when the wiki has pages flagged `stale` by `wiki-lint` or when a topic area needs an update from a new source.
+
+- **Pull mode** — you have a recent research project: `/knowledge-refresh --knowledge-slug <slug> --mode pull --from-research <project-slug>`. Delegates to `wiki-refresh` to deposit the new findings.
+- **Push mode** — re-research from scratch: `/knowledge-refresh --knowledge-slug <slug> --mode push`. The skill lints the wiki, presents a multi-select of stale topics, and runs the full inverted pipeline per confirmed topic.
+
+---
+
+## Data Model
+
+### binding.json
+
+```json
+{
+  "knowledge_slug": "eu-ai-act",
+  "knowledge_title": "EU AI Act knowledge base",
+  "wiki_path": "/absolute/path/to/eu-ai-act/",
+  "research_projects": [
+    {
+      "slug": "article-6-high-risk",
+      "deposited_at": "2026-05-24",
+      "report_path": "/absolute/path/to/output/report.md",
+      "report_source": "wiki",
+      "project_path": "/absolute/path/to/project/"
+    }
+  ],
+  "topic_lineage": {
+    "covered_themes": ["high-risk classification", "conformity assessment"],
+    "open_themes": ["foundation model obligations"]
+  },
+  "curator_defaults": {
+    "max_candidates_per_sq": 12,
+    "score_threshold": 0.5,
+    "fetch_cache_max_age_days": 30
+  },
+  "created": "2026-05-20",
+  "schema_version": "0.1.0"
+}
+```
+
+The file is small (< 4 KiB even at 20+ deposited projects) and is a narrative manifest — not a database. To search content, use `knowledge-query` against the wiki itself.
+
+### Wiki Pages Written
+
+| Path | Type | Key frontmatter |
+|------|------|-----------------|
+| `wiki/sources/<slug>.md` | source | `type: source`, `sources: [<URL>]`, `pre_extracted_claims:` |
+| `wiki/syntheses/<slug>.md` | synthesis | `type: synthesis`, `derived_from_research: <project-slug>`, `sources: [wiki://<slug>/<cited-slug>]` |
+
+The fetch-cache lives at `<knowledge-root>/.cogni-knowledge/fetch-cache/<sha256>.json` — content-addressed, URL → body, with negative caching for unavailable URLs and a configurable freshness gate (`fetch_cache_max_age_days`).
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `knowledge-finalize` refuses with "cycle detected" | The project's citations include a page that was itself derived from this project | This is `cycle-guard.py` working correctly — the synthesis would cite itself. Start a new project with a different topic framing |
+| `knowledge-verify` shard count is 0 | `citation-manifest.json` is missing `id` / `draft_sentence` fields (pre-v0.0.28 manifest) | Re-run `knowledge-compose` to regenerate the manifest with the current schema, then re-run `knowledge-verify` |
+| Cobrowse step hangs | `claude-in-chrome` extension not running | Either start the extension and retry, or skip cobrowse — misses are recorded as `unavailable` and the pipeline continues without those sources |
+| Dashboard shows no deposits | `knowledge-finalize` was not run to completion | Check `wiki/log.md` — if no finalize entry appears, run `knowledge-finalize` for the project |
+| `knowledge-query` returns thin results | Few sources ingested, or syntheses cover a narrow slice | Run `knowledge-dashboard` to inspect coverage; run additional pipeline projects on open themes |
+| Binding reads a stale wiki path | `wiki_path` in `binding.json` no longer resolves | Edit `binding.json::wiki_path` to the current absolute path of the wiki root |
+
+---
+
+## Extending This Plugin
+
+The delegation contract is the primary constraint on extension: no logic that already exists in cogni-wiki or cogni-research should be duplicated here. If a new capability belongs to wiki structure, file it upstream in cogni-wiki. If it belongs to web research patterns, file it upstream in cogni-research.
+
+What does belong here:
+
+- New binding manifest fields (additive schema changes — bump `schema_version`)
+- New read-side skills that combine `pipeline-summary.py` data with binding data
+- New `curator_defaults` options that configure inverted-pipeline agent behavior
+- Adjustments to `cycle-guard.py` for new citation input shapes
+
+See `cogni-knowledge/references/delegation-contract.md` for the full mapping of which work goes where, and `cogni-knowledge/references/inverted-pipeline.md` for the phase-by-phase design spec.
+
+For contribution guidelines, see the [insight-wave contribution guide](../../CONTRIBUTING.md).

--- a/docs/plugin-guide/cogni-wiki.md
+++ b/docs/plugin-guide/cogni-wiki.md
@@ -21,8 +21,9 @@ The plugin implements [Andrej Karpathy's LLM Wiki pattern](https://gist.github.c
 | **`[[wikilink]]`** | A bidirectional reference between wiki pages — audited after every ingest to keep the knowledge graph connected |
 | **SCHEMA.md** | The contract file shipped inside every wiki — defines conventions, frontmatter fields, and linking rules so the wiki is self-describing |
 | **Compile-time knowledge** | Karpathy's core insight: synthesize once at ingest, not per query. The wiki gets denser over time instead of re-discovering the same ground |
-| **Page type** | Classification of a wiki page: `concept`, `entity`, `summary`, `decision`, `learning`, or `note` |
-| **Lint** | A health audit that checks for broken wikilinks, orphan pages, stale dates, missing frontmatter, and contradictions between pages |
+| **Page type** | Classification of a wiki page: `concept`, `entity`, `summary`, `decision`, `interview`, `meeting`, `learning`, `synthesis`, `note`, or `source`. The directory the page lives in must match its `type:` frontmatter field |
+| **Health check** | A zero-LLM structural integrity preflight (broken wikilinks, missing frontmatter, id mismatches, stub pages, layout drift) — fast enough to run every session automatically via `wiki-resume` |
+| **Lint** | A tokenful semantic audit — contradictions, type drift, undercited claims, missing concept pages. Runs periodically; refuses to start while the health check reports errors |
 
 ---
 
@@ -44,7 +45,17 @@ cogni-wiki/ai-safety-research/
 │   ├── index.md           One-line summary per page
 │   ├── log.md             Append-only operation log
 │   ├── overview.md        Evolving synthesis
-│   └── pages/             Your wiki pages live here
+│   ├── concepts/          type: concept pages
+│   ├── entities/          type: entity pages
+│   ├── summaries/         type: summary pages
+│   ├── decisions/         type: decision pages
+│   ├── interviews/        type: interview pages
+│   ├── meetings/          type: meeting pages
+│   ├── learnings/         type: learning pages
+│   ├── syntheses/         type: synthesis pages (filed-back query answers)
+│   ├── notes/             type: note pages
+│   ├── sources/           type: source pages
+│   └── audits/            lint and health audit reports
 └── .cogni-wiki/config.json
 ```
 
@@ -60,73 +71,118 @@ Claude reads the source, writes a structured summary page with YAML frontmatter,
 
 ## Capabilities
 
+### wiki-resume — Session entry point
+
+Run `wiki-resume` at the start of every session. It automatically runs a zero-LLM `wiki-health` preflight, surfaces the structural-integrity counts (broken links, missing frontmatter, stub pages, layout drift), shows page counts by type, days since last lint, and recommends a concrete next action. If the wiki needs a schema migration, `wiki-resume` surfaces that nudge before anything else.
+
+**Example:**
+> "Where was I with my wiki?"
+
 ### wiki-setup — Bootstrap a new wiki
 
-Run `wiki-setup` to create a fresh wiki at a directory you choose. The skill creates the full layout (raw/, wiki/pages/, assets/, .cogni-wiki/) and seeds the contract files — SCHEMA.md, index.md, log.md, and overview.md. After setup, the wiki is immediately ready to receive sources.
+Run `wiki-setup` to create a fresh wiki at a directory you choose. The skill creates the full per-type directory layout (raw/, wiki/concepts/, wiki/entities/, wiki/summaries/, ..., wiki/audits/, assets/, .cogni-wiki/) and seeds the contract files — SCHEMA.md, index.md, log.md, and overview.md. After setup, the wiki is immediately ready to receive sources. Setup also prompts to prefill the consulting foundations subset via `wiki-prefill`.
 
 **Example:**
 > "Set up a wiki for my AI safety research"
 
 ### wiki-ingest — Add sources to the wiki
 
-Run `wiki-ingest` after dropping a source document (PDF, URL, pasted text, transcript) into `raw/`. Claude reads the source, surfaces key takeaways, writes a summary page with YAML frontmatter (id, title, type, tags, sources), updates `wiki/index.md`, appends to `wiki/log.md`, and runs a backlink audit to weave the new page into existing knowledge.
+Run `wiki-ingest` after dropping a source document (PDF, URL, pasted text, transcript) into `raw/`. Claude reads the source, surfaces key takeaways, writes a summary page with YAML frontmatter (id, title, type, tags, sources) into the appropriate per-type subdirectory, updates `wiki/index.md`, appends to `wiki/log.md`, and runs a backlink audit to weave the new page into existing knowledge. For deferred draining, `--enqueue` / `--next` / `--queue-status` / `--queue-retry` operate a persistent file-based ingest queue.
 
 **Example:**
 > "Ingest this paper into the wiki"
 
 ### wiki-query — Ask questions from the wiki
 
-Run `wiki-query` to ask a question that Claude answers by reading the wiki — never from model memory. The skill consults `wiki/index.md` to find relevant pages, reads them, and synthesizes an answer with `[[wikilink]]` citations. If the wiki doesn't contain the answer, Claude says so rather than hallucinating. Optionally, the answer itself can be filed as a new wiki page so the knowledge compounds.
+Run `wiki-query` to ask a question that Claude answers by reading the wiki — never from model memory. The skill consults `wiki/index.md` to find relevant pages, reads them, and synthesizes an answer with `[[wikilink]]` citations. If the wiki doesn't contain the answer, Claude says so rather than hallucinating. Pass `--file-back yes` to file the answer as a `type: synthesis` page in `wiki/syntheses/` so the exploration compounds rather than evaporating into chat history.
 
 **Example:**
-> "What does my wiki say about constitutional AI?"
+> "What does my wiki say about constitutional AI? Save the answer as a synthesis."
 
-### wiki-lint — Audit wiki health
+### wiki-health — Zero-LLM structural preflight
 
-Run `wiki-lint` after every 5-10 ingests as a maintenance pass. The audit checks for broken `[[wikilinks]]`, orphan pages with no inbound links, stale dates, missing frontmatter fields, contradictions between pages, tag typos, and sources that no longer exist in `raw/`. Results are written to a severity-tiered lint report at `wiki/pages/lint-YYYY-MM-DD.md`.
+Run `wiki-health` (or let `wiki-resume` run it automatically every session) for a free structural integrity scan: broken `[[wikilinks]]`, missing frontmatter fields, broken raw/`wiki://` sources, id mismatches, invalid page types, stub pages, `entries_count` drift between config and filesystem, index/filesystem drift, and the count of citation-drift findings from the last `wiki-claims-resweep`. Zero LLM calls — safe to run before any other work.
 
 **Example:**
-> "Is my wiki healthy?"
+> "Is my wiki structurally sound?" (or just run `wiki-resume`)
+
+### wiki-lint — Tokenful semantic audit
+
+Run `wiki-lint` after every 5-10 ingests as a periodic maintenance pass. The audit checks for contradictions between pages, type drift, undercited claims, missing concept pages, and the deterministic warnings that need narrative — orphans, stale dates, tag typos, reverse-link gaps, claim-drift severity from the latest resweep. Lint calls `wiki-health` as a free preflight and refuses to run while structural errors are pending, so you never burn tokens reasoning about a broken graph. Results are written to `wiki/audits/lint-YYYY-MM-DD.md`.
+
+**Example:**
+> "Audit my wiki for contradictions"
 
 ### wiki-update — Revise existing pages
 
-Run `wiki-update` when knowledge has changed and a page needs correction. The skill shows you the planned diff before writing (diff-before-write discipline), requires a source citation for every new claim, and sweeps related pages for now-stale statements that the update contradicts. This is the wiki equivalent of `git diff` + manual inspection before commit.
+Run `wiki-update` when knowledge has changed and a page needs correction. The skill shows you the planned diff before writing (diff-before-write discipline), requires a source citation for every new claim, and sweeps related pages for now-stale statements that the update contradicts.
 
 **Example:**
 > "Update the constitutional-ai page with findings from this new paper"
 
-### wiki-resume — Status and next action
-
-Run `wiki-resume` to see where you left off — entry count, days since last lint, recent log activity, stale drafts, and a recommended next action. Use this when returning to a wiki after a break.
-
-**Example:**
-> "Where was I with my wiki?"
-
 ### wiki-dashboard — Visual HTML overview
 
-Run `wiki-dashboard` to generate a self-contained HTML file with pages by type, a tag cloud, a backlink graph, recent activity, and size/age histograms. The file has no external CDN calls — safe to open offline or share with collaborators.
+Run `wiki-dashboard` to generate a self-contained HTML file with pages by type (including synthesis), a tag cloud, a backlink graph, recent activity, and size/age histograms. The file has no external CDN calls — safe to open offline or share with collaborators. Add `--graph yes` for the two-pass interactive graph view.
 
 **Example:**
 > "Show me the wiki as a dashboard"
+
+### wiki-from-research — Cold-start from a research project
+
+Run `wiki-from-research` to bootstrap a new wiki directly from a cogni-research project in one dispatch. Mode A (`--topic`) starts fresh — it chains `cogni-research:research-setup` → `research-report` → `wiki-setup` → `wiki-ingest --discover research:<slug>`. Mode B (`--research-slug`) starts from an existing research project and skips straight to setup and ingest. Pre-flight detects wiki-target collisions before any research budget is spent.
+
+**Example:**
+> "Cold-start a wiki from research on agent economy"
+
+### wiki-refresh — Refresh stale pages from research
+
+Run `wiki-refresh --from-research <slug>` to pull fresh evidence from a completed cogni-research project into stale wiki pages. The skill calls `lint_wiki.py` to enumerate `stale_page` (>365 days) and `stale_draft` (>180 days) findings, uses Jaccard token overlap to match each stale page to the most relevant research sub-question, prints the batch plan for one user confirmation, then dispatches `wiki-update` sequentially per matched page.
+
+**Example:**
+> "Refresh stale pages from the agent-economy research"
+
+### wiki-claims-resweep — Re-verify cited URLs
+
+Run `wiki-claims-resweep` to check whether the sources cited in existing wiki pages still support the claims made. The skill walks every per-type page directory, extracts inline-cited statements deterministically, dispatches them through `cogni-claims` for re-verification, and writes a sweep report to `raw/claims-resweep-<date>/report.md` plus a lint-bridge JSON at `.cogni-wiki/last-resweep.json`. Report-only: it never modifies wiki pages directly. Stale-marker decisions go through `wiki-update` manually after reviewing the report.
+
+**Example:**
+> "Re-verify wiki citations against current sources"
+
+### wiki-prefill — Seed foundation concept pages
+
+Run `wiki-prefill` to seed `wiki/concepts/` with curated `foundation: true` concept pages — Porter's Five Forces, Jobs-to-be-Done, MECE, Pyramid Principle, OODA Loop, SWOT, BCG Matrix, Value Chain, Lean Canvas, Wardley Mapping, Double Diamond. The skill is idempotent and locked; existing foundation pages are never overwritten. Pass `--filter consulting|product|strategy|all` to select a subset, `--list` to preview, or `--dry-run` to plan without writing.
+
+**Example:**
+> "Seed my wiki with consulting framework foundations"
 
 ---
 
 ## Integration Points
 
-### Upstream — no plugin dependencies
+### cogni-research (live)
 
-cogni-wiki is standalone in v0.0.x. Sources come from the user (documents dropped in `raw/`, URLs, pasted text), not from other plugins.
+Three skills connect cogni-wiki to cogni-research:
 
-### Downstream — future integration contracts
+- **wiki-from-research** bootstraps a new wiki directly from a cogni-research project — either from a free-text topic (Mode A) or an existing project slug (Mode B). This is the fastest path from "I want a wiki on X" to a populated, queryable knowledge base.
+- **wiki-refresh** pulls fresh research evidence into stale wiki pages. After running a new research cycle on a topic your wiki already covers, `wiki-refresh --from-research <slug>` matches the stale pages to relevant sub-questions and dispatches `wiki-update` per match.
+- **wiki-ingest --discover research:\<slug\>** can also be run standalone to deposit a completed research project's sub-question findings into an existing wiki without the full cold-start orchestration.
 
-These integrations are deferred to post-MVP but documented in the plugin's CLAUDE.md:
+### cogni-claims (live)
 
-| Plugin | Planned integration |
-|--------|-------------------|
-| cogni-research | Research reports deposit verified findings as wiki pages |
-| cogni-narrative | Narrative skill reads wiki pages as structured input |
-| cogni-consulting | Engagement knowledge (interviews, decisions, constraints) persists beyond the engagement |
-| cogni-claims | Wiki claim extraction and verification via cogni-claims |
+**wiki-claims-resweep** closes the citation-drift loop. It extracts inline-cited statements from every wiki page, dispatches them through cogni-claims for source re-verification, and writes a sweep report. The findings feed back into `wiki-health` (which surfaces a `claim_drift_count`) and `wiki-lint` (which surfaces `claim_drift` warnings with severity), so regular health checks give you a running signal on citation freshness without re-running the full resweep.
+
+The reverse direction — cogni-claims propagating corrections back into wiki pages — remains deferred. Current workflow: review the resweep report, then run `wiki-update` manually on flagged pages.
+
+### cogni-knowledge (live)
+
+cogni-knowledge uses cogni-wiki as its substrate. When `cogni-knowledge:knowledge-ingest` processes sources, it writes `type: source` pages into `wiki/sources/`. When `cogni-knowledge:knowledge-compose` and `knowledge-finalize` run, they write `type: synthesis` pages into `wiki/syntheses/`. cogni-wiki recognizes these page types and routes them correctly; the per-type semantics (e.g., `pre_extracted_claims:` frontmatter on source pages) are owned by cogni-knowledge, not by cogni-wiki's schema.
+
+### Planned integrations
+
+| Plugin | Status | Integration direction |
+|--------|--------|-----------------------|
+| cogni-narrative | Planned (v0.1.x) | Narrative skill reads wiki pages as structured input |
+| cogni-consulting | Planned (v0.1.x) | Engagement knowledge (interviews, decisions, constraints) persists beyond the engagement slug |
 
 ---
 
@@ -193,6 +249,27 @@ helpful, harmless, and honest using a set of principles...
 - [[ai-safety-overview]] — broader context for alignment approaches
 ```
 
+This page lives at `wiki/concepts/constitutional-ai.md` because its `type:` is `concept`. The `type:` frontmatter field must match the directory — `wiki-health`'s `type_directory_mismatch` check catches any drift.
+
+**Page types and their directories:**
+
+| type | directory | notes |
+|------|-----------|-------|
+| `concept` | `wiki/concepts/` | Framework definitions, foundational ideas |
+| `entity` | `wiki/entities/` | Named actors, organizations, products |
+| `summary` | `wiki/summaries/` | Source document summaries |
+| `decision` | `wiki/decisions/` | Recorded decisions with rationale |
+| `interview` | `wiki/interviews/` | Customer calls, expert interviews |
+| `meeting` | `wiki/meetings/` | Meeting notes |
+| `learning` | `wiki/learnings/` | Retrospectives and lessons learned |
+| `synthesis` | `wiki/syntheses/` | LLM-derived answers filed back by `wiki-query --file-back yes`; cite `wiki://` provenance |
+| `note` | `wiki/notes/` | Unstructured notes |
+| `source` | `wiki/sources/` | Raw source bodies written by cogni-knowledge |
+
+Audit reports (`lint-YYYY-MM-DD.md`, `health-YYYY-MM-DD.md`) live in `wiki/audits/`.
+
+`[[wikilinks]]` use slugs only — no path component — so they work regardless of which directory a page lives in. Slugs must be globally unique across all page types.
+
 The wiki's metadata lives in `.cogni-wiki/config.json`:
 
 ```json
@@ -201,7 +278,8 @@ The wiki's metadata lives in `.cogni-wiki/config.json`:
   "slug": "ai-safety-research",
   "created": "2026-04-12",
   "entries_count": 23,
-  "last_lint": "2026-04-12"
+  "last_lint": "2026-04-12",
+  "schema_version": "0.0.6"
 }
 ```
 
@@ -230,7 +308,7 @@ Claude Code has its own memory system at `~/.claude/projects/.../memory/` — th
 cogni-wiki is open-source under AGPL-3.0. The most useful contribution areas are:
 
 - **New page types** — the current taxonomy covers concept, entity, summary, decision, learning, and note. Domain-specific types (e.g., `experiment`, `protocol`, `glossary-entry`) would help specialized wikis.
-- **Cross-plugin integration** — the planned cogni-research and cogni-claims integrations are documented but not yet implemented. Contributions that connect wiki ingestion to the research or claims pipeline are high-value.
+- **Cross-plugin integration** — cogni-research and cogni-claims integrations are live (`wiki-from-research`, `wiki-refresh`, `wiki-claims-resweep`). The next open frontier is the cogni-narrative and cogni-consulting directions (planned for v0.1.x) — contributions that surface wiki pages as structured narrative input or persist consulting engagement knowledge are high-value.
 - **Lint rules** — new health checks (e.g., detecting circular wikilink chains, flagging pages with no sources, or checking citation freshness) expand the quality audit.
 
 See [CONTRIBUTING.md](../../cogni-wiki/CONTRIBUTING.md) for guidelines and the [plugin development guide](../contributing/plugin-development.md) for the plugin standard.


### PR DESCRIPTION
## Summary
- Regenerate structural sections (components, architecture, dependencies, entry-point + markets callouts, version annotations) for 11 plugins via doc-generate, plus description sync for cogni-narrative and cogni-portfolio
- Refresh stale cogni-wiki plugin guide and bootstrap missing cogni-knowledge plugin guide
- Regenerate root README to include cogni-knowledge as the 15th plugin (was claiming 14), with refreshed glance-table counts (118 skills / 86 agents)
- Reframe all plugin intros from "A Claude Cowork plugin" to "Claude Code / Claude Cowork" so the pitch matches each plugin's readiness callout (Claude Code is the recommended interface; Cowork is the secondary path)

Branch: `docs/sync-drift-2026-05-25` (base: `main`, rebased onto the cogni-knowledge 0.1.3 merge)

## Plugins fixed
- **cogni-narrative**: descriptions — "10"→"11 arc frameworks" (intro, "What it is", "What it means for you")
- **cogni-workspace**: components + architecture — 3 missing skills added (audit-region-sources, manage-markets, workspace-dashboard); "6"→"9 workspace management skills"
- **cogni-trends**: architecture + entry_point — "11"→"12 research agents", `tests/` added to tree, Start-here callout + Quick start promotion
- **cogni-portfolio**: architecture + dependencies + entry_point + descriptions — "13"→"18 utility scripts", cogni-research dependency added, market-coverage scope synced to plugin.json, callout + Quick start + Components promotion
- **cogni-visual**: architecture — stale version annotation v0.16.20 → v0.16.22
- **cogni-help**: architecture — stale version annotation v0.0.6 → v0.0.7
- **cogni-marketing**: entry_point — Start-here callout + Quick start + Components promotion
- **cogni-research**: components + architecture + markets + entry_point — audit-arcs added (table + tree, "4"→"5 skills"); stale authorities corrected (CONACYT→Conahcyt, Xinhua→Caixin); callout + Quick start + Components promotion
- **cogni-website**: entry_point — Start-here callout + Quick start + Components promotion
- **cogni-consulting**: architecture + entry_point — discover-projects.sh + _discover_extractor.py added to tree; callout + Quick start + Components promotion
- **cogni-wiki**: docs + entry_point — plugin guide refreshed (7→12 skills, live integrations, per-type layout, no `wiki/pages/`); callout + Quick start + Components promotion
- **cogni-knowledge**: dependencies + docs — cogni-workspace runtime dependency added; plugin guide created
- **Root README**: now 15 plugins with a cogni-knowledge glance-table row, repo-tree entry, and Knowledge Management blurb

## Review findings — resolved
- **major (resolved, commit `a4ff172b`)** — the "Claude Cowork plugin" intro framing contradicted the per-plugin readiness callouts. Settled ecosystem-wide: all 8 affected plugin READMEs (consulting, copywriting, claims, portfolio ×2, visual, trends, workspace) now read "Claude Code / Claude Cowork", Claude Code first. This brought cogni-copywriting and cogni-claims into the diff for the Cowork line only — the deferred cogni-copywriting EN↔DE intro rewrite is unrelated and stays out of scope.
- **minor (resolved, commit `3f52b1c`)** — cogni-narrative line 37 "Ten"→"Eleven" frameworks.
- **moot** — the audit's "stale `incubating` keyword" finding on cogni-knowledge plugin.json was a false positive; the live keywords array already reads `preview`. No fix needed.

## Deferred to follow-up (need human judgment — out of scope for this sweep)
- **cogni-copywriting**: README intro omits the EN↔DE translation pass that plugin.json describes — brand/voice judgment, not a mechanical doc-sync rewrite.
- **cogni-knowledge**: WEAK messaging — no `## What it means for you` section (MEANS embedded inline); needs `/doc-power`.
- **pipeline-registry.json drift**: +31 skills / −1 removed; reconciling via `/cogni-docs:doc-meta --apply` requires a human to fill artifact paths for the added skills. Until then, doc-audit's pipeline-suffix checks (10a) run against a stale registry.
- **docs/ Cowork mentions**: `docs/deployment-guide.md` (intentional interface comparison), `docs/audit-report.md` (historical), and `docs/plugin-guide/cogni-claims.md` still say "Claude Cowork" — left untouched; sweep separately if desired.

## Test plan
- [x] Root README shows 15 plugins; glance-table totals (118 skills / 86 agents) sum correctly against the per-plugin rows
- [x] No standalone "Claude Cowork plugin" intro remains in any plugin README
- [ ] Spot-check each fixed plugin's README renders on github.com (tables, callouts, version annotations)
- [ ] Run `/cogni-docs:doc-audit all` on this branch to confirm per-plugin and root-README drift is gone
