### PR TITLE
cogni-knowledge 0.1.3: default knowledge-root to cogni-knowledge/&lt;slug&gt;/ (#296)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -277,7 +277,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds a cogni-wiki knowledge base to a project so every research run deposits into the same persistent, queryable, interlinked markdown wiki — and so future runs read what previous runs filed instead of starting from zero. The v0.1.0 inverted pipeline (plan → curate → fetch → ingest → compose → verify → finalize) forks dedicated agents locally and runs zero-network claim verification against pre-extracted source claims. The differentiator vs. one-shot deep-research tools (OpenAI Deep Research, Perplexity Spaces, GPT Researcher) is the binding: knowledge accumulates across projects instead of dying in chat history.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Wiki-first research that compounds. Binds a cogni-wiki knowledge base to a project so every research run deposits into the same persistent, queryable, interlinked markdown wiki — and so future runs read what previous runs filed instead of starting from zero. The v0.1.0 inverted pipeline (plan → curate → fetch → ingest → compose → verify → finalize) forks dedicated agents locally and runs zero-network claim verification against pre-extracted source claims. The differentiator vs. one-shot deep-research tools (OpenAI Deep Research, Perplexity Spaces, GPT Researcher) is the binding: knowledge accumulates across projects instead of dying in chat history.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/CHANGELOG.md
+++ b/cogni-knowledge/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.3 — 2026-05-25
 
-Fixes the default knowledge-base location (**#296**). `knowledge-setup` defaulted `--knowledge-root` to `<cwd>/<knowledge-slug>/`, which in a multi-plugin workspace drops the base at the repo root instead of under the plugin namespace — breaking the monorepo's `cogni-{plugin}/{project-slug}/` convention and diverging from its only dependency, `cogni-wiki:wiki-setup`, which already defaults to `cogni-wiki/{slug}`. The default now resolves to `cogni-knowledge/<knowledge-slug>/` (relative to cwd). The `--knowledge-root` override is unchanged. Clean change, no legacy fallback — appropriate for a Preview plugin with no in-repo base relying on the old default. Maturity stays **Preview**. Closes **#296**; epic **#264**.
+Fixes the default knowledge-base location (**#296**). `knowledge-setup` defaulted `--knowledge-root` to `<cwd>/<knowledge-slug>/`, which in a multi-plugin workspace drops the base at the repo root instead of under the plugin namespace — breaking the monorepo's `cogni-{plugin}/{project-slug}/` convention and diverging from its only dependency, `cogni-wiki:wiki-setup`, which already defaults to `cogni-wiki/{slug}`. The default now resolves to `cogni-knowledge/<knowledge-slug>/` (relative to cwd). The `--knowledge-root` override is unchanged. Clean change, no legacy fallback — appropriate for a Preview plugin with no in-repo base relying on the old default. Migration: a knowledge base created before 0.1.3 at the old `<cwd>/<slug>/` default needs an explicit `--knowledge-root <path>` on subsequent `knowledge-*` calls, since the new default resolves to `cogni-knowledge/<slug>/`. Maturity stays **Preview**. Closes **#296**; epic **#264**.
 
 ### Fixed
 

--- a/cogni-knowledge/CHANGELOG.md
+++ b/cogni-knowledge/CHANGELOG.md
@@ -1,5 +1,17 @@
 # cogni-knowledge changelog
 
+## 0.1.3 — 2026-05-25
+
+Fixes the default knowledge-base location (**#296**). `knowledge-setup` defaulted `--knowledge-root` to `<cwd>/<knowledge-slug>/`, which in a multi-plugin workspace drops the base at the repo root instead of under the plugin namespace — breaking the monorepo's `cogni-{plugin}/{project-slug}/` convention and diverging from its only dependency, `cogni-wiki:wiki-setup`, which already defaults to `cogni-wiki/{slug}`. The default now resolves to `cogni-knowledge/<knowledge-slug>/` (relative to cwd). The `--knowledge-root` override is unchanged. Clean change, no legacy fallback — appropriate for a Preview plugin with no in-repo base relying on the old default. Maturity stays **Preview**. Closes **#296**; epic **#264**.
+
+### Fixed
+
+- **Default knowledge-root now follows the cogni-plugin convention.** The default resolves to `cogni-knowledge/<knowledge-slug>/` instead of `<cwd>/<knowledge-slug>/`, mirroring `cogni-wiki:wiki-setup`'s `cogni-wiki/{slug}` default. The resolution lives entirely in skill prose (the LLM passes an already-resolved `--knowledge-root` to `knowledge-binding.py init`; the script never computes the default), so this is a prose-only change with no script or test edit. `knowledge-setup` Step 1 is the canonical resolver and now carries the convention note; the five sibling skills that restate the formula (`knowledge-plan` / `knowledge-resume` / `knowledge-query` / `knowledge-dashboard` / `knowledge-refresh`) were updated in lockstep, and the six pipeline skills that delegate via "same logic as <prev>" inherit it. The bound wiki nests correctly with no extra change — Step 3 passes `--wiki-root <knowledge_root>` and the binding's `--wiki-path` is `<knowledge_root>`. Files: `skills/{knowledge-setup,knowledge-plan,knowledge-resume,knowledge-query,knowledge-dashboard,knowledge-refresh}/SKILL.md`, `CLAUDE.md`.
+
+### Version
+
+- `.claude-plugin/plugin.json` + root `.claude-plugin/marketplace.json` — `0.1.2` → `0.1.3` (mirrored). Maturity stays `preview`.
+
 ## 0.1.2 — 2026-05-25
 
 Follow-up from the PR #290 review (**#291**) — guards `knowledge-verify` against a citation-manifest written before v0.0.28. F22 (v0.0.28) made `id` + `draft_sentence` required per citation but kept the additive `schema_version: "0.1.0"`, so a manifest from a ≤0.0.27 composer still declares `0.1.0` while carrying neither field. Run against such a mid-upgrade draft, the verifier would mass-drop every citation as `sentence_not_in_draft` and merge could trip its duplicate-id check on the `None` ids. Now it fails loud and early with a "re-run knowledge-compose" message. Plus secondary housekeeping. Maturity stays **Preview**. Closes **#291**; epic **#264**.

--- a/cogni-knowledge/CLAUDE.md
+++ b/cogni-knowledge/CLAUDE.md
@@ -122,7 +122,7 @@ A few specifics:
 - Skill names: `knowledge-*` (generic skill names like `setup`, `research`, `resume` MUST be prefixed per `../CLAUDE.md` §"Contributing").
 - Skill frontmatter: `name`, `description`, `allowed-tools` — same shape as cogni-wiki/cogni-research skills.
 - Script CLI: `python3 scripts/<name>.py --action ...`, JSON envelope output.
-- Path conventions: knowledge bases default to `<cwd>/<knowledge-slug>/` (matching `cogni-wiki/{slug}/`).
+- Path conventions: knowledge bases default to `cogni-knowledge/<knowledge-slug>/` (standard cogni-plugin convention, matching `cogni-wiki/{slug}/`).
 - Versioning: bump patch on any skill/script change; mirror in `marketplace.json` (`../CLAUDE.md` §"Version Management").
 - Citation count (F24 pin): the one authoritative count is `len(.metadata/citation-manifest.json::citations)` for the latest draft version — surfaced by `pipeline-summary.py project`. The composer's return `citations` field and the `knowledge-compose`/`knowledge-verify` summary lines all source this same length (never an LLM estimate). A `verify-vN.json` `counts.total` is verdicts scored for draft-vN at that round's start (before the §3.2 `sentence_not_in_draft` prune), NOT the citation count.
 

--- a/cogni-knowledge/skills/knowledge-dashboard/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-dashboard/SKILL.md
@@ -31,7 +31,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` once per session 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `--knowledge-slug` | Yes | Slug of the bound knowledge base. Resolves to `cogni-knowledge/<slug>/` unless `--knowledge-root` overrides. |
-| `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `cogni-knowledge/<knowledge-slug>/` (relative to the cwd). |
+| `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `cogni-knowledge/<knowledge-slug>/` (relative to the current working directory). |
 | `--graph` | No | Pass-through to `cogni-wiki:wiki-dashboard --graph`. Values: `no` (default) / `pass1` / `yes`. |
 | `--open` | No | Pass-through to `cogni-wiki:wiki-dashboard --open`. Values: `yes` / `no` (default). |
 
@@ -62,7 +62,7 @@ Then continue with the binding-resolution checks:
 
 1. Resolve `knowledge_root`:
    - If `--knowledge-root` is set, use it.
-   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the cwd).
+   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the current working directory).
 
 2. Read the binding:
    ```

--- a/cogni-knowledge/skills/knowledge-dashboard/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-dashboard/SKILL.md
@@ -30,8 +30,8 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` once per session 
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--knowledge-slug` | Yes | Slug of the bound knowledge base. Resolves to `<cwd>/<slug>/` unless `--knowledge-root` overrides. |
-| `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `<cwd>/<knowledge-slug>/`. |
+| `--knowledge-slug` | Yes | Slug of the bound knowledge base. Resolves to `cogni-knowledge/<slug>/` unless `--knowledge-root` overrides. |
+| `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `cogni-knowledge/<knowledge-slug>/` (relative to the cwd). |
 | `--graph` | No | Pass-through to `cogni-wiki:wiki-dashboard --graph`. Values: `no` (default) / `pass1` / `yes`. |
 | `--open` | No | Pass-through to `cogni-wiki:wiki-dashboard --open`. Values: `yes` / `no` (default). |
 
@@ -62,7 +62,7 @@ Then continue with the binding-resolution checks:
 
 1. Resolve `knowledge_root`:
    - If `--knowledge-root` is set, use it.
-   - Otherwise, `knowledge_root = <cwd>/<knowledge-slug>/`.
+   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the cwd).
 
 2. Read the binding:
    ```

--- a/cogni-knowledge/skills/knowledge-plan/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-plan/SKILL.md
@@ -24,7 +24,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/inverted-pipeline.md` once at the start o
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--knowledge-slug` | Yes | Slug of the bound knowledge base. Resolves to `<cwd>/<slug>/` unless `--knowledge-root` overrides. |
+| `--knowledge-slug` | Yes | Slug of the bound knowledge base. Resolves to `cogni-knowledge/<slug>/` unless `--knowledge-root` overrides. |
 | `--topic` | Yes (prompted) | Free-text research topic, e.g. `"GDPR Article 30 records of processing"`. |
 | `--knowledge-root` | No | Override the default knowledge-base directory. |
 | `--market` | No | Market code (default `dach`). One of: `dach`, `de`, `fr`, `it`, `pl`, `nl`, `es`, `us`, `uk`, `eu`. |
@@ -58,7 +58,7 @@ If `WIKI_OK=no`, abort:
 
 **Binding.** Resolve `knowledge_root`:
 1. If `--knowledge-root` is set, use it.
-2. Otherwise, `knowledge_root = <cwd>/<knowledge-slug>/`.
+2. Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the cwd).
 
 Read the binding:
 

--- a/cogni-knowledge/skills/knowledge-plan/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-plan/SKILL.md
@@ -58,7 +58,7 @@ If `WIKI_OK=no`, abort:
 
 **Binding.** Resolve `knowledge_root`:
 1. If `--knowledge-root` is set, use it.
-2. Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the cwd).
+2. Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the current working directory).
 
 Read the binding:
 

--- a/cogni-knowledge/skills/knowledge-query/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-query/SKILL.md
@@ -32,7 +32,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/differentiation-thesis.md` once per sessi
 |-----------|----------|-------------|
 | `--knowledge-slug` | Yes | Slug of the bound knowledge base. Resolves to `cogni-knowledge/<slug>/` unless `--knowledge-root` overrides. |
 | `--question` | Yes (prompted) | Free-text question. Forwarded to `cogni-wiki:wiki-query --question`. |
-| `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `cogni-knowledge/<knowledge-slug>/` (relative to the cwd). |
+| `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `cogni-knowledge/<knowledge-slug>/` (relative to the current working directory). |
 | `--file-back` | No | `auto` (default — wiki-query asks the user) / `yes` / `no`. Pass-through to `cogni-wiki:wiki-query --file-back`. |
 | `--max-pages` | No | Cap on how many pages wiki-query reads. Pass-through to `cogni-wiki:wiki-query --max-pages`. Default 12 (upstream). |
 
@@ -65,7 +65,7 @@ Then continue with the binding-resolution checks:
 
 1. Resolve `knowledge_root`:
    - If `--knowledge-root` is set, use it.
-   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the cwd).
+   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the current working directory).
 
 2. Read the binding:
    ```

--- a/cogni-knowledge/skills/knowledge-query/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-query/SKILL.md
@@ -30,9 +30,9 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/differentiation-thesis.md` once per sessi
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--knowledge-slug` | Yes | Slug of the bound knowledge base. Resolves to `<cwd>/<slug>/` unless `--knowledge-root` overrides. |
+| `--knowledge-slug` | Yes | Slug of the bound knowledge base. Resolves to `cogni-knowledge/<slug>/` unless `--knowledge-root` overrides. |
 | `--question` | Yes (prompted) | Free-text question. Forwarded to `cogni-wiki:wiki-query --question`. |
-| `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `<cwd>/<knowledge-slug>/`. |
+| `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `cogni-knowledge/<knowledge-slug>/` (relative to the cwd). |
 | `--file-back` | No | `auto` (default — wiki-query asks the user) / `yes` / `no`. Pass-through to `cogni-wiki:wiki-query --file-back`. |
 | `--max-pages` | No | Cap on how many pages wiki-query reads. Pass-through to `cogni-wiki:wiki-query --max-pages`. Default 12 (upstream). |
 
@@ -65,7 +65,7 @@ Then continue with the binding-resolution checks:
 
 1. Resolve `knowledge_root`:
    - If `--knowledge-root` is set, use it.
-   - Otherwise, `knowledge_root = <cwd>/<knowledge-slug>/`.
+   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the cwd).
 
 2. Read the binding:
    ```

--- a/cogni-knowledge/skills/knowledge-refresh/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-refresh/SKILL.md
@@ -72,7 +72,7 @@ Then continue with the binding-resolution checks:
 
 1. Resolve `knowledge_root`:
    - If `--knowledge-root` is set, use it.
-   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the cwd).
+   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the current working directory).
 
 2. Read the binding:
    ```

--- a/cogni-knowledge/skills/knowledge-refresh/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-refresh/SKILL.md
@@ -31,7 +31,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` once per session 
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--knowledge-slug` | Yes | Slug of the bound knowledge base. Resolves to `<cwd>/<slug>/` unless `--knowledge-root` overrides. |
+| `--knowledge-slug` | Yes | Slug of the bound knowledge base. Resolves to `cogni-knowledge/<slug>/` unless `--knowledge-root` overrides. |
 | `--mode` | Yes | `push` or `pull`. Selects the workflow. |
 | `--knowledge-root` | No | Override the default knowledge-base directory. |
 | `--from-research <slug>` | Pull-mode only | Slug of the cogni-research project to pull from. Required when `--mode pull`. |
@@ -72,7 +72,7 @@ Then continue with the binding-resolution checks:
 
 1. Resolve `knowledge_root`:
    - If `--knowledge-root` is set, use it.
-   - Otherwise, `knowledge_root = <cwd>/<knowledge-slug>/`.
+   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the cwd).
 
 2. Read the binding:
    ```

--- a/cogni-knowledge/skills/knowledge-resume/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-resume/SKILL.md
@@ -25,7 +25,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` once at the start
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--knowledge-slug` | Yes | Slug of the knowledge base to resume. Resolves to `<cwd>/<slug>/` unless `--knowledge-root` overrides. |
+| `--knowledge-slug` | Yes | Slug of the knowledge base to resume. Resolves to `cogni-knowledge/<slug>/` unless `--knowledge-root` overrides. |
 | `--knowledge-root` | No | Override the default knowledge-base directory. |
 | `--verbose` | No | Forward to `cogni-wiki:wiki-resume --verbose`. Includes recent log activity verbatim. |
 
@@ -58,7 +58,7 @@ Resume is read-only with respect to disk, but it still dispatches `cogni-wiki:wi
 
 1. Resolve `knowledge_root`:
    - If `--knowledge-root` is set, use it.
-   - Otherwise, `knowledge_root = <cwd>/<knowledge-slug>/`.
+   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the cwd).
 
 2. Read the binding:
    ```

--- a/cogni-knowledge/skills/knowledge-resume/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-resume/SKILL.md
@@ -58,7 +58,7 @@ Resume is read-only with respect to disk, but it still dispatches `cogni-wiki:wi
 
 1. Resolve `knowledge_root`:
    - If `--knowledge-root` is set, use it.
-   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the cwd).
+   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the current working directory).
 
 2. Read the binding:
    ```

--- a/cogni-knowledge/skills/knowledge-setup/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-setup/SKILL.md
@@ -29,7 +29,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/differentiation-thesis.md` once at the st
 |-----------|----------|-------------|
 | `--knowledge-slug` | Yes (prompted) | Kebab-case identifier for the knowledge base, e.g. `eu-ai-act`. Used for the directory name (`cogni-knowledge/<slug>/`) and the `knowledge_slug` field in the binding. |
 | `--knowledge-title` | Yes (prompted) | Human-readable title, e.g. `"EU AI Act knowledge base"`. Used as the `--name` for `cogni-wiki:wiki-setup`. |
-| `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `cogni-knowledge/<knowledge-slug>/` (relative to the cwd). Both the wiki and the binding live inside this directory. |
+| `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `cogni-knowledge/<knowledge-slug>/` (relative to the current working directory). Both the wiki and the binding live inside this directory. |
 | `--description` | No | One-sentence description forwarded to `cogni-wiki:wiki-setup --description`. |
 | `--publisher-base-url` | No | Forwarded to `cogni-wiki:wiki-setup --publisher-base-url`. Used as last-resort fallback URL when wiki pages have no per-page publisher URL. |
 
@@ -67,7 +67,7 @@ The same probe runs in every other `knowledge-*` skill (rolled out at v0.0.14, a
 ### 1. Resolve the knowledge root
 
 1. If `--knowledge-root` was passed, use it as-is.
-2. Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` relative to the cwd — the standard cogni-plugin convention (`cogni-{plugin}/{project-slug}/`), matching `cogni-wiki/{slug}/`.
+2. Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` relative to the current working directory — the standard cogni-plugin convention (`cogni-{plugin}/{project-slug}/`), matching `cogni-wiki/{slug}/`.
 3. If `<knowledge_root>/.cogni-knowledge/binding.json` already exists: read it, report the existing knowledge_slug/title/wiki_path, and stop. Do not overwrite.
 
 ### 2. Pre-flight: wiki vs no wiki

--- a/cogni-knowledge/skills/knowledge-setup/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-setup/SKILL.md
@@ -27,9 +27,9 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/differentiation-thesis.md` once at the st
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--knowledge-slug` | Yes (prompted) | Kebab-case identifier for the knowledge base, e.g. `eu-ai-act`. Used for the directory name (`<cwd>/<slug>/`) and the `knowledge_slug` field in the binding. |
+| `--knowledge-slug` | Yes (prompted) | Kebab-case identifier for the knowledge base, e.g. `eu-ai-act`. Used for the directory name (`cogni-knowledge/<slug>/`) and the `knowledge_slug` field in the binding. |
 | `--knowledge-title` | Yes (prompted) | Human-readable title, e.g. `"EU AI Act knowledge base"`. Used as the `--name` for `cogni-wiki:wiki-setup`. |
-| `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `<cwd>/<knowledge-slug>/`. Both the wiki and the binding live inside this directory. |
+| `--knowledge-root` | No | Override the default knowledge-base directory. Defaults to `cogni-knowledge/<knowledge-slug>/` (relative to the cwd). Both the wiki and the binding live inside this directory. |
 | `--description` | No | One-sentence description forwarded to `cogni-wiki:wiki-setup --description`. |
 | `--publisher-base-url` | No | Forwarded to `cogni-wiki:wiki-setup --publisher-base-url`. Used as last-resort fallback URL when wiki pages have no per-page publisher URL. |
 
@@ -67,7 +67,7 @@ The same probe runs in every other `knowledge-*` skill (rolled out at v0.0.14, a
 ### 1. Resolve the knowledge root
 
 1. If `--knowledge-root` was passed, use it as-is.
-2. Otherwise, `knowledge_root = <cwd>/<knowledge-slug>/`.
+2. Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` relative to the cwd — the standard cogni-plugin convention (`cogni-{plugin}/{project-slug}/`), matching `cogni-wiki/{slug}/`.
 3. If `<knowledge_root>/.cogni-knowledge/binding.json` already exists: read it, report the existing knowledge_slug/title/wiki_path, and stop. Do not overwrite.
 
 ### 2. Pre-flight: wiki vs no wiki


### PR DESCRIPTION
## Summary

Fixes #296. `cogni-knowledge:knowledge-setup` defaulted `--knowledge-root` to `<cwd>/<knowledge-slug>/`, which in a multi-plugin workspace drops the knowledge base at the repo root instead of under the plugin namespace — breaking the monorepo's `cogni-{plugin}/{project-slug}/` convention and diverging from its only dependency, `cogni-wiki:wiki-setup`, which already defaults to `cogni-wiki/{slug}`.

The default now resolves to **`cogni-knowledge/<knowledge-slug>/`** (relative to cwd). The `--knowledge-root` explicit override is unchanged. Clean change, no legacy fallback — appropriate for a Preview (v0.1.x) plugin with no in-repo base relying on the old default.

## Why it's prose-only

The default is resolved **entirely in SKILL.md prose** — the LLM reads the formula and passes an already-resolved `--knowledge-root` to `scripts/knowledge-binding.py init`; the script never computes the default. So:

- **No script edit** — the binding script receives the resolved root.
- **No test edit** — no test asserts the default path (verified).
- **No README / doc-generate** — the change is workflow-step prose, not skill descriptions/names/components.
- **Wiki nests correctly with no extra change** — `knowledge-setup` Step 3 passes `--wiki-root <knowledge_root>` and the binding's `--wiki-path` is `<knowledge_root>`, so both follow the new path.

## Changes

- **`knowledge-setup/SKILL.md`** Step 1 — the canonical resolver — now carries the convention note, mirroring `cogni-wiki:wiki-setup` Step 1.
- The five sibling skills that restate the formula updated in lockstep: `knowledge-plan`, `knowledge-resume`, `knowledge-query`, `knowledge-dashboard`, `knowledge-refresh`.
- The six delegating pipeline skills (`knowledge-curate` → … → `knowledge-finalize`, "same logic as <prev>") inherit the fix — no edit.
- `CLAUDE.md` §Conventions — fixed the previously self-contradictory path-convention line.
- Version bump `0.1.2` → `0.1.3` (`plugin.json` + `marketplace.json` mirrored) + CHANGELOG entry. Maturity stays Preview.

## Test plan

- [x] `grep -rn '<cwd>' cogni-knowledge/skills/` → zero `<cwd>` tokens (two unrelated bare-word `cwd` mentions intentionally untouched)
- [x] `cogni-knowledge/.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` both at `0.1.3`
- [x] `tests/test_verify_contract.sh`, `tests/test_verify_store.sh`, `tests/test_skill_contracts.sh`, `tests/test_knowledge_setup_probe.sh` — all green

Closes #296.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyLWSVmNhjLkHe4w2LeCQr)_