### PR TITLE
cogni-knowledge 0.1.32: knowledge-resume next-action branching + sibling-skill coverage (closes #371)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/skills/knowledge-resume/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-resume/SKILL.md
@@ -109,12 +109,31 @@ Print a ≤ 12-line summary that layers the binding onto the wiki status:
 - **Deposited research projects.** `<count>` — one line per project (newest first, cap 5, "and N more" for the rest), each as: `<slug> — <sub_questions> sub-questions · <fetched> fetched · phase <phase_reached>` + ` · <concepts_total> concepts (<claims_deduped>/<claims_attached> claims deduped)` when `concepts_total > 0` (the Phase-4.5 distill compounding signal) + `· synthesis ✓` when the binding entry's `report_source == "wiki"` + ` (<deposited_at>)`. Legacy deposits show `<slug> — (legacy deposit) (<deposited_at>)`.
 - **Pipeline status.** Knowledge-base-global fetch-cache (one shared cache across all projects): one line by `verdict` — `healthy` → `fetch-cache healthy (<entries> sources)`; `stale` → `fetch-cache stale — run knowledge-fetch --refresh`; `empty` → `fetch-cache empty — run knowledge-plan first`.
 - **Topic lineage.** If `covered_themes` or `open_themes` are non-empty, print them as two short lists. Else omit.
-- **Next action.** Recommend based on state:
-  - If `research_projects` is empty: "Run the inverted pipeline (`knowledge-plan --knowledge-slug <slug> --topic '...'`, then `knowledge-curate` → `knowledge-fetch` → `knowledge-ingest` → `knowledge-compose` → `knowledge-verify` → `knowledge-finalize`) to deposit your first project."
-  - If wiki has structural issues: "Fix structural issues first — see the wiki-resume output above. Then run the inverted pipeline for more deposits, or `cogni-wiki:wiki-query` to ask the base."
-  - Otherwise: "Run the inverted pipeline (`knowledge-plan` → … → `knowledge-finalize`) to keep accumulating, or `cogni-wiki:wiki-query --question '...'` to ask the base what it knows."
+- **Next action.** One line, selected by the decision tree below.
 
 The full `wiki-resume` output appears verbatim above the summary so the user has the structural detail at hand; cogni-knowledge's contribution is the binding overlay.
+
+#### Next action — recommend by pipeline phase
+
+Pick the **one** Next-action line to print by branching on workflow state, not by reading out a fixed sequence. The state field is each project's `phase_reached` from `pipeline-summary.py project` (`none` → `plan` → `curate` → `fetch` → `ingest` → `distill` → `compose` → `verify`); a finalized project has `report_source == "wiki"` in its binding entry (the `· synthesis ✓` marker). Evaluate top to bottom and stop at the first match:
+
+- **No projects** (`research_projects` empty): "Run the inverted pipeline — `knowledge-plan --knowledge-slug <slug> --topic '...'`, then `knowledge-curate` → `knowledge-fetch` → `knowledge-ingest` → `knowledge-distill` → `knowledge-compose` → `knowledge-verify` → `knowledge-finalize` — to deposit your first project."
+- **Wiki has structural issues** (Step 2 verdict ≠ OK): "Fix the structural issues first — see the wiki-resume output above. Then resume the pipeline, or `knowledge-query --knowledge-slug <slug> --question '...'` to ask what the base already knows."
+
+Otherwise branch on the newest in-flight project's `phase_reached` (the deepest phase that ran but did not finalize) — one recommendation per state:
+
+| `phase_reached` | Recommend |
+|---|---|
+| `none` (legacy deposit, no `.metadata/`) | Re-run from `knowledge-plan` — the project predates the inverted pipeline and has no resumable state. |
+| `plan` | `knowledge-curate` — sources are planned but not yet discovered/fetched. |
+| `curate` | `knowledge-fetch` — candidates scored; build the fetch manifest (add `--cobrowse` to recover WebFetch misses). |
+| `fetch` | `knowledge-ingest` — bodies fetched; deposit per-source wiki pages with extracted claims. |
+| `ingest` | `knowledge-distill` (optional Phase 4.5 — compounds concepts/entities), then `knowledge-compose`. |
+| `distill` | `knowledge-compose` — distillation done; draft the synthesis from the populated wiki. |
+| `compose` | `knowledge-verify` — draft + citation manifest exist; run the zero-network claim check. |
+| `verify` | `knowledge-finalize` — verified; deposit the synthesis into `wiki/syntheses/` and close the loop. |
+
+- **All projects finalized** (every entry `report_source == "wiki"`, none in flight): the base is compounding — "Ask it with `knowledge-query --question '...'`, render an overview with `knowledge-dashboard`, refresh stale topics with `knowledge-refresh`, or start a new project with `knowledge-plan` to keep accumulating."
 
 ## Edge cases
 

--- a/cogni-knowledge/skills/knowledge-resume/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-resume/SKILL.md
@@ -133,7 +133,7 @@ Otherwise branch on the newest in-flight project's `phase_reached` (the deepest 
 | `compose` | `knowledge-verify` — draft + citation manifest exist; run the zero-network claim check. |
 | `verify` | `knowledge-finalize` — verified; deposit the synthesis into `wiki/syntheses/` and close the loop. |
 
-- **All projects finalized** (every entry `report_source == "wiki"`, none in flight): the base is compounding — "Ask it with `knowledge-query --question '...'`, render an overview with `knowledge-dashboard`, refresh stale topics with `knowledge-refresh`, or start a new project with `knowledge-plan` to keep accumulating."
+- **All projects finalized** (every entry `report_source == "wiki"`, none in flight): the base is compounding — "Ask it with `knowledge-query --knowledge-slug <slug> --question '...'`, render an overview with `knowledge-dashboard`, refresh stale topics with `knowledge-refresh`, or start a new project with `knowledge-plan` to keep accumulating."
 
 ## Edge cases
 


### PR DESCRIPTION
## What

Resolves #371 — the two pre-existing `resume-audit` failures on `knowledge-resume` that were deferred from #370.

Reworks the Next-action section of `cogni-knowledge/skills/knowledge-resume/SKILL.md` into a phase-keyed decision tree:

- **C2 (state-driven next actions)** — adds a `#### Next action — recommend by pipeline phase` header (the missing recommend-section signal the audit's `RECOMMEND_SECTION_PATTERNS` looks for) plus a per-state decision table keyed on `pipeline-summary.py`'s `phase_reached` (`none`/`plan`/`curate`/`fetch`/`ingest`/`distill`/`compose`/`verify`) and the finalized (`report_source == "wiki"`) case. One recommendation per state.
- **C3 (own-plugin completeness)** — the tree now references all **11/11** operational `knowledge-*` skills by slug, adding the four that were missing: `knowledge-dashboard`, `knowledge-distill`, `knowledge-query`, `knowledge-refresh`.

Pure structural change to the resume surface — no inverted-pipeline behavior change.

## Verification

`audit-resume --scope cogni-knowledge` (was `fail`, now `pass`):

```
overall: pass
  C1_discovery          -> pass
  C2_next_actions       -> pass  (state + conditional + recommend section)
  C3_skill_completeness -> pass  (11/11 operational skills referenced)
```

- All `cogni-knowledge/tests/test_*.sh` stay green (incl. `test_skill_contracts.sh` clean-break + #350 cross-ref invariants).
- Version bumped `0.1.31 → 0.1.32` in both `plugin.json` and `marketplace.json`.

## Acceptance criteria

- [x] `cogni-dev:audit-resume --scope cogni-knowledge` passes C2 and C3
- [x] `knowledge-resume`'s next-action section branches on project phase/status
- [x] All four missing skills referenced by slug in the decision tree
- [x] Tests remain green; `plugin.json` + `marketplace.json` patch version bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)