### PR TITLE
cogni-knowledge 0.1.33: fix knowledge-resume stale-cache hint to a real invocation (closes #373)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/skills/knowledge-resume/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-resume/SKILL.md
@@ -107,7 +107,7 @@ Print a ≤ 12-line summary that layers the binding onto the wiki status:
 - **Knowledge base.** `<knowledge_title>` (`<knowledge_slug>`), created `<created>`
 - **Wiki path.** `<wiki_path>` — wiki health verdict from Step 2 (one line: "OK" / "N issues — see wiki-resume output above")
 - **Deposited research projects.** `<count>` — one line per project (newest first, cap 5, "and N more" for the rest), each as: `<slug> — <sub_questions> sub-questions · <fetched> fetched · phase <phase_reached>` + ` · <concepts_total> concepts (<claims_deduped>/<claims_attached> claims deduped)` when `concepts_total > 0` (the Phase-4.5 distill compounding signal) + `· synthesis ✓` when the binding entry's `report_source == "wiki"` + ` (<deposited_at>)`. Legacy deposits show `<slug> — (legacy deposit) (<deposited_at>)`.
-- **Pipeline status.** Knowledge-base-global fetch-cache (one shared cache across all projects): one line by `verdict` — `healthy` → `fetch-cache healthy (<entries> sources)`; `stale` → `fetch-cache stale — run knowledge-fetch --refresh`; `empty` → `fetch-cache empty — run knowledge-plan first`.
+- **Pipeline status.** Knowledge-base-global fetch-cache (one shared cache across all projects): one line by `verdict` — `healthy` → `fetch-cache healthy (<entries> sources)`; `stale` → `fetch-cache stale — re-run knowledge-curate to re-fetch aged sources (or knowledge-refresh to re-run the pipeline on stale topics)`; `empty` → `fetch-cache empty — run knowledge-plan first`.
 - **Topic lineage.** If `covered_themes` or `open_themes` are non-empty, print them as two short lists. Else omit.
 - **Next action.** One line, selected by the decision tree below.
 


### PR DESCRIPTION
## Summary

Fixes [#373](https://github.com/cogni-work/insight-wave/issues/373) — a doc-accuracy bug surfaced during the `/review` of #372.

`cogni-knowledge/skills/knowledge-resume/SKILL.md` Step 3 mapped the fetch-cache `stale` verdict to `run knowledge-fetch --refresh`, but **`knowledge-fetch` has no `--refresh` flag** (its only flags are `--cobrowse` / `--no-cobrowse` / `--tier` / `--dry-run` / `--max-age-days` / `--batch-size`). The resume skill is read-only and only prints the line, so this was a misleading hint, not a runtime break.

## Change

One line in `knowledge-resume/SKILL.md`. The `stale` verdict now recommends two real, accurate invocations:

> `stale → fetch-cache stale — re-run knowledge-curate to re-fetch aged sources (or knowledge-refresh to re-run the pipeline on stale topics)`

Both are correct:
- **knowledge-curate** — its Phase-4 fetch-cache lookup treats a `stale` entry as a miss (`source-curator.md:171`; confirmed by `knowledge-fetch/SKILL.md:135` "Re-running `knowledge-curate` re-fetches everything missing from cache"), so re-curating genuinely refreshes aged sources.
- **knowledge-refresh** — push-mode re-runs the full pipeline per stale topic, already the recommended "refresh stale topics" UX on `knowledge-resume/SKILL.md:136` and in `knowledge-dashboard`.

`healthy` / `empty` mappings untouched. Patch-bumped `plugin.json` + `marketplace.json` 0.1.32 → 0.1.33.

## Verification

- `grep -rn "knowledge-fetch --refresh" cogni-knowledge/` → **zero matches**
- `test_skill_contracts.sh` → ALL PASS
- `test_pipeline_summary.sh` → ALL PASS

## Acceptance criteria
- [x] `stale` line recommends a real, existing invocation
- [x] No `knowledge-fetch --refresh` (or any non-existent flag) in the skill body
- [x] Tests green; `plugin.json` + `marketplace.json` patch bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)