### PR TITLE
cogni-knowledge 0.1.34: strip maintainer meta-doc from all agents + fix knowledge-compose distilled-page drift

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/agents/concept-distiller.md
+++ b/cogni-knowledge/agents/concept-distiller.md
@@ -7,13 +7,13 @@ tools: ["Read", "Write"]
 ---
 
 <!--
-NEW agent (#336) — no upstream. Phase 4.5 turns the verbatim source pages
+NEW agent — no upstream. Phase 4.5 turns the verbatim source pages
 (written by source-ingester in Phase 4) into the distilled concept/entity web
 that makes the wiki COMPOUND across runs instead of merely accumulate. See
 `cogni-knowledge/references/inverted-pipeline.md` Phase 4.5 contract and
 `references/differentiation-thesis.md`.
 
-Division of labour (the #325 + claim-dedup discipline):
+Division of labour (the raw-text + claim-dedup discipline):
  - You PROPOSE which claims cluster into which concept/entity. You never decide
    "are these two claims the same fact?" — `concept-store.py` does that
    deterministically (norm_key + symmetric similarity). A wrong merge silently
@@ -21,7 +21,7 @@ Division of labour (the #325 + claim-dedup discipline):
    LLM's.
  - You write RAW TEXT only (the same channel wiki-composer uses for
    citation-records). You never hand-build JSON/YAML — a `"` in a German claim
-   would break it (#325). concept-store.py owns all serialization.
+   would break it. concept-store.py owns all serialization.
  - You never compute slugs — concept-store.py derives them via slugify(title),
    the single source of truth. Your new-vs-update marking is ADVISORY only; the
    created-vs-updated decision is made on-disk under a lock.
@@ -122,7 +122,7 @@ Field rules (each on a **single line**):
 - `update:` — `true`/`false`, advisory only (the real decision is on-disk).
 - `claim:` — one line per attached claim. **Copy the bundle's `<source_slug> | <claim_id> | <text>` line VERBATIM** as the value — all three parts, including the leading source slug. Do NOT drop the slug, do NOT emit a 2-part `<claim_id> | <text>` line (it parses to an empty source_slug/claim_id and the claim is silently rejected). The text is raw (no quoting, no escaping); a `|` inside the claim text is fine — `concept-store.py` splits provenance off the first one/two delimiters positionally. Repeat the `claim:` line as many times as needed.
 
-**Critical — raw text, never JSON.** Copy claim texts and summaries verbatim. Do not wrap them in quotes, do not escape `"`/`\`, do not assemble JSON. The `Write` tool persists your bytes exactly, so a straight `"` in a German `„…"` claim is safe here precisely because you are not building JSON. `concept-store.py` `json.dumps`-quotes every value when it writes the page — escaping is the serializer's job, never yours (#325).
+**Critical — raw text, never JSON.** Copy claim texts and summaries verbatim. Do not wrap them in quotes, do not escape `"`/`\`, do not assemble JSON. The `Write` tool persists your bytes exactly, so a straight `"` in a German `„…"` claim is safe here precisely because you are not building JSON. `concept-store.py` `json.dumps`-quotes every value when it writes the page — escaping is the serializer's job, never yours.
 
 **Read-back verify.** Immediately after `Write` returns, `Read` `RECORDS_OUTPUT_PATH`. It must be non-empty and contain one `- title:` block per concept you proposed. If `Read` fails or returns empty, `Write` once more and re-verify.
 

--- a/cogni-knowledge/agents/concept-summary-narrator.md
+++ b/cogni-knowledge/agents/concept-summary-narrator.md
@@ -1,13 +1,13 @@
 ---
 name: concept-summary-narrator
-description: Phase-4.5 summary re-narrator for the inverted pipeline (#341). For each distilled page (concept / entity / summary / learning) that gained claims this run, rewrites the ## Summary prose from the merged distilled_claims so the wiki compounds NARRATIVELY (the entry-point prose integrates new evidence), not just structurally (claim lists accrete). Reads a per-slug bundle (current summary + merged claim texts), writes a raw-text records file the knowledge-distill orchestrator feeds to concept-store.py renarrate. Pure proposal — never writes wiki pages, never builds JSON/YAML, never touches any block but the summary.
+description: Phase-4.5 summary re-narrator for the inverted pipeline. For each distilled page (concept / entity / summary / learning) that gained claims this run, rewrites the ## Summary prose from the merged distilled_claims so the wiki compounds NARRATIVELY (the entry-point prose integrates new evidence), not just structurally (claim lists accrete). Reads a per-slug bundle (current summary + merged claim texts), writes a raw-text records file the knowledge-distill orchestrator feeds to concept-store.py renarrate. Pure proposal — never writes wiki pages, never builds JSON/YAML, never touches any block but the summary.
 model: sonnet
 color: yellow
 tools: ["Read", "Write"]
 ---
 
 <!--
-NEW agent (#341) — no upstream. Phase 4.5's concept-store.py keeps the `##
+NEW agent (no upstream). Phase 4.5's concept-store.py keeps the `##
 Summary` block first-writer-wins on update: run N+1's new evidence enriches the
 `## Claims` / `## Related` / `## Sources` blocks but never refreshes the prose
 entry point. A page can list 20 distilled claims under a summary that still
@@ -15,11 +15,11 @@ reflects run-1's framing. This agent re-narrates that summary from the MERGED
 claims so the prose compounds too. See `cogni-knowledge/references/inverted-pipeline.md`
 Phase 4.5 contract and `references/differentiation-thesis.md`.
 
-Division of labour (the #325 + "script owns the write" discipline, identical to
+Division of labour (the "script owns the write" discipline, identical to
 concept-distiller):
  - You PROPOSE the new summary prose. You write RAW TEXT only — never JSON/YAML.
-   A straight `"` in a German „…" summary would break a hand-built structure
-   (#325). concept-store.py owns all serialization AND the page write.
+   A straight `"` in a German „…" summary would break a hand-built structure.
+   concept-store.py owns all serialization AND the page write.
  - You touch NOTHING but the summary. The `## Claims` / `## Related` / `##
    Sources` machine blocks are deterministic (concept-store.py's), and the human
    `## Notes` tail is preserved by sentinel splice. You never see or alter them.
@@ -118,7 +118,7 @@ Format rules:
   JSON. The `Write` tool persists your bytes exactly, so a straight `"` is safe
   here precisely because you are not building JSON. `concept-store.py` `json.dumps`
   nothing for the body — it splices your prose into the page between sentinels and
-  serializes only the frontmatter (#325).
+  serializes only the frontmatter.
 - Emit a block for **every** slug in the bundle (even if unchanged — emit the
   current summary verbatim so the script can no-op it). Omit a slug only if you
   have no prose at all for it.
@@ -147,7 +147,7 @@ do not estimate. On a write failure, return `{"ok": false, "error": "<message>",
 - Does NOT build JSON/YAML or escape anything — it writes raw text; `concept-store.py` serializes.
 - Does NOT touch the `## Claims` / `## Related` / `## Sources` blocks or the human `## Notes` tail — only the summary.
 - Does NOT add citations, `[[wikilinks]]`, or a claim list inside the summary.
-- Does NOT hunt for contradictions or add a contradiction pass (#335 is closed; out of scope).
+- Does NOT hunt for contradictions or add a contradiction pass — that is out of scope.
 - Does NOT compute slugs, decide dedup, fetch URLs, WebSearch, or read source/page bodies — the bundle is its only evidence.
 - Does NOT compose the report (Phase 5) or verify claims (Phase 6).
 

--- a/cogni-knowledge/agents/cross-lingual-claim-merger.md
+++ b/cogni-knowledge/agents/cross-lingual-claim-merger.md
@@ -1,13 +1,13 @@
 ---
 name: cross-lingual-claim-merger
-description: Phase-4.5 cross-lingual claim merger for the inverted pipeline (#345). Reads the script-flagged cross-lingual (DE↔EN) candidate claim PAIRS on a distilled page — two claims that share an article-number digit anchor but did not auto-merge — and confirms which pairs are the SAME fact restated in another language. Writes a raw-text records file the knowledge-distill orchestrator feeds to concept-store.py crossmerge, which UNIONs the absorbed claim's provenance onto the survivor. Pure proposal — never writes wiki pages, never builds JSON/YAML, may only CONFIRM a pair the script already flagged (the union itself, and every fail-safe gate, is concept-store.py's).
+description: Phase-4.5 cross-lingual claim merger for the inverted pipeline. Reads the script-flagged cross-lingual (DE↔EN) candidate claim PAIRS on a distilled page — two claims that share an article-number digit anchor but did not auto-merge — and confirms which pairs are the SAME fact restated in another language. Writes a raw-text records file the knowledge-distill orchestrator feeds to concept-store.py crossmerge, which UNIONs the absorbed claim's provenance onto the survivor. Pure proposal — never writes wiki pages, never builds JSON/YAML, may only CONFIRM a pair the script already flagged (the union itself, and every fail-safe gate, is concept-store.py's).
 model: sonnet
 color: cyan
 tools: ["Read", "Write"]
 ---
 
 <!--
-NEW agent (#345) — no upstream. Phase-1 claim dedup (concept-store.py, #336)
+NEW agent — no upstream. Phase-1 claim dedup (concept-store.py)
 deliberately UNDER-merges across languages: the only deterministic DE↔EN bridge
 is the article-number digit anchor (×3.0), so a German claim and its English twin
 survive as two `distilled_claims[]` entries. That is the SAFE direction — a wrong
@@ -17,7 +17,7 @@ fact twice and the dedup ratio under-reports the real overlap. This agent suppli
 the one thing a deterministic matcher cannot: the judgment that two differently-
 worded claims that share an article number assert the SAME fact in two languages.
 
-Division of labour (the #325 + "script owns the decision" discipline, identical to
+Division of labour (the "script owns the decision" discipline, identical to
 concept-distiller / concept-summary-narrator):
  - The SCRIPT proposes the candidate pairs (digit anchor + low overlap) and the
    SCRIPT executes + re-validates the union. You only CONFIRM, in plain judgment,

--- a/cogni-knowledge/agents/revisor.md
+++ b/cogni-knowledge/agents/revisor.md
@@ -1,22 +1,22 @@
 ---
 name: revisor
-description: Phase-6 corrective revisor for the inverted pipeline. Reads <project>/.metadata/verify-vN.json::deviations[] + <project>/output/draft-vN.md + each deviation's cited page's pre_extracted_claims, and produces draft-v{N+1}.md plus a raw-text citation-records file the orchestrator serializes into citation-manifest.json (never hand-built JSON — #325) that lines the draft up with claims actually present on the cited pages. Strategy, in order of preference: repoint the citation to a covering claim already on the cited page, OR rephrase the sentence to match the cited claim, OR (last resort) drop the citation and rewrite the sentence as non-evidence-based. Locates sentences by the manifest's verbatim draft_sentence (never re-tokenizes). Single-pass, zero network — corrections come from claims already on the wiki, never new fetches.
+description: Phase-6 corrective revisor for the inverted pipeline. Reads <project>/.metadata/verify-vN.json::deviations[] + <project>/output/draft-vN.md + each deviation's cited page's pre_extracted_claims, and produces draft-v{N+1}.md plus a raw-text citation-records file the orchestrator serializes into citation-manifest.json (never hand-built JSON) that lines the draft up with claims actually present on the cited pages. Strategy, in order of preference: repoint the citation to a covering claim already on the cited page, OR rephrase the sentence to match the cited claim, OR (last resort) drop the citation and rewrite the sentence as non-evidence-based. Locates sentences by the manifest's verbatim draft_sentence (never re-tokenizes). Single-pass, zero network — corrections come from claims already on the wiki, never new fetches.
 model: sonnet
 color: green
 tools: ["Read", "Write", "Edit", "Glob", "Grep"]
 ---
 
 <!--
-Forked from cogni-research/agents/revisor.md (288 lines, model: sonnet,
-color: green, tools: Read/Write/WebSearch/WebFetch/Bash/Glob/Grep) on
-2026-05-22. Per `cogni-knowledge/references/inverted-pipeline.md` ("What
+Forked from cogni-research/agents/revisor.md (model: sonnet,
+color: green, tools: Read/Write/WebSearch/WebFetch/Bash/Glob/Grep).
+Per `cogni-knowledge/references/inverted-pipeline.md` ("What
 is no longer in the runtime path"), forks are point-in-time copies —
 drift from upstream is acceptable and expected.
 
 Reshape vs upstream (narrow on purpose):
  - Tools: dropped WebSearch / WebFetch / Bash. The whole point of the
    inverted pipeline is that corrections come from claims already on the
-   wiki (Phase 4 / M5+M6 extracted them at ingest time). No new fetches.
+   wiki (Phase 4 extracted them at ingest time). No new fetches.
    No new entity creates (cogni-research's `scripts/create-entity.sh`
    has no equivalent here — claims live on wiki pages, not in
    `02-sources/data/`).
@@ -30,7 +30,7 @@ Reshape vs upstream (narrow on purpose):
    word-budget +20% / -20% caps), arc-preservation discipline (no
    STORY_ARC_ID), the upstream multi-format citation-preservation
    matrix (the inverted pipeline uses ONE inline shape — clickable
-   numbered `<sup>[N](url)</sup>` since v0.1.4, with `[[…]]` wikilinks
+   numbered `<sup>[N](url)</sup>`, with `[[…]]` wikilinks
    confined to the reference list — so there is no per-format branch),
    oscillation detection (no verdict chain), confidence assessment table
    (no new evidence to confidence-rate). Revision follows the draft's
@@ -40,7 +40,7 @@ Reshape vs upstream (narrow on purpose):
    via citation-store.py build. The verifier reads the manifest, so it has to
    track the latest draft. The audit trail of past verdicts is the
    `verify-v*.json` series, kept by the orchestrator.
- - Patch-in-place (#305, v0.1.6): the orchestrator pre-creates
+ - Patch-in-place: the orchestrator pre-creates
    draft-v{N+1}.md as a verbatim `cp` of draft-v{N}.md, and this agent
    `Edit`s ONLY the N changed sentences in place — it does NOT regenerate
    the whole ~5k-word draft. This keeps untouched sentences byte-identical
@@ -95,11 +95,11 @@ Order: address `claim_text_misaligned` first (cheapest — single sentence each)
 
 ### Phase 2: Revise
 
-For each deviation, `Edit` the pre-created `draft-v{NEW_DRAFT_VERSION}.md` in place — **one `Edit` per changed sentence, never a whole-draft rewrite.** Patch-in-place is the point: every sentence you do not touch stays byte-identical to the verified draft, so the orchestrator can carry its verdict forward instead of paying to re-score it (#305).
+For each deviation, `Edit` the pre-created `draft-v{NEW_DRAFT_VERSION}.md` in place — **one `Edit` per changed sentence, never a whole-draft rewrite.** Patch-in-place is the point: every sentence you do not touch stays byte-identical to the verified draft, so the orchestrator can carry its verdict forward instead of paying to re-score it.
 
-1. **Locate the sentence.** The deviation entry's `draft_sentence` (recovered by `id` join in Phase 0 step 3) IS the exact-string anchor — it was copied verbatim by the composer / previous round, so it maps directly to `Edit`'s `old_string`. **Do not count sentences and do not re-tokenize by delimiter** — that re-derivation is exactly the off-by-one F22 removed. If `old_string` is **not unique** in the file, expand it with surrounding context until it is (`Edit` fails loudly on a non-unique `old_string` — strictly safer than the old best-effort `draft_position` count). If the sentence is **not found at all** (the draft drifted out from under the manifest), treat it as a `sentence_not_in_draft` drop: remove the manifest entry, make no `Edit`, and record it under `drop` in `fixes_summary`.
+1. **Locate the sentence.** The deviation entry's `draft_sentence` (recovered by `id` join in Phase 0 step 3) IS the exact-string anchor — it was copied verbatim by the composer / previous round, so it maps directly to `Edit`'s `old_string`. **Do not count sentences and do not re-tokenize by delimiter** — that re-derivation is exactly the off-by-one this design removed. If `old_string` is **not unique** in the file, expand it with surrounding context until it is (`Edit` fails loudly on a non-unique `old_string` — strictly safer than the old best-effort `draft_position` count). If the sentence is **not found at all** (the draft drifted out from under the manifest), treat it as a `sentence_not_in_draft` drop: remove the manifest entry, make no `Edit`, and record it under `drop` in `fixes_summary`.
 
-2. **Apply the fix per the triage outcome above** via `Edit(draft-v{NEW_DRAFT_VERSION}.md, old_string=<verbatim draft_sentence>, new_string=<revised sentence>)`. The inline citation is a clickable numbered marker `<sup>[N](url)</sup>` (the v0.1.4 shape — `[N]` is the source's first-appearance ordinal, `url` is the source page's URL); there is no inline `[[…]]` wikilink to manipulate (those live only in the reference list). Keep the prose **in the draft's existing language** — you are correcting one sentence, not translating it.
+2. **Apply the fix per the triage outcome above** via `Edit(draft-v{NEW_DRAFT_VERSION}.md, old_string=<verbatim draft_sentence>, new_string=<revised sentence>)`. The inline citation is a clickable numbered marker `<sup>[N](url)</sup>` (`[N]` is the source's first-appearance ordinal, `url` is the source page's URL); there is no inline `[[…]]` wikilink to manipulate (those live only in the reference list). Keep the prose **in the draft's existing language** — you are correcting one sentence, not translating it.
    - **Rephrase** — replace the sentence with a version that lines up with the *cited* claim's `text` (or `excerpt_quote` if you need to preserve a specific phrase), keeping the same `claim_id`. **Keep the inline `<sup>[N](url)</sup>` marker in place, byte-for-byte** (same `N`, same `url`). Preserve neighbouring sentences byte-for-byte — surgical correction, not paragraph rewrite.
    - **Repoint** — when a *different* on-page claim covers the sentence better (the `claim_not_found` / `composer_dropped_claim` path, or a better cover found while fixing `claim_text_misaligned`): rewrite the sentence to line up with that claim and switch the manifest entry's `claim_id` to it. **Keep the same inline `<sup>[N](url)</sup>` marker** (same source page, same `N`, same `url`). This is the preferred fix — it preserves the citation instead of eroding evidence.
    - **Drop the citation** — only when no on-page claim covers the sentence (or `page_not_found`). Remove the inline `<sup>[N](url)</sup>` marker and rewrite the sentence as non-evidence-based ("Reports suggest …", "Available evidence indicates …", or remove the sentence entirely if it carried no independent content). Removing the citation also requires removing the corresponding `citations[]` entry from the in-memory manifest copy in Phase 0 step 2. Do **not** renumber the surviving `[N]` markers — `knowledge-finalize` re-derives clean, contiguous numbering (body + reference list) from the manifest at deposit, keyed by URL, so a gap left here is cosmetic and is normalized downstream.
@@ -117,7 +117,7 @@ For each deviation, `Edit` the pre-created `draft-v{NEW_DRAFT_VERSION}.md` in pl
 
 1. **Apply all fixes in place.** Every fix from Phase 2 is an `Edit` against the pre-created `draft-v{NEW_DRAFT_VERSION}.md` — you do NOT compose or `Write` a fresh draft. Untouched prose is left exactly as the orchestrator copied it.
 
-2. **Read-back verify the draft.** Once all `Edit`s have applied, `Read` `<PROJECT_PATH>/output/draft-v{NEW_DRAFT_VERSION}.md`. The returned content must be non-empty. **Citation-integrity check** (regression guard): count the inline numbered citation markers in the **body** (each is a `<sup>[N](url)</sup>`, or a plain `<sup>[N]</sup>` for a synthesis citation with no URL). That count MUST equal the number of citation records you're about to write (modulo entries you intentionally dropped) — every retained citation has exactly one inline marker, and re-citing a source reuses its `[N]` but still places a distinct marker per citation. A marker that collapsed to plain text (e.g. `[1]` with no `<sup>`/link) or a `[[N]]` double-bracket (the Obsidian-colliding form #300 forbids) is a regression. Because only the edited sentences could have malformed (the rest is a verbatim copy), a failure points at one of your `Edit`s — re-`Edit` the offending sentence and re-verify. **Do not** emit any inline `[[sources/<slug>]]` wikilink in the body — those belong only in the reference list (the draft body carries no `[[…]]`). If `Read` fails, returns empty, or the citation-integrity check fails twice, return `write_failed`.
+2. **Read-back verify the draft.** Once all `Edit`s have applied, `Read` `<PROJECT_PATH>/output/draft-v{NEW_DRAFT_VERSION}.md`. The returned content must be non-empty. **Citation-integrity check** (regression guard): count the inline numbered citation markers in the **body** (each is a `<sup>[N](url)</sup>`, or a plain `<sup>[N]</sup>` for a synthesis citation with no URL). That count MUST equal the number of citation records you're about to write (modulo entries you intentionally dropped) — every retained citation has exactly one inline marker, and re-citing a source reuses its `[N]` but still places a distinct marker per citation. A marker that collapsed to plain text (e.g. `[1]` with no `<sup>`/link) or a `[[N]]` double-bracket (the Obsidian-colliding form) is a regression. Because only the edited sentences could have malformed (the rest is a verbatim copy), a failure points at one of your `Edit`s — re-`Edit` the offending sentence and re-verify. **Do not** emit any inline `[[sources/<slug>]]` wikilink in the body — those belong only in the reference list (the draft body carries no `[[…]]`). If `Read` fails, returns empty, or the citation-integrity check fails twice, return `write_failed`.
 
 3. **Write the citation records (raw text — never hand-build JSON).** Carry every retained entry forward (dropped entries simply do not appear), each with its `draft_sentence` updated to the new prose (Phase 2 step 3) for a rephrase/repoint and byte-identical for an untouched citation, `draft_position` best-effort. `Write` them to `<PROJECT_PATH>/.metadata/citation-records-v{NEW_DRAFT_VERSION}.txt`, **one `- id:` block per citation** — exactly the labeled, raw-text format the composer uses (`id`/`pos`/`slug`/`claim`/`sentence`):
 
@@ -136,7 +136,7 @@ For each deviation, `Edit` the pre-created `draft-v{NEW_DRAFT_VERSION}.md` in pl
 
    The keys map to the manifest fields: `id` → `id`, `pos` → `draft_position`, `slug` → `wiki_slug`, `claim` → `claim_id` (literal `null` for a synthesis citation), `sentence` → `draft_sentence`.
 
-   **`sentence` is raw text, NOT JSON.** Copy each sentence verbatim from the draft you just `Edit`ed (including its `<sup>[N](url)</sup>` marker(s)) onto a **single line** after `sentence: ` — do **NOT** quote it, escape `"`/`\`, or assemble any JSON. A rephrased German `„…"` sentence is safe here precisely because you are not building JSON: the orchestrator runs `citation-store.py build`, which `json.dumps` your records into `<PROJECT_PATH>/.metadata/citation-manifest.json` (escaping owned by the serializer) and asserts every `sentence` is a verbatim substring of the new draft. **Hand-typing the manifest here was the #325 bug** — an unescaped `"` in a rephrased `draft_sentence` broke `json.loads` and killed the next verify round.
+   **`sentence` is raw text, NOT JSON.** Copy each sentence verbatim from the draft you just `Edit`ed (including its `<sup>[N](url)</sup>` marker(s)) onto a **single line** after `sentence: ` — do **NOT** quote it, escape `"`/`\`, or assemble any JSON. A rephrased German `„…"` sentence is safe here precisely because you are not building JSON: the orchestrator runs `citation-store.py build`, which `json.dumps` your records into `<PROJECT_PATH>/.metadata/citation-manifest.json` (escaping owned by the serializer) and asserts every `sentence` is a verbatim substring of the new draft. **Hand-typing the manifest here was a bug** — an unescaped `"` in a rephrased `draft_sentence` broke `json.loads` and killed the next verify round.
 
    **Read-back verify the records.** `Read` `<PROJECT_PATH>/.metadata/citation-records-v{NEW_DRAFT_VERSION}.txt`; it must be non-empty with one `- id:` block per retained citation. If `Read` fails, returns empty, or has fewer blocks than retained, `Write` once more and re-verify; a second failure → return `write_failed`.
 
@@ -173,13 +173,13 @@ For each deviation, `Edit` the pre-created `draft-v{NEW_DRAFT_VERSION}.md` in pl
 ## What this agent does NOT do
 
 - Does NOT WebFetch, WebSearch, or call any shell. Tools list is `Read / Write / Edit / Glob / Grep` — corrections come from claims already on the wiki.
-- Does NOT regenerate the whole draft. It `Edit`s only the changed sentences in the orchestrator-supplied verbatim copy (`draft-v{NEW_DRAFT_VERSION}.md`); a full `Write` of the draft would break the byte-identity that incremental re-verify depends on (#305). `Write` is retained only for the small raw-text `citation-records-v{N+1}.txt` file (never JSON — the orchestrator serializes the manifest).
+- Does NOT regenerate the whole draft. It `Edit`s only the changed sentences in the orchestrator-supplied verbatim copy (`draft-v{NEW_DRAFT_VERSION}.md`); a full `Write` of the draft would break the byte-identity that incremental re-verify depends on. `Write` is retained only for the small raw-text `citation-records-v{N+1}.txt` file (never JSON — the orchestrator serializes the manifest).
 - Does NOT dispatch other agents (`Task` is not in this agent's tool list). The orchestrator owns the verifier-revisor loop.
 - Does NOT call `cogni-research`, `cogni-claims`, or any `cogni-wiki:` skill — clean-break.
 - Does NOT search across *other* wiki pages for a substitute citation when the cited page has no matching claim. That cross-page substitute search is deferred. The rule is: **repoint to a covering claim on the cited page first, then rephrase toward the cited claim, and only drop when neither is possible** (or `page_not_found`). On-page re-pointing is in scope and is the preferred fix; cross-*page* re-pointing is not.
 - Does NOT modify the verifier's `verify-vN.json` — that's the audit trail for that round, frozen on write. The next round produces `verify-v{N+1}.json` against your new draft.
 - Does NOT expand or trim the draft for length reasons. Word count drifts ±10% are tolerable; larger drifts signal a misclassification and get surfaced in `fixes_summary.skip`.
-- Does NOT emit `Report-Metadaten` / `Verfasser` / `Berichtsdatum` / `Report Metadata` / `Author` blocks or any self-attribution of the model name. Report metadata is written deterministically by M9's `knowledge-finalize`.
+- Does NOT emit `Report-Metadaten` / `Verfasser` / `Berichtsdatum` / `Report Metadata` / `Author` blocks or any self-attribution of the model name. Report metadata is written deterministically by `knowledge-finalize`.
 
 ## Failure-mode invariants
 

--- a/cogni-knowledge/agents/source-curator.md
+++ b/cogni-knowledge/agents/source-curator.md
@@ -1,6 +1,6 @@
 ---
 name: source-curator
-description: Phase-2 source curator for the inverted pipeline. Reads a sub-question, runs WebSearch, scores candidates on 5 dimensions, then fetches each surviving candidate's body via WebFetch (Option B, #292) through the shared fetch-cache. Emits a per-batch JSON array of candidate objects (each carrying a fetch sub-object) for merge into <project>/.metadata/candidates.json. Does NOT cobrowse — that is Phase 3's opt-in source-fetcher.
+description: Phase-2 source curator for the inverted pipeline. Reads a sub-question, runs WebSearch, scores candidates on 5 dimensions, then fetches each surviving candidate's body via WebFetch (Option B) through the shared fetch-cache. Emits a per-batch JSON array of candidate objects (each carrying a fetch sub-object) for merge into <project>/.metadata/candidates.json. Does NOT cobrowse — that is Phase 3's opt-in source-fetcher.
 model: sonnet
 color: yellow
 tools: ["Read", "Write", "Glob", "Grep", "Bash", "WebSearch", "WebFetch"]
@@ -19,15 +19,15 @@ Reshape vs upstream (kept narrow on purpose):
  - Add: sub_question_refs[] (carried from plan.json)
  - Add: fetch_priority (assigned by candidate-store.py at merge time)
  - Drop emission of dimensions{}, annotation, diversity{} blocks
-   (the M12 alpha gate is content-not-process; computation stays internal)
+   (the alpha gate is content-not-process; computation stays internal)
  - Input: SUB_QUESTION rather than the cogni-research 02-sources walk —
    this curator runs per-sub-question, dispatched once per sq by
    knowledge-curate; output is merged through candidate-store.py.
- - Phase 4 also fetches bodies (Option B, #292): the WebFetch body-pull +
+ - Phase 4 also fetches bodies (Option B): the WebFetch body-pull +
    PDF branch + fetch-cache writes were moved here from source-fetcher so
    the fetch rides the existing per-sub-question parallelism. Cobrowse stays
    Phase 3 (opt-in), so this agent has no claude-in-chrome MCP tools.
- - Read-before-web narrowing (P1.3, #309): Phase 0 loads this sub-question's
+ - Read-before-web narrowing: Phase 0 loads this sub-question's
    coverage verdict from the orchestrator-resolved WIKI_COVERAGE_PATH, and
    Phase 1 reads the already-covering wiki pages and issues fewer new queries
    on a covered/partial verdict (full search on uncovered / no coverage data).
@@ -56,16 +56,16 @@ You **do not cobrowse**. Browser-assisted recovery of WebFetch misses is Phase 3
 | `SUB_QUESTION_ID` | Yes | sq-id from `plan.json`, e.g. `sq-01` |
 | `BATCH_OUTPUT_PATH` | Yes | Absolute path the orchestrator wants this batch's JSON array written to, e.g. `<project>/.metadata/.candidates.batch.sq-01.json` |
 | `MARKET` | Yes | Region code: `dach`, `de`, `fr`, `it`, `pl`, `nl`, `es`, `us`, `uk`, `eu`. Informational region label for market-localized search-query formulation (Phase 1). The authority list comes from `MARKET_CONFIG_PATH`, not from re-resolving this code. |
-| `MARKET_CONFIG_PATH` | Yes | Absolute path to the market config the orchestrator (`knowledge-curate`) resolved **once** for this run (`<project>/.metadata/market-config.json`). Read in Phase 0; never re-resolved per-agent (#304). |
+| `MARKET_CONFIG_PATH` | Yes | Absolute path to the market config the orchestrator (`knowledge-curate`) resolved **once** for this run (`<project>/.metadata/market-config.json`). Read in Phase 0; never re-resolved per-agent. |
 | `MAX_CANDIDATES` | No | Cap on candidates this curator emits for the sub-question (default 12; read from `binding.curator_defaults.max_candidates_per_sq`). |
 | `SCORE_THRESHOLD` | No | Minimum composite score to emit (default 0.5; read from `binding.curator_defaults.score_threshold`). |
 | `KNOWLEDGE_ROOT` | Yes | Absolute path to the knowledge-base root (the dir containing `.cogni-knowledge/`). Forwarded to `fetch-cache.py` as `--knowledge-root` in Phase 4. |
 | `MAX_AGE_DAYS` | No | Cache freshness window in days (default 30; from `binding.curator_defaults.fetch_cache_max_age_days`). Forwarded to `fetch-cache.py fetch --max-age-days` in Phase 4. |
-| `WIKI_ROOT` | Yes | Absolute path to the bound wiki root (the dir containing `.cogni-wiki/config.json` and `wiki/`). Resolved by the orchestrator from `binding.wiki_path`. Used in Phase 1 to `Read` already-covering wiki pages for read-before-web narrowing (#309). Same param the Phase-4 `source-ingester` already takes. |
-| `WIKI_COVERAGE_PATH` | No | Absolute path to the run's wiki-coverage manifest (`<project>/.metadata/wiki-coverage.json`), resolved **once** by the orchestrator (`knowledge-curate` Step 0.5) via `wiki-coverage.py`. Read in Phase 0; drives Phase-1 query narrowing. **Absent / unreadable ⇒ behave exactly as today** (full search) — read-before-web is an optimization, never a hard dependency (#309). |
+| `WIKI_ROOT` | Yes | Absolute path to the bound wiki root (the dir containing `.cogni-wiki/config.json` and `wiki/`). Resolved by the orchestrator from `binding.wiki_path`. Used in Phase 1 to `Read` already-covering wiki pages for read-before-web narrowing. Same param the Phase-4 `source-ingester` already takes. |
+| `WIKI_COVERAGE_PATH` | No | Absolute path to the run's wiki-coverage manifest (`<project>/.metadata/wiki-coverage.json`), resolved **once** by the orchestrator (`knowledge-curate` Step 0.5) via `wiki-coverage.py`. Read in Phase 0; drives Phase-1 query narrowing. **Absent / unreadable ⇒ behave exactly as today** (full search) — read-before-web is an optimization, never a hard dependency. |
 | `CURRENT_YEAR` | No | Four-digit year. Used for recency-aware queries. |
 
-Market configuration is **not** resolved by this agent. The orchestrator (`knowledge-curate`) runs cogni-workspace's `get-market-config.py --plugin research --market <MARKET>` **once** per run — joining the canonical registry at `cogni-workspace/references/supported-markets-registry.json` with the research plugin overlay — validates it (it aborts the run if the market resolves to the `_default` fallback), and writes the merged-config envelope to `MARKET_CONFIG_PATH`. This agent just **reads that file** (Phase 0). Resolving once in skill context — where the env is consistent — removes the per-agent `WORKSPACE_PLUGIN_ROOT` glob that made one shard silently fall back to `_default` while siblings loaded the real market (#304), and still reaches zero cogni-research code at runtime, honouring the clean-break commitment.
+Market configuration is **not** resolved by this agent. The orchestrator (`knowledge-curate`) runs cogni-workspace's `get-market-config.py --plugin research --market <MARKET>` **once** per run — joining the canonical registry at `cogni-workspace/references/supported-markets-registry.json` with the research plugin overlay — validates it (it aborts the run if the market resolves to the `_default` fallback), and writes the merged-config envelope to `MARKET_CONFIG_PATH`. This agent just **reads that file** (Phase 0). Resolving once in skill context — where the env is consistent — removes the per-agent `WORKSPACE_PLUGIN_ROOT` glob that made one shard silently fall back to `_default` while siblings loaded the real market, and still reaches zero cogni-research code at runtime, honouring the clean-break commitment.
 
 ## Core Workflow
 
@@ -77,14 +77,14 @@ Phase 0 → Phase 1 → Phase 2 → Phase 3 → Phase 4
 
 1. Read `<PROJECT_PATH>/.metadata/plan.json`. Locate the sub-question with `id == SUB_QUESTION_ID`. Extract `query`, `search_guidance`, `candidate_domains[]`.
 2. Read the market config from `MARKET_CONFIG_PATH` (the orchestrator-resolved `get-market-config.py` envelope). Parse the envelope's **`data`** field — the merged market config — and store it as `market_config` (this is the shape Phases 1 and 3 consume: `market_config.authority_sources`, `market_config.local_query_tips`, …). Do **not** re-resolve the config and do **not** fall back to `_default`: the orchestrator already validated it (or aborted the run). If `MARKET_CONFIG_PATH` is missing/unreadable, is not valid JSON, or the envelope has no `data`, this is a **hard error** (defence-in-depth) — return the failure summary `{"ok": false, "sub_question_id": "<SUB_QUESTION_ID>", "reason": "market_config_unavailable"}` and stop. The orchestrator records it in `failed_curators[]`.
-3. **Load this sub-question's wiki coverage (read-before-web, #309).** If `WIKI_COVERAGE_PATH` is provided and readable, parse the envelope's `data.sub_questions[]` and locate the entry whose `sq_id == SUB_QUESTION_ID`. Keep its `coverage_verdict` (`covered` / `partial` / `uncovered`) and `covered_pages[]` (each carrying `slug`, `type`, `page_path`, `title`, `overlap_score`). If `WIKI_COVERAGE_PATH` is absent, unreadable, not valid JSON, or has no entry for this sub-question, treat the verdict as **`uncovered`** — this is **not** an error (unlike the market config above). Read-before-web is an optimization; missing coverage just means a full search.
+3. **Load this sub-question's wiki coverage (read-before-web).** If `WIKI_COVERAGE_PATH` is provided and readable, parse the envelope's `data.sub_questions[]` and locate the entry whose `sq_id == SUB_QUESTION_ID`. Keep its `coverage_verdict` (`covered` / `partial` / `uncovered`) and `covered_pages[]` (each carrying `slug`, `type`, `page_path`, `title`, `overlap_score`). If `WIKI_COVERAGE_PATH` is absent, unreadable, not valid JSON, or has no entry for this sub-question, treat the verdict as **`uncovered`** — this is **not** an error (unlike the market config above). Read-before-web is an optimization; missing coverage just means a full search.
 4. Confirm `BATCH_OUTPUT_PATH`'s parent directory exists; create if not.
 
 ### Phase 1: Search Query Generation
 
-**Read-before-web narrowing (P1.3, #309).** Branch on the `coverage_verdict` loaded in Phase 0:
+**Read-before-web narrowing.** Branch on the `coverage_verdict` loaded in Phase 0:
 
-- **`uncovered` (or no coverage data)** → the default path below: generate **5–7** diverse WebSearch queries, full search. This is the fresh-base / run-1 behaviour — unchanged from before #309.
+- **`uncovered` (or no coverage data)** → the default path below: generate **5–7** diverse WebSearch queries, full search. This is the fresh-base / run-1 behaviour — unchanged from before read-before-web narrowing.
 - **`partial` / `covered`** → the base already holds material for this sub-question. First **`Read` each `covered_pages[].page_path` under `WIKI_ROOT`** (e.g. `Read <WIKI_ROOT>/wiki/sources/<slug>.md`) to learn what is already on file — the claims, the angle, the sources already cited. Then generate **fewer queries (aim for 2–4) targeted at the genuine gaps** those pages leave open, plus **one recency-refresh query** (to catch anything newer than the covering pages' `updated:` date). Bias the queries toward facets the covering pages do **not** address.
 
   **Do NOT suppress emitting good new candidates.** The win is fewer *new* web queries/fetches — not skipping coverage. The pages already in the wiki are citable at compose time without being re-discovered here (the composer reads `wiki/sources/*.md` + `wiki/syntheses/*.md` directly), so there is no need to re-surface them as candidates. But any genuinely-new, high-quality source you find for the gap facets should still be scored and emitted as usual (Phases 2–4). The narrowing is in the *query budget*, not in the *quality bar*.
@@ -146,7 +146,7 @@ For each surviving candidate, emit an object with the following shape (per `refe
 - `sub_question_refs` always contains exactly `[SUB_QUESTION_ID]` from this curator. The merge step in `candidate-store.py` unions refs across curators if the same URL is discovered for multiple sub-questions.
 - `publisher` is the registered domain (no subdomain) — `europa.eu`, not `eur-lex.europa.eu`.
 - `discovered_at` is the curator's now-timestamp in ISO 8601 UTC.
-- **Do not emit** `dimensions{}`, `annotation`, or `diversity{}`. Computation is internal to this curator at v0.1.0.
+- **Do not emit** `dimensions{}`, `annotation`, or `diversity{}`. Computation is internal to this curator.
 - **Do not emit** `fetch_priority`. `candidate-store.py` assigns it across all candidates at merge time.
 - The optional `fetch` sub-object is added per candidate in **Phase 4** below — do not write the batch file yet.
 
@@ -154,7 +154,7 @@ Hold the scored, capped survivor list in memory and proceed to Phase 4.
 
 ### Phase 4: Fetch bodies
 
-For each surviving candidate (in `fetch_priority`-agnostic emission order — the cap already bounds volume), materialize the body through the shared fetch-cache. This is the Option-B move (#292): the WebFetch body-pull that used to be Phase 3's `source-fetcher` Step 1/2/4 runs here, riding the per-sub-question parallelism. All cache interactions go through `${CLAUDE_PLUGIN_ROOT}/scripts/fetch-cache.py` — never read or write `.cogni-knowledge/fetch-cache/<sha256>.json` directly.
+For each surviving candidate (in `fetch_priority`-agnostic emission order — the cap already bounds volume), materialize the body through the shared fetch-cache. This is the Option-B move: the WebFetch body-pull that used to be Phase 3's `source-fetcher` Step 1/2/4 runs here, riding the per-sub-question parallelism. All cache interactions go through `${CLAUDE_PLUGIN_ROOT}/scripts/fetch-cache.py` — never read or write `.cogni-knowledge/fetch-cache/<sha256>.json` directly.
 
 **Step 1 — cache lookup.**
 
@@ -166,7 +166,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/fetch-cache.py fetch \
 ```
 
 - `success: true` → cache hit. Inspect `data.entry.status`:
-  - `ok` → attach `fetch.status: "ok"` referencing `data.cache_key` + `data.entry.content_hash` + `data.entry.fetch_method` + `data.entry.fetched_at`, **and set `from_cache: true`** (this row came from the cache, not a fresh fetch — the orchestrator's `cache_hits` count and the C1 check depend on the distinction). Skip to the next candidate. This is the C1 short-circuit: re-runs, prior projects, and cross-wave repeats reuse the cached body instead of re-fetching.
+  - `ok` → attach `fetch.status: "ok"` referencing `data.cache_key` + `data.entry.content_hash` + `data.entry.fetch_method` + `data.entry.fetched_at`, **and set `from_cache: true`** (this row came from the cache, not a fresh fetch — the orchestrator's `cache_hits` count and the cache-reuse check depend on the distinction). Skip to the next candidate. This is the cache short-circuit: re-runs, prior projects, and cross-wave repeats reuse the cached body instead of re-fetching.
   - `unavailable` → negative-cache hit. Attach `fetch.status: "unavailable"` with `reason: <data.entry.reason>`, `cobrowse_eligible` per the cached reason (`true` only for the `webfetch_*` classes; `false` for `pdf_extraction_failed` and for any cached `cobrowse_failed`/`cobrowse_unavailable` — a prior cobrowse already dispositioned those), `attempted_at: <data.entry.fetched_at>`, `fallback_attempted: false`, `from_cache: true`. Skip to the next candidate.
 - `success: false` with `data.reason == "miss"` or `"stale"` → proceed to Step 2.
 
@@ -189,7 +189,7 @@ This line is an **undocumented tool-output convention** — parse defensively. T
 
 1. Loop `Read` over the saved PDF in 20-page windows (`pages: "1-20"`, then `"21-40"`, then `"41-60"`, …) until either:
    - the next window returns no transcribed page content **or** Read surfaces an out-of-range page indication (end of PDF), **or**
-   - the cumulative page count reaches a **200-page hard cap** (cost guard — Read transcribes PDFs via vision-rendered images, so cost scales linearly with pages; #278).
+   - the cumulative page count reaches a **200-page hard cap** (cost guard — Read transcribes PDFs via vision-rendered images, so cost scales linearly with pages).
 
    Track the final `<N>` pages successfully read across all windows.
 2. Concatenate the per-window text into a single body string in window order.
@@ -206,7 +206,7 @@ This line is an **undocumented tool-output convention** — parse defensively. T
        --http-status 200
    ```
    The body is text; `fetch_method` stays `webfetch` (it describes the transport, not the MIME).
-5. Attach `fetch.status: "ok"` with the returned `cache_key` + `content_hash`, plus `pdf_pages_read: <N>`. Set `pdf_truncated: true` **only** when the 200-page hard cap fired before the PDF ended; otherwise omit it. These PDF fields live in the candidate's `fetch` sub-object — `fetch-cache.py`'s cache-entry schema is unchanged (#278).
+5. Attach `fetch.status: "ok"` with the returned `cache_key` + `content_hash`, plus `pdf_pages_read: <N>`. Set `pdf_truncated: true` **only** when the 200-page hard cap fired before the PDF ended; otherwise omit it. These PDF fields live in the candidate's `fetch` sub-object — `fetch-cache.py`'s cache-entry schema is unchanged.
 
 If no saved-file path is found in the WebFetch output (the EUR-Lex case empirically observed) → proceed to Step 4 with `reason: pdf_extraction_failed`. Cobrowse downloads PDFs rather than rendering their text, so it is not a usable fallback for the PDF branch.
 
@@ -274,7 +274,7 @@ Return a compact summary:
  "cost_estimate": {"input_words": 0, "output_words": 13000, "estimated_usd": 0.036}}
 ```
 
-`wiki_coverage_verdict` echoes the Phase-0 verdict (`covered` / `partial` / `uncovered`); `wiki_covered_pages` is the count of `covered_pages[]` you saw; `queries_issued` is how many WebSearch queries you actually ran (vs the 5–7 baseline) — so the orchestrator can report how much the read-before-web narrowing saved (#309).
+`wiki_coverage_verdict` echoes the Phase-0 verdict (`covered` / `partial` / `uncovered`); `wiki_covered_pages` is the count of `covered_pages[]` you saw; `queries_issued` is how many WebSearch queries you actually ran (vs the 5–7 baseline) — so the orchestrator can report how much the read-before-web narrowing saved.
 
 `cost_estimate` covers content read (search results + fetched bodies) and produced (batch JSON). See `cogni-research/references/model-strategy.md` for the formula; carry it through unchanged at fork time. A WebFetch exception while fetching one candidate must not abort the batch — record it `unavailable` with the closest applicable class and move on. If a `fetch-cache.py store` call itself fails (disk full, permission denied), record that candidate `unavailable` with `reason: cache_write_failed` (in `VALID_REASONS`) and continue — the orchestrator will see the rate climb and decide. Remove temp files at end of batch (`trap rm -f "$TMP" EXIT` or equivalent).
 

--- a/cogni-knowledge/agents/source-fetcher.md
+++ b/cogni-knowledge/agents/source-fetcher.md
@@ -1,16 +1,16 @@
 ---
 name: source-fetcher
-description: Phase-3 cobrowse reconcile for the inverted pipeline. Takes a list of WebFetch-miss URLs the orchestrator (knowledge-fetch --cobrowse) hands it, recovers each via the claude-in-chrome browser extension, and writes successes through fetch-cache.py. Emits per-batch {fetched[], unavailable[]} for merge into fetch-manifest.json. Does NOT WebFetch — that moved to Phase 2's source-curator (Option B, #292). Records availability — never decides to drop a URL.
+description: Phase-3 cobrowse reconcile for the inverted pipeline. Takes a list of WebFetch-miss URLs the orchestrator (knowledge-fetch --cobrowse) hands it, recovers each via the claude-in-chrome browser extension, and writes successes through fetch-cache.py. Emits per-batch {fetched[], unavailable[]} for merge into fetch-manifest.json. Does NOT WebFetch — that moved to Phase 2's source-curator (Option B). Records availability — never decides to drop a URL.
 model: sonnet
 color: blue
 tools: ["Read", "Bash", "mcp__claude-in-chrome__tabs_create_mcp", "mcp__claude-in-chrome__navigate", "mcp__claude-in-chrome__get_page_text", "mcp__claude-in-chrome__read_page", "mcp__claude-in-chrome__find"]
 ---
 
 <!--
-NEW agent at v0.0.17 — no upstream. The inverted pipeline separates
-curation (Phase 2, source-curator) from cobrowse reconcile (Phase 3). At
-v0.0.29 (Option B, #292) the WebFetch body-pull + PDF branch moved to
-source-curator's Phase 4, so this agent shrank to cobrowse-only: it is
+NEW agent — no upstream. The inverted pipeline separates
+curation (Phase 2, source-curator) from cobrowse reconcile (Phase 3).
+Under Option B the WebFetch body-pull + PDF branch moved to
+source-curator's Phase 4, so this agent is cobrowse-only: it is
 dispatched only when the user opts in (`knowledge-fetch --cobrowse`) to
 recover the curator's WebFetch misses through the browser. See
 `cogni-knowledge/references/inverted-pipeline.md` Phase 3 contract and
@@ -29,7 +29,7 @@ agent; if a tool call still fails mid-loop the URL records `cobrowse_failed`
 
 You take a list of WebFetch-miss URLs (the orchestrator already tried WebFetch in Phase 2 and recorded them `unavailable` + `cobrowse_eligible`), recover each via the `claude-in-chrome` browser extension, and record availability. Successful recoveries go to the shared `<knowledge-root>/.cogni-knowledge/fetch-cache/` (URL-keyed), overwriting the curator's negative-cache entry. Failures get a cobrowse negative-cache entry so a re-run within the freshness window does not re-attempt.
 
-You **never WebFetch** — that is Phase 2's `source-curator` (Option B, #292). You **never decide whether a URL should be dropped from the project**. You record `fetched[]` and `unavailable[]` for the batch; the orchestrator (`knowledge-fetch`) decides whether the overall unavailable rate is acceptable.
+You **never WebFetch** — that is Phase 2's `source-curator` (Option B). You **never decide whether a URL should be dropped from the project**. You record `fetched[]` and `unavailable[]` for the batch; the orchestrator (`knowledge-fetch`) decides whether the overall unavailable rate is acceptable.
 
 ## Input Parameters
 
@@ -71,7 +71,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/fetch-cache.py fetch \
 
 **Step 2 — cobrowse.**
 
-If the `claude-in-chrome` MCP tools are **not** in your runtime tool list (the extension is not enabled in this environment), do NOT attempt the cobrowse calls — record `unavailable` with `reason: cobrowse_unavailable` and `fallback_attempted: false` (Step 3). This is the F14 signal (#276): "fixable by enabling the extension", distinct from "actually dead".
+If the `claude-in-chrome` MCP tools are **not** in your runtime tool list (the extension is not enabled in this environment), do NOT attempt the cobrowse calls — record `unavailable` with `reason: cobrowse_unavailable` and `fallback_attempted: false` (Step 3). This signals "fixable by enabling the extension", distinct from "actually dead".
 
 Otherwise invoke the cobrowse equivalent (navigate to URL, extract page text, return body). On success:
 

--- a/cogni-knowledge/agents/source-ingester.md
+++ b/cogni-knowledge/agents/source-ingester.md
@@ -7,8 +7,8 @@ tools: ["Read", "Write", "Bash", "Task"]
 ---
 
 <!--
-NEW agent at v0.0.20 — no upstream. The inverted pipeline separates
-fetching (Phase 2's source-curator since Option B / #292; cobrowse-only
+NEW agent — no upstream. The inverted pipeline separates
+fetching (Phase 2's source-curator under Option B; cobrowse-only
 source-fetcher in Phase 3) from ingest (Phase 4), where cogni-research's
 section-researcher conflated discovery + fetch + write.
 See `cogni-knowledge/references/inverted-pipeline.md` Phase 4 contract
@@ -16,7 +16,7 @@ and `references/claim-at-ingest.md` for the claim-shape contract.
 
 The cached body comes from the shared per-knowledge-base cache populated
 by `source-fetcher`; this agent never reaches the network. The
-`type: source` page type was added to cogni-wiki's allowlist at v0.0.44
+`type: source` page type is in cogni-wiki's allowlist
 (`_wikilib.PAGE_TYPE_DIRS`); per-type body semantics
 (`pre_extracted_claims:`) are owned here, not in cogni-wiki.
 -->

--- a/cogni-knowledge/agents/wiki-composer.md
+++ b/cogni-knowledge/agents/wiki-composer.md
@@ -1,6 +1,6 @@
 ---
 name: wiki-composer
-description: Phase-5 draft composer for the inverted pipeline. Reads wiki/index.md + selected wiki/sources/*.md + prior wiki/syntheses/*.md + distilled wiki/{concepts,entities,summaries,learnings}/*.md (used for framing AND citable as cross-source evidence — #344: cite the distilled page itself with its dcl-NNN claim_id when ≥2 sources converge) and writes <project>/output/draft-vN.md plus a raw-text citation-records file the orchestrator serializes into <project>/.metadata/citation-manifest.json (the composer never hand-builds JSON — #325). Inline citations are clickable numbered [N] markers linking to the source URL; [[sources/<slug>]] wikilinks live only in the reference list so the backlink graph survives without polluting prose. Persists writer-outline-vN.json before drafting (F11 recovery contract). Single pass — no expansion loops, no per-section sharding, standard density; honours OUTPUT_LANGUAGE.
+description: Phase-5 draft composer for the inverted pipeline. Reads wiki/index.md + selected wiki/sources/*.md + prior wiki/syntheses/*.md + distilled wiki/{concepts,entities,summaries,learnings}/*.md (used for framing AND citable as cross-source evidence — cite the distilled page itself with its dcl-NNN claim_id when ≥2 sources converge) and writes <project>/output/draft-vN.md plus a raw-text citation-records file the orchestrator serializes into <project>/.metadata/citation-manifest.json (the composer never hand-builds JSON). Inline citations are clickable numbered [N] markers linking to the source URL; [[sources/<slug>]] wikilinks live only in the reference list so the backlink graph survives without polluting prose. Persists writer-outline-vN.json before drafting (outline-recovery contract). Single pass — no expansion loops, no per-section sharding, standard density; honours OUTPUT_LANGUAGE.
 model: sonnet
 color: green
 tools: ["Read", "Write", "Glob", "Grep"]
@@ -10,8 +10,8 @@ tools: ["Read", "Write", "Glob", "Grep"]
 Forked from cogni-research/agents/writer.md. Point-in-time copy; drift
 acceptable per `cogni-knowledge/references/inverted-pipeline.md`
 ("What is no longer in the runtime path"). Reshape rationale + the full
-deferral list live in CHANGELOG v0.0.22 and `references/absorption-roadmap.md`
-Slice 3 — not duplicated here.
+deferral list live in the plugin CHANGELOG and `references/absorption-roadmap.md`
+— not duplicated here.
 -->
 
 # Wiki Composer Agent (inverted pipeline, Phase 5)
@@ -20,7 +20,7 @@ Slice 3 — not duplicated here.
 
 You read a populated cogni-wiki knowledge base and a per-project plan + ingest manifest, and you write a single draft report at `<project>/output/draft-vN.md` with `[[sources/<slug>]]` citations. You also write a parallel **citation-records file** (raw text — never JSON) that the orchestrator serializes into `<project>/.metadata/citation-manifest.json` — each entry carries a stable `id`, the cited sentence verbatim (`draft_sentence`), and `(wiki_slug, claim_id)` — so the `wiki-verifier` can score each citation against its claim without re-parsing or re-tokenizing the draft.
 
-You never fetch URLs. The wiki has every source body verbatim under `wiki/sources/`, with `pre_extracted_claims:` in frontmatter; that is your only evidence source. The orchestrator (`knowledge-compose`) populated the wiki via M5/M6; your job is to read it and compose.
+You never fetch URLs. The wiki has every source body verbatim under `wiki/sources/`, with `pre_extracted_claims:` in frontmatter; that is your only evidence source. The orchestrator (`knowledge-compose`) populated the wiki during ingest; your job is to read it and compose.
 
 ## Input Parameters
 
@@ -44,9 +44,9 @@ Phase 0 (load context) → Phase 1 (outline) → Phase 2 (draft + collect citati
 
 1. `Read` `<PROJECT_PATH>/.metadata/plan.json`. Extract `topic`, `sub_questions[]` (each has `id`, `query`, `search_guidance`).
 2. `Read` `<PROJECT_PATH>/.metadata/ingest-manifest.json`. Build an in-memory list of `ingested[]` entries: `{url, slug, title, publisher, summary, claims_extracted, sub_question_refs[]}`. Skip entries in `skipped[]` — they have no wiki page.
-3. `Read` `<WIKI_ROOT>/wiki/index.md`. Focus on the `## Sources` category (lists every ingested source with its summary) and the `## Syntheses` category if present — those are the catalogs relevant to composition. Also note the `## Concepts`, `## Entities`, `## Summaries`, and `## Learnings` categories if present: those are the distilled pages Phase 4.5 (`knowledge-distill`) deposited — **higher-order framing AND citable cross-source evidence** (see step 5, #344). Other categories (`## Decisions`, `## Interviews`, …) can be skipped where they aren't part of this project's evidence.
+3. `Read` `<WIKI_ROOT>/wiki/index.md`. Focus on the `## Sources` category (lists every ingested source with its summary) and the `## Syntheses` category if present — those are the catalogs relevant to composition. Also note the `## Concepts`, `## Entities`, `## Summaries`, and `## Learnings` categories if present: those are the distilled pages Phase 4.5 (`knowledge-distill`) deposited — **higher-order framing AND citable cross-source evidence** (see step 5). Other categories (`## Decisions`, `## Interviews`, …) can be skipped where they aren't part of this project's evidence.
 4. `Glob` `<WIKI_ROOT>/wiki/syntheses/*.md`. Read any synthesis pages that look relevant to the topic (rough match on title or sub-question keywords). Prior syntheses can supply cross-source framing; cite them inline via `[[syntheses/<slug>]]` exactly as you would a source page.
-5. **Read distilled pages for framing AND as citable cross-source evidence (#344).** `Glob` `<WIKI_ROOT>/wiki/concepts/*.md` + `<WIKI_ROOT>/wiki/entities/*.md` + `<WIKI_ROOT>/wiki/summaries/*.md` + `<WIKI_ROOT>/wiki/learnings/*.md` and read the **few** whose title/topic matches this report's themes (lazily + topic-matched — a populated base may have many; do not pre-load all). These pages carry a `distilled_claims:` block (cross-source distilled facts with their source backlinks) — use them first to shape the narrative arc, the cross-cutting analysis, and which sources converge on a point. A `summary` page sketches a theme across sources; a `learning` page records a run-level methodological lesson — both orient the narrative the same way concepts/entities do.
+5. **Read distilled pages for framing AND as citable cross-source evidence.** `Glob` `<WIKI_ROOT>/wiki/concepts/*.md` + `<WIKI_ROOT>/wiki/entities/*.md` + `<WIKI_ROOT>/wiki/summaries/*.md` + `<WIKI_ROOT>/wiki/learnings/*.md` and read the **few** whose title/topic matches this report's themes (lazily + topic-matched — a populated base may have many; do not pre-load all). These pages carry a `distilled_claims:` block (cross-source distilled facts with their source backlinks) — use them first to shape the narrative arc, the cross-cutting analysis, and which sources converge on a point. A `summary` page sketches a theme across sources; a `learning` page records a run-level methodological lesson — both orient the narrative the same way concepts/entities do.
 
    **When to cite a distilled page vs. its underlying sources.** A distilled claim carries cross-source weight ("N sources agree") that no single source page can. Two cases:
    - **Cross-source fact → cite the distilled page.** When ≥2 sources converge on a fact and the distilled page's `distilled_claims:` already captures it, cite the **distilled page itself** (`wiki_slug: <distilled-slug>`, `claim_id: <the dcl-NNN>`). This is the right move when you want the convergence to carry epistemic weight rather than enumerating 5 source markers. **Draw the cited sentence's wording from the distilled claim's `text`** — that is the exact string the verifier scores `draft_sentence` against for a distilled-page citation. The inline marker is a plain `<sup>[N]</sup>` (a distilled page has no external URL — its `sources:` are `wiki://…` backlinks), exactly like a synthesis-page citation; its `[[concepts/<slug>]]` (or `entities/`/`summaries/`/`learnings/`) wikilink lives **only** in the reference list.
@@ -79,7 +79,7 @@ Before drafting a single paragraph, commit to an explicit section plan with per-
    }
    ```
 
-   Use `Write` to create the file. **F11 contract:** this file MUST be on disk before Phase 2 attempts to write the draft. If you crash between Phase 1 and Phase 2, the orchestrator's pre-flight will detect the outline on the next dispatch and pass `RESUME_FROM_OUTLINE=true` so Phase 2 re-runs without re-doing Phase 1.
+   Use `Write` to create the file. **Outline-recovery contract:** this file MUST be on disk before Phase 2 attempts to write the draft. If you crash between Phase 1 and Phase 2, the orchestrator's pre-flight will detect the outline on the next dispatch and pass `RESUME_FROM_OUTLINE=true` so Phase 2 re-runs without re-doing Phase 1.
 
 5. Each section entry carries a zero-padded `index` string and a `drafted_words` placeholder you fill with the final word count on your last pass through the draft.
 
@@ -110,9 +110,9 @@ Maintain an in-memory `citations: list[dict]` you will flush in Phase 3.
 
    `**[N]** Publisher, "Title". [URL](URL) — [[sources/<slug>]]`
 
-   The visible `**[N]**` is bolded; the URL renders as a clickable markdown link (it is the page's `sources:` URL). The `[[sources/<slug>]]` wikilink at the end is the **only** place a wikilink appears anywhere in the draft — it keeps the cogni-wiki backlink graph intact without polluting the prose. Synthesis-page citations have no external URL: emit `**[N]** Title — [[syntheses/<slug>]]` (no link). **Distilled-page citations** (concept/entity/summary/learning, #344) likewise have no external URL: emit `**[N]** Title — [[concepts/<slug>]]` (or `[[entities/<slug>]]` / `[[summaries/<slug>]]` / `[[learnings/<slug>]]`, matching the directory the page lives under). Source pages carry no year field, so omit a year. This list is standalone-readable; M9 (`knowledge-finalize`) re-derives the canonical list from the citation-manifest at deposit, so keep the numbering consistent with your inline markers.
+   The visible `**[N]**` is bolded; the URL renders as a clickable markdown link (it is the page's `sources:` URL). The `[[sources/<slug>]]` wikilink at the end is the **only** place a wikilink appears anywhere in the draft — it keeps the cogni-wiki backlink graph intact without polluting the prose. Synthesis-page citations have no external URL: emit `**[N]** Title — [[syntheses/<slug>]]` (no link). **Distilled-page citations** (concept/entity/summary/learning) likewise have no external URL: emit `**[N]** Title — [[concepts/<slug>]]` (or `[[entities/<slug>]]` / `[[summaries/<slug>]]` / `[[learnings/<slug>]]`, matching the directory the page lives under). Source pages carry no year field, so omit a year. This list is standalone-readable; `knowledge-finalize` re-derives the canonical list from the citation-manifest at deposit, so keep the numbering consistent with your inline markers.
 
-4. **Word-count self-check.** Tally per-section drafted words. Update each `sections[].drafted_words` in the outline file (re-`Write` the outline atomically — Phase 1's path) so the verifier has a pre-written audit hook. If the total is below `TARGET_WORDS`, log the shortfall in your return JSON and move on — there is no re-dispatch loop in v0.0.22. Do not pad with filler.
+4. **Word-count self-check.** Tally per-section drafted words. Update each `sections[].drafted_words` in the outline file (re-`Write` the outline atomically — Phase 1's path) so the verifier has a pre-written audit hook. If the total is below `TARGET_WORDS`, log the shortfall in your return JSON and move on — there is no re-dispatch loop. Do not pad with filler.
 
 5. **The draft prose belongs in the file, not in your response body.** Compose the full markdown, then call `Write` exactly once with the entire draft as `content` on `<PROJECT_PATH>/output/draft-v{DRAFT_VERSION}.md`. Spilling the draft into the response body can exhaust your output token budget before the `Write` call fires, leaving an empty file. The orchestrator reads the file, not your message.
 
@@ -137,7 +137,7 @@ Maintain an in-memory `citations: list[dict]` you will flush in Phase 3.
 
    The five keys map one-to-one to the citation entry you built in Phase 2 step 1.4: `id` → `id`, `pos` → `draft_position`, `slug` → `wiki_slug`, `claim` → `claim_id` (write the literal `null` for a synthesis citation with no claim), `sentence` → `draft_sentence`.
 
-   **Critical — `sentence` is raw text, NOT JSON.** Copy the cited sentence verbatim (including its inline `<sup>[N](url)</sup>` marker(s)) onto a **single line** after `sentence: `. Do **NOT** wrap it in quotes, do **NOT** escape `"`, `\`, or any other character, and do **NOT** assemble JSON yourself. The `Write` tool persists your text byte-for-byte, so a straight `"` closing a German `„…"` pair (or any quoted English term) is safe here precisely because you are not building JSON. The orchestrator (`knowledge-compose`) then runs `citation-store.py build`, which `json.dumps` your records into `<PROJECT_PATH>/.metadata/citation-manifest.json` — escaping is the serializer's job, never yours. That script self-checks by re-parsing the manifest it wrote and asserting every `sentence` is a verbatim substring of the draft, so a hand-built-JSON regression can no longer ship a broken `citation-manifest.json` (#325 — a straight `"` in a `draft_sentence` used to break `json.loads` downstream and kill the verify phase).
+   **Critical — `sentence` is raw text, NOT JSON.** Copy the cited sentence verbatim (including its inline `<sup>[N](url)</sup>` marker(s)) onto a **single line** after `sentence: `. Do **NOT** wrap it in quotes, do **NOT** escape `"`, `\`, or any other character, and do **NOT** assemble JSON yourself. The `Write` tool persists your text byte-for-byte, so a straight `"` closing a German `„…"` pair (or any quoted English term) is safe here precisely because you are not building JSON. The orchestrator (`knowledge-compose`) then runs `citation-store.py build`, which `json.dumps` your records into `<PROJECT_PATH>/.metadata/citation-manifest.json` — escaping is the serializer's job, never yours. That script self-checks by re-parsing the manifest it wrote and asserting every `sentence` is a verbatim substring of the draft, so a hand-built-JSON regression can no longer ship a broken `citation-manifest.json` (a straight `"` in a `draft_sentence` used to break `json.loads` downstream and kill the verify phase).
 
    **Read-back verify the records.** Immediately after `Write` returns, `Read` `<PROJECT_PATH>/.metadata/citation-records-v{DRAFT_VERSION}.txt`. It must be non-empty and contain one `- id:` block per citation you collected (a phantom-empty or truncated write would otherwise serialize to a silently-undersized manifest — `citation-store.py build` parses an empty file into a valid *empty* manifest, so the gap must be caught here). If `Read` fails, returns empty, or has fewer `- id:` blocks than you collected, `Write` once more with the same content and re-verify. If the second attempt also fails, stop and return the `write_failed` JSON shown below.
 
@@ -168,7 +168,7 @@ Maintain an in-memory `citations: list[dict]` you will flush in Phase 3.
    `citations` is the **exact number of records you just wrote to
    `citation-records-v{N}.txt`** — count them, do not estimate. The orchestrator re-derives the
    authoritative count from the manifest `citation-store.py build` emits, but your count must match it;
-   a guessed number is the F24 count-drift bug. (The `38` above is illustrative.)
+   a guessed number is the count-drift bug. (The `38` above is illustrative.)
 
    On input failure (no `ingested[]` entries to draw on):
    ```json
@@ -180,14 +180,14 @@ Maintain an in-memory `citations: list[dict]` you will flush in Phase 3.
    {"ok": false, "error": "write_failed", "reason": "Write returned but read-back verification failed twice — likely output token budget exhausted before Write fired."}
    ```
 
-   `cost_estimate.input_words` ≈ word count of every wiki page + outline + manifests you read. `cost_estimate.output_words` ≈ word count of the draft + citation manifest. Carry the estimation formula from `cogni-research/references/model-strategy.md` unchanged at fork time.
+   `cost_estimate.input_words` ≈ word count of every wiki page + outline + manifests you read. `cost_estimate.output_words` ≈ word count of the draft + citation manifest. Carry the estimation formula from `cogni-research/references/model-strategy.md` unchanged.
 
 ## Writing guidelines
 
 - **Output language follows `OUTPUT_LANGUAGE`** (default `en`). When it is not `en`, write the **entire** draft — body, section headings, and the reference-section heading — in that language, with proper character encoding and never ASCII fallbacks: German `ä/ö/ü/ß` (never `ae/oe/ue/ss` in prose), French `é/è/ê/ç`, Italian `à/è/é/ì/ò/ù`, Polish `ą/ć/ę/ł/ń/ó/ś/ź/ż`, Dutch `ë/ï`, Spanish `á/é/í/ó/ú/ñ/¿/¡`. Keep established framework names in English (SWOT, MECE). Source-language quotes are reproduced verbatim. (The slug transliteration `ä→ae` is a separate slug-grammar concern handled by `_knowledge_lib.slugify` — never ASCII-fold the prose itself.)
 - **Tone is objective and analytical.** Lead with the most important findings, not methodology. Use evidence-based assertions, not speculation. Vary sentence structure; keep paragraphs focused (3–5 sentences).
-- **Cite inline; never make unsourced claims.** Every number, percentage, date, quoted phrase, named finding gets an inline numbered `[N]` citation (clickable, linking to the source URL) with a matching `citation-manifest.json` entry pointing at a real claim id — a `pre_extracted_claims[].id` on a source/synthesis page, or a `distilled_claims[].claim_id` on a distilled page (#344). Wikilinks (`[[sources/<slug>]]` / `[[syntheses/<slug>]]` / `[[concepts/<slug>]]` / `[[entities/<slug>]]` / `[[summaries/<slug>]]` / `[[learnings/<slug>]]`) appear **only** in the reference list, never in prose.
-- **Do NOT emit `Report-Metadaten` / `Verfasser` / `Berichtsdatum` / `Report Metadata` / `Author` blocks** or any self-attribution of the model name anywhere in the draft. Report metadata is written deterministically by the finalize phase (M9). Self-attribution as any specific Claude model is a grounding violation even when hedged.
+- **Cite inline; never make unsourced claims.** Every number, percentage, date, quoted phrase, named finding gets an inline numbered `[N]` citation (clickable, linking to the source URL) with a matching `citation-manifest.json` entry pointing at a real claim id — a `pre_extracted_claims[].id` on a source/synthesis page, or a `distilled_claims[].claim_id` on a distilled page. Wikilinks (`[[sources/<slug>]]` / `[[syntheses/<slug>]]` / `[[concepts/<slug>]]` / `[[entities/<slug>]]` / `[[summaries/<slug>]]` / `[[learnings/<slug>]]`) appear **only** in the reference list, never in prose.
+- **Do NOT emit `Report-Metadaten` / `Verfasser` / `Berichtsdatum` / `Report Metadata` / `Author` blocks** or any self-attribution of the model name anywhere in the draft. Report metadata is written deterministically by the finalize phase. Self-attribution as any specific Claude model is a grounding violation even when hedged.
 - **Section headings follow `OUTPUT_LANGUAGE`.** For `en`: `## Introduction`, `## Cross-cutting analysis`, `## Conclusion`, `## References`, plus topical H2s named for the sub-question theme. For other languages, translate the structural headings (e.g. German `## Einleitung`, `## Schlussfolgerung`, `## Referenzen`) and name topical H2s in the output language. The reference-section heading must match the localized word listed in Phase 2 step 3.
 
 ## What this agent does NOT do
@@ -195,14 +195,14 @@ Maintain an in-memory `citations: list[dict]` you will flush in Phase 3.
 - Does NOT WebFetch or WebSearch — every source is already in the wiki.
 - Does NOT dispatch other agents (`Task` is not in this agent's tool list). It is a single-pass composer.
 - Does NOT call `cogni-research`, `cogni-claims`, or any `cogni-wiki:` skill — clean-break.
-- Does NOT verify claims — that is M8's `wiki-verifier`.
-- Does NOT deposit a synthesis page — that is M9's `knowledge-finalize`.
+- Does NOT verify claims — that is `wiki-verifier`'s job (Phase 6).
+- Does NOT deposit a synthesis page — that is `knowledge-finalize`'s job (Phase 7).
 - Does NOT modify `binding.json` or any wiki page — read-only against the wiki; writes only to `<PROJECT_PATH>/output/` and `<PROJECT_PATH>/.metadata/`.
 - Does NOT iterate on word-count shortfall. The single pass returns whatever lands; the orchestrator does not re-dispatch on under-target.
 
 ## Failure-mode invariants
 
-- Phase 1's outline file is the F11 anchor. If you cannot write it for any reason, return `{"ok": false, "error": "outline_write_failed", ...}` and stop — do not attempt Phase 2 without an outline on disk.
+- Phase 1's outline file is the outline-recovery anchor. If you cannot write it for any reason, return `{"ok": false, "error": "outline_write_failed", ...}` and stop — do not attempt Phase 2 without an outline on disk.
 - A draft `Write` that succeeds but reads back empty is a phantom write (output token budget exhausted). Retry once; on second failure return `write_failed`.
 - A citation that lacks a matching `pre_extracted_claims[].id` on the cited page is dropped from the manifest (not fabricated). The corresponding inline `<sup>[N](url)</sup>` marker either gets removed in the same pass, or — for synthesis pages with no claims — is kept and recorded with `claim_id: null`. (No `[[sources/<slug>]]` is ever placed in prose; wikilinks live only in the reference list.)
 - If `ingest-manifest.json::ingested[]` is empty, return `no_ingested_sources` and stop — there is nothing to compose from.

--- a/cogni-knowledge/agents/wiki-contradictor.md
+++ b/cogni-knowledge/agents/wiki-contradictor.md
@@ -1,37 +1,36 @@
 ---
 name: wiki-contradictor
-description: Phase-7 zero-network contradiction scorer for the inverted pipeline. Reads the just-deposited <wiki>/syntheses/<slug>.md + each cited page's claim frontmatter (pre_extracted_claims on wiki/sources/<slug>.md; distilled_claims on wiki/{concepts,entities,summaries,learnings}/<slug>.md — distilled pages citable + scored since #344/#363, against distilled_claims[].text which has no excerpt_quote), walks the synthesis body sentence-by-sentence against every claim, and emits <project>/.metadata/contradictor-vN.json (schema 0.1.0) with findings carrying kind ∈ {contradiction, unknown} and severity ∈ {high, medium, low}. Pure observability — no auto-resolution, no rollback, no behaviour change downstream. Phase 1 of approach (a) from #335 (distilled-page scoring added #363); partially defends references/differentiation-thesis.md Pillar 2 at synthesis-write time. Never fetches and never modifies any wiki page — the alignment surface is the synthesis body matched against claims extracted at ingest/distill time (M5/M6/Phase 4.5).
+description: Phase-7 zero-network contradiction scorer for the inverted pipeline. Reads the just-deposited <wiki>/syntheses/<slug>.md + each cited page's claim frontmatter (pre_extracted_claims on wiki/sources/<slug>.md; distilled_claims on wiki/{concepts,entities,summaries,learnings}/<slug>.md — distilled pages are citable + scored, against distilled_claims[].text which has no excerpt_quote), walks the synthesis body sentence-by-sentence against every claim, and emits <project>/.metadata/contradictor-vN.json (schema 0.1.0) with findings carrying kind ∈ {contradiction, unknown} and severity ∈ {high, medium, low}. Pure observability — no auto-resolution, no rollback, no behaviour change downstream. Phase 1 of approach (a); partially defends references/differentiation-thesis.md Pillar 2 at synthesis-write time. Never fetches and never modifies any wiki page — the alignment surface is the synthesis body matched against claims extracted at ingest/distill time.
 model: sonnet
 color: orange
 tools: ["Read", "Write", "Glob", "Grep"]
 ---
 
 <!--
-NEW agent at v0.1.15 — no upstream. Mirrors wiki-verifier.md's posture
-(single-pass, zero-network, JSON envelope out, no Task in tools list)
-because the structural cost-win is identical: the wiki already carries
-every cited page's claims (wiki/sources/<slug>.md::pre_extracted_claims;
+Mirrors wiki-verifier.md's posture (single-pass, zero-network, JSON
+envelope out, no Task in tools list) because the structural cost-win is
+identical: the wiki already carries every cited page's claims
+(wiki/sources/<slug>.md::pre_extracted_claims;
 wiki/{concepts,entities,summaries,learnings}/<slug>.md::distilled_claims),
 so contradiction scoring at synthesis-write time is a zero-network
 string-judgement, not a re-fetch.
 
-#363 (v0.1.28) — distilled-page citations are now scored. Since #344 a
-synthesis can cite a distilled page (concept/entity/summary/learning)
-carrying distilled_claims:; those sentences were previously compared
-against no claims and silently escaped the tripwire. Resolution now probes
-the four distilled dirs after wiki/sources/ and scores distilled_claims[].text
-(no excerpt_quote) — mirroring the wiki-verifier #344/#362 pattern. The
-orchestrator's Step 5/6 filter (knowledge-finalize SKILL.md) widened in
-lockstep from page_kind == "source" to {source, concept, entity, summary,
+Distilled-page citations are scored. A synthesis can cite a distilled page
+(concept/entity/summary/learning) carrying distilled_claims:; those
+sentences would otherwise be compared against no claims and silently escape
+the tripwire. Resolution probes the four distilled dirs after wiki/sources/
+and scores distilled_claims[].text (no excerpt_quote) — mirroring the
+wiki-verifier pattern. The orchestrator's Step 5/6 filter
+(knowledge-finalize SKILL.md) covers {source, concept, entity, summary,
 learning}; synthesis still excluded (no claim block).
 
-Phase 1 scope (this release) — see #335 for the smallest→fullest path:
+Phase 1 scope:
 
   - kind ∈ {contradiction, unknown} only. type_drift +
-    undercited_synthesis defer to v0.1.16 once Phase 1 produces real
+    undercited_synthesis defer until Phase 1 produces real
     false-positive volume data.
-  - Cited source + distilled page comparison (#363). Synthesis-vs-prior-
-    syntheses comparison defers to v0.1.16 — synthesis pages carry no
+  - Cited source + distilled page comparison. Synthesis-vs-prior-
+    syntheses comparison is deferred — synthesis pages carry no
     claim block, so the same structural cheap-comparison surface doesn't
     exist; body-vs-body scoring is expensive and best done after Phase 1
     proves the lower-cost layer is worth keeping.
@@ -43,11 +42,11 @@ Single-pass — no Task in tools list, no sub-dispatch, no re-fetch.
 
 ## Role
 
-You read a just-deposited synthesis page and the cited pages it claims to summarize, walk the synthesis body sentence-by-sentence against each cited page's claim frontmatter — `pre_extracted_claims:` on a `wiki/sources/<slug>.md` page, or `distilled_claims:` on a distilled `wiki/{concepts,entities,summaries,learnings}/<slug>.md` page (citable since #344, scored here since #363) — and emit `<project>/.metadata/contradictor-v{N}.json` with the contradiction findings. The `knowledge-finalize` orchestrator surfaces a one-line warning in the Step 11 summary; reconciliation (rewriting the synthesis, updating cited pages, dropping a stale source) is for `cogni-wiki:wiki-update` — your job is to flag, not to resolve.
+You read a just-deposited synthesis page and the cited pages it claims to summarize, walk the synthesis body sentence-by-sentence against each cited page's claim frontmatter — `pre_extracted_claims:` on a `wiki/sources/<slug>.md` page, or `distilled_claims:` on a distilled `wiki/{concepts,entities,summaries,learnings}/<slug>.md` page (citable and scored here) — and emit `<project>/.metadata/contradictor-v{N}.json` with the contradiction findings. The `knowledge-finalize` orchestrator surfaces a one-line warning in the Step 11 summary; reconciliation (rewriting the synthesis, updating cited pages, dropping a stale source) is for `cogni-wiki:wiki-update` — your job is to flag, not to resolve.
 
-You **never fetch URLs**. The wiki has every cited source body verbatim under `wiki/sources/` with `pre_extracted_claims:` in frontmatter, and the cross-source distilled pages under `wiki/{concepts,entities,summaries,learnings}/` carry `distilled_claims:`; those are your only evidence sources. M5/M6 populated the source claims at ingest time and Phase 4.5 populated the distilled claims; your job is to score the deposited synthesis against them at finalize time.
+You **never fetch URLs**. The wiki has every cited source body verbatim under `wiki/sources/` with `pre_extracted_claims:` in frontmatter, and the cross-source distilled pages under `wiki/{concepts,entities,summaries,learnings}/` carry `distilled_claims:`; those are your only evidence sources. The source claims are populated at ingest time and the distilled claims at distill time; your job is to score the deposited synthesis against them at finalize time.
 
-This step partially defends `references/differentiation-thesis.md` Pillar 2 (*"Contradictions surface at ingest. When `wiki-ingest` writes page B and page A already says something incompatible, the conflict is visible at file-write time."*) at *synthesis-write time*. The literal "wiki-ingest writes page B" framing — per-source ingest-time check — is approach **(b)** from #335, deferred to v0.1.17+ until this Phase-1 (a) layer produces ≥ 3 confirmed real-fork examples.
+This step partially defends `references/differentiation-thesis.md` Pillar 2 (*"Contradictions surface at ingest. When `wiki-ingest` writes page B and page A already says something incompatible, the conflict is visible at file-write time."*) at *synthesis-write time*. The literal "wiki-ingest writes page B" framing — per-source ingest-time check — is approach **(b)**, deferred until this Phase-1 (a) layer produces ≥ 3 confirmed real-fork examples.
 
 ## Input Parameters
 
@@ -56,7 +55,7 @@ This step partially defends `references/differentiation-thesis.md` Pillar 2 (*"C
 | `WIKI_ROOT` | Yes | Absolute path to the bound wiki root (the dir containing `.cogni-wiki/config.json` and `wiki/`). Resolved by the orchestrator from `binding.wiki_path`. |
 | `PROJECT_PATH` | Yes | Absolute path to the project directory. Used only to derive the default `CONTRADICTOR_OUT_PATH`. |
 | `SYNTHESIS_PAGE_PATH` | Yes | Absolute path to the just-deposited synthesis page (`<WIKI_ROOT>/wiki/syntheses/<SYNTHESIS_SLUG>.md`). The orchestrator threads this from Step 6's deposit. |
-| `CITED_SOURCE_SLUGS` | Yes | Comma-separated list of cited **source *and* distilled** page slugs to compare the synthesis against (the name is retained for input-contract stability; semantics widened at #363). The orchestrator filters `citation-manifest.json::citations[].wiki_slug` to `page_kind_by_slug[slug] ∈ {source, concept, entity, summary, learning}` — source pages (`pre_extracted_claims:`) and the four distilled kinds (`distilled_claims:`, citable since #344). `synthesis`-page citations are still excluded (synthesis pages carry no claim block). Empty/blank => the orchestrator skips this step before dispatching. Hard cap: 30 slugs; the orchestrator truncates above that and surfaces the truncation as a Step 11 warning (`⚠ contradiction tripwire truncated at 30/<N>`). The agent only ever sees the post-truncation CSV — it has no way to know the original `N` and therefore does NOT emit a `truncated_at` field. Truncation is the orchestrator's signal to surface; the on-disk envelope records exactly what was scored, never what was dropped. |
+| `CITED_SOURCE_SLUGS` | Yes | Comma-separated list of cited **source *and* distilled** page slugs to compare the synthesis against (the name is retained for input-contract stability). The orchestrator filters `citation-manifest.json::citations[].wiki_slug` to `page_kind_by_slug[slug] ∈ {source, concept, entity, summary, learning}` — source pages (`pre_extracted_claims:`) and the four distilled kinds (`distilled_claims:`). `synthesis`-page citations are still excluded (synthesis pages carry no claim block). Empty/blank => the orchestrator skips this step before dispatching. Hard cap: 30 slugs; the orchestrator truncates above that and surfaces the truncation as a Step 11 warning (`⚠ contradiction tripwire truncated at 30/<N>`). The agent only ever sees the post-truncation CSV — it has no way to know the original `N` and therefore does NOT emit a `truncated_at` field. Truncation is the orchestrator's signal to surface; the on-disk envelope records exactly what was scored, never what was dropped. |
 | `OUTPUT_LANGUAGE` | Yes | The language the synthesis and its sources are written in (from `plan.json::output_language`, default `"en"`). You operate in this language natively — never translate. Cross-language scoring (DE↔EN sources) is approach (c) territory and explicitly out of scope. |
 | `DRAFT_VERSION` | Yes | Integer N. Drives the output filename (`contradictor-v{N}.json`). |
 | `CONTRADICTOR_OUT_PATH` | Yes | Absolute path where you `Write` the JSON envelope. Default `<PROJECT_PATH>/.metadata/contradictor-v{DRAFT_VERSION}.json`; the orchestrator threads it explicitly so a re-finalize on the same draft overwrites a single canonical file (matches `verify-v{N}.json` convention). |
@@ -73,8 +72,8 @@ Phase 0 (load context) → Phase 1 (score per sentence) → Phase 2 (write + ver
 
 2. Parse `CITED_SOURCE_SLUGS` as a comma-separated list. Strip whitespace; drop empty entries. For each slug, resolve the page by probing these five directories **in order, first hit wins** (mirrors `wiki-verifier.md` Phase 0 step 3 exactly — a slug is one page, so the directories are mutually exclusive and `dcl-NNN` vs `clm-NNN` ids never collide):
    - `<WIKI_ROOT>/wiki/sources/<slug>.md` — a **source** page. `Read` it and parse `pre_extracted_claims:` from frontmatter into `claims_by_slug[slug] = [{claim_id, text, excerpt_quote}, ...]`.
-   - else `<WIKI_ROOT>/wiki/concepts/<slug>.md`, `…/entities/<slug>.md`, `…/summaries/<slug>.md`, `…/learnings/<slug>.md` — a **distilled** page (citable since #344, scored here since #363). `Read` it and parse `distilled_claims:` into `claims_by_slug[slug] = [{claim_id, text}, ...]` — **there is no `excerpt_quote`** on a distilled claim (this is the verifier's contract too).
-   - An absent or empty claim block (`pre_extracted_claims:` on a source — rare, `claim-extractor` runs on every Phase-4 ingest; `distilled_claims:` on a distilled page — legitimate mid-build) yields an empty list for that slug; do not crash, emit no findings against it (AD-7).
+   - else `<WIKI_ROOT>/wiki/concepts/<slug>.md`, `…/entities/<slug>.md`, `…/summaries/<slug>.md`, `…/learnings/<slug>.md` — a **distilled** page (citable and scored here). `Read` it and parse `distilled_claims:` into `claims_by_slug[slug] = [{claim_id, text}, ...]` — **there is no `excerpt_quote`** on a distilled claim (this is the verifier's contract too).
+   - An absent or empty claim block (`pre_extracted_claims:` on a source — rare, `claim-extractor` runs on every Phase-4 ingest; `distilled_claims:` on a distilled page — legitimate mid-build) yields an empty list for that slug; do not crash, emit no findings against it.
    - If the slug exists under **none** of the five directories, record it in `compared_against.missing_pages[]` and continue. A cited page that disappeared between Step 6 and Step 10.6 is rare but possible (concurrent wiki maintenance); surface it in the envelope and skip. The orchestrator pre-filters `CITED_SOURCE_SLUGS` to existing source/distilled pages at Step 5/6, so a non-empty `missing_pages[]` necessarily signals a TOCTOU race between orchestrator resolution and your read — not a bug in the orchestrator's slug list.
 
    **Parsing the `distilled_claims:` block.** Stdlib line-by-line only — **never `import yaml`** (not stdlib). Mirror `scripts/concept-store.py::_render_distilled_claims` (the writer) / `wiki-verifier.md` Phase 0's `distilled_claims` reader: two-space indent under the block key, each item begins `  - claim_id: dcl-NNN` followed by `    text: <json-quoted>`. **Capture `claim_id` + `text` only**; ignore the writer-side metadata keys `norm_key` / `backlinks` / `source_claim_refs` / `created` / `updated`.
@@ -107,7 +106,7 @@ For each `contradiction` finding, set `severity`:
 **Discipline:**
 
 - Default to `low` on doubt. Promote to `medium` only when scope overlap is clearly established. Promote to `high` only when the same entity/quantity flips.
-- **Emit ONE finding per (sentence, cited-page) pair, not per claim** — holds for distilled pages too. When a sentence contradicts multiple claims on the same page, pick the most severe one (highest-severity match wins; ties broken by `claim_id` lexical order) and record only that pair. The other contradicting claims are summarised in the `note` (e.g. `"synthesis asserts 12-month EU-wide deadline; cited source has 24-month transition (clm-004) AND Germany-only scope (clm-007)"`). This keeps the v0.1.16 de-dup key `(synthesis_excerpt, conflicting_page, conflicting_claim_id)` unambiguous.
+- **Emit ONE finding per (sentence, cited-page) pair, not per claim** — holds for distilled pages too. When a sentence contradicts multiple claims on the same page, pick the most severe one (highest-severity match wins; ties broken by `claim_id` lexical order) and record only that pair. The other contradicting claims are summarised in the `note` (e.g. `"synthesis asserts 12-month EU-wide deadline; cited source has 24-month transition (clm-004) AND Germany-only scope (clm-007)"`). This keeps the future de-dup key `(synthesis_excerpt, conflicting_page, conflicting_claim_id)` unambiguous.
 - A single sentence will rarely contradict more than 2 cited pages cleanly; if you find yourself emitting more, your bar is too loose — re-read with conservative discipline.
 
 Each finding entry shape:
@@ -125,7 +124,7 @@ Each finding entry shape:
 }
 ```
 
-`id` is `ctr-001`, `ctr-002`, … in emission order within the current envelope — stable join key WITHIN one `contradictor-v<N>.json`, but **not stable across re-runs**: a re-finalize on the same draft may notice findings in a different order and assign different `ctr-NNN` ids. Cross-run de-dup is v0.1.16 work and will key on `(synthesis_excerpt, conflicting_page, conflicting_claim_id)` — not `id`.
+`id` is `ctr-001`, `ctr-002`, … in emission order within the current envelope — stable join key WITHIN one `contradictor-v<N>.json`, but **not stable across re-runs**: a re-finalize on the same draft may notice findings in a different order and assign different `ctr-NNN` ids. Cross-run de-dup is future work and will key on `(synthesis_excerpt, conflicting_page, conflicting_claim_id)` — not `id`.
 
 ### Phase 2: Write + verify
 
@@ -176,9 +175,9 @@ Return a compact JSON envelope via the Task return path — and nothing else in 
  "cost_estimate": {"input_words": 4200, "output_words": 110, "estimated_usd": 0.011}}
 ```
 
-`compared_against` is the single source of truth for the `sources[]` actually scored, `source_count`, and `missing_pages[]` — both on-disk (Phase 2 written envelope) and in the Task return value. The `sources[]` array name is retained for schema stability (no bump at #363) but now records **all scored pages — source *and* distilled slugs alike**; `source_count` is the count of all of them. Do NOT emit `missing_pages` at the top level of the envelope — duplicating a single datum in two locations bakes in schema drift the moment one copy is updated and the other is not.
+`compared_against` is the single source of truth for the `sources[]` actually scored, `source_count`, and `missing_pages[]` — both on-disk (Phase 2 written envelope) and in the Task return value. The `sources[]` array name is retained for schema stability but now records **all scored pages — source *and* distilled slugs alike**; `source_count` is the count of all of them. Do NOT emit `missing_pages` at the top level of the envelope — duplicating a single datum in two locations bakes in schema drift the moment one copy is updated and the other is not.
 
-`cost_estimate.input_words` ≈ word count of the synthesis body + every cited page's claim block you read (`pre_extracted_claims:` on sources, `distilled_claims:` on distilled pages). `cost_estimate.output_words` ≈ word count of the emitted JSON. Compute `estimated_usd` using the Sonnet pricing constants from `cogni-research/references/model-strategy.md` — at the v0.1.15 fork point: input tokens ≈ words × 0.75, Sonnet input $3 / MTok and output $15 / MTok, so `estimated_usd ≈ input_words × 0.75 × 3 / 1_000_000 + output_words × 0.75 × 15 / 1_000_000`. (The 4200/110 example above resolves to ~$0.0094 + $0.00124 ≈ $0.011, NOT $0.044 — the original draft's $0.044 anchored on the wrong constant.)
+`cost_estimate.input_words` ≈ word count of the synthesis body + every cited page's claim block you read (`pre_extracted_claims:` on sources, `distilled_claims:` on distilled pages). `cost_estimate.output_words` ≈ word count of the emitted JSON. Compute `estimated_usd` using the Sonnet pricing constants from `cogni-research/references/model-strategy.md`: input tokens ≈ words × 0.75, Sonnet input $3 / MTok and output $15 / MTok, so `estimated_usd ≈ input_words × 0.75 × 3 / 1_000_000 + output_words × 0.75 × 15 / 1_000_000`. (The 4200/110 example above resolves to ~$0.0094 + $0.00124 ≈ $0.011, NOT $0.044 — the original draft's $0.044 anchored on the wrong constant.)
 
 **Synthesis unreadable** (Phase 0 step 1 failed):
 
@@ -200,7 +199,7 @@ Never raise — always return one of these envelopes so the orchestrator's Step 
 - **Be conservative on `high`.** A `high` finding should be something the human almost certainly needs to reconcile before publishing. Soft tensions, plausible date shifts, scope language that *could* be interpreted either way — those are `medium` or `low`. When you doubt, downgrade.
 - **Cap `unknown` at 3.** Beyond that you are pattern-matching noise; collapse the rest into one rolled-up entry per Phase 1.
 - **One pass, no loops.** The orchestrator dispatches you once per finalize. There is no revisor loop, no second opinion.
-- **Operate in the source language.** A German synthesis cited against German sources is scored in German; never translate. Cross-language scoring (`Hochrisiko-Klassifizierung` vs `high-risk classification`) is approach (c) territory from #335 and explicitly out of scope here — a finding that requires translation to detect is correctly emitted as `unknown` or skipped.
+- **Operate in the source language.** A German synthesis cited against German sources is scored in German; never translate. Cross-language scoring (`Hochrisiko-Klassifizierung` vs `high-risk classification`) is approach (c) territory and explicitly out of scope here — a finding that requires translation to detect is correctly emitted as `unknown` or skipped.
 
 ## What this agent does NOT do
 
@@ -210,22 +209,22 @@ Never raise — always return one of these envelopes so the orchestrator's Step 
 - Does NOT modify the synthesis page, any cited source page, the citation manifest, the verify manifest, the binding, or `wiki/log.md`. Read-only against everything except `CONTRADICTOR_OUT_PATH`.
 - Does NOT translate between languages. Operates in `OUTPUT_LANGUAGE` natively; cross-language scoring is approach (c) territory.
 - Does NOT resolve contradictions — surfacing only. Reconciliation is `cogni-wiki:wiki-update`'s job, gated on human judgment.
-- Does NOT compare against prior `wiki/syntheses/*.md` pages. Phase 1 scope is synthesis-vs-cited-source-or-distilled only; synthesis-vs-prior-syntheses comparison defers to v0.1.16 (synthesis pages have no claim block for a cheap structural comparison, so body-vs-body scoring is expensive and best layered on after Phase 1 produces signal). **Distilled pages are the opposite** — a cited `concepts/`/`entities/`/`summaries/`/`learnings/` page carries `distilled_claims:` and IS resolved + scored (its `text`, no `excerpt_quote`) exactly like a source (#363).
+- Does NOT compare against prior `wiki/syntheses/*.md` pages. Phase 1 scope is synthesis-vs-cited-source-or-distilled only; synthesis-vs-prior-syntheses comparison is deferred (synthesis pages have no claim block for a cheap structural comparison, so body-vs-body scoring is expensive and best layered on after Phase 1 produces signal). **Distilled pages are the opposite** — a cited `concepts/`/`entities/`/`summaries/`/`learnings/` page carries `distilled_claims:` and IS resolved + scored (its `text`, no `excerpt_quote`) exactly like a source.
 - Does NOT treat a distilled cited page as missing. It resolves the four distilled dirs after `wiki/sources/`; only a slug found under none of the five dirs lands in `compared_against.missing_pages[]`.
-- Does NOT score `type_drift`, `undercited_synthesis`, `missing_concept`, or any other check from `cogni-wiki/skills/wiki-lint/SKILL.md` §"4a–4d". Phase 1 ships `contradiction` + `unknown` only; the other check kinds defer to v0.1.16 once the false-positive volume of this layer is known.
-- Does NOT emit findings with `kind: type_drift` or `kind: undercited_synthesis`. The schema vocabulary for `kind` in v0.1.15 is `{contradiction, unknown}` exclusively.
+- Does NOT score `type_drift`, `undercited_synthesis`, `missing_concept`, or any other check from `cogni-wiki/skills/wiki-lint/SKILL.md` §"4a–4d". Phase 1 ships `contradiction` + `unknown` only; the other check kinds are deferred once the false-positive volume of this layer is known.
+- Does NOT emit findings with `kind: type_drift` or `kind: undercited_synthesis`. The schema vocabulary for `kind` is `{contradiction, unknown}` exclusively.
 
 ## Failure-mode invariants
 
 - A `SYNTHESIS_PAGE_PATH` that cannot be `Read` or has no parseable frontmatter returns `synthesis_unreadable` and stops — never score against a phantom body.
 - A cited slug found under none of the five dirs (`wiki/sources/` + the four distilled dirs `wiki/{concepts,entities,summaries,learnings}/`) lands in `compared_against.missing_pages[]`. The remaining pages are still scored (best-effort), so a single concurrent deletion does not abort the run.
-- A cited page with an empty claim block (`pre_extracted_claims:` on a source, `distilled_claims:` on a distilled page) is scored as if it carried no comparable claims — no findings against it, no error. On a source page this is rare (most likely a malformed ingest); on a distilled page it is a legitimate mid-build state (#363, AD-7).
+- A cited page with an empty claim block (`pre_extracted_claims:` on a source, `distilled_claims:` on a distilled page) is scored as if it carried no comparable claims — no findings against it, no error. On a source page this is rare (most likely a malformed ingest); on a distilled page it is a legitimate mid-build state.
 - A `Write` that succeeds but reads back malformed (JSON parse fails, schema mismatch, count invariant fails) is a phantom write. Retry once; on second failure return `write_failed`.
 - A request to compare against more than 30 cited slugs (source + distilled combined) is the orchestrator's responsibility to truncate (Step 10.6 in `knowledge-finalize`'s SKILL.md), and the orchestrator surfaces the truncation as a Step 11 warning. The agent only ever sees the post-truncation CSV and scores exactly what it sees — it does not silently drop slugs and does not emit a truncation marker (it lacks the pre-truncation N).
 
-## Phase 1 scope reminders (v0.1.15 #335; distilled-page scoring v0.1.28 #363)
+## Phase 1 scope reminders
 
 - `kind ∈ {contradiction, unknown}` only.
-- Cited **source AND distilled** page comparison (sources' `pre_extracted_claims:` + distilled pages' `distilled_claims:`); still **no** synthesis-vs-prior-syntheses adjacency (synthesis pages carry no claim block — defers to v0.1.16).
+- Cited **source AND distilled** page comparison (sources' `pre_extracted_claims:` + distilled pages' `distilled_claims:`); still **no** synthesis-vs-prior-syntheses adjacency (synthesis pages carry no claim block — deferred).
 - `severity ∈ {high, medium, low}`; `unknown` carries no severity.
 - The schema literal is `"schema_version": "0.1.0"`. Future kind additions land at `0.1.1` (additive); a semantic change to existing kinds would bump the major.

--- a/cogni-knowledge/agents/wiki-reviewer.md
+++ b/cogni-knowledge/agents/wiki-reviewer.md
@@ -1,13 +1,13 @@
 ---
 name: wiki-reviewer
-description: Phase-7 zero-network structural quality reviewer for the inverted pipeline. Reads the latest <project>/output/draft-vN.md + .metadata/plan.json (sub-questions, output_language) + .metadata/ingest-manifest.json (source diversity), scores the draft on 5 weighted structural dimensions (Completeness 0.25, Coherence 0.20, Source-Diversity 0.20, Depth 0.20, Clarity 0.15) with an inline citation-density gate that caps Depth, and emits <project>/.metadata/structural-review-vN.json (schema 0.1.0) with structural_scores, citation_density, source_diversity, issues[], strengths[], verdict, score. Ported from cogni-research/agents/reviewer.md; DROPS the claims-verification multiplier (Phase 6 owns claim alignment), the Arc-Structural Gate (no arcs), the Word-Count/prose-density gate (no target_words plumbing), and the Diagram Quality Gate (composer emits no Mermaid). Pure advisory — non-blocking, fail-soft, no auto-fix loop. Never fetches and never modifies any draft or wiki page. #309 P1.1.
+description: Phase-7 zero-network structural quality reviewer for the inverted pipeline. Reads the latest <project>/output/draft-vN.md + .metadata/plan.json (sub-questions, output_language) + .metadata/ingest-manifest.json (source diversity), scores the draft on 5 weighted structural dimensions (Completeness 0.25, Coherence 0.20, Source-Diversity 0.20, Depth 0.20, Clarity 0.15) with an inline citation-density gate that caps Depth, and emits <project>/.metadata/structural-review-vN.json (schema 0.1.0) with structural_scores, citation_density, source_diversity, issues[], strengths[], verdict, score. Ported from cogni-research/agents/reviewer.md; DROPS the claims-verification multiplier (Phase 6 owns claim alignment), the Arc-Structural Gate (no arcs), the Word-Count/prose-density gate (no target_words plumbing), and the Diagram Quality Gate (composer emits no Mermaid). Pure advisory — non-blocking, fail-soft, no auto-fix loop. Never fetches and never modifies any draft or wiki page.
 model: sonnet
 color: yellow
 tools: ["Read", "Write", "Glob", "Grep"]
 ---
 
 <!--
-NEW agent at v0.1.29 — no upstream live path. Point-in-time PORT of
+NEW agent — no upstream live path. Point-in-time PORT of
 cogni-research/agents/reviewer.md (drift acceptable, same posture as the
 wiki-composer / wiki-verifier / revisor forks). Mirrors wiki-contradictor.md's
 shape (single-pass, zero-network, JSON envelope out, no Task in tools list)
@@ -15,7 +15,7 @@ because the structural cost-win is identical: the draft and its plan/ingest
 manifests are already on disk, so structural scoring is a zero-network reading
 judgement, not a re-fetch.
 
-This implements #309 P1.1 — the structural-quality half of the cogni-research
+This is the structural-quality half of the cogni-research
 feature-parity gate. knowledge-verify (Phase 6) checks ONLY citation-claim
 alignment; a synthesis can cite every source cleanly and still treat a
 sub-question superficially, be poorly structured, or be single-sourced. This
@@ -107,12 +107,12 @@ Evaluate the draft on 5 dimensions (0.0–1.0 each):
 
 The Source Diversity dimension above measures variety of unique publishers in the reference list — it is insensitive to paragraph-level distribution. A draft with 32 unique cited sources scores high on diversity even when half the paragraphs are uncited. This gate closes that blind spot by measuring inline citation density per section so under-cited prose cannot ride a high diversity score into an accept verdict.
 
-cogni-knowledge's composer (`wiki-composer`, #300) emits inline citations as clickable numbered superscripts `<sup>[N](url)</sup>`, with `[[sources/<slug>]]` wikilinks confined to the reference list. Scan the draft for H2 section boundaries, **excluding** a trailing references section — match the heading language-aware against `## References` / `## Quellen` / `## Referenzen` / `## Bibliographie` / `## Literaturverzeichnis` / `## Bibliografia` / `## Bibliografía` / `## Bibliografie` (pick whichever matches `OUTPUT_LANGUAGE`). For each remaining H2 section, count:
+cogni-knowledge's composer (`wiki-composer`) emits inline citations as clickable numbered superscripts `<sup>[N](url)</sup>`, with `[[sources/<slug>]]` wikilinks confined to the reference list. Scan the draft for H2 section boundaries, **excluding** a trailing references section — match the heading language-aware against `## References` / `## Quellen` / `## Referenzen` / `## Bibliographie` / `## Literaturverzeichnis` / `## Bibliografia` / `## Bibliografía` / `## Bibliografie` (pick whichever matches `OUTPUT_LANGUAGE`). For each remaining H2 section, count:
 
 - **Body words**: the full word count of the section, excluding the heading itself.
 - **Inline citations**: the superscript-wrapped numeric link the composer emits, `<sup>[N](url)</sup>` — regex approximately `<sup>\[\d+\]\([^)]+\)</sup>`. Also count the URL-less fallback `<sup>[N]</sup>` (regex `<sup>\[\d+\]</sup>`) for sources with an empty URL field.
 
-**Anti-pattern detection — double-bracket numbered citations.** Independently of the density count, scan for `\[\[\d+\]\]` anywhere in the body (not inside a fenced code block). Each match is a **high-severity citation format violation**: emit an issue with the exact prefix `Citation format violation` and message "Double-bracket numbered citation `[[N]]` will break in Obsidian — the composer must emit single-bracket superscript-URL `<sup>[N](url)</sup>`." One or more occurrences caps the Depth dimension at 0.70 (same cap as a high-severity citation density deficit). The composer (#300) never emits `[[N]]`; a match signals composer drift.
+**Anti-pattern detection — double-bracket numbered citations.** Independently of the density count, scan for `\[\[\d+\]\]` anywhere in the body (not inside a fenced code block). Each match is a **high-severity citation format violation**: emit an issue with the exact prefix `Citation format violation` and message "Double-bracket numbered citation `[[N]]` will break in Obsidian — the composer must emit single-bracket superscript-URL `<sup>[N](url)</sup>`." One or more occurrences caps the Depth dimension at 0.70 (same cap as a high-severity citation density deficit). The composer never emits `[[N]]`; a match signals composer drift.
 
 Compute `density = cites / words × 1000` for each section. Apply the tiered thresholds:
 
@@ -267,7 +267,7 @@ Never raise — always return one of these envelopes so the orchestrator's Step 
 - A `Write` that succeeds but reads back malformed (JSON parse fails, schema mismatch, missing `structural_scores` key) is a phantom write. Retry once; on second failure return `write_failed`.
 - Never raise — always return one of the three Phase-3 envelopes so the orchestrator's Step 10.7 fail-soft path surfaces a clean message.
 
-## Phase scope reminders (v0.1.29, #309 P1.1)
+## Phase scope reminders
 
 - Five weighted dimensions: Completeness 0.25, Coherence 0.20, Source-Diversity 0.20, Depth 0.20, Clarity 0.15.
 - Overall = bare weighted average (no claims multiplier). Accept ≥ 0.82 (the operative bar; the 0.78 relaxation is reserved for a future multi-round host and never fires under the single finalize dispatch).

--- a/cogni-knowledge/agents/wiki-verifier.md
+++ b/cogni-knowledge/agents/wiki-verifier.md
@@ -1,13 +1,13 @@
 ---
 name: wiki-verifier
-description: Phase-6 zero-network claim verifier for the inverted pipeline. Reads <project>/output/draft-vN.md + a citation manifest (full or a shard via CITATIONS_PATH) + each cited page's claim frontmatter (pre_extracted_claims on wiki/sources/<slug>.md; distilled_claims on wiki/{concepts,entities,summaries,learnings}/<slug>.md — distilled pages are citable + scored since #344), and scores every citation's draft_sentence as verbatim / paraphrase / unsupported / synthesis. Writes verify-vN.json (or a per-shard fragment via VERIFY_OUT_PATH) schema 0.1.0. Never fetches and never re-tokenizes the draft — the alignment surface is the manifest's verbatim draft_sentence matched against claims extracted at ingest/distill time (M5/M6/Phase 4.5).
+description: Phase-6 zero-network claim verifier for the inverted pipeline. Reads <project>/output/draft-vN.md + a citation manifest (full or a shard via CITATIONS_PATH) + each cited page's claim frontmatter (pre_extracted_claims on wiki/sources/<slug>.md; distilled_claims on wiki/{concepts,entities,summaries,learnings}/<slug>.md — distilled pages are citable + scored), and scores every citation's draft_sentence as verbatim / paraphrase / unsupported / synthesis. Writes verify-vN.json (or a per-shard fragment via VERIFY_OUT_PATH) schema 0.1.0. Never fetches and never re-tokenizes the draft — the alignment surface is the manifest's verbatim draft_sentence matched against claims extracted at ingest/distill time.
 model: sonnet
 color: yellow
 tools: ["Read", "Write", "Glob", "Grep"]
 ---
 
 <!--
-NEW agent at v0.0.23 — no upstream. cogni-research has no equivalent;
+No upstream. cogni-research has no equivalent;
 cogni-claims' verifier re-fetches each cited URL (20–30 min wall-clock
 on a 5K draft). The inverted pipeline extracts claims at ingest time
 (see `references/claim-at-ingest.md`) so verification at draft time is
@@ -15,7 +15,7 @@ a zero-network string-match (< 5 min). The structural cost win versus
 cogni-claims is the whole reason this agent exists.
 
 Single-pass — no Task in tools list, no sub-dispatch, no re-fetch.
-Fan-out (F21, v0.0.28) is orchestrator-driven: `knowledge-verify` shards
+Fan-out is orchestrator-driven: `knowledge-verify` shards
 the manifest and dispatches N copies of THIS agent in parallel, each
 scoped to a citation subset via CITATIONS_PATH / VERIFY_OUT_PATH. The
 agent itself stays single-pass — it just scores whatever subset it's handed.
@@ -25,9 +25,9 @@ agent itself stays single-pass — it just scores whatever subset it's handed.
 
 ## Role
 
-You read a draft and its citation manifest, look up each cited claim in the corresponding page's claim frontmatter — `pre_extracted_claims:` on a `wiki/sources/<slug>.md` page, or `distilled_claims:` on a distilled `wiki/{concepts,entities,summaries,learnings}/<slug>.md` page (citable since #344) — and score every citation as `verbatim` / `paraphrase` / `unsupported` / `synthesis`. You emit `<project>/.metadata/verify-vN.json` for the `knowledge-verify` orchestrator to consume.
+You read a draft and its citation manifest, look up each cited claim in the corresponding page's claim frontmatter — `pre_extracted_claims:` on a `wiki/sources/<slug>.md` page, or `distilled_claims:` on a distilled `wiki/{concepts,entities,summaries,learnings}/<slug>.md` page (citable) — and score every citation as `verbatim` / `paraphrase` / `unsupported` / `synthesis`. You emit `<project>/.metadata/verify-vN.json` for the `knowledge-verify` orchestrator to consume.
 
-You **never fetch URLs**. The wiki has every source body verbatim under `wiki/sources/` with `pre_extracted_claims:` in frontmatter, and the cross-source distilled pages carry `distilled_claims:`; those are your only evidence sources. M5/M6 populated the source claims at ingest time and Phase 4.5 populated the distilled claims; your job is to align the draft against them.
+You **never fetch URLs**. The wiki has every source body verbatim under `wiki/sources/` with `pre_extracted_claims:` in frontmatter, and the cross-source distilled pages carry `distilled_claims:`; those are your only evidence sources. The source claims were populated at ingest time and the distilled claims at distill time; your job is to align the draft against them.
 
 ## Input Parameters
 
@@ -53,10 +53,10 @@ Phase 0 (load context) → Phase 1 (score per citation) → Phase 2 (write + ver
 3. Build the set of distinct `wiki_slug` values referenced in the manifest. For each slug, locate the page **and record which directory it resolved under** in a `page_kind_by_slug` map (try these directories in order; first hit wins):
    - `<WIKI_ROOT>/wiki/sources/<slug>.md` → `page_kind_by_slug[slug] = "source"`.
    - `<WIKI_ROOT>/wiki/syntheses/<slug>.md` → `page_kind_by_slug[slug] = "synthesis"`.
-   - `<WIKI_ROOT>/wiki/concepts/<slug>.md` → `"concept"`; `…/entities/<slug>.md` → `"entity"`; `…/summaries/<slug>.md` → `"summary"`; `…/learnings/<slug>.md` → `"learning"` (the four **distilled** page kinds, citable since #344).
+   - `<WIKI_ROOT>/wiki/concepts/<slug>.md` → `"concept"`; `…/entities/<slug>.md` → `"entity"`; `…/summaries/<slug>.md` → `"summary"`; `…/learnings/<slug>.md` → `"learning"` (the four **distilled** page kinds, citable).
    - If none exists, record the slug in a `missing_pages` set — every citation pointing at it gets verdict `unsupported` with `reason: "page_not_found"` in Phase 1.
 
-   The directory is the **only** authoritative signal for what a citation targets: first-class source evidence (`sources/`), cross-source framing (`syntheses/`), or distilled cross-source evidence (`concepts/`/`entities/`/`summaries/`/`learnings/`). Phase 1's `synthesis` verdict depends on this — do not infer page kind from `claim_id == null` alone (M7's composer emits `claim_id: null` on synthesis-page citations AND when it failed to find a matching claim on a source page; only the directory disambiguates).
+   The directory is the **only** authoritative signal for what a citation targets: first-class source evidence (`sources/`), cross-source framing (`syntheses/`), or distilled cross-source evidence (`concepts/`/`entities/`/`summaries/`/`learnings/`). Phase 1's `synthesis` verdict depends on this — do not infer page kind from `claim_id == null` alone (the composer emits `claim_id: null` on synthesis-page citations AND when it failed to find a matching claim on a source page; only the directory disambiguates).
 
 4. For each present page, `Read` it and parse the YAML frontmatter:
    - **Source / synthesis pages:** extract `pre_extracted_claims:` into an in-memory dict `claims_by_id[claim_id] = {text, excerpt_quote}`. If the field is absent or empty (synthesis pages typically have none), leave the dict empty for that slug.
@@ -136,21 +136,21 @@ Walk `citations[]` in manifest order. For each entry `{id, draft_position, draft
 - **Be conservative on `paraphrase`.** A draft sentence that adds a quantifier (`mostly`, `largely`, `in some cases`) or shifts scope (`EU-wide` vs. `Germany`) is **not** a paraphrase — that's `unsupported`. The revisor needs the strict signal to do its job.
 - **Verbatim is fine but flag it.** Aggressive copy-paste signals weak synthesis; the dashboard surfaces the verbatim/paraphrase ratio later. Do not "promote" a verbatim match to paraphrase out of generosity.
 - **Synthesis is informational.** Citations whose `wiki_slug` resolves to a `syntheses/` page carry `claim_id: null` by design; do not attempt to score them and do not count them as deviations. **Distilled pages are the opposite** — a `concepts/`/`entities/`/`summaries/`/`learnings/` citation carries a real `dcl-NNN` claim_id and IS scored (`verbatim`/`paraphrase`/`unsupported`) against its `distilled_claims[].text`, exactly like a source. Only `synthesis` is waved through.
-- **Surface the verbatim/paraphrase ratio as the operator's confidence signal.** Downstream surfaces (`knowledge-finalize` Step 11, `knowledge-verify` Step 6, the dashboard's §"Claim verification scope" block, the synthesis-page `verification_ratio:` frontmatter) qualify this agent's `verbatim` + `paraphrase` counts as **citation-consistent** — the agent compared the draft sentence to the page's ingest-time pre-extracted claim, not to the live source. Heavy verbatim copy-paste signals weak synthesis; heavy paraphrase signals the composer reframed the source's claims. Neither is wrong; both are informational. Score conservatively per the rules above; the qualifier upstream makes the limitation explicit (#337).
+- **Surface the verbatim/paraphrase ratio as the operator's confidence signal.** Downstream surfaces (`knowledge-finalize` Step 11, `knowledge-verify` Step 6, the dashboard's §"Claim verification scope" block, the synthesis-page `verification_ratio:` frontmatter) qualify this agent's `verbatim` + `paraphrase` counts as **citation-consistent** — the agent compared the draft sentence to the page's ingest-time pre-extracted claim, not to the live source. Heavy verbatim copy-paste signals weak synthesis; heavy paraphrase signals the composer reframed the source's claims. Neither is wrong; both are informational. Score conservatively per the rules above; the qualifier upstream makes the limitation explicit.
 
 ## What this agent does NOT do
 
-- Does NOT WebFetch or WebSearch — every claim is already on a wiki page. Re-fetch defeats the entire cost-win premise. For live-source re-verification (the long-tail drift problem — URLs 404, paywalls appear, content gets rewritten after ingest), the bound wiki is swept **opt-in** via `/cogni-knowledge:knowledge-refresh --resweep`, which dispatches `cogni-wiki:wiki-claims-resweep` (#337). That sweep is structurally separate from this verifier's per-finalize zero-network alignment — by design, never auto-run.
+- Does NOT WebFetch or WebSearch — every claim is already on a wiki page. Re-fetch defeats the entire cost-win premise. For live-source re-verification (the long-tail drift problem — URLs 404, paywalls appear, content gets rewritten after ingest), the bound wiki is swept **opt-in** via `/cogni-knowledge:knowledge-refresh --resweep`, which dispatches `cogni-wiki:wiki-claims-resweep`. That sweep is structurally separate from this verifier's per-finalize zero-network alignment — by design, never auto-run.
 - Does NOT dispatch other agents (`Task` is not in this agent's tool list). It is a single-pass scorer.
 - Does NOT call `cogni-research`, `cogni-claims`, or any `cogni-wiki:` skill — clean-break.
-- Does NOT revise the draft — that is the revisor's job (M8's second agent).
+- Does NOT revise the draft — that is the revisor's job.
 - Does NOT loop — the orchestrator (`knowledge-verify`) owns the verifier-revisor loop. You run once per dispatch.
 - Does NOT modify the draft, the citation manifest, or any wiki page. Read-only against everything except `verify-vN.json`.
-- Does NOT use `excerpt_position` offsets for scoring — that's the indexing primitive for context rendering in M9+. Verdict scoring uses `text` + `excerpt_quote` (source/synthesis pages) or `text` only (distilled pages — no `excerpt_quote`).
+- Does NOT use `excerpt_position` offsets for scoring — that's the indexing primitive for context rendering. Verdict scoring uses `text` + `excerpt_quote` (source/synthesis pages) or `text` only (distilled pages — no `excerpt_quote`).
 
 ## Failure-mode invariants
 
 - A `citation-manifest.json` with `schema_version != "0.1.0"` or `draft_version != DRAFT_VERSION` returns `manifest_mismatch` and stops — never score against a stale manifest.
 - A missing wiki page (slug in none of the source / synthesis / distilled directories) produces `unsupported` + `reason: "page_not_found"` for every citation that points at it. The slug also appears in `missing_pages[]` so the orchestrator can surface it.
-- A page with an empty claim block (`pre_extracted_claims:` on a source, `distilled_claims:` on a distilled page) AND `claim_id != null` produces `unsupported` + `reason: "claim_not_found"` for citations targeting it. (This is the upstream-data symptom M7's composer warned about in its `⚠ Zero citations` line.)
+- A page with an empty claim block (`pre_extracted_claims:` on a source, `distilled_claims:` on a distilled page) AND `claim_id != null` produces `unsupported` + `reason: "claim_not_found"` for citations targeting it. (This is the upstream-data symptom the composer warned about in its `⚠ Zero citations` line.)
 - A `Write` that succeeds but reads back malformed (JSON parse fails, schema mismatch) is a phantom write. Retry once; on second failure return `write_failed`.

--- a/cogni-knowledge/skills/knowledge-compose/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-compose/SKILL.md
@@ -6,7 +6,11 @@ allowed-tools: Read, Write, Bash, Task
 
 # Knowledge Compose
 
-Phase 5 of the inverted pipeline. Reads the per-project `plan.json` + `ingest-manifest.json` + the populated wiki at `<binding.wiki_path>/wiki/`, dispatches `wiki-composer` once, and verifies the two output files land on disk. The composer reads `wiki/index.md` + selected `wiki/sources/*.md` (lazily) + prior `wiki/syntheses/*.md` — and, since the distillation interphase (`knowledge-distill`), the distilled `wiki/concepts/*.md` + `wiki/entities/*.md` pages as **framing context only** (topic-matched, lazily). Concept/entity pages shape the narrative but are **never cited**: they carry `distilled_claims:` (not `pre_extracted_claims:`), are absent from the citation manifest, and the verifier does not score them — so Phases 5/6/7 stay byte-stable whether or not distill ran. The composer then writes:
+Phase 5 of the inverted pipeline. Reads the per-project `plan.json` + `ingest-manifest.json` + the populated wiki at `<binding.wiki_path>/wiki/`, dispatches `wiki-composer` once, and verifies the output files land on disk.
+
+The composer reads `wiki/index.md` + selected `wiki/sources/*.md` (lazily) + prior `wiki/syntheses/*.md`. Since the distillation interphase (`knowledge-distill`), it also reads the distilled `wiki/{concepts,entities,summaries,learnings}/*.md` pages (topic-matched, lazily) — these serve **both** as narrative framing **and** as citable cross-source evidence: when ≥2 sources converge on a fact the distilled page already captures, the composer cites the distilled page itself via its `dcl-NNN` claim id, so the convergence carries epistemic weight rather than a row of source markers. Distilled pages carry `distilled_claims:` (not `pre_extracted_claims:`), and a distilled-page citation is scored by the verifier against that claim's `text`. Distillation stays optional and fail-soft: when it hasn't run, the composer simply has no distilled pages to draw on and composes from sources + syntheses alone.
+
+The composer then writes:
 
 - `<project>/output/draft-v{N}.md` — the draft, with clickable numbered `[N]` inline citations (wikilinks confined to the reference list).
 - `<project>/.metadata/citation-records-v{N}.txt` — one raw-text record per citation (the composer writes this; it never hand-builds JSON). This skill then runs `citation-store.py build` to serialize and validate `<project>/.metadata/citation-manifest.json` (schema `0.1.0`, one `{id, draft_position, draft_sentence, wiki_slug, claim_id}` entry per citation). Escaping is owned by `json.dumps`, never the LLM — a straight `"` in a `draft_sentence` would otherwise break a hand-built manifest's `json.loads` and kill the verify phase.
@@ -240,7 +244,7 @@ Print ≤ 10 lines:
 - Citations: `<N_CITES>` (authoritative count = `len(citation-manifest.json::citations)`, from Step 5)
 - Outline: `.metadata/writer-outline-v<N>.json` (outline-recovery anchor; recovery used: `<RESUME_FROM_OUTLINE>`)
 - Cost: `$X.XXX` (from composer return)
-- Next: `knowledge-verify` will run zero-network claim alignment by reading the citation manifest + each cited page's `pre_extracted_claims[]`.
+- Next: `knowledge-verify` will run zero-network claim alignment by reading the citation manifest + each cited page's claim block — `pre_extracted_claims[]` on a source/synthesis page, or `distilled_claims[]` on a cited distilled page.
 
 If the composer returned a word-count well below `TARGET_WORDS`, surface a `⚠ Below target (N/TARGET)` warning line — but do not auto-retry.
 
@@ -249,7 +253,7 @@ If the composer returned a word-count well below `TARGET_WORDS`, surface a `⚠ 
 - **Outline recovery in action.** The outline file exists from a prior crashed run. The composer skips Phase 1 (saves model time and avoids re-deriving the section plan), runs Phase 2 fresh, and writes the draft + citation manifest. The outline's `drafted_words` placeholders get filled by the resume pass. Surface "RESUME_FROM_OUTLINE=true (outline recovery)" in the summary so the operator sees what happened.
 - **Re-run with same N.** The user explicitly passes `--draft-version <N>` against an existing draft. The composer overwrites `draft-v<N>.md` and `citation-manifest.json` (and re-writes the outline — Phase 1 runs unless `writer-outline-v<N>.json` is present and `RESUME_FROM_OUTLINE=true` was inferred). No automatic backup — the user asked for it.
 - **Empty `ingested[]` after a re-ingest cleanup.** Step 0 aborts with the "no ingested sources" message; do not dispatch the composer against an empty manifest.
-- **Citation manifest empty.** If the composer returns `ok: true` but `citations[] == 0` (every page had zero `pre_extracted_claims:` — unusual but possible if the claim-extractor failed across the board), surface as `⚠ Zero citations — every cited statement will fail verification`. Do not block — that's an upstream-data issue, not a composer bug.
+- **Citation manifest empty.** If the composer returns `ok: true` but `citations[] == 0` (every cited page had zero claims — no source `pre_extracted_claims:` and no distilled `distilled_claims:` — unusual but possible if the claim-extractor failed across the board), surface as `⚠ Zero citations — every cited statement will fail verification`. Do not block — that's an upstream-data issue, not a composer bug.
 - **Plan changed between ingest and compose.** Step 1.2 of the composer aligns `covers_sub_questions` from `ingest-manifest.json` (resolved sources carry `sub_question_refs[]`), so a sub-question added to `plan.json` after `knowledge-ingest` ran will have no sources mapped to it. The introduction and conclusion still list it (synthesis sections list all `plan.json` sub-question ids), but a topical section for that sub-question won't have evidence. Surface in the summary as `⚠ Sub-question <id> has no ingested sources`.
 
 ## Out of scope

--- a/cogni-knowledge/tests/test_contradictor_contract.sh
+++ b/cogni-knowledge/tests/test_contradictor_contract.sh
@@ -58,10 +58,10 @@ assert_grep '`low`' "$CTR" "wiki-contradictor: documents severity=low"
 # Schema literal — the contract version-pin.
 assert_grep '"schema_version": "0.1.0"' "$CTR" "wiki-contradictor: documents schema_version 0.1.0 literal"
 
-# Issue reference — the agent must say WHICH issue it implements.
-assert_grep '#335' "$CTR" "wiki-contradictor: references issue #335"
-# #363 — distilled-page scoring extension.
-assert_grep '#363' "$CTR" "wiki-contradictor: references issue #363 (distilled-page scoring)"
+# Pure-observability posture — the agent's defining contract (it scores, never resolves).
+# (The distilled-page-scoring extension is asserted directly by the distilled_claims /
+# four-dirs / no-excerpt_quote checks below — no need to pin an issue tag for it.)
+assert_grep 'Pure observability\|pure observability' "$CTR" "wiki-contradictor: documents the pure-observability posture"
 
 # #363: cited-page resolution must probe the four distilled dirs after
 # wiki/sources/ and parse distilled_claims (no excerpt_quote) — mirrors the

--- a/cogni-knowledge/tests/test_distill_contract.sh
+++ b/cogni-knowledge/tests/test_distill_contract.sh
@@ -110,9 +110,9 @@ assert_grep 'RECORDS_OUTPUT_PATH' "$NARRATOR" "concept-summary-narrator: writes 
 assert_grep 'OUTPUT_LANGUAGE' "$NARRATOR" "concept-summary-narrator: re-narrates in OUTPUT_LANGUAGE"
 assert_grep '<<<SUMMARY' "$NARRATOR" "concept-summary-narrator: sentinel-fenced records idiom"
 assert_grep 'raw text' "$NARRATOR" "concept-summary-narrator: writes raw text, never JSON/YAML (#325)"
-# Summary-only discipline + scope guard (no contradiction pass — #335 is closed).
+# Summary-only discipline + scope guard (a contradiction pass stays out of scope).
 assert_grep 'only the summary\|only the SUMMARY\|touch .*only\|Summary-only\|summary-only' "$NARRATOR" "concept-summary-narrator: touches only the summary block"
-assert_grep '#335' "$NARRATOR" "concept-summary-narrator: names #335 as out-of-scope (no contradiction pass)"
+assert_grep 'contradiction pass' "$NARRATOR" "concept-summary-narrator: names a contradiction pass as out-of-scope"
 assert_grep 'tools: \["Read", "Write"\]' "$NARRATOR" "concept-summary-narrator: tools Read + Write only"
 
 # --- cross-lingual-claim-merger agent (#345) ---------------------------------

--- a/cogni-knowledge/tests/test_reviewer_contract.sh
+++ b/cogni-knowledge/tests/test_reviewer_contract.sh
@@ -83,8 +83,9 @@ assert_grep '0.82' "$REV" "wiki-reviewer: structural-only accept threshold 0.82"
 # Schema literal — the contract version-pin.
 assert_grep '"schema_version": "0.1.0"' "$REV" "wiki-reviewer: documents schema_version 0.1.0 literal"
 
-# Issue reference — the agent must say WHICH issue it implements.
-assert_grep '#309' "$REV" "wiki-reviewer: references issue #309"
+# Self-identity — the agent must name itself as the structural-quality reviewer
+# (the half of the cogni-research parity gate that is NOT citation-claim alignment).
+assert_grep 'structural-quality\|structural quality' "$REV" "wiki-reviewer: identifies as the structural-quality reviewer"
 
 # Advisory / fail-soft posture — must be explicit so a future maintainer
 # doesn't turn it into a blocking gate.

--- a/cogni-knowledge/tests/test_skill_contracts.sh
+++ b/cogni-knowledge/tests/test_skill_contracts.sh
@@ -277,12 +277,12 @@ if [ $errors -eq 0 ]; then
   green "PASS: clean-break — no cogni-research/cogni-claims/cogni-wiki skill dispatch in new files"
 fi
 
-# --- #337 wiki-verifier agent honesty bullets ----------------------------
+# --- wiki-verifier agent honesty bullets ---------------------------------
 # Two prose bullets close the loop between the agent's internal honesty and
 # the operator-facing surfaces. No behaviour-level change — the regression
 # guard below proves the load-bearing zero-network invariant survived the edit.
-assert_grep '#337' "$VERIFIER" "wiki-verifier: references #337 (the verbatim/paraphrase confidence-signal + resweep cross-ref)"
-assert_grep 'knowledge-refresh --resweep' "$VERIFIER" "wiki-verifier: names knowledge-refresh --resweep as the live-source path (#337)"
+assert_grep 'verbatim/paraphrase' "$VERIFIER" "wiki-verifier: surfaces the verbatim/paraphrase ratio as the operator confidence signal"
+assert_grep 'knowledge-refresh --resweep' "$VERIFIER" "wiki-verifier: names knowledge-refresh --resweep as the live-source path"
 # Regression guard: the strengthened 'does NOT' bullet must NOT drop the
 # original load-bearing zero-network assertion.
 assert_grep 'Does NOT WebFetch or WebSearch' "$VERIFIER" "wiki-verifier: retains the 'Does NOT WebFetch or WebSearch' invariant (#337 must not erode it)"


### PR DESCRIPTION
## Context

Extends the **#370** skill cleanup (commit `7926269`, "strip maintainer meta-documentation from all 13 skills") to the plugin's **11 agent files**, and corrects stale documentation in `knowledge-compose`.

A SKILL/agent body *is the prompt the model executes*. Bare issue refs (`#344`), version tags (`v0.1.16`), and milestone/slice/finding codes (`M8`, `Slice 3`, `F11`) read as "go look this up", bloat context, bury the instruction, and rot. Provenance belongs in git history / CHANGELOG / `references/`, not the prompt.

## What changed

### `knowledge-compose` SKILL.md (drift fix)
- The intro claimed distilled (concept/entity) pages were *"framing context only"*, *"never cited"*, *"absent from the citation manifest"*, and that *"the verifier does not score them"* — all **stale**. The dispatched `wiki-composer` agent has cited distilled pages (via their `dcl-NNN` claim id, across all four distilled dirs) and the verifier has scored them for several versions. Rewrote the intro to match shipped behavior; corrected the "Next:" summary line (`pre_extracted_claims[]` **or** `distilled_claims[]`).
- **Behavior unchanged** — the orchestrator's steps (dispatch → `citation-store.py build` → verify → log → summary) are untouched.

### `agents/` (11 files)
- Stripped the four maintainer-breadcrumb classes (~140 total: ≈79 issue refs, ≈29 version tags, ≈30 M/Slice/F codes) from `description` frontmatter and bodies.
- **Preserved** every "why this matters" explanation, fail-soft posture, skip condition, and edge case; replaced load-bearing code refs with their semantic meaning (e.g. *"the F11 anchor"* → *"the outline-recovery anchor"*). Embedded code blocks byte-identical; all field/flag/schema-value names (incl. `schema_version "0.1.0"`) intact; YAML `model`/`color`/`tools` unchanged.

### `tests/` (4 files)
- Repointed **5 assertions** that pinned a bare tag as required prose to the adjacent semantic check the tag stood for (`#335` → pure-observability posture, `#309` → structural-quality identity, `#335` → contradiction-pass-out-of-scope, `#337` → verbatim/paraphrase confidence signal). The `#363` contradictor pin was redundant with the `distilled_claims`/four-dirs/no-`excerpt_quote` asserts.

### Version
- `plugin.json` + `marketplace.json` bumped `0.1.33 → 0.1.34`.

## Testing
- All **33** cogni-knowledge tests pass (`for t in tests/test_*.sh; do bash "$t"; done`).
- Verified zero `#NNN` / `vX.Y.Z` remain in `agents/` and the edited skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)