### PR TITLE
ci: deterministic maintainer-breadcrumb guard (ratchet + CI) (closes #377)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  breadcrumb-guard:
+    name: Maintainer-breadcrumb guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so `git ls-files` sees every tracked SKILL.md / agent file.
+          fetch-depth: 0
+
+      - name: Check for maintainer breadcrumbs in SKILL.md + agents
+        run: |
+          set -euo pipefail
+          python3 scripts/check-breadcrumbs.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          # Full history so `git ls-files` sees every tracked SKILL.md / agent file.
-          fetch-depth: 0
+        # Default shallow checkout is sufficient: the guard reads the working
+        # tree via `git ls-files` (the index at this commit), not git history.
 
       - name: Check for maintainer breadcrumbs in SKILL.md + agents
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,9 @@ Run `cogni-workspace/scripts/check-skill-names.sh` to validate naming before sub
 
 The guard is a **ratchet**: every occurrence present today is recorded in `scripts/baselines/breadcrumb-baseline.json` and allowed to pass, so the guard fails **only on newly introduced** breadcrumbs. The baseline can only shrink — as a plugin is cleaned, its entries drop out on the next regeneration.
 
-When the guard trips, the fix is to **remove** the breadcrumb and state the rationale semantically — **not** to reconcile a mismatched version tag. Run it locally before a PR:
+If a line is a genuine **false positive** — an Apple M-series chip name (`M2 Mac`), a function key (`F12`), or similar prose that looks like a code — add the marker `breadcrumb-guard:allow` anywhere on that line (e.g. in an HTML comment) and the guard skips it. Prefer this over `--update-baseline` for false positives, so the baseline stays reserved for real-but-grandfathered breadcrumbs.
+
+When the guard trips on a real breadcrumb, the fix is to **remove** it and state the rationale semantically — **not** to reconcile a mismatched version tag. Run it locally before a PR:
 
 ```bash
 python3 scripts/check-breadcrumbs.py        # fails (exit 1) on any new breadcrumb

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,25 @@ All contributions to core plugins require signing the [Contributor License Agree
 
 Run `cogni-workspace/scripts/check-skill-names.sh` to validate naming before submitting a PR.
 
+### Breadcrumb Guard
+
+`SKILL.md` bodies/frontmatter and `agents/*.md` prompts are the text the model executes — they must not carry **maintainer breadcrumbs**: bare issue/PR refs (`#344`), plugin-version tags (`v0.1.16`), or milestone/slice/finding codes (`M8`, `Slice 3`, `F11`). That provenance belongs in git history, the CHANGELOG, or `references/`. The CI `Lint` workflow runs `scripts/check-breadcrumbs.py` on every PR and fails when a new breadcrumb appears.
+
+The guard is a **ratchet**: every occurrence present today is recorded in `scripts/baselines/breadcrumb-baseline.json` and allowed to pass, so the guard fails **only on newly introduced** breadcrumbs. The baseline can only shrink — as a plugin is cleaned, its entries drop out on the next regeneration.
+
+When the guard trips, the fix is to **remove** the breadcrumb and state the rationale semantically — **not** to reconcile a mismatched version tag. Run it locally before a PR:
+
+```bash
+python3 scripts/check-breadcrumbs.py        # fails (exit 1) on any new breadcrumb
+bash tests/test_check_breadcrumbs.sh        # self-test the guard itself
+```
+
+A genuine load-bearing compatibility fact (e.g. "requires `gh` ≥ 2.40 because…") or an intentional plugin clean-up regenerates the baseline — justify the diff in the PR:
+
+```bash
+python3 scripts/check-breadcrumbs.py --update-baseline
+```
+
 ---
 
 ## Publishing a Marketplace Plugin

--- a/scripts/baselines/breadcrumb-baseline.json
+++ b/scripts/baselines/breadcrumb-baseline.json
@@ -1,0 +1,905 @@
+{
+  "_comment": "Breadcrumb-guard ratchet baseline. Each entry is a breadcrumb occurrence present when the baseline was captured and therefore allowed to pass. Regenerate with `python3 scripts/check-breadcrumbs.py --update-baseline`. The fix for a NEW breadcrumb is to remove it and state the rationale semantically — not to add it here.",
+  "entries": [
+    {
+      "file": "cogni-copywriting/skills/copywriter/SKILL.md",
+      "match": "#255",
+      "line_sha": "34a60df590c11837302373a0b6779a5de1330dbc"
+    },
+    {
+      "file": "cogni-copywriting/skills/copywriter/SKILL.md",
+      "match": "#255",
+      "line_sha": "4ec315b928e32015549abf8dd8ea49b1824b1b76"
+    },
+    {
+      "file": "cogni-copywriting/skills/copywriter/SKILL.md",
+      "match": "#255",
+      "line_sha": "86359af92d8d254f9de23b483236832631b8da0f"
+    },
+    {
+      "file": "cogni-copywriting/skills/copywriter/SKILL.md",
+      "match": "Slice 3",
+      "line_sha": "34a60df590c11837302373a0b6779a5de1330dbc"
+    },
+    {
+      "file": "cogni-knowledge/_archive/skills/knowledge-report/SKILL.md",
+      "match": "v0.0.14",
+      "line_sha": "5aecf3aca76ff2471ed30473b4a0ffbb572711c6"
+    },
+    {
+      "file": "cogni-knowledge/_archive/skills/knowledge-report/SKILL.md",
+      "match": "v0.0.43",
+      "line_sha": "65665ccc6a60ae3f8f1e0f2556877acc99c42a6d"
+    },
+    {
+      "file": "cogni-knowledge/_archive/skills/knowledge-report/SKILL.md",
+      "match": "v0.0.7",
+      "line_sha": "b1eca0631f17f3b99248dc5614f48411c0eb1d58"
+    },
+    {
+      "file": "cogni-knowledge/_archive/skills/knowledge-report/SKILL.md",
+      "match": "v0.0.7",
+      "line_sha": "ca19d6e5106d52c353d6d6492285de1c252153be"
+    },
+    {
+      "file": "cogni-knowledge/_archive/skills/knowledge-research/SKILL.md",
+      "match": "v0.0.14",
+      "line_sha": "5aecf3aca76ff2471ed30473b4a0ffbb572711c6"
+    },
+    {
+      "file": "cogni-knowledge/_archive/skills/knowledge-research/SKILL.md",
+      "match": "v0.0.43",
+      "line_sha": "7fe494df7831a9b3eece5192a8d045d0010f45d0"
+    },
+    {
+      "file": "cogni-portfolio/skills/portfolio-consolidate/SKILL.md",
+      "match": "#103",
+      "line_sha": "dbec4d286ae03f8004926ad4fa381b7b12f4c9c2"
+    },
+    {
+      "file": "cogni-portfolio/skills/portfolio-consolidate/SKILL.md",
+      "match": "v0.9.23",
+      "line_sha": "ffaa3e048f33cb2a669df27987bddb891c17e7b2"
+    },
+    {
+      "file": "cogni-portfolio/skills/portfolio-dashboard/SKILL.md",
+      "match": "v1.2.0",
+      "line_sha": "56c19444cde76c15ef1437e517004c1c2ebcdf5f"
+    },
+    {
+      "file": "cogni-portfolio/skills/portfolio-dashboard/SKILL.md",
+      "match": "v1.2.0",
+      "line_sha": "72fc08934ac94325b8798ad73f58674745242c7c"
+    },
+    {
+      "file": "cogni-portfolio/skills/portfolio-dashboard/SKILL.md",
+      "match": "v1.3.0",
+      "line_sha": "72fc08934ac94325b8798ad73f58674745242c7c"
+    },
+    {
+      "file": "cogni-portfolio/skills/portfolio-scan/SKILL.md",
+      "match": "v1.0.0",
+      "line_sha": "93480210a71ebf315b69eadee5205cb2bf936d4e"
+    },
+    {
+      "file": "cogni-portfolio/skills/portfolio-scan/SKILL.md",
+      "match": "v1.0.0",
+      "line_sha": "a6186147e3803747e88049cd8327639fb4087988"
+    },
+    {
+      "file": "cogni-portfolio/skills/portfolio-scan/SKILL.md",
+      "match": "v1.1.0",
+      "line_sha": "93480210a71ebf315b69eadee5205cb2bf936d4e"
+    },
+    {
+      "file": "cogni-portfolio/skills/portfolio-scan/SKILL.md",
+      "match": "v1.1.0",
+      "line_sha": "a6186147e3803747e88049cd8327639fb4087988"
+    },
+    {
+      "file": "cogni-portfolio/skills/portfolio-scan/SKILL.md",
+      "match": "v1.2.0",
+      "line_sha": "cfc429f3ab09148a064b2b3929ed00db0bbfa6bb"
+    },
+    {
+      "file": "cogni-portfolio/skills/portfolio-scan/SKILL.md",
+      "match": "v1.2.0",
+      "line_sha": "de29f658f45746fc4fecf25eac723c0e0f147dc7"
+    },
+    {
+      "file": "cogni-portfolio/skills/portfolio-scan/SKILL.md",
+      "match": "v1.3.0",
+      "line_sha": "b34be6cbd8643c0d923be57619ff4f1953a61b34"
+    },
+    {
+      "file": "cogni-portfolio/skills/portfolio-scan/SKILL.md",
+      "match": "v1.3.0",
+      "line_sha": "de29f658f45746fc4fecf25eac723c0e0f147dc7"
+    },
+    {
+      "file": "cogni-portfolio/skills/portfolio-scan/SKILL.md",
+      "match": "v1.4.0",
+      "line_sha": "b34be6cbd8643c0d923be57619ff4f1953a61b34"
+    },
+    {
+      "file": "cogni-research/agents/local-researcher.md",
+      "match": "v0.7.14",
+      "line_sha": "1b04b0bd7ba8e5396ef05445f253fe670b16bfb3"
+    },
+    {
+      "file": "cogni-research/agents/local-researcher.md",
+      "match": "v0.7.14",
+      "line_sha": "c4e08714ed49df63cdbb4c03cc79ed6c0828c594"
+    },
+    {
+      "file": "cogni-research/agents/reviewer.md",
+      "match": "v0.7.7",
+      "line_sha": "c77ae2f70bbeec8c10919b8c844b18910711146c"
+    },
+    {
+      "file": "cogni-research/agents/reviewer.md",
+      "match": "v0.8.0",
+      "line_sha": "047215fd9d1adb04931aec9360507f1922ec7674"
+    },
+    {
+      "file": "cogni-research/agents/reviewer.md",
+      "match": "v0.8.0",
+      "line_sha": "6b31b50f13abcdf177752ba76d5c07b8b1130fb0"
+    },
+    {
+      "file": "cogni-research/agents/reviewer.md",
+      "match": "v0.8.0",
+      "line_sha": "fdbb17acaf22ae6d42d6b79d75f6c03c9d05c2b7"
+    },
+    {
+      "file": "cogni-research/agents/revisor.md",
+      "match": "#25",
+      "line_sha": "4e8f7940bac564d47fc69fff889b1fa9341f6121"
+    },
+    {
+      "file": "cogni-research/agents/revisor.md",
+      "match": "#33",
+      "line_sha": "3841aa8555b6326fe5b30611bf7a2611dd055d17"
+    },
+    {
+      "file": "cogni-research/agents/revisor.md",
+      "match": "#33",
+      "line_sha": "bb6c1cf81c3751abd29a714ee1b083275eaf0a56"
+    },
+    {
+      "file": "cogni-research/agents/revisor.md",
+      "match": "#48",
+      "line_sha": "bec106dfd71b0e65f33bde519a88d2cede36c5fd"
+    },
+    {
+      "file": "cogni-research/agents/revisor.md",
+      "match": "#49",
+      "line_sha": "6794dd85d210f8f1cda1f28b063c572b9607163a"
+    },
+    {
+      "file": "cogni-research/agents/revisor.md",
+      "match": "v0.7.7",
+      "line_sha": "324f4efc27cab6f66b4c7847a55d9baf8938ff69"
+    },
+    {
+      "file": "cogni-research/agents/revisor.md",
+      "match": "v0.8.0",
+      "line_sha": "67d38485efbdd71fdb992e82b1dd3c953d6a3e74"
+    },
+    {
+      "file": "cogni-research/agents/wiki-researcher.md",
+      "match": "v0.7.14",
+      "line_sha": "07e2d4e5ed145619742efcec2d5691538bc969f4"
+    },
+    {
+      "file": "cogni-research/agents/wiki-researcher.md",
+      "match": "v0.7.14",
+      "line_sha": "33c72bd885089780f2dfc3c737b098d67da89a25"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "#35",
+      "line_sha": "1d4a590a6a430e2161e4716400c8cd2a5c49dc17"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "#48",
+      "line_sha": "fd12662cd67301096f8fe07ee8b9416217b0722b"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "#49",
+      "line_sha": "0c67e24e1951f2962cfa12e07187f8058bedc98b"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "v0.7.0",
+      "line_sha": "b43a1d4ab2a19bc8045c0efc34cc9fe817dc5f7d"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "v0.7.7",
+      "line_sha": "0a6a886ec1c2270b6caed77a370fc628b5dd5b87"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "v0.7.7",
+      "line_sha": "0be915866e7802bc6c6f1d6283dc9409af8885b7"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "v0.7.7",
+      "line_sha": "1d4a590a6a430e2161e4716400c8cd2a5c49dc17"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "v0.7.7",
+      "line_sha": "9f597160459f1a0e179a28ffcc7c4a20cf07b8ed"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "v0.7.7",
+      "line_sha": "d20c474b38ac90a09cda196071666968cf2bbb83"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "v0.7.7",
+      "line_sha": "fb49a1df22770c2a15ccb5311258c54c6437fdaa"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "v0.8.0",
+      "line_sha": "b180b59084d9a0dad2e5ba69e7f620864339a115"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "v0.8.0",
+      "line_sha": "cd480f32b21f213ecbdaaeda2a1970decb226441"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "v0.8.0",
+      "line_sha": "d8a2a7083656055ff16a565883d80ae786acaae6"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "v0.8.3",
+      "line_sha": "0115d927ea3e633aca29104c87214755ef9b8536"
+    },
+    {
+      "file": "cogni-research/agents/writer.md",
+      "match": "v0.8.3",
+      "line_sha": "fd12662cd67301096f8fe07ee8b9416217b0722b"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "#35",
+      "line_sha": "af6894d2132f6b3b362216b90c87471d7326a545"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "#35",
+      "line_sha": "ee9040ccfdcba26d91a9cf6cd2f74de43b1d48c0"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "#49",
+      "line_sha": "111fbca861c4def95a2d918bed4878356c7a85c5"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.7.14",
+      "line_sha": "87d8293f547168b4c8174ad6d8c4ea1ecfb37913"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.7.14",
+      "line_sha": "cba9589df6a56bfbf2793ea508c88d35fbf7df27"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.7.14",
+      "line_sha": "d8760cdb9dc1ba380e9646e79968b9fc5c88862c"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.7.14",
+      "line_sha": "e2d75663a448dd231e87606b447aa964d752bb3d"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.7.7",
+      "line_sha": "13c93afd58d6a790ca2d749ff9155c84c5d0fafd"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.7.7",
+      "line_sha": "2dca814e5dc7f10f6eab0b097881346a92ab2244"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.7.7",
+      "line_sha": "309e4eae934179a14f5e814a5bd697afd28b720e"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.7.7",
+      "line_sha": "6c18a196af47aec629525c98e92acf702faa503a"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.7.7",
+      "line_sha": "71ac6bd1b4898aa1b25ac66072cf255fa3f2453c"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.7.7",
+      "line_sha": "73e8e976f7b57ce0f52f77cb8b6387605afe7f86"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.7.7",
+      "line_sha": "7963460f9467d6d6b88bdb2a7acbf2012d1e8006"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.7.7",
+      "line_sha": "7f0daecfda72392dab24fe3bb5fb097f6933f90f"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.7.7",
+      "line_sha": "af6894d2132f6b3b362216b90c87471d7326a545"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.7.7",
+      "line_sha": "c3bc04417902daf8e0d72c0b0674c3eabb0a9556"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.8.0",
+      "line_sha": "1ccf09b6d26e5ea99470488cfb098466df3a5527"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.8.0",
+      "line_sha": "849939989c01532c01a16a7e1e69ec849c6bf57f"
+    },
+    {
+      "file": "cogni-research/skills/research-report/SKILL.md",
+      "match": "v0.8.0",
+      "line_sha": "af6894d2132f6b3b362216b90c87471d7326a545"
+    },
+    {
+      "file": "cogni-research/skills/research-resume/SKILL.md",
+      "match": "v0.6.26",
+      "line_sha": "47f2e7586c7a0dfeb846ec8f6252ae8558d88110"
+    },
+    {
+      "file": "cogni-research/skills/research-resume/SKILL.md",
+      "match": "v0.6.26",
+      "line_sha": "c28b888a86f57204d392f775f0a8833e71c4ba42"
+    },
+    {
+      "file": "cogni-research/skills/research-setup/SKILL.md",
+      "match": "#35",
+      "line_sha": "9b53c07ce7334009c68618035e266550abce05ca"
+    },
+    {
+      "file": "cogni-research/skills/research-setup/SKILL.md",
+      "match": "#35",
+      "line_sha": "c39cd09fb7373efe694a3f434b67ed5a23240140"
+    },
+    {
+      "file": "cogni-research/skills/research-setup/SKILL.md",
+      "match": "v0.7.7",
+      "line_sha": "0bac84e933dc1f193731dd23e977d4642425b454"
+    },
+    {
+      "file": "cogni-research/skills/research-setup/SKILL.md",
+      "match": "v0.7.7",
+      "line_sha": "7b30ef2c7bd66f6feb4437e9a50497befccc0b93"
+    },
+    {
+      "file": "cogni-research/skills/research-setup/SKILL.md",
+      "match": "v0.7.7",
+      "line_sha": "9b53c07ce7334009c68618035e266550abce05ca"
+    },
+    {
+      "file": "cogni-research/skills/research-setup/SKILL.md",
+      "match": "v0.7.7",
+      "line_sha": "c39cd09fb7373efe694a3f434b67ed5a23240140"
+    },
+    {
+      "file": "cogni-research/skills/research-setup/SKILL.md",
+      "match": "v0.8.0",
+      "line_sha": "0062291b4c8b450f2baf94841f1ef54053aaa131"
+    },
+    {
+      "file": "cogni-research/skills/research-setup/SKILL.md",
+      "match": "v0.8.0",
+      "line_sha": "41c8d881bba9e450aa4fccdc289709eae40aa519"
+    },
+    {
+      "file": "cogni-research/skills/research-setup/SKILL.md",
+      "match": "v0.8.0",
+      "line_sha": "a2fab11214af50d0723543b0c99310eba0d96fac"
+    },
+    {
+      "file": "cogni-research/skills/research-setup/SKILL.md",
+      "match": "v0.8.1",
+      "line_sha": "ba67be05c8c5c30b19329bdca2c8be623f7c7845"
+    },
+    {
+      "file": "cogni-research/skills/research-setup/SKILL.md",
+      "match": "v0.8.2",
+      "line_sha": "9b1e57756acffd402b2f5c4b2b13ccbbafdd10c6"
+    },
+    {
+      "file": "cogni-research/skills/research-setup/SKILL.md",
+      "match": "v0.8.2",
+      "line_sha": "f023c651dab8de9a0d3c22a14688ae816815a3ea"
+    },
+    {
+      "file": "cogni-trends/agents/trend-candidate-reviewer.md",
+      "match": "#12",
+      "line_sha": "8265c53483fe4d76ffdfafc16fb30e25198e6e0a"
+    },
+    {
+      "file": "cogni-trends/agents/trend-candidate-reviewer.md",
+      "match": "#12",
+      "line_sha": "b5ac2cd94500292abd299d4ab4f528db84c2c4b5"
+    },
+    {
+      "file": "cogni-trends/agents/trend-candidate-reviewer.md",
+      "match": "#12",
+      "line_sha": "ff200d0bf46c1f8df85b8d92dc40af3092160c9b"
+    },
+    {
+      "file": "cogni-trends/agents/trend-candidate-reviewer.md",
+      "match": "#34",
+      "line_sha": "8265c53483fe4d76ffdfafc16fb30e25198e6e0a"
+    },
+    {
+      "file": "cogni-trends/agents/trend-candidate-reviewer.md",
+      "match": "#34",
+      "line_sha": "b5ac2cd94500292abd299d4ab4f528db84c2c4b5"
+    },
+    {
+      "file": "cogni-trends/agents/trend-candidate-reviewer.md",
+      "match": "#34",
+      "line_sha": "ff200d0bf46c1f8df85b8d92dc40af3092160c9b"
+    },
+    {
+      "file": "cogni-trends/skills/trend-research/SKILL.md",
+      "match": "#182",
+      "line_sha": "6bcd9f3435d225b939cdf4a00e727601449e2e9d"
+    },
+    {
+      "file": "cogni-visual/skills/enrich-report/SKILL.md",
+      "match": "v0.16.11",
+      "line_sha": "ed7134f0ef6634689a6610cd4f885ad8e88cc31a"
+    },
+    {
+      "file": "cogni-visual/skills/render-html-slides/SKILL.md",
+      "match": "v1.0.0",
+      "line_sha": "7c3683e8533ead775f970b7a51cf2abfcd0d5582"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-dashboard/SKILL.md",
+      "match": "#221",
+      "line_sha": "af77779efca5405f52542c89bc4e67c673a37382"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-from-research/SKILL.md",
+      "match": "v0.0.40",
+      "line_sha": "9fdc1e7264a314523de6578cef2a63c0e128618d"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "#212",
+      "line_sha": "7bda2750f68e4ecca03184877602f3b24e4eaf6a"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "#73",
+      "line_sha": "035bd4b004e6d3b62abae8fe3cf4370998ca96d3"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "#84",
+      "line_sha": "4d659a332d699540bb2513de5d5db740dc6ba6a3"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.12",
+      "line_sha": "4d659a332d699540bb2513de5d5db740dc6ba6a3"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.22",
+      "line_sha": "3c2f057c04b13c94c21a882cae4846e356e477eb"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.29",
+      "line_sha": "0e5c2fde5f898fd3d8bf10b1dec43ac074def2d5"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.29",
+      "line_sha": "87e1ef5a889c269faeb0e79928c94001bddeaa43"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.29",
+      "line_sha": "a8dd84cc0c8df9c52d59639f77a1c225d29273bc"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.29",
+      "line_sha": "d56bc823fbfde86b6bcdabedf9e07987b2b8332d"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "020f846182f6ac3ec6ab0ae721efe3e22006d302"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "2b6d0d62305603e1082f9a5ad97391e65adae782"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "2ca78af5e1f53bfd3ee536e097511baaf1630342"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "3598f9b9c712714ef25b9976b94e2777f66a2459"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "543256c71497d9633a1a3ec5125da15778d93845"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "57681aa431cde4b8d7f7302088b02520b6383d58"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "70c71a274cca740688b811a469a7074f944263cb"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "a3ec01736c42185b9930ba799d60328c2f184b35"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-ingest/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "f50b9b782efeb59ac4783c42e6ea503441e529ce"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "#222",
+      "line_sha": "11b4515ad28886af62923d86172c39c4761e2d64"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "#222",
+      "line_sha": "54354e78fa96418f56a5c4c022b185d06c26104c"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "#222",
+      "line_sha": "d581bdb4fbeb208695d566fd27804ef14a673de0"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "#222",
+      "line_sha": "e9e1e50f59d49bffa008affc214acb7945bbcaf7"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "#222",
+      "line_sha": "f691687bd27b53ea7188b2e38203d1da02531d1a"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "#223",
+      "line_sha": "d09260b1c80f5060bb436b487e36a3891b7400bb"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "#354",
+      "line_sha": "abe75dbe9549f0340211068fe24673c2222d3745"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "v0.0.30",
+      "line_sha": "1bc648ba3254e27e19c20da2e55d052152a53099"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "v0.0.30",
+      "line_sha": "37855d1ada2eef5a50f48bb515787236a02aaf42"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "v0.0.30",
+      "line_sha": "41e3965b40977d1a18f2478a4190de155af1e48d"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "v0.0.30",
+      "line_sha": "abf6c61d2faa87cca045a5f54de5304ba44abbcc"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "v0.0.30",
+      "line_sha": "ce23fa406482f226d21bf4fb132b4dddca9a5d92"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "v0.0.30",
+      "line_sha": "d2404e1bbdf534135d96164338a0e1c264a8fefa"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "v0.0.31",
+      "line_sha": "d09260b1c80f5060bb436b487e36a3891b7400bb"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "v0.0.32",
+      "line_sha": "11b4515ad28886af62923d86172c39c4761e2d64"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "v0.0.32",
+      "line_sha": "54354e78fa96418f56a5c4c022b185d06c26104c"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "v0.0.32",
+      "line_sha": "7eee87f791bdf1af091894d2a703ee774cf289c5"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "v0.0.32",
+      "line_sha": "d581bdb4fbeb208695d566fd27804ef14a673de0"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "v0.0.32",
+      "line_sha": "e9e1e50f59d49bffa008affc214acb7945bbcaf7"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "v0.0.32",
+      "line_sha": "f5c60181acd51c2247dbb306ef02ca635c1b0afc"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-lint/SKILL.md",
+      "match": "v0.0.32",
+      "line_sha": "f691687bd27b53ea7188b2e38203d1da02531d1a"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-query/SKILL.md",
+      "match": "v0.0.23",
+      "line_sha": "29f8c4e258a28f5880f6a5c904c77cdbeb2609be"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-query/SKILL.md",
+      "match": "v0.0.23",
+      "line_sha": "57bdf6cc4fe90eadfb36eac91de6214340d5a2f2"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-refresh/SKILL.md",
+      "match": "#197",
+      "line_sha": "fd8169a8732eaed07246e8f49671b07f9570e803"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-refresh/SKILL.md",
+      "match": "#223",
+      "line_sha": "03f4d7dbaec9b683c8c1cf1eb5cab45c07ae425c"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-refresh/SKILL.md",
+      "match": "v0.0.31",
+      "line_sha": "03f4d7dbaec9b683c8c1cf1eb5cab45c07ae425c"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.23",
+      "line_sha": "47afab183e38fc0ba36afd1f4d6fe9474dc812ea"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.27",
+      "line_sha": "1ba6dc9c1a8135b51be86d52fc6543a9fdf8830f"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.27",
+      "line_sha": "1f871d2a4d5ee1a3e89d07b973186dfdb7d52330"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.27",
+      "line_sha": "1fed0819268f9220e3f3e85c484fd97469ed0e1a"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.27",
+      "line_sha": "e109771121f721adda61342a96f965ce16f4d5f6"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.27",
+      "line_sha": "f8aa32aba63085b5bb84b1327bbeba781565dd9f"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.29",
+      "line_sha": "1ba6dc9c1a8135b51be86d52fc6543a9fdf8830f"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.29",
+      "line_sha": "1e55b5576c200270d9222a92b5c6f7723697fd11"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.29",
+      "line_sha": "2137c638552cdd07aeb661bf105337b79e53e63b"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.29",
+      "line_sha": "d30061fb847117bd1dc61eb39d1399bc7ff62df6"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.29",
+      "line_sha": "e109771121f721adda61342a96f965ce16f4d5f6"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.30",
+      "line_sha": "1f871d2a4d5ee1a3e89d07b973186dfdb7d52330"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.30",
+      "line_sha": "ba48190fbf72a0f8e6c2efba7d0507598f760b07"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "18aa83aac9eda6b9e6c6060fe50eb62e8b78400e"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "1f871d2a4d5ee1a3e89d07b973186dfdb7d52330"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "386f1c58acc7ec285b6246b72fc2859af5c24407"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "4f4342255211e3ef57c0b6029ed5043f4f863cac"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "ab882740455bfb77912614b05fb319063e2ed307"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.35",
+      "line_sha": "bfba45348a929643be6159785209f2119a1f78a0"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.39",
+      "line_sha": "1f871d2a4d5ee1a3e89d07b973186dfdb7d52330"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.39",
+      "line_sha": "8add45095c30f5a11f7af08987dccf404ca9dc6a"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.39",
+      "line_sha": "ab882740455bfb77912614b05fb319063e2ed307"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.39",
+      "line_sha": "bfba45348a929643be6159785209f2119a1f78a0"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-resume/SKILL.md",
+      "match": "v0.0.4",
+      "line_sha": "575d5423ff9ea3d390fa4167a76111e2599360a3"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-setup/SKILL.md",
+      "match": "v0.0.28",
+      "line_sha": "01b97e8318f777c01ff1262fd462e584f40cf456"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-setup/SKILL.md",
+      "match": "v0.0.28",
+      "line_sha": "927d84925a3e2552ce880b56bec2bf92a3722240"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-setup/SKILL.md",
+      "match": "v0.0.33",
+      "line_sha": "f883bd7fafc9e786f57e13dfc31379b346de7b6b"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-setup/SKILL.md",
+      "match": "v0.0.4",
+      "line_sha": "c31de6bb9e7175395bb9669e7c69d7bef20edd45"
+    },
+    {
+      "file": "cogni-wiki/skills/wiki-setup/SKILL.md",
+      "match": "v0.0.44",
+      "line_sha": "927d84925a3e2552ce880b56bec2bf92a3722240"
+    },
+    {
+      "file": "cogni-workspace/skills/manage-themes/SKILL.md",
+      "match": "#10",
+      "line_sha": "b97ffccdde83fda2d8f82ea00a24475d08146e52"
+    },
+    {
+      "file": "cogni-workspace/skills/manage-themes/SKILL.md",
+      "match": "#10",
+      "line_sha": "d724851381197b14ae0ac8ac059b9ef5c7c7a6c1"
+    },
+    {
+      "file": "cogni-workspace/skills/manage-themes/SKILL.md",
+      "match": "#10",
+      "line_sha": "f8af5ce7c32fd8e2321be611373e04ba851d11bb"
+    },
+    {
+      "file": "cogni-workspace/skills/manage-themes/SKILL.md",
+      "match": "#10",
+      "line_sha": "fed8e17dd3af7a111423995c20f29fc10f12abb2"
+    },
+    {
+      "file": "cogni-workspace/skills/manage-themes/SKILL.md",
+      "match": "#124",
+      "line_sha": "d1f4b52289bbfe18963af2b44695d8f0bd80edea"
+    },
+    {
+      "file": "cogni-workspace/skills/manage-themes/SKILL.md",
+      "match": "#132",
+      "line_sha": "06301d7fe1e044233907886ccf38861ef0273990"
+    },
+    {
+      "file": "cogni-workspace/skills/manage-themes/SKILL.md",
+      "match": "v0.5.0",
+      "line_sha": "fed8e17dd3af7a111423995c20f29fc10f12abb2"
+    },
+    {
+      "file": "cogni-workspace/skills/workspace-status/SKILL.md",
+      "match": "#132",
+      "line_sha": "ae26d34e3e7df36efa214a22b878bb5bc909275c"
+    }
+  ]
+}

--- a/scripts/check-breadcrumbs.py
+++ b/scripts/check-breadcrumbs.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""check-breadcrumbs.py — deterministic maintainer-breadcrumb guard.
+
+Greps tracked `*/skills/*/SKILL.md` and `*/agents/*.md` for maintainer
+meta-documentation breadcrumbs that should live in git history / CHANGELOG /
+references/, not in the prompt the model executes:
+
+  - bare issue/PR refs ........ #344
+  - plugin-version tags ....... v0.1.16
+  - milestone codes ........... M8
+  - slice codes ............... Slice 3
+  - finding codes ............. F11
+
+The repo is not breadcrumb-free today, and many matches are legitimate
+(hex colors, the cogni-trends `F1` patent formula, emitted candidate IDs,
+compatibility-fact version cites). This guard therefore works as a *ratchet*:
+every occurrence present at baseline-capture time is recorded in
+scripts/baselines/breadcrumb-baseline.json and allowed to pass; the guard fails
+only on occurrences that are NOT in the baseline — i.e. newly introduced
+breadcrumbs. The baseline can only shrink: as a plugin is cleaned, its entries
+are dropped on the next --update-baseline.
+
+The fix when the guard trips is to REMOVE the breadcrumb and state the rationale
+semantically — NOT to reconcile mismatched version tags. A genuinely new
+load-bearing compatibility fact is admitted by re-running --update-baseline and
+justifying the new baseline entry in the PR.
+
+stdlib only; runs under any python3. Exit 0 = clean, 1 = new breadcrumb(s),
+2 = script error.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+
+DEFAULT_GLOBS = ["*/skills/*/SKILL.md", "*/agents/*.md"]
+
+# Version/issue/milestone/slice/finding matchers. issue_ref is handled
+# specially (hex-color disambiguation); the rest are plain regexes.
+VERSION_RE = re.compile(r"\bv[0-9]+\.[0-9]+\.[0-9]+\b")
+MILESTONE_RE = re.compile(r"\bM[0-9]+\b")
+SLICE_RE = re.compile(r"\bSlice [0-9]+\b")
+# 2+ digits: excludes the single-digit cogni-trends `F1` patent formula and the
+# archived `F2` fix note, still catches real finding codes (F11, F20, F26).
+FINDING_RE = re.compile(r"\bF[0-9]{2,}\b")
+# Capture the run after `#` so we can tell an issue ref from a hex color.
+ISSUE_RUN_RE = re.compile(r"#([0-9a-fA-F]{2,})\b")
+
+
+def _issue_refs(line):
+    """Yield issue-ref tokens on a line, skipping hex colors.
+
+    A run that is all-digits and not length 6 or 8 is an issue ref (#222, #12,
+    #103). A run containing hex letters, or an all-digit run of length 6/8, is a
+    color/hash (#000000, #000000B3, #abc123) and is skipped.
+    """
+    for m in ISSUE_RUN_RE.finditer(line):
+        run = m.group(1)
+        if not run.isdigit():
+            continue  # contains a-f -> color or hash, not an issue ref
+        if len(run) in (6, 8):
+            continue  # 6/8-digit run -> treat as a hex color
+        yield "#" + run
+
+
+def find_matches(line):
+    """Return a list of (pattern_name, matched_token) for one line."""
+    out = []
+    for token in _issue_refs(line):
+        out.append(("issue_ref", token))
+    for m in VERSION_RE.finditer(line):
+        out.append(("version_tag", m.group(0)))
+    for m in MILESTONE_RE.finditer(line):
+        out.append(("milestone", m.group(0)))
+    for m in SLICE_RE.finditer(line):
+        out.append(("slice", m.group(0)))
+    for m in FINDING_RE.finditer(line):
+        out.append(("finding", m.group(0)))
+    return out
+
+
+def line_sha(line):
+    return hashlib.sha1(line.strip().encode("utf-8")).hexdigest()
+
+
+def occurrence_key(rel_path, token, sha):
+    """Position-independent identity for a single breadcrumb occurrence."""
+    return "{}\x00{}\x00{}".format(rel_path, token, sha)
+
+
+def discover_files(root):
+    """Tracked SKILL.md + agents/*.md, relative to root, via git ls-files."""
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", root, "ls-files", "-z"] + DEFAULT_GLOBS,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, OSError) as exc:
+        raise RuntimeError("git ls-files failed: {}".format(exc))
+    return [p for p in out.decode("utf-8").split("\x00") if p]
+
+
+def scan_file(abs_path, rel_path):
+    """Yield occurrence dicts for one file."""
+    try:
+        with open(abs_path, "r", encoding="utf-8") as fh:
+            lines = fh.readlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise RuntimeError("cannot read {}: {}".format(rel_path, exc))
+    for lineno, raw in enumerate(lines, start=1):
+        line = raw.rstrip("\n")
+        for pattern, token in find_matches(line):
+            yield {
+                "file": rel_path,
+                "line": lineno,
+                "pattern": pattern,
+                "match": token,
+                "line_sha": line_sha(line),
+                "context": line.strip()[:140],
+            }
+
+
+def collect(root, explicit_files):
+    """Collect every occurrence across the scanned files."""
+    occ = []
+    if explicit_files:
+        pairs = []
+        for f in explicit_files:
+            abs_path = f if os.path.isabs(f) else os.path.join(root, f)
+            rel = os.path.relpath(abs_path, root)
+            pairs.append((abs_path, rel))
+    else:
+        pairs = [(os.path.join(root, rel), rel) for rel in discover_files(root)]
+    for abs_path, rel in pairs:
+        occ.extend(scan_file(abs_path, rel))
+    return occ
+
+
+def load_baseline(path):
+    if not path or not os.path.exists(path):
+        return set()
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    entries = data.get("entries", []) if isinstance(data, dict) else data
+    return {occurrence_key(e["file"], e["match"], e["line_sha"]) for e in entries}
+
+
+def write_baseline(path, occ):
+    entries = sorted(
+        ({"file": o["file"], "match": o["match"], "line_sha": o["line_sha"]}
+         for o in occ),
+        key=lambda e: (e["file"], e["match"], e["line_sha"]),
+    )
+    # De-duplicate identical (file, match, sha) tuples.
+    deduped = []
+    seen = set()
+    for e in entries:
+        k = occurrence_key(e["file"], e["match"], e["line_sha"])
+        if k not in seen:
+            seen.add(k)
+            deduped.append(e)
+    payload = {
+        "_comment": (
+            "Breadcrumb-guard ratchet baseline. Each entry is a breadcrumb "
+            "occurrence present when the baseline was captured and therefore "
+            "allowed to pass. Regenerate with "
+            "`python3 scripts/check-breadcrumbs.py --update-baseline`. The fix "
+            "for a NEW breadcrumb is to remove it and state the rationale "
+            "semantically — not to add it here."
+        ),
+        "entries": deduped,
+    }
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+    return len(deduped)
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("files", nargs="*",
+                    help="explicit files to scan (default: git ls-files globs)")
+    ap.add_argument("--root", default=None,
+                    help="repo root for discovery + relative paths "
+                         "(default: parent of scripts/)")
+    ap.add_argument("--baseline", default=None,
+                    help="baseline JSON path "
+                         "(default: scripts/baselines/breadcrumb-baseline.json)")
+    ap.add_argument("--update-baseline", action="store_true",
+                    help="regenerate the baseline from the current tree, exit 0")
+    args = ap.parse_args(argv)
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.abspath(args.root) if args.root else os.path.dirname(script_dir)
+    baseline_path = args.baseline or os.path.join(
+        script_dir, "baselines", "breadcrumb-baseline.json")
+
+    try:
+        occ = collect(root, args.files)
+    except RuntimeError as exc:
+        print(json.dumps({"success": False, "data": {}, "error": str(exc)}))
+        return 2
+
+    if args.update_baseline:
+        n = write_baseline(baseline_path, occ)
+        print(json.dumps({
+            "success": True,
+            "data": {"baseline_size": n, "baseline_path": baseline_path},
+            "error": "",
+        }))
+        return 0
+
+    try:
+        baseline = load_baseline(baseline_path)
+    except (OSError, ValueError, KeyError) as exc:
+        print(json.dumps({"success": False, "data": {},
+                          "error": "bad baseline: {}".format(exc)}))
+        return 2
+
+    violations = [
+        o for o in occ
+        if occurrence_key(o["file"], o["match"], o["line_sha"]) not in baseline
+    ]
+
+    by_pattern = {}
+    for o in violations:
+        by_pattern[o["pattern"]] = by_pattern.get(o["pattern"], 0) + 1
+
+    result = {
+        "success": not violations,
+        "data": {
+            "violations": violations,
+            "summary": {
+                "total": len(violations),
+                "by_pattern": by_pattern,
+                "files_affected": len(sorted({o["file"] for o in violations})),
+                "baseline_size": len(baseline),
+                "scanned_occurrences": len(occ),
+            },
+        },
+        "error": "",
+    }
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+    if violations:
+        print("\nFAIL: {} new maintainer breadcrumb(s) found "
+              "(not in baseline):".format(len(violations)), file=sys.stderr)
+        for o in violations:
+            print("  {}:{}: [{}] {}  ->  {}".format(
+                o["file"], o["line"], o["pattern"], o["match"], o["context"]),
+                file=sys.stderr)
+        print("\nFix: remove the breadcrumb and state the rationale "
+              "semantically (do NOT reconcile version tags). A genuine new "
+              "compatibility fact is admitted via "
+              "`python3 scripts/check-breadcrumbs.py --update-baseline` with a "
+              "PR justification.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-breadcrumbs.py
+++ b/scripts/check-breadcrumbs.py
@@ -39,6 +39,11 @@ import sys
 
 DEFAULT_GLOBS = ["*/skills/*/SKILL.md", "*/agents/*.md"]
 
+# A line carrying this marker is skipped entirely — the per-line escape hatch
+# for a deterministic false positive (an Apple M-series chip name, a function
+# key like F12, etc.) so it need not be parked in the baseline.
+ALLOW_MARKER = "breadcrumb-guard:allow"
+
 # Version/issue/milestone/slice/finding matchers. issue_ref is handled
 # specially (hex-color disambiguation); the rest are plain regexes.
 VERSION_RE = re.compile(r"\bv[0-9]+\.[0-9]+\.[0-9]+\b")
@@ -113,6 +118,11 @@ def scan_file(abs_path, rel_path):
         raise RuntimeError("cannot read {}: {}".format(rel_path, exc))
     for lineno, raw in enumerate(lines, start=1):
         line = raw.rstrip("\n")
+        if ALLOW_MARKER in line:
+            # Per-line escape hatch for a genuine false positive (e.g. an Apple
+            # M-series chip name "M2 Mac", a function key "F12"). Keeps the
+            # baseline reserved for real-but-grandfathered breadcrumbs.
+            continue
         for pattern, token in find_matches(line):
             yield {
                 "file": rel_path,
@@ -132,6 +142,13 @@ def collect(root, explicit_files):
         for f in explicit_files:
             abs_path = f if os.path.isabs(f) else os.path.join(root, f)
             rel = os.path.relpath(abs_path, root)
+            if rel == os.pardir or rel.startswith(os.pardir + os.sep):
+                # An explicit file outside --root would produce a machine-specific
+                # "../../.." baseline key that never matches the git ls-files key.
+                # Refuse rather than silently poison the baseline / false-flag.
+                raise RuntimeError(
+                    "file {!r} is outside --root {!r}; pass paths under the "
+                    "repo root".format(f, root))
             pairs.append((abs_path, rel))
     else:
         pairs = [(os.path.join(root, rel), rel) for rel in discover_files(root)]
@@ -214,6 +231,14 @@ def main(argv):
             "error": "",
         }))
         return 0
+
+    # A mistyped explicit --baseline must not be silently read as "empty"
+    # (which would flag the whole tree). The default baseline legitimately may
+    # not exist on a first run, so only an EXPLICIT missing path is an error.
+    if args.baseline is not None and not os.path.exists(baseline_path):
+        print(json.dumps({"success": False, "data": {},
+                          "error": "baseline not found: {}".format(baseline_path)}))
+        return 2
 
     try:
         baseline = load_baseline(baseline_path)

--- a/tests/test_check_breadcrumbs.sh
+++ b/tests/test_check_breadcrumbs.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# test_check_breadcrumbs.sh — self-test for the maintainer-breadcrumb guard.
+#
+# Cases:
+#   1. Negative controls (hex color, F1 formula, bare schema version) -> exit 0.
+#   2. Breadcrumb-laden fixture (#999, v9.9.9, M9, Slice 9, F99) -> exit 1,
+#      with the offending file + line reported (issue #377 acceptance test).
+#   3. Real tree against the committed baseline -> exit 0 (ratchet passes today).
+#
+# bash 3.2 + stdlib python3 only.
+
+set -eu
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+GUARD="$REPO_ROOT/scripts/check-breadcrumbs.py"
+
+red()   { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+
+FAILED=0
+check() {  # check <label> <condition-exit-code>
+  if [ "$2" -eq 0 ]; then
+    green "PASS: $1"
+  else
+    red "FAIL: $1"
+    FAILED=1
+  fi
+}
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# A baseline path that does not exist -> guard treats the baseline as empty, so
+# every detected occurrence counts as a (new) violation. This is what lets the
+# breadcrumb fixture fail deterministically without depending on the real baseline.
+EMPTY_BASELINE="$WORK/no-such-baseline.json"
+
+# ---------------------------------------------------------------------------
+# Case 1 — negative controls: nothing here may trip the guard.
+# ---------------------------------------------------------------------------
+mkdir -p "$WORK/clean/skills/demo"
+cat > "$WORK/clean/skills/demo/SKILL.md" <<'EOF'
+---
+name: demo
+---
+Overlay fill uses #000000B3 for readability.
+Rankings use the F1 averaging formula from the patent.
+Schema is pinned at "version": "0.1.0" in the JSON envelope.
+Filenames follow the draft-vN convention.
+EOF
+
+set +e
+OUT=$(python3 "$GUARD" --root "$WORK/clean" --baseline "$EMPTY_BASELINE" \
+        "skills/demo/SKILL.md" 2>/dev/null)
+CODE=$?
+set -e
+check "negative controls exit 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+echo "$OUT" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is True, d
+assert d['data']['summary']['total']==0, d['data']['summary']
+"
+check "negative controls report zero violations" "$?"
+
+# ---------------------------------------------------------------------------
+# Case 2 — breadcrumb-laden fixture: must fail, naming file + lines.
+# ---------------------------------------------------------------------------
+mkdir -p "$WORK/dirty/agents"
+cat > "$WORK/dirty/agents/bad.md" <<'EOF'
+Internal note about #999 regression handling.
+This behaviour shipped in v9.9.9 last release.
+Tracked under M9 and the Slice 9 scope cut.
+Root cause is finding F99 from the audit.
+EOF
+
+set +e
+OUT=$(python3 "$GUARD" --root "$WORK/dirty" --baseline "$EMPTY_BASELINE" \
+        "agents/bad.md" 2>/dev/null)
+CODE=$?
+set -e
+check "breadcrumb fixture exits 1" "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
+echo "$OUT" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+v=d['data']['violations']
+got={(x['pattern'],x['match'],x['line']) for x in v}
+want={
+  ('issue_ref','#999',1),
+  ('version_tag','v9.9.9',2),
+  ('milestone','M9',3),
+  ('slice','Slice 9',3),
+  ('finding','F99',4),
+}
+missing=want-got
+assert not missing, 'missing: %r (got %r)' % (missing, got)
+assert all(x['file']=='agents/bad.md' for x in v), v
+assert d['success'] is False, d
+"
+check "breadcrumb fixture names every token with correct file+line" "$?"
+
+# ---------------------------------------------------------------------------
+# Case 3 — real tree against the committed baseline: ratchet passes.
+# ---------------------------------------------------------------------------
+set +e
+python3 "$GUARD" >/dev/null 2>&1
+CODE=$?
+set -e
+check "real tree passes against committed baseline" \
+  "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+  green "All breadcrumb-guard tests passed."
+  exit 0
+else
+  red "Some breadcrumb-guard tests failed."
+  exit 1
+fi

--- a/tests/test_check_breadcrumbs.sh
+++ b/tests/test_check_breadcrumbs.sh
@@ -5,7 +5,11 @@
 #   1. Negative controls (hex color, F1 formula, bare schema version) -> exit 0.
 #   2. Breadcrumb-laden fixture (#999, v9.9.9, M9, Slice 9, F99) -> exit 1,
 #      with the offending file + line reported (issue #377 acceptance test).
-#   3. Real tree against the committed baseline -> exit 0 (ratchet passes today).
+#   3. Inline-allow escape hatch -> the flagged line is skipped.
+#   4. Real tree against the committed baseline -> exit 0 (ratchet passes today).
+#
+# Note: case 4 reads the working tree via `git ls-files`, so an uncommitted
+# edit that adds a NEW breadcrumb to a tracked file will (correctly) fail it.
 #
 # bash 3.2 + stdlib python3 only.
 
@@ -28,13 +32,24 @@ check() {  # check <label> <condition-exit-code>
   fi
 }
 
+# Run a python assertion block on stdin without letting `set -e` abort the
+# harness — capture the exit code, then report it through check().
+assert_json() {  # assert_json <label> <json> <python-asserts>
+  set +e
+  printf '%s' "$2" | python3 -c "$3"
+  local _code=$?
+  set -e
+  check "$1" "$_code"
+}
+
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 
-# A baseline path that does not exist -> guard treats the baseline as empty, so
-# every detected occurrence counts as a (new) violation. This is what lets the
-# breadcrumb fixture fail deterministically without depending on the real baseline.
-EMPTY_BASELINE="$WORK/no-such-baseline.json"
+# A real, explicitly-empty baseline -> every detected occurrence is a (new)
+# violation. (An explicitly-passed *missing* path is now a hard error, so the
+# test must materialise the empty baseline rather than rely on a nonexistent one.)
+EMPTY_BASELINE="$WORK/empty-baseline.json"
+printf '{"entries": []}\n' > "$EMPTY_BASELINE"
 
 # ---------------------------------------------------------------------------
 # Case 1 — negative controls: nothing here may trip the guard.
@@ -56,13 +71,12 @@ OUT=$(python3 "$GUARD" --root "$WORK/clean" --baseline "$EMPTY_BASELINE" \
 CODE=$?
 set -e
 check "negative controls exit 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
-echo "$OUT" | python3 -c "
+assert_json "negative controls report zero violations" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 assert d['success'] is True, d
 assert d['data']['summary']['total']==0, d['data']['summary']
 "
-check "negative controls report zero violations" "$?"
 
 # ---------------------------------------------------------------------------
 # Case 2 — breadcrumb-laden fixture: must fail, naming file + lines.
@@ -81,7 +95,7 @@ OUT=$(python3 "$GUARD" --root "$WORK/dirty" --baseline "$EMPTY_BASELINE" \
 CODE=$?
 set -e
 check "breadcrumb fixture exits 1" "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
-echo "$OUT" | python3 -c "
+assert_json "breadcrumb fixture names every token with correct file+line" "$OUT" "
 import json,sys
 d=json.load(sys.stdin)
 v=d['data']['violations']
@@ -98,10 +112,29 @@ assert not missing, 'missing: %r (got %r)' % (missing, got)
 assert all(x['file']=='agents/bad.md' for x in v), v
 assert d['success'] is False, d
 "
-check "breadcrumb fixture names every token with correct file+line" "$?"
 
 # ---------------------------------------------------------------------------
-# Case 3 — real tree against the committed baseline: ratchet passes.
+# Case 3 — inline-allow escape hatch skips an otherwise-flagged line.
+# ---------------------------------------------------------------------------
+mkdir -p "$WORK/allow/agents"
+cat > "$WORK/allow/agents/ok.md" <<'EOF'
+Runs great on the M2 Mac.  <!-- breadcrumb-guard:allow -->
+EOF
+
+set +e
+OUT=$(python3 "$GUARD" --root "$WORK/allow" --baseline "$EMPTY_BASELINE" \
+        "agents/ok.md" 2>/dev/null)
+CODE=$?
+set -e
+check "inline-allow line exits 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "inline-allow suppresses the M2 match" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['data']['summary']['total']==0, d['data']['summary']
+"
+
+# ---------------------------------------------------------------------------
+# Case 4 — real tree against the committed baseline: ratchet passes.
 # ---------------------------------------------------------------------------
 set +e
 python3 "$GUARD" >/dev/null 2>&1


### PR DESCRIPTION
## Summary

Adds the deterministic breadcrumb guard requested in #377 — a grep-based CI check that fails when maintainer meta-documentation **breadcrumbs** leak into a `SKILL.md` body/frontmatter or an `agents/*.md` prompt:

- bare issue/PR refs — `#344`
- plugin-version tags — `v0.1.16`
- milestone / slice / finding codes — `M8`, `Slice 3`, `F11`

These belong in git history / CHANGELOG / `references/`, not in the prompt the model executes. This is the deterministic companion to the probabilistic `skill-quality-reviewer` LLM gate (the "secondary check" managed-service#55 deferred here).

## Why ratchet + baseline (not a hard repo-wide grep)

Only **cogni-knowledge** is breadcrumb-free today. A naive repo-wide grep of the three patterns hits 180+ lines elsewhere, **mostly legitimate**: hex colors (`#000000B3`), the cogni-trends `F1` patent formula, emitted content (copywriter quotes `#255`, trend-reviewer JSON uses candidate IDs `#12`/`#34`), `Operation #10`, and compatibility-fact version cites (`cogni-wiki v0.0.43`) — mixed with real breadcrumbs (`issue #48`, `(#222)`, `v0.0.32+`). A hard-fail grep could not satisfy the issue's "current clean tree passes" criterion without rewriting 100+ legitimate lines.

So the guard is a **ratchet**: every occurrence present at capture time is recorded in `scripts/baselines/breadcrumb-baseline.json` (180 entries) and allowed to pass; the guard fails **only on newly introduced** breadcrumbs. The baseline can only shrink — as a plugin is cleaned, its entries drop on the next `--update-baseline`.

## Pattern refinements (keep the baseline quiet)

- **Finding codes require 2+ digits** (`F[0-9]{2,}`) — excludes the single-digit `F1` patent formula and the archived `F2` note, still catches real `F11`/`F20`/`F26`.
- **6/8-digit hex runs** are treated as colors, not issue refs (`#000000`, `#000000B3`).
- **Version tags match leading-`v` semver only** — bare schema/data versions (`"version": "0.1.0"`) never trip; `-vN`/`draft-vN` placeholders don't match either.

## Files

| File | What |
|------|------|
| `scripts/check-breadcrumbs.py` | python3 stdlib guard; `--update-baseline`; JSON envelope; exit 0/1/2; file+line on failure |
| `scripts/baselines/breadcrumb-baseline.json` | captured baseline (180 occurrences) |
| `.github/workflows/lint.yml` | runs the guard on every PR — the repo's first test-CI workflow |
| `tests/test_check_breadcrumbs.sh` | negative controls, breadcrumb-laden fixture fails with file+line, real tree passes |
| `CONTRIBUTING.md` | guard usage + **remove-don't-reconcile** guidance |

No plugin version bump — this is repo-level infra only (no plugin `skills/`, `agents/`, or `plugin.json` touched).

## Acceptance criteria (#377)

- [x] CI/test step greps SKILL.md + agent files for the three breadcrumb classes
- [x] Allowlist exempts schema/data versions, `-vN` placeholders, and (via the ratchet) compatibility-fact citations
- [x] On a match, the step fails with file + line so the author can locate it
- [x] A deliberately breadcrumb-laden fixture fails the check; the current tree passes

## Verification

```
python3 scripts/check-breadcrumbs.py        # exit 0 (ratchet passes today)
bash tests/test_check_breadcrumbs.sh        # 5/5 green
```

Regression probe on a real tracked `SKILL.md` (`#999 v9.9.9 M9 F99`) → exit 1 naming the file + line 167; clean restore confirmed.

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)