### PR TITLE
cogni-knowledge: collapse normalizers + route citation_format through _knowledge_lib (cleanup)

### DIFF
--- a/cogni-knowledge/scripts/_knowledge_lib.py
+++ b/cogni-knowledge/scripts/_knowledge_lib.py
@@ -235,25 +235,32 @@ CITATION_FAMILY = {
 }
 
 
+def _normalize_choice(value: str | None, valid: frozenset, default: str) -> str:
+    """Lowercase + strip a free-text choice and validate it against `valid`;
+    unknown/empty → `default`. The shared rule behind the writer-quality
+    string normalizers below."""
+    v = str(value or "").strip().lower()
+    return v if v in valid else default
+
+
 def normalize_tone(value: str | None) -> str:
     """Lowercase + validate a tone against VALID_TONES; unknown/empty → objective."""
-    v = str(value or "").strip().lower()
-    return v if v in VALID_TONES else "objective"
+    return _normalize_choice(value, VALID_TONES, "objective")
 
 
 def normalize_prose_density(value: str | None) -> str:
     """Lowercase + validate a prose density; unknown/empty → standard."""
-    v = str(value or "").strip().lower()
-    return v if v in VALID_PROSE_DENSITIES else "standard"
+    return _normalize_choice(value, VALID_PROSE_DENSITIES, "standard")
 
 
 def normalize_citation_format(value: str | None) -> str:
     """Lowercase + validate a citation format; `wikilink` aliases to `ieee`;
-    unknown/empty → ieee (the numbered default the pipeline renders end-to-end)."""
-    v = str(value or "").strip().lower()
-    if v == "wikilink":
+    unknown/empty → ieee (the numbered default the pipeline renders end-to-end).
+    The alias is mapped explicitly so it survives any future change to the
+    default or the valid set, even though `wikilink` would also fall through."""
+    if str(value or "").strip().lower() == "wikilink":
         return "ieee"
-    return v if v in VALID_CITATION_FORMATS else "ieee"
+    return _normalize_choice(value, VALID_CITATION_FORMATS, "ieee")
 
 
 def normalize_target_words(value, default: int = 5000) -> int:

--- a/cogni-knowledge/skills/knowledge-finalize/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-finalize/SKILL.md
@@ -265,6 +265,7 @@ sys.path.insert(0, os.environ["KNOWLEDGE_SCRIPTS"])
 from _knowledge_lib import (
     atomic_write_text, ref_heading, first_url, md_link_dest,
     strip_reference_section, renumber_inline_citations,
+    normalize_citation_format,
 )
 
 wiki_root = Path(os.environ["WIKI_ROOT"])
@@ -300,10 +301,10 @@ heading = ref_heading(output_language)
 # `Publisher, "Title"`; chicago: `Publisher. "Title."`). apa/mla/harvard are the
 # staged author-date follow-up: the composer renders them as numbered, so they
 # fall through to the ieee string here too (no author-date reference rows until
-# the format-aware finalize rework lands). wikilink aliases to ieee.
-citation_format = (plan.get("citation_format") or "ieee").strip().lower()
-if citation_format == "wikilink":
-    citation_format = "ieee"
+# the format-aware finalize rework lands). Validation (lowercase, wikilink→ieee,
+# unknown→ieee) lives once in _knowledge_lib.normalize_citation_format — the
+# single source of truth the composer/plan also resolve through.
+citation_format = normalize_citation_format(plan.get("citation_format"))
 # UTC date so frontmatter created/updated align with Step 10s `date -u +%F` log
 # stamp. Mixed local/UTC across midnight produced cross-artifact date skew.
 today = _dt.datetime.now(_dt.timezone.utc).date().isoformat()


### PR DESCRIPTION
Reuse + altitude cleanup of the #309 P2 writer-quality knobs — re-cut cleanly from `main`. **Supersedes #381**, which was based on the pre-merge `claude/resolve-309-p2-rOJ81` branch (already squash-merged via #380) and therefore showed the whole feature as its diff and would have reverted #380's shipped review fixes.

This branch contains **only** the two behaviour-preserving fixes, cherry-picked onto current `main`:

1. **`_knowledge_lib.py` — collapse the three string normalizers onto a shared `_normalize_choice` helper.** `normalize_tone` / `normalize_prose_density` / `normalize_citation_format` shared a byte-for-byte `str(value or "").strip().lower(); return v if v in VALID else default` body. The validate-against-set rule now lives once; `citation_format` keeps its explicit `wikilink → ieee` alias so it survives a future change to the default or the valid set. `normalize_target_words` is intentionally left separate (int coercion, not set validation).

2. **`knowledge-finalize` — route `citation_format` through `normalize_citation_format`.** The finalize Python block re-inlined the lowercase + `wikilink → ieee` aliasing by hand even though it already imports `_knowledge_lib`. Now calls the documented single-source-of-truth normalizer; behaviour-identical for every input.

### Verification
- Cherry-picked clean onto current `main` (no conflicts); diff is exactly these 2 files.
- #380's `target_words` coercion guard is preserved.
- Full cogni-knowledge contract suite: **35 passed, 0 failed.**

No version bump — behaviour-preserving, and 0.1.36 already shipped via #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
