### PR TITLE
test(cogni-knowledge): commit the #386 redundant-marker drop acceptance fixture

### DIFF
--- a/cogni-knowledge/tests/README.md
+++ b/cogni-knowledge/tests/README.md
@@ -10,6 +10,10 @@ stdlib, no pytest, no pip dependencies — matches the convention used by
 tests/
 ├── README.md
 ├── fixtures/                              Shared test fixtures
+│   └── redundant-marker-386/              Agent-driven (not bash-CI) acceptance
+│                                          fixture for the #386 redundant-marker
+│                                          drop — see its README to re-run the
+│                                          revisor + wiki-verifier by hand
 ├── test_knowledge_setup_probe.sh          F1 + A4: probe handles dev-repo
 │                                          and marketplace cache layouts,
 │                                          present in every gating knowledge-*

--- a/cogni-knowledge/tests/fixtures/redundant-marker-386/README.md
+++ b/cogni-knowledge/tests/fixtures/redundant-marker-386/README.md
@@ -1,0 +1,104 @@
+# Fixture: redundant-marker drop (#386)
+
+Manual, agent-driven acceptance fixture for the **redundant-marker drop** precondition
+added to `agents/revisor.md` (Phase 0/1/2) at v0.1.46 (#386), with the same-source
+identical-marker doc clause at v0.1.47 (#404).
+
+Unlike the other `tests/` files, this fixture is **not run by bash CI** — exercising it
+requires dispatching the `revisor` and `wiki-verifier` LLM agents, which a stdlib bash
+test cannot do. The committed CI guard for #386/#404 is the grep block in
+`tests/test_verify_contract.sh`. This fixture is the *behavioral* counterpart: a
+self-contained, re-runnable reproduction of the bug the precondition fixes, for use in
+release bake-ins or when revisiting the revisor.
+
+## The scenario
+
+The body has two sentences:
+
+| Sentence | Citations | Verifier verdict (round 0) |
+|---|---|---|
+| **S1** "…fines even without a preceding security incident… governance structures." | `cit-001` activeMind `clm-003` **+** `cit-002` BSI `clm-004` | `cit-001` **paraphrase (aligned)**, `cit-002` **unsupported** (`claim_not_found`) |
+| **S2** "Essential and important entities across eighteen regulated sectors…" | `cit-003` BSI `clm-001` | `cit-003` **paraphrase (aligned)** (control) |
+
+`cit-002` is a **redundant** second marker on S1 — the sentence is already covered by the
+aligned sibling `cit-001`. The BSI page (`bsi-nis2-pflichten`) carries a deliberate
+**near-miss repoint trap**, `clm-005` ("sanctions and penalties are set by national
+authorities") — topically adjacent to S1's "fines" but **non-covering**. The pre-#386
+revisor repointed the surplus marker into such a near-miss (and missed again), leaving a
+residual `unsupported` at the 2-round cap (the NIS2 German bake-in capped at 98.9%).
+
+S1 and S2 both cite the BSI page, so `cit-002` (S1) and `cit-003` (S2) render the
+**byte-identical** marker `<sup>[2](https://www.bsi.bund.de/nis2-pflichten)</sup>` — this
+also exercises the #404 same-source identical-marker handling (the drop must remove only
+the S1 occurrence, via a sentence-level `Edit`).
+
+## Expected behavior (with the precondition)
+
+1. **Revisor** detects that S1's `cit-002` has an aligned same-sentence sibling
+   (`cit-001 ∈ aligned_ids`) → **drops** the surplus marker rather than repointing into
+   `clm-005`:
+   - `fixes_summary: {repoint: 0, rephrase: 0, drop: 1, skip: 0}`
+   - S1 keeps `[1]`; the surplus `[2]` is removed from S1 only; S2's `[2]` is untouched.
+   - S1 prose is **not** rewritten as non-evidence-based (it stays evidenced via `cit-001`).
+   - **Surviving-sibling bookkeeping:** `cit-001`'s `draft_sentence` is updated to the
+     marker-removed text (else the next verify round prunes the sentence's only valid
+     citation).
+2. **Re-verify** of `draft-v2` reaches **0 unsupported** within the round cap
+   (`{verbatim/paraphrase = 2, unsupported = 0, total = 2}`).
+
+## Files (inputs only)
+
+```
+kb/wiki/sources/activemind-nis2.md      aligned page (clm-003 covers S1)
+kb/wiki/sources/bsi-nis2-pflichten.md   scope/registration + clm-005 near-miss trap
+project/output/draft-v1.md              the draft (S1 with two markers, S2 control)
+project/.metadata/citation-manifest.json  draft_version 1, 3 citations
+project/.metadata/verify-v1.json        round-0 verdicts (cit-002 unsupported)
+```
+
+The v2 artifacts (`draft-v2.md`, `citation-records-v2.txt`, `citation-manifest.json`
+@ draft_version 2, `verify-v2.json`) are **generated** by the run — they are not committed.
+
+> The two `project/.metadata/*.json` inputs are committed via `git add -f` — the repo
+> `.gitignore` has a broad `**/.metadata/` rule for live run state, which this fixture's
+> *template* inputs are deliberately exempt from. Re-runs happen in a scratch copy (below),
+> so the committed copies are never mutated in place.
+
+## How to re-run
+
+Run against a **scratch copy** so the committed fixture stays pristine
+(`.alpha/` is gitignored):
+
+```bash
+cd <repo-root>
+SCRATCH=.alpha/redundant-marker-386
+rm -rf "$SCRATCH" && mkdir -p "$SCRATCH"
+cp -R cogni-knowledge/tests/fixtures/redundant-marker-386/* "$SCRATCH"/
+PROJ="$PWD/$SCRATCH/project"
+KB="$PWD/$SCRATCH/kb"
+
+# Orchestrator pre-creates draft-v2 as a verbatim copy of draft-v1 (patch-in-place).
+cp "$PROJ/output/draft-v1.md" "$PROJ/output/draft-v2.md"
+```
+
+Then dispatch the two agents (via the `Agent` tool / `subagent_type`), in order:
+
+1. `cogni-knowledge:revisor` with
+   `PROJECT_PATH=$PROJ  WIKI_ROOT=$KB  DRAFT_VERSION=1  NEW_DRAFT_VERSION=2`
+   → expect `fixes_summary.drop == 1`, `repoint == 0`.
+
+2. Rebuild the manifest from the revisor's records (orchestrator step):
+   ```bash
+   python3 cogni-knowledge/scripts/citation-store.py build \
+     --records "$PROJ/.metadata/citation-records-v2.txt" \
+     --draft   "$PROJ/output/draft-v2.md" \
+     --out     "$PROJ/.metadata/citation-manifest.json" \
+     --draft-version 2
+   ```
+
+3. `cogni-knowledge:wiki-verifier` with
+   `PROJECT_PATH=$PROJ  WIKI_ROOT=$KB  DRAFT_VERSION=2`
+   → expect `counts.unsupported == 0`.
+
+Last validated: 2026-06-01, cogni-knowledge v0.1.46 (precondition) / v0.1.47 (#404 doc).
+Result: revisor `drop=1 repoint=0`; re-verify `{verbatim:1, paraphrase:1, unsupported:0}`.

--- a/cogni-knowledge/tests/fixtures/redundant-marker-386/kb/wiki/sources/activemind-nis2.md
+++ b/cogni-knowledge/tests/fixtures/redundant-marker-386/kb/wiki/sources/activemind-nis2.md
@@ -1,0 +1,19 @@
+---
+type: source
+title: NIS2 fines and governance obligations (activeMind)
+sources: [https://www.activemind.de/nis2]
+pre_extracted_claims:
+  - id: clm-003
+    text: "Authorities may impose fines even without a preceding security incident, and affected entities must maintain documented governance structures."
+    excerpt_quote: "Bußgelder können auch ohne vorausgehenden Sicherheitsvorfall verhängt werden; betroffene Einrichtungen müssen Governance-Strukturen nachweisen."
+    excerpt_position: 1
+    sub_question_refs: [sq-01]
+    extracted_at: 2026-06-01
+---
+
+# NIS2 fines and governance obligations
+
+Source body (verbatim cached content elided for the fixture). The page asserts that
+fines under NIS2 do not require a prior incident and that governance structures must
+be documented. This is the page whose claim (clm-003) covers the target sentence —
+the *aligned sibling* that makes the BSI marker on that sentence redundant.

--- a/cogni-knowledge/tests/fixtures/redundant-marker-386/kb/wiki/sources/bsi-nis2-pflichten.md
+++ b/cogni-knowledge/tests/fixtures/redundant-marker-386/kb/wiki/sources/bsi-nis2-pflichten.md
@@ -1,0 +1,33 @@
+---
+type: source
+title: NIS2 obligations — scope and registration (BSI)
+sources: [https://www.bsi.bund.de/nis2-pflichten]
+pre_extracted_claims:
+  - id: clm-001
+    text: "NIS2 applies to essential and important entities across eighteen regulated sectors."
+    excerpt_quote: "NIS2 gilt für wesentliche und wichtige Einrichtungen in achtzehn regulierten Sektoren."
+    excerpt_position: 1
+    sub_question_refs: [sq-02]
+    extracted_at: 2026-06-01
+  - id: clm-002
+    text: "Affected entities must register with the BSI within three months of identification."
+    excerpt_quote: "Betroffene Einrichtungen müssen sich innerhalb von drei Monaten beim BSI registrieren."
+    excerpt_position: 2
+    sub_question_refs: [sq-02]
+    extracted_at: 2026-06-01
+  - id: clm-005
+    text: "Sanctions and penalties under NIS2 are set by the national supervisory authorities."
+    excerpt_quote: "Sanktionen und Bußgelder nach NIS2 werden von den nationalen Aufsichtsbehörden festgelegt."
+    excerpt_position: 3
+    sub_question_refs: [sq-02]
+    extracted_at: 2026-06-01
+---
+
+# NIS2 obligations — scope and registration
+
+Source body (verbatim cached content elided for the fixture). The page covers which
+entities fall in scope (clm-001), the registration deadline (clm-002), and that
+sanctions are set by national authorities (clm-005). It does NOT discuss fines
+*without a prior incident* or governance-structure documentation — so none of its
+claims actually cover the target sentence. clm-005 is the deliberate near-miss
+*repoint trap*: topically adjacent ("sanctions and penalties") but non-covering.

--- a/cogni-knowledge/tests/fixtures/redundant-marker-386/project/.metadata/citation-manifest.json
+++ b/cogni-knowledge/tests/fixtures/redundant-marker-386/project/.metadata/citation-manifest.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "0.1.1",
+  "draft_version": 1,
+  "citations": [
+    {
+      "id": "cit-001",
+      "draft_position": "02:01",
+      "draft_sentence": "Under the NIS2 regime, authorities may impose fines even without a preceding security incident, and affected entities must maintain documented governance structures.<sup>[1](https://www.activemind.de/nis2)</sup><sup>[2](https://www.bsi.bund.de/nis2-pflichten)</sup>",
+      "wiki_slug": "activemind-nis2",
+      "claim_id": "clm-003",
+      "url": "https://www.activemind.de/nis2"
+    },
+    {
+      "id": "cit-002",
+      "draft_position": "02:01",
+      "draft_sentence": "Under the NIS2 regime, authorities may impose fines even without a preceding security incident, and affected entities must maintain documented governance structures.<sup>[1](https://www.activemind.de/nis2)</sup><sup>[2](https://www.bsi.bund.de/nis2-pflichten)</sup>",
+      "wiki_slug": "bsi-nis2-pflichten",
+      "claim_id": "clm-004",
+      "url": "https://www.bsi.bund.de/nis2-pflichten"
+    },
+    {
+      "id": "cit-003",
+      "draft_position": "02:02",
+      "draft_sentence": "Essential and important entities across eighteen regulated sectors fall within the directive's scope.<sup>[2](https://www.bsi.bund.de/nis2-pflichten)</sup>",
+      "wiki_slug": "bsi-nis2-pflichten",
+      "claim_id": "clm-001",
+      "url": "https://www.bsi.bund.de/nis2-pflichten"
+    }
+  ]
+}

--- a/cogni-knowledge/tests/fixtures/redundant-marker-386/project/.metadata/verify-v1.json
+++ b/cogni-knowledge/tests/fixtures/redundant-marker-386/project/.metadata/verify-v1.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "0.1.0",
+  "draft_version": 1,
+  "revision_round": 0,
+  "verified": [
+    {"id": "cit-001", "draft_position": "02:01", "wiki_slug": "activemind-nis2", "claim_id": "clm-003", "verdict": "paraphrase"},
+    {"id": "cit-003", "draft_position": "02:02", "wiki_slug": "bsi-nis2-pflichten", "claim_id": "clm-001", "verdict": "paraphrase"}
+  ],
+  "deviations": [
+    {"id": "cit-002", "draft_position": "02:01", "wiki_slug": "bsi-nis2-pflichten", "claim_id": "clm-004", "verdict": "unsupported", "reason": "claim_not_found", "note": "cited clm-004 is absent on the BSI page; no on-page claim covers the fines-without-incident / governance-structures assertion (clm-001 = sector scope, clm-002 = registration deadline, clm-005 = sanctions set by authorities — near-miss). The sentence is already covered by the adjacent activeMind citation cit-001 (clm-003, paraphrase)."}
+  ],
+  "counts": {"verbatim": 0, "paraphrase": 2, "synthesis": 0, "unsupported": 1, "total": 3}
+}

--- a/cogni-knowledge/tests/fixtures/redundant-marker-386/project/output/draft-v1.md
+++ b/cogni-knowledge/tests/fixtures/redundant-marker-386/project/output/draft-v1.md
@@ -1,0 +1,8 @@
+# NIS2 Compliance Obligations
+
+Under the NIS2 regime, authorities may impose fines even without a preceding security incident, and affected entities must maintain documented governance structures.<sup>[1](https://www.activemind.de/nis2)</sup><sup>[2](https://www.bsi.bund.de/nis2-pflichten)</sup> Essential and important entities across eighteen regulated sectors fall within the directive's scope.<sup>[2](https://www.bsi.bund.de/nis2-pflichten)</sup>
+
+## References
+
+**[1]** [https://www.activemind.de/nis2](https://www.activemind.de/nis2) [[activemind-nis2]]
+**[2]** [https://www.bsi.bund.de/nis2-pflichten](https://www.bsi.bund.de/nis2-pflichten) [[bsi-nis2-pflichten]]


### PR DESCRIPTION
## Summary

Promotes the agent-driven dry-run used to validate the **#386 redundant-marker drop** precondition (shipped in PR #403, v0.1.46) into a committed, documented fixture under `cogni-knowledge/tests/fixtures/redundant-marker-386/`.

The #386 acceptance was *"a fixture where a sentence has one aligned + one unsupported-redundant citation → the revisor drops the redundant one (not repoint) → verify reaches 0 unsupported within the round cap."* That fixture lived ephemerally in gitignored `.alpha/`; this commits it so it survives as a release-bake-in / regression artifact.

## What's in it (inputs only)

- `kb/wiki/sources/activemind-nis2.md` — aligned page (`clm-003` covers the target sentence).
- `kb/wiki/sources/bsi-nis2-pflichten.md` — scope/registration claims **plus `clm-005`, a deliberate non-covering near-miss** ("sanctions and penalties") — the **repoint trap** the pre-#386 revisor fell into.
- `project/output/draft-v1.md` — two-sentence draft; sentence 1 carries an aligned activeMind marker + a redundant unsupported BSI marker; sentence 2 is an untouched control. The two BSI markers are byte-identical, so it also exercises the #404 same-source identical-marker handling.
- `project/.metadata/{citation-manifest.json, verify-v1.json}` — round-0 state (`cit-002` unsupported, `cit-001`/`cit-003` aligned).
- `README.md` — scenario, expected outcome, and exact re-run commands against a gitignored scratch copy.

The v2 artifacts (draft-v2, citation-records-v2, manifest@v2, verify-v2) are **generated by the run**, not committed.

## Last validated (2026-06-01, v0.1.46/v0.1.47)

- Revisor: `fixes_summary {repoint: 0, rephrase: 0, drop: 1, skip: 0}` — dropped the surplus marker, ignored the `clm-005` repoint trap, applied the surviving-sibling `draft_sentence` bookkeeping.
- Re-verify: `{verbatim: 1, paraphrase: 1, unsupported: 0, total: 2}` — **0 unsupported** in one round.

## Notes for the reviewer

- **Not run by bash CI** — exercising it needs the `revisor` + `wiki-verifier` LLM agents, which a stdlib bash test can't dispatch. The committed CI guard for #386/#404 remains the grep block in `tests/test_verify_contract.sh`. This is the behavioral counterpart.
- **Tests-only change — no version bump.** No skill/agent/script/structure touched, so `plugin.json` stays at `0.1.47`.
- The two `project/.metadata/*.json` inputs are committed via `git add -f` (the repo's broad `**/.metadata/` ignore targets live run state; these template inputs are deliberately exempt). Documented in the fixture README.

Refs #386, #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)