### PR TITLE
docs(cogni-knowledge): sync README architecture-tree script/reference counts

### DIFF
--- a/cogni-knowledge/README.md
+++ b/cogni-knowledge/README.md
@@ -173,8 +173,8 @@ cogni-knowledge/
 ├── LICENSE                       AGPL-3.0
 ├── _archive/                     Retired v0.0.x research+report chain (see _archive/README.md)
 ├── agents/                       12 forked + new pipeline agents
-├── references/                   7 framework + design docs
-├── scripts/                      9 utility scripts (binding, cycle-guard, fetch-cache, candidate-store, citation-store, concept-store, pipeline-summary, verify-store, wiki-coverage) + _knowledge_lib helper
+├── references/                   11 framework + design docs
+├── scripts/                      12 utility scripts (binding, cycle-guard, fetch-cache, candidate-store, citation-store, concept-store, question-store, ingest-integrity, pipeline-summary, verify-store, wiki-coverage, build-open-questions) + _knowledge_lib helper
 ├── skills/                       13 knowledge-* skills
 └── tests/                        Contract tests (one per phase)
 ```


### PR DESCRIPTION
doc-generate sync after #420 landed `scripts/ingest-integrity.py`.

The README Architecture tree carried two stale auto-generated count annotations (scripts aren't in the Components table, so the integrity-sweep PR didn't surface them):

- `scripts/` — said **9**, actually **12** (was missing `question-store` #407, `ingest-integrity` #413, and `build-open-questions`).
- `references/` — said **7**, actually **11** (pre-existing drift from earlier slices).

Tree annotations only — no prose, skill, or agent change. Components/What-it-does/Quick-start are unaffected (no skills/agents added or renamed by #420).

🤖 Generated with [Claude Code](https://claude.com/claude-code)