### PR TITLE
docs: document the maintainer-breadcrumb guard in contributing guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,4 +158,5 @@ Managed by `cogni-workspace:install-mcp`. Plugin `.mcp.json` files reference ins
 - CLA required on first PR to core plugins (CLA Assistant bot prompts on PR)
 - Feature branches from `main`; one feature or fix per PR
 - Validate skill names with `cogni-workspace/scripts/check-skill-names.sh` before PR
+- Keep maintainer breadcrumbs out of SKILL.md / agent files — `scripts/check-breadcrumbs.py` (CI: "Maintainer-breadcrumb guard" in `.github/workflows/lint.yml`) fails on newly introduced issue/PR refs (`#NNN`), version tags, or milestone/slice/finding codes. It ratchets against `scripts/baselines/breadcrumb-baseline.json`, so only *new* breadcrumbs trip it; fix by removing the breadcrumb and stating the rationale semantically (provenance lives in git history, CHANGELOG, and `references/`)
 - Generic skill names (`setup`, `scan`, `resume`, `dashboard`, `verify`) must be prefixed with the domain term

--- a/docs/contributing/plugin-development.md
+++ b/docs/contributing/plugin-development.md
@@ -277,6 +277,8 @@ Your plugin must satisfy the quality standards in [MARKETPLACE_TERMS.md](https:/
 
 Run `cogni-workspace/scripts/check-skill-names.sh` to validate your skill names against the naming convention.
 
+Run `scripts/check-breadcrumbs.py` to confirm your `SKILL.md` and agent files carry no maintainer breadcrumbs — issue/PR refs (`#NNN`), plugin-version tags, or milestone/slice/finding codes. The **Maintainer-breadcrumb guard** CI check (`.github/workflows/lint.yml`) enforces this on every PR. It ratchets against `scripts/baselines/breadcrumb-baseline.json`, so it fails only on *newly introduced* breadcrumbs; the fix is to remove the breadcrumb and state the rationale semantically, keeping provenance in git history, CHANGELOG, or `references/` rather than in the prompt the model executes. Use a per-line `breadcrumb-guard:allow` marker only for a genuine false positive (e.g. an Apple M-series chip name).
+
 ### Marketplace Entry
 
 To list your plugin, submit a PR to the insight-wave repository that adds your plugin to `marketplace.json`. The entry format is:


### PR DESCRIPTION
Closes #440.

## Context

The deterministic maintainer-breadcrumb guard that #440 requested **already exists** and is CI-enforced — `scripts/check-breadcrumbs.py`, wired into the "Maintainer-breadcrumb guard" job in `.github/workflows/lint.yml` (it ran and passed on PR #439, which prompted the advisory). It catches newly-introduced issue/PR refs (`#NNN`), version tags, and milestone/slice/finding codes in `*/skills/*/SKILL.md` + `*/agents/*.md`, ratcheting against a baseline so only *new* breadcrumbs trip it.

The only unmet acceptance item from #440 was that the guard was **undocumented** — `grep check-breadcrumbs` found zero hits in `CLAUDE.md` or `docs/`. This PR closes that gap.

## Changes

- `CLAUDE.md` §Contributing — one bullet documenting the guard alongside the existing `check-skill-names.sh` bullet (ratchet behavior + semantic-provenance fix).
- `docs/contributing/plugin-development.md` — a paragraph after the `check-skill-names.sh` line covering the guard, the CI enforcement, the baseline ratchet, and the `breadcrumb-guard:allow` per-line escape hatch.

Documentation only — no code, no plugin version bump (repo-root docs are not plugin-versioned). The breadcrumb guard itself stays green (the touched files are not in its `SKILL.md`/agent scan scope).
