### PR TITLE
[cogni-service remote-test] cogni-knowledge: Phase 3.5 post-write id read-back in source-ingester

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/agents/source-ingester.md
+++ b/cogni-knowledge/agents/source-ingester.md
@@ -152,6 +152,18 @@ if obs_id != slug or normalize_url(obs_src) != normalize_url(url) or Path(os.env
     sys.stderr.write(f"integrity_mismatch: id={obs_id!r} slug={slug!r} src={obs_src!r} url={url!r}\n")
     sys.exit(3)
 atomic_write_text(Path(os.environ["PAGE_PATH"]), page)
+# Phase 3.5 post-write read-back — thin guard against a bug in the pre-write
+# assertion's own Python code path. The file is now on disk; re-read and confirm
+# id == SLUG. On mismatch the page IS on disk; Step 3.5 sweep quarantines it on
+# the next wave. Exit 4 is distinct from exit 3 (pre-write mismatch) for diagnosis.
+written_id, _ = extract_page_id_and_url(
+    Path(os.environ["PAGE_PATH"]).read_text(encoding="utf-8")
+)
+if written_id != slug:
+    sys.stderr.write(
+        f"post_write_check_failed: written_id={written_id!r} slug={slug!r}\n"
+    )
+    sys.exit(4)
 '
 ```
 
@@ -191,6 +203,8 @@ For the skip cases (cache miss / unavailable / empty body / slug collision / int
 
 `reason: integrity_mismatch` is the value when the Phase 3 pre-write assertion fails (the composed page's `id:` / `sources:` URL did not match the dispatched `SLUG` / `URL`, or the wrapper exited 3) — the page was never written. The orchestrator's Step 3.5 sweep is the deterministic backstop for the same failure; this in-agent fail-fast simply stops most of it before disk.
 
+`reason: post_write_id_check_failed` is the value when the Phase 3.5 post-write read-back fails: `atomic_write_text` completed but the re-read `id:` on disk does not equal `SLUG` (the wrapper exited 4, distinct from exit 3). Unlike `integrity_mismatch`, the page IS on disk; the orchestrator's Step 3.5 sweep quarantines it on the next run. Emit the Phase 4 envelope as `ok: false` with this reason so the orchestrator accounts for the source.
+
 `summary` is one crisp, self-contained sentence describing what the page is about, derived from the body — a complete thought, never truncated mid-word, no leading/trailing whitespace. Use **regular spaces** between words — never a typographic dagger (`†` U+2020 / `‡` U+2021) or a non-breaking/exotic space (U+00A0/U+202F/U+2009) where a normal space belongs (these render oddly as `§†30` / `Dezember†2025` in the index one-liner). The orchestrator runs `_knowledge_lib.sanitize_summary` to normalize any such stray glyph before storage and passes the result to `wiki_index_update.py --summary`, which applies a defensive word-boundary clamp as a backstop — but clean authoring keeps the batch envelope itself clean.
 
 Return a compact summary to the calling Task:
@@ -213,3 +227,4 @@ Return a compact summary to the calling Task:
 - An exception while ingesting one source must produce an `ok: false` batch envelope, not a crash. The orchestrator continues with the remaining sources.
 - A claim-extractor failure (`{"ok": false, …}`) does NOT block the page write — write the page with an empty `pre_extracted_claims:` list and surface the extractor's error in the batch envelope's `notes` field.
 - Temp files (body, page) are removed at end of dispatch (`trap rm -f "$TMP" EXIT` or equivalent). Leftover `.tmp` is tolerable but unsightly.
+- Exit 4 (post-write `id:` check) complements exit 3 (pre-write integrity mismatch): exit 4 means the page reached disk but its `id:` does not match `SLUG`; Step 3.5 sweep remains the deterministic backstop for both.

--- a/cogni-knowledge/tests/test_ingest_contract.sh
+++ b/cogni-knowledge/tests/test_ingest_contract.sh
@@ -177,6 +177,8 @@ assert_grep 'sanitize_summary' "$INGESTER" "source-ingester: names the orchestra
 assert_grep 'integrity' "$INGESTER" "source-ingester: documents the pre-write integrity assertion (#413)"
 assert_grep 'sys.exit(3)' "$INGESTER" "source-ingester: pre-write guard exits 3 on mismatch, writes nothing (#413)"
 assert_grep 'integrity_mismatch' "$INGESTER" "source-ingester: emits skip reason integrity_mismatch (#413)"
+assert_grep 'sys.exit(4)' "$INGESTER" "source-ingester: post-write read-back exits 4 on id mismatch"
+assert_grep 'post_write_id_check_failed' "$INGESTER" "source-ingester: names post_write_id_check_failed reason"
 # Frontmatter tools must not include WebFetch (re-fetch is forbidden in Phase 4).
 INGESTER_TOOLS_LINE=$(grep '^tools:' "$INGESTER" || true)
 if ! echo "$INGESTER_TOOLS_LINE" | grep -q WebFetch; then


### PR DESCRIPTION
<!-- cogni-service:remote-impl-test v0 issue=#417 -->

## Summary

- Adds an 8-line Phase 3.5 post-write read-back block inside the `source-ingester` Phase 3 Python write wrapper: after `atomic_write_text` completes, re-reads the page from disk and asserts the on-disk `id:` equals `SLUG`. On mismatch, emits `post_write_check_failed` to stderr and exits 4 (distinct from the pre-write guard's exit 3).
- Documents `reason: post_write_id_check_failed` in the Phase 4 skip-reason prose and adds an exit-4 bullet to the Failure-mode invariants.
- Adds two `assert_grep` assertions to `test_ingest_contract.sh` covering `sys.exit(4)` and `post_write_id_check_failed`.
- Bumps `cogni-knowledge` version `0.1.59 → 0.1.60` in `plugin.json` and `marketplace.json`.

Refs #417

## Assumptions (plan open questions)

**Open question 2 — exit-4 semantics:** soft path chosen. The page is already on disk when exit 4 fires (the pre-write Guard 1 passed and `atomic_write_text` completed), so a hard abort would leave the dispatch state unaccounted. Exit 4 emits `ok: false, reason: post_write_id_check_failed`; Step 3.5 sweep is the deterministic backstop that quarantines it on re-run.

**Open question 3 — URL re-check scope:** `id:`-only. The URL is already covered by the pre-write assertion (Guard 1); the post-write check closes only the residual risk of a bug in Guard 1's own Python code path on the `id:` field, which was the specific field that drifted in #415.

## Note

This PR was filed autonomously by a remote routine as a step-3→4 feasibility test of the cogni-service local→remote workflow and is safe for the maintainer to close. It does not supersede the maintainer's existing decision to close #417 as resolved by #413/#420 — it implements the plan that was approved as a workflow test regardless of issue disposition.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGPj4q8M1LkRqEFWHFAR7Q)_