### PR TITLE
docs: sync 6 plugins with code reality

### DIFF
--- a/cogni-copywriting/README.md
+++ b/cogni-copywriting/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-A [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai/cowork) plugin that turns AI-generated drafts into executive-ready documents. Seven messaging frameworks, five parallel stakeholder personas for blind-spot review, multilingual readability validation (Flesch-family scoring for DE/EN/FR/IT/PL/NL/ES, plus German Wolf Schneider), and Power Positions sales enhancement — while preserving upstream story arc structure from cogni-narrative. A `copy-json` adapter polishes text fields inside JSON files, and `audit-copywriter` verifies arc contracts stay in sync with cogni-narrative upstream.
+A [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai/cowork) plugin that turns AI-generated drafts into executive-ready documents. Seven messaging frameworks, five parallel stakeholder personas for blind-spot review, multilingual readability validation (Flesch-family scoring for DE/EN/FR/IT/PL/NL/ES, plus German Wolf Schneider), translate-then-polish across those same seven languages via an EN/DE pivot, and Power Positions sales enhancement — while preserving upstream story arc structure from cogni-narrative. A `copy-json` adapter polishes text fields inside JSON files, and `audit-copywriter` verifies arc contracts stay in sync with cogni-narrative upstream.
 
 ## Why this exists
 
@@ -154,7 +154,8 @@ cogni-copywriting/
 └── copywriter-workspace/         Evaluation and iteration workspace
     ├── evals/
     ├── iteration-1/
-    └── test-docs/
+    ├── test-docs/
+    └── test-fixtures/
 ```
 
 ## Dependencies

--- a/cogni-narrative/README.md
+++ b/cogni-narrative/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-The story arc engine for the insight-wave ecosystem — transforms structured research and portfolio output into executive-grade narratives using 11 arc frameworks (Corporate Visions, JTBD Portfolio, Strategic Foresight, Trend Panorama, and seven more) and 8 narrative techniques, sitting between cogni-research and cogni-copywriting in the pipeline and feeding cogni-visual, cogni-sales, and cogni-marketing downstream. Bilingual EN/DE.
+The story arc engine for the insight-wave ecosystem — transforms structured research and portfolio output into executive-grade narratives using 11 arc frameworks (Corporate Visions, JTBD Portfolio, Strategic Foresight, Trend Panorama, and seven more) and 8 narrative techniques, with review scoring (0–100, A–F) and derivative formats (executive brief, talking points, one-pager), sitting between cogni-research and cogni-copywriting in the pipeline and feeding cogni-visual, cogni-sales, and cogni-marketing downstream. Bilingual EN/DE.
 
 ## Why this exists
 

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -189,7 +189,8 @@ cogni-portfolio/
 ├── hooks/                        1 guardrail hook (Excalidraw canvas auto-start)
 ├── references/
 │   └── data-model.md             Full entity schema and project structure reference
-└── scripts/                      18 utility scripts
+├── scripts/                      18 utility scripts
+└── tests/                        Entity-validation test harness
 ```
 
 ## Dependencies

--- a/cogni-visual/README.md
+++ b/cogni-visual/README.md
@@ -128,7 +128,7 @@ The pipeline follows a compose-polish-visualize flow: narratives from cogni-narr
 
 ```
 cogni-visual/                              # 7 skills · 19 agents · 6 commands · 1 hook
-├── .claude-plugin/                        Plugin manifest (v0.16.23)
+├── .claude-plugin/                        Plugin manifest (v0.16.24)
 ├── skills/                               7 visual skills (4 brief generators · 1 renderer · 1 enricher · 1 reviewer)
 │   ├── story-to-slides/
 │   ├── story-to-web/

--- a/cogni-wiki/README.md
+++ b/cogni-wiki/README.md
@@ -170,6 +170,8 @@ cogni-wiki/
 │   ├── claude-research-karparthy.md RAG vs wiki benchmark research
 │   └── scheduled-drainer/           T3.2 scheduled-runner deployment shapes (v0.0.39+)
 ├── foundations/                    Curated terminal concept pages (foundation: true)
+├── docs/                            Design + planning notes (docs/plans/)
+├── tests/                           Contract + integration tests (tests/fixtures/)
 └── skills/                          12 wiki skills
     ├── wiki-setup/                  Bootstrap a new wiki
     ├── wiki-ingest/                 Ingest sources into wiki pages

--- a/docs/plugin-guide/cogni-trends.md
+++ b/docs/plugin-guide/cogni-trends.md
@@ -115,7 +115,7 @@ What happens:
 }
 ```
 
-From there: `/value-modeler` → `/trend-report` → `/trends-catalog`.
+From there: `/value-modeler` → `/trend-research` → `/trend-synthesis` → `/trends-catalog`.
 
 ---
 
@@ -137,11 +137,35 @@ Transform agreed candidates into investment themes and ranked solution templates
 
 ---
 
-### trend-report
+### trend-research
 
-Generate a CxO-level narrative report organized around investment themes. Dispatches one `trend-report-investment-theme-writer` agent per theme in parallel — each writes a narrative section using the Corporate Visions arc (Why Change → Why Now → Why You → Why Pay) backed by T→I→P→S evidence. Enriches every quantitative claim with web-sourced evidence and inline citations. Assembles the final report with executive summary, portfolio analysis, and a verifiable claims registry compatible with cogni-claims.
+Run the research groundwork stage of the TIPS pipeline. Reads the agreed trend-scout candidates, optionally performs recursive deep research on 3–5 high-value ACT-horizon trends, then dispatches four parallel `trend-report-writer` agents to enrich every candidate with web-sourced quantitative evidence and extract verifiable claims. Produces per-dimension enriched-trends and claims artefacts plus a single research manifest (`.metadata/trend-research-output.json`) that the synthesis and booklet skills consume.
 
-**Example prompt:** "Generate the trend report from the modeled investment themes"
+**Example prompt:** "Run the research stage for the modeled investment themes"
+
+---
+
+### trend-synthesis
+
+Compose the canonical TIPS report from the research artefacts. The report is always organized around the four Smarter Service dimensions (Forces → Impact → Horizons → Foundations) as H2 sections, with investment themes nested as anchored H3 cases in a slim 3-beat structure (Stake / Move / Cost-of-Inaction) and a closing "Capability Imperative" synthesis. The four dimensions form a single CxO story arc.
+
+**Example prompt:** "Synthesize the trend report from the research output"
+
+---
+
+### trend-booklet
+
+Build a comprehensive, browsable TIPS booklet that catalogs every trend-scout candidate (~60) organized by Smarter Service dimension → subcategory → horizon, with per-entry summary, key citations, theme back-references, and keywords. It is the companion catalog to the canonical themes report — surfacing *all* candidates, including the ones that didn't make it into a theme-case (orphans go in an appendix), so readers see the full landscape behind the report's curated argument.
+
+**Example prompt:** "Generate the full trend booklet for this project"
+
+---
+
+### verify-trend-report
+
+Run the extended quality pipeline on a generated report — verify every claim against its cited source via cogni-claims, run cross-theme structural review, apply corrections through the revisor, then surface downstream polish and visualization options. Use it after synthesis to fact-check and tighten the report before it ships.
+
+**Example prompt:** "Verify the claims in the trend report and fix any deviations"
 
 ---
 
@@ -184,7 +208,7 @@ Re-enter a project mid-stream. Reads project state, shows phase progress and ent
 |--------|-------|-----------------|
 | cogni-portfolio | trends-bridge | Solution templates exported as portfolio features |
 | cogni-narrative | (manual) | Trend report and insight summary as narrative input |
-| cogni-claims | trend-report | Claims registry submitted for source URL verification |
+| cogni-claims | verify-trend-report | Claims registry submitted for source URL verification |
 | cogni-copywriting | (manual) | Report prose for executive polish |
 | cogni-visual | story-to-slides | Trend report narratives as slide deck input |
 
@@ -194,13 +218,15 @@ Re-enter a project mid-stream. Reads project state, shows phase progress and ent
 
 ### Workflow 1: Full TIPS Pipeline
 
-The standard four-stage sequence for a new industry engagement.
+The standard sequence for a new industry engagement.
 
 1. `/trend-scout` — industry selection, bilingual web research, 60 candidates
 2. Review and agree on candidates (interactive checkpoint)
 3. `/value-modeler` — investment themes, T→I→P→S networks, solution blueprints, BR scoring
-4. `/trend-report` — CxO narrative with parallel theme writers, evidence enrichment, claims registry
-5. `/trends-catalog` — promote curated solutions to the industry catalog
+4. `/trend-research` — evidence enrichment and claim extraction across the four dimensions
+5. `/trend-synthesis` — CxO narrative report organized around the Smarter Service dimensions
+6. `/verify-trend-report` — verify claims against sources and apply corrections
+7. `/trends-catalog` — promote curated solutions to the industry catalog
 
 For the extended flow that connects trend output to portfolio messaging and solution blueprints, see [../workflows/trends-to-solutions.md](../workflows/trends-to-solutions.md).
 
@@ -214,7 +240,7 @@ Use this when existing portfolio messaging needs to be refreshed against current
 2. `/value-modeler` — model investment themes, anchor to portfolio products via cogni-portfolio
 3. `/trends-bridge` (in cogni-portfolio) — import TIPS solution templates as new portfolio features
 4. `/propositions` (in cogni-portfolio) — generate messaging for the new Feature x Market pairs
-5. `/trend-report` — generate a briefing document for internal stakeholders
+5. `/trend-synthesis` — generate a briefing document for internal stakeholders
 
 ---
 
@@ -222,10 +248,10 @@ Use this when existing portfolio messaging needs to be refreshed against current
 
 Use this when you have a completed trend report and need to transform it into visual and narrative deliverables.
 
-1. `/trend-report` — complete the trend report with evidence and claims
+1. `/trend-synthesis` — compose the trend report from research evidence and claims
 2. cogni-narrative `/narrative` — transform the report into an arc-driven narrative
 3. cogni-visual `/story-to-slides` — create a slide deck from the narrative
-5. cogni-claims `/claims` — verify the claims registry
+4. cogni-claims `/claims` — verify the claims registry
 
 ---
 
@@ -233,7 +259,7 @@ Use this when you have a completed trend report and need to transform it into vi
 
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
-| "No TIPS project found" | Running value-modeler or trend-report without completing trend-scout | Run `/trend-scout` first or use `/trends-resume` to find an existing project |
+| "No TIPS project found" | Running value-modeler or trend-research without completing trend-scout | Run `/trend-scout` first or use `/trends-resume` to find an existing project |
 | Web research returns few results | Industry subsector too narrow | Try a broader subsector during the trend-scout selection step |
 | Candidate scores all low | Research signals are weak or mixed for this horizon | Accept candidates at Act horizon first; Observe-horizon candidates are inherently speculative |
 | Investment themes overlap | Too many candidates per dimension | Reduce to the 10–15 highest-scoring candidates before running value-modeler |


### PR DESCRIPTION
Branch: docs/sync-drift-2026-06-03

## Summary
- Sync architecture trees with code reality for cogni-copywriting, cogni-portfolio, cogni-visual, cogni-wiki (missing directories + a stale version annotation)
- Realign README lead pitches for cogni-copywriting (translate-then-polish pivot) and cogni-narrative (review scoring + derivative formats) with plugin.json / marketplace.json
- Refresh the stale cogni-trends plugin guide (was 6 of 9 skills) to cover trend-research, trend-synthesis, trend-booklet, verify-trend-report
- Defer cogni-knowledge MEANS messaging for human / `doc-power` review

## Plugins fixed
- **cogni-copywriting** — architecture (`copywriter-workspace/test-fixtures/` added to tree) + descriptions (README pitch now names translate-then-polish across DE/EN/FR/IT/PL/NL/ES via EN/DE pivot, matching plugin.json/marketplace.json)
- **cogni-narrative** — descriptions (README pitch now names review scoring 0–100/A–F and derivative formats: executive brief, talking points, one-pager)
- **cogni-portfolio** — architecture (`tests/` directory added to tree)
- **cogni-trends** — docs/ (plugin guide now lists all 9 skills and the research → synthesis → verify split; workflow/troubleshooting references updated off the retired `/trend-report`)
- **cogni-visual** — architecture (manifest annotation v0.16.23 → v0.16.24, matches plugin.json)
- **cogni-wiki** — architecture (`docs/` incl. `docs/plans/` and `tests/` incl. `tests/fixtures/` added to tree)

## Plugins deferred
- **cogni-knowledge** — WEAK messaging: missing `## What it means for you` (MEANS) section. Hand-written IS/DOES/MEANS editorial work, out of scope for an autonomous structural sweep. Run `/doc-power cogni-knowledge`.

## Notes on two false positives (no change made, by design)
- **cogni-trends architecture** — the pre-audit flagged "6 → 7 utility scripts". The 7th entry is a git-ignored `__pycache__` directory; the README's "6 utility scripts" is correct, so `cogni-trends/README.md` was intentionally left unchanged.
- **cogni-wiki components/architecture (post-audit)** — a re-audit pass counted `skills/wiki-ingest-workspace/` as a 13th skill. That directory is git-ignored with no `SKILL.md` (a local evals workspace); there are exactly 12 real skills, so the README's "12 wiki skills" is correct and was not touched.

## Test plan
- [ ] Re-run `/cogni-docs:doc-audit all` on this branch and confirm the architecture/descriptions/docs drift for the 6 fixed plugins is gone
- [ ] Confirm the cogni-trends plugin guide lists all 9 skills with the research → synthesis → verify ordering
- [ ] Verify cogni-knowledge is untouched in the diff
- [ ] Confirm no unrelated plugins or sections were modified

## Open questions
- `references/pipeline-registry.json` is DRIFT (+33 skills unmapped incl. 16 cogni-knowledge skills, −1 removed `trend-report`) — owned by `/doc-meta --apply` in the cogni-docs source repo (managed-service), out of scope for this insight-wave docs PR. Run `/doc-meta --apply --file pipeline-registry` against the source repo separately.
- cogni-knowledge needs a hand-written `## What it means for you` (MEANS) section — `/doc-power` can draft business-outcome candidates, but a human should pick the voice before it ships.

## Automated review — ✅ PASS (open as draft — escalations present)

### Completeness
6 of 6 planned plugins verified clean in the post-audit.
- cogni-copywriting: architecture (`test-fixtures/` added) + descriptions (translate-then-polish pivot added) — cleared
- cogni-narrative: descriptions (review scoring 0–100/A–F + derivative formats added) — cleared
- cogni-portfolio: architecture (`tests/` added) — cleared
- cogni-visual: architecture (manifest annotation v0.16.23 → v0.16.24, matches plugin.json) — cleared
- cogni-wiki: architecture (`docs/` + `tests/` added) — cleared
- cogni-trends: docs/ (plugin guide now lists all 9 skills) — cleared

### Regressions
None. Two flagged items verified as git-ignored false positives, not regressions:
- cogni-wiki post-audit "13th skill" (`wiki-ingest-workspace`): git-ignored, no SKILL.md — confirmed exactly 12 real skills; README untouched on skills count.
- cogni-trends architecture "6 → 7 scripts": 7th entry is `__pycache__` (git-ignored); 6 tracked scripts confirmed; cogni-trends/README.md correctly unchanged.

### Suggested next step
Merge-clean on the structural sweep. Shipped as draft (`ready_hint=false`) so the human can action the two open questions before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
