### PR TITLE
fix(cogni-knowledge): documented citation-store.py build passed empty --records (#455)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/CHANGELOG.md
+++ b/cogni-knowledge/CHANGELOG.md
@@ -24,6 +24,11 @@ directory: '<cwd>'`. Run verbatim, the documented compose/verify pipeline step f
   populates, and keep an apostrophe-bearing path out of the interpolated Python source literal).
 - **No script change** — `citation-store.py` is correct; `tests/test_citation_store.sh` already calls
   `build` with quoted literal `--records` args.
+- **Regression guard** — `tests/test_compose_contract.sh` + `tests/test_verify_contract.sh` now assert
+  the Step 4.5 / Step 3.3 build block passes `--records` as a quoted literal path AND carries no
+  command-prefix `RECORDS_PATH="` assignment, so the env-var antipattern cannot silently return on a
+  future edit (the corrected rationale prose names `RECORDS_PATH=…` / `"$RECORDS_PATH"` — neither
+  matches the `="` assignment anchor, so the prose is not a false positive).
 
 ## 0.1.65 — 2026-06-03 — feat: charter re-frame / update path — #451
 

--- a/cogni-knowledge/CHANGELOG.md
+++ b/cogni-knowledge/CHANGELOG.md
@@ -1,5 +1,30 @@
 # cogni-knowledge changelog
 
+## 0.1.66 — 2026-06-03 — fix: documented `citation-store.py build` passed empty `--records` (env-var-prefix antipattern) — #455
+
+The `citation-store.py build` invocation documented in `knowledge-compose` Step 4.5 (and the identical
+post-revisor rebuild in `knowledge-verify` Step 3.3) used a **command-prefix env-var antipattern** —
+it set `RECORDS_PATH=…/DRAFT_PATH=…/…` as a temporary command prefix and then referenced them as
+`--records "$RECORDS_PATH"` CLI args on the **same** command line. Per POSIX, the shell expands
+`"$RECORDS_PATH"` against the *current* environment (where the var is still unset) **before** applying
+the prefix assignments and exec'ing the child, so `--records` received an empty string. The script
+declares `--records` as a required argparse flag with no `os.environ` fallback, so the empty path
+resolved to the cwd and the build aborted with `records file is not readable: [Errno 21] Is a
+directory: '<cwd>'`. Run verbatim, the documented compose/verify pipeline step failed.
+
+- **`skills/knowledge-compose/SKILL.md`** (Step 4.5) and **`skills/knowledge-verify/SKILL.md`**
+  (Step 3.3) — the build block now passes `--records` / `--draft` / `--out` / `--ingest-manifest` as
+  **quoted literal paths** (`--records "<project_path>/.metadata/citation-records-v<N>.txt"`, …),
+  dropping the four `RECORDS_PATH=…/DRAFT_PATH=…/OUT_PATH=…/INGEST_PATH=…` prefix lines. A quoted
+  literal is already one space-/apostrophe-safe argv element, so the indirection was both unnecessary
+  and broken on a CLI flag. The misleading "paths via env vars so the literal can't break" rationale is
+  corrected to state why the prefix form expands to empty.
+- The sibling `python3 -c '… os.environ["RECORDS_PATH"] …'` blocks in the same SKILLs are **unchanged**
+  — env vars are correct and necessary there (they read from the child process environment the prefix
+  populates, and keep an apostrophe-bearing path out of the interpolated Python source literal).
+- **No script change** — `citation-store.py` is correct; `tests/test_citation_store.sh` already calls
+  `build` with quoted literal `--records` args.
+
 ## 0.1.65 — 2026-06-03 — feat: charter re-frame / update path — #451
 
 v0.1.63 (#449) added the base **charter** (`{domain, audience, scope, framed_at}` in

--- a/cogni-knowledge/skills/knowledge-compose/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-compose/SKILL.md
@@ -180,16 +180,15 @@ Parse the return envelope:
 
 ### 4.5 Build citation-manifest.json from the composer's records
 
-The composer wrote a raw-text **citation-records** file (`<project_path>/.metadata/citation-records-v<N>.txt`), never JSON — so a `draft_sentence` containing a straight `"` (routine in German/FR/IT/ES/PL prose) can't break the manifest. Serialize and self-check the manifest with `citation-store.py build`. Paths go via env vars so spaces / apostrophes in project paths can't break the literal:
+The composer wrote a raw-text **citation-records** file (`<project_path>/.metadata/citation-records-v<N>.txt`), never JSON — so a `draft_sentence` containing a straight `"` (routine in German/FR/IT/ES/PL prose) can't break the manifest. Serialize and self-check the manifest with `citation-store.py build`. Pass each path as a **quoted literal CLI arg** — a quoted string is one space-/apostrophe-safe argv element, so quoting alone is sufficient. Do **not** wrap this in a command-prefix env-var form (`RECORDS_PATH=… python3 … --records "$RECORDS_PATH"`): the shell expands `"$RECORDS_PATH"` against the *current* environment — where the var is still unset — **before** applying the prefix assignment and exec'ing, so `--records` would receive an empty string and the build aborts resolving the cwd as the records path.
 
 ```
-RECORDS_PATH="<project_path>/.metadata/citation-records-v<N>.txt" \
-DRAFT_PATH="<project_path>/output/draft-v<N>.md" \
-OUT_PATH="<project_path>/.metadata/citation-manifest.json" \
-INGEST_PATH="<project_path>/.metadata/ingest-manifest.json" \
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/citation-store.py build \
-    --records "$RECORDS_PATH" --draft "$DRAFT_PATH" --out "$OUT_PATH" --draft-version <N> \
-    --ingest-manifest "$INGEST_PATH"
+    --records "<project_path>/.metadata/citation-records-v<N>.txt" \
+    --draft "<project_path>/output/draft-v<N>.md" \
+    --out "<project_path>/.metadata/citation-manifest.json" \
+    --draft-version <N> \
+    --ingest-manifest "<project_path>/.metadata/ingest-manifest.json"
 ```
 
 `citation-store.py build` parses the records, `json.dumps` the manifest (`ensure_ascii=False` — escaping owned by the serializer, never the LLM), asserts every `draft_sentence` is a verbatim substring of the draft, **asserts every inline citation URL is a known ingested-source URL** (the `--ingest-manifest` gate; the composer must copy each cited page's real `sources:` URL, never reconstruct it from the slug), and round-trips the file it wrote (`json.loads` + count). Parse the envelope:

--- a/cogni-knowledge/skills/knowledge-verify/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-verify/SKILL.md
@@ -318,16 +318,15 @@ Task(revisor,
 
 Parse the return envelope:
 
-- `ok: true` → **build the manifest from the revisor's records.** The revisor wrote `citation-records-v<NEW_DRAFT_VERSION>.txt`, not the manifest (so a rephrased German `„…"` sentence can't break `json.loads`). Serialize + self-check it exactly as Phase 5 does (paths via env vars):
+- `ok: true` → **build the manifest from the revisor's records.** The revisor wrote `citation-records-v<NEW_DRAFT_VERSION>.txt`, not the manifest (so a rephrased German `„…"` sentence can't break `json.loads`). Serialize + self-check it exactly as Phase 5 does — pass each path as a **quoted literal CLI arg**, never a command-prefix env-var form (a `RECORDS_PATH=… python3 … --records "$RECORDS_PATH"` prefix expands `"$RECORDS_PATH"` before the assignment takes effect, so `--records` gets an empty string and the build aborts):
 
   ```
-  RECORDS_PATH="<project_path>/.metadata/citation-records-v<NEW_DRAFT_VERSION>.txt" \
-  DRAFT_PATH="<project_path>/output/draft-v<NEW_DRAFT_VERSION>.md" \
-  OUT_PATH="<project_path>/.metadata/citation-manifest.json" \
-  INGEST_PATH="<project_path>/.metadata/ingest-manifest.json" \
   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/citation-store.py build \
-      --records "$RECORDS_PATH" --draft "$DRAFT_PATH" --out "$OUT_PATH" --draft-version <NEW_DRAFT_VERSION> \
-      --ingest-manifest "$INGEST_PATH"
+      --records "<project_path>/.metadata/citation-records-v<NEW_DRAFT_VERSION>.txt" \
+      --draft "<project_path>/output/draft-v<NEW_DRAFT_VERSION>.md" \
+      --out "<project_path>/.metadata/citation-manifest.json" \
+      --draft-version <NEW_DRAFT_VERSION> \
+      --ingest-manifest "<project_path>/.metadata/ingest-manifest.json"
   ```
 
   `build` `json.dumps` the records into `citation-manifest.json`, asserts every `draft_sentence` is a verbatim substring of `draft-v<NEW_DRAFT_VERSION>.md` (which doubly catches a revisor whose `Edit` didn't land the rephrased sentence verbatim), and — via the `--ingest-manifest` gate — asserts every inline citation URL is a known ingested-source URL (so a revisor that re-introduced a slug-derived URL on a rephrase round can't ship it). On `success: false` — e.g. `error: "write_failed"` with `failed_check: "sentence_not_in_draft"` (a revised sentence is not in the draft), `duplicate_id`, or `url_not_in_sources` (an inline URL is not a real ingested source) — surface `error` + `data` verbatim and **stop**; the prior `verify-v<CURRENT_DRAFT_VERSION>.json` remains the latest valid audit trail. On `success: true`, continue.

--- a/cogni-knowledge/tests/test_compose_contract.sh
+++ b/cogni-knowledge/tests/test_compose_contract.sh
@@ -59,6 +59,16 @@ assert_grep 'dcl=' "$COMPOSE" "knowledge-compose: Step 6 log line records dcl=<n
 # gate, issue #4). The '#325' marker tags the substring guard line.
 assert_grep 'citation-store.py' "$COMPOSE" "knowledge-compose: builds the manifest via citation-store.py (#325)"
 assert_grep 'verbatim substring of the draft' "$COMPOSE" "knowledge-compose: Step-5 asserts every draft_sentence is a verbatim substring of the draft"
+# #455: Step 4.5 must pass the build paths as quoted LITERAL CLI args, never a
+# command-prefix env-var form (`RECORDS_PATH=… python3 … --records "$RECORDS_PATH"`).
+# That form expands "$RECORDS_PATH" against the still-unset current environment
+# BEFORE the prefix assignment takes effect, so --records receives "" and the build
+# aborts resolving the cwd as the records path. The positive guard pins the fixed
+# literal shape; the negative guard catches the antipattern silently returning. The
+# `RECORDS_PATH="` anchor matches only the assignment form — the corrected rationale
+# prose names `RECORDS_PATH=…` / `"$RECORDS_PATH"`, neither of which contains `="`.
+assert_grep '\-\-records "<project_path>/.metadata/citation-records-v' "$COMPOSE" "knowledge-compose: Step 4.5 passes --records as a quoted literal path (#455)"
+assert_not_grep 'RECORDS_PATH="' "$COMPOSE" "knowledge-compose: Step 4.5 build has no command-prefix RECORDS_PATH= env-var (the #455 empty-arg antipattern)"
 # Match the actual log-line shape Step 6 emits (`## [DATE] compose | project=...`)
 # rather than the bare word `compose`, which would also match the filename,
 # skill name, and every doc paragraph.

--- a/cogni-knowledge/tests/test_verify_contract.sh
+++ b/cogni-knowledge/tests/test_verify_contract.sh
@@ -36,6 +36,16 @@ assert_grep 'verify-store.py merge' "$VERIFY" "knowledge-verify: merges fragment
 # #383: the revisor-round manifest rebuild cross-checks inline URLs against the ingest manifest.
 assert_grep 'citation-store.py build' "$VERIFY" "knowledge-verify: rebuilds the manifest via citation-store.py build"
 assert_grep 'ingest-manifest' "$VERIFY" "knowledge-verify: revisor-round build passes --ingest-manifest (#383 URL gate)"
+# #455: the Step 3.3 post-revisor rebuild must pass the build paths as quoted
+# LITERAL CLI args, never a command-prefix env-var form
+# (`RECORDS_PATH=… python3 … --records "$RECORDS_PATH"`) — that form expands
+# "$RECORDS_PATH" against the still-unset current environment before the prefix
+# assignment takes effect, so --records receives "" and the build aborts on the cwd.
+# Positive guard pins the fixed literal shape; negative guard catches the antipattern
+# returning. `RECORDS_PATH="` matches only the assignment form (the corrected prose
+# names `RECORDS_PATH=…` / `"$RECORDS_PATH"`, neither of which contains `="`).
+assert_grep '\-\-records "<project_path>/.metadata/citation-records-v' "$VERIFY" "knowledge-verify: Step 3.3 rebuild passes --records as a quoted literal path (#455)"
+assert_not_grep 'RECORDS_PATH="' "$VERIFY" "knowledge-verify: Step 3.3 rebuild has no command-prefix RECORDS_PATH= env-var (the #455 empty-arg antipattern)"
 assert_grep 'CITATIONS_PATH' "$VERIFY" "knowledge-verify: passes CITATIONS_PATH shard subset to each verifier"
 assert_grep 'VERIFY_OUT_PATH' "$VERIFY" "knowledge-verify: passes VERIFY_OUT_PATH fragment path to each verifier"
 # Completeness guard: merge must catch a crashed/under-populated shard rather


### PR DESCRIPTION
## Summary

Fixes #455. The `citation-store.py build` invocation documented in `knowledge-compose` Step 4.5 (and the identical post-revisor rebuild in `knowledge-verify` Step 3.3) used a **command-prefix env-var antipattern** that fails when run verbatim:

```
RECORDS_PATH="…" DRAFT_PATH="…" … \
python3 …/citation-store.py build --records "$RECORDS_PATH" --draft "$DRAFT_PATH" …
```

Per POSIX, the shell expands `"$RECORDS_PATH"` against the **current** environment (where the var is still unset) *before* applying the temporary prefix assignments and exec'ing the child. So `--records` receives an empty string. The script declares `--records` as a required `argparse` flag with **no `os.environ` fallback**, so the empty path resolves to the cwd and the build aborts:

```
records file is not readable: [Errno 21] Is a directory: '<cwd>'
```

## Fix

- **`skills/knowledge-compose/SKILL.md`** (Step 4.5) and **`skills/knowledge-verify/SKILL.md`** (Step 3.3) — the build block now passes `--records` / `--draft` / `--out` / `--ingest-manifest` as **quoted literal paths**, dropping the four `RECORDS_PATH=…/DRAFT_PATH=…/OUT_PATH=…/INGEST_PATH=…` prefix lines. A quoted literal is already one space-/apostrophe-safe argv element, so the indirection was both unnecessary and broken on a CLI flag. The misleading "paths via env vars so the literal can't break" rationale is corrected to explain why the prefix form expands to empty.
- The sibling `python3 -c '… os.environ["RECORDS_PATH"] …'` blocks in the same SKILLs are **left unchanged** — env vars are correct and necessary there (they read from the child process environment the prefix populates, and keep an apostrophe-bearing path out of the interpolated Python source literal).
- **No script change** — `citation-store.py` is correct; `tests/test_citation_store.sh` already calls `build` with quoted literal `--records` args.
- Version bump `0.1.65 → 0.1.66` (plugin.json + marketplace.json mirror) + CHANGELOG entry.

This matches the workaround the reporter used in their real run.

## Verification

- `bash cogni-knowledge/tests/test_compose_contract.sh` — ALL PASS
- `bash cogni-knowledge/tests/test_verify_contract.sh` — ALL PASS
- `bash cogni-knowledge/tests/test_citation_store.sh` — ALL PASS
- `python3 scripts/check-breadcrumbs.py` — `files_affected: 0` (no new issue refs in SKILL.md; `#455` lives only in CHANGELOG)
- Version mirror: plugin.json and marketplace.json both read `0.1.66`

Closes #455

https://claude.ai/code/session_01PNuoC7WRzszCpguHYDeSyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNuoC7WRzszCpguHYDeSyi)_