### PR TITLE
cogni-knowledge: make source-curator's candidate-store.py boundary explicit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/agents/source-curator.md
+++ b/cogni-knowledge/agents/source-curator.md
@@ -44,7 +44,7 @@ upstream at fork time; future tuning is local. See also
 
 ## Role
 
-You score and rank web-discovered source candidates for a single sub-question, then fetch each surviving candidate's body via WebFetch through the shared fetch-cache. You produce a JSON array of candidate objects (each carrying an optional `fetch` sub-object), written to a batch file the orchestrator (`knowledge-curate`) merges into `<project>/.metadata/candidates.json` via `candidate-store.py append-batch`.
+You score and rank web-discovered source candidates for a single sub-question, then fetch each surviving candidate's body via WebFetch through the shared fetch-cache. You produce a JSON array of candidate objects (each carrying an optional `fetch` sub-object), written to a batch file that the orchestrator (`knowledge-curate`) — not you — merges into `<project>/.metadata/candidates.json` via `candidate-store.py append-batch`. You never run that merge yourself.
 
 You **do not cobrowse**. Browser-assisted recovery of WebFetch misses is Phase 3 (`source-fetcher`), opt-in. You also do not extract claims — that is Phase 4 (`source-ingester`).
 
@@ -143,11 +143,11 @@ For each surviving candidate, emit an object with the following shape (per `refe
 
 - `score` is the composite (renamed from upstream `composite_score`).
 - `tier` is derived: `primary` if score >= 0.80, `secondary` if 0.50-0.79, `supporting` if < 0.50. (`candidate-store.py` recomputes after merge — emit the local tier for clarity.)
-- `sub_question_refs` always contains exactly `[SUB_QUESTION_ID]` from this curator. The merge step in `candidate-store.py` unions refs across curators if the same URL is discovered for multiple sub-questions.
+- `sub_question_refs` always contains exactly `[SUB_QUESTION_ID]` from this curator. The orchestrator's merge step (`candidate-store.py append-batch`, which you never run) unions refs across curators if the same URL is discovered for multiple sub-questions.
 - `publisher` is the registered domain (no subdomain) — `europa.eu`, not `eur-lex.europa.eu`.
 - `discovered_at` is the curator's now-timestamp in ISO 8601 UTC.
 - **Do not emit** `dimensions{}`, `annotation`, or `diversity{}`. Computation is internal to this curator.
-- **Do not emit** `fetch_priority`. `candidate-store.py` assigns it across all candidates at merge time.
+- **Do not emit** `fetch_priority`. The orchestrator's `candidate-store.py` merge assigns it across all candidates at merge time (you never run that merge).
 - The optional `fetch` sub-object is added per candidate in **Phase 4** below — do not write the batch file yet.
 
 Hold the scored, capped survivor list in memory and proceed to Phase 4.
@@ -284,5 +284,5 @@ Return a compact summary:
 - No claim extraction (Phase 4 / `source-ingester`).
 - No wiki writes (Phase 4).
 - No verification (Phase 6).
-- No direct write to `candidates.json` — only to the batch file the orchestrator merges through `candidate-store.py`.
+- **Never invoke `candidate-store.py`** (any subcommand — `append-batch`, `init`, `read`). You write **only** to `BATCH_OUTPUT_PATH`; the orchestrator (`knowledge-curate`) owns *every* merge into `candidates.json` (it runs `append-batch` once per sub-question after the wave returns). Pre-merging from inside the curator is a contract violation even though the merge is idempotent today — the "agents propose, orchestrator commits" boundary must hold so a future merge-semantics change (e.g. score accumulation) can't double-count. This prohibition is `candidate-store.py`-specific: you DO invoke `fetch-cache.py` in Phase 4 (the next bullet).
 - No bypass of `fetch-cache.py` — even the temp body file goes through `store`.


### PR DESCRIPTION
Closes #467.

## Summary
- Strengthen the `agents/source-curator.md` closing boundary bullet so it explicitly names `candidate-store.py` and makes the prohibition absolute: the curator must **never** invoke `candidate-store.py` (any subcommand — `append-batch` / `init` / `read`). It writes **only** to `BATCH_OUTPUT_PATH`; the orchestrator (`knowledge-curate`) owns *all* merges into `candidates.json`.
- Annotate the three descriptive merge mentions (the role paragraph, the `sub_question_refs` note, the `fetch_priority` note) so `candidate-store.py append-batch` / merge-union / `fetch_priority`-assignment read unambiguously as orchestrator-side behavior the curator describes but does not execute — removing the instruction-shaped phrasing that caused the drift.
- Bump `cogni-knowledge` `0.1.67 → 0.1.68` and mirror in `marketplace.json`.

## Why
After the curator fan-out, the orchestrator's per-sub-question `append-batch` for one sq reported "0 added" — its candidates were already present because the `source-curator` had run `append-batch` **itself**, whereas `knowledge-curate` Step 4 documents the merge as the orchestrator's responsibility. Harmless today (`append-batch` dedups by URL idempotently), but a real "agents propose, orchestrator commits" contract drift that could double-count or race if merge semantics ever change. This is suggested fix #1 from the issue (the smaller option that preserves the boundary), as adopted by triage.

## Scope decisions
- **In:** prompt-text hardening of `agents/source-curator.md` only + version bump + marketplace mirror.
- **Out (no change needed):** `knowledge-curate/SKILL.md` Step 4 already correctly documents the orchestrator as the sole owner of the merge — the contract was right; only the agent prompt drifted.
- **Deliberately precise:** the prohibition targets `candidate-store.py` specifically and leaves the curator's legitimate `fetch-cache.py` Phase-4 invocations untouched.

## Test plan
- [x] Boundary bullet now names `candidate-store.py` and states the curator never invokes it (any subcommand).
- [x] The three descriptive mentions now attribute the merge/union/`fetch_priority`-assignment explicitly to the orchestrator ("you never run that merge").
- [x] Curator's Phase-4 `fetch-cache.py` invocations unchanged.
- [x] `plugin.json` + the `cogni-knowledge` `marketplace.json` entry both read `0.1.68`.
- [x] `tests/test_skill_contracts.sh` and `tests/test_ingest_contract.sh` pass; both manifests valid JSON; no new `#NNN` issue ref introduced into the agent text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
