### PR TITLE
cogni-knowledge: set-charter help-ref + framed_at clearing-case nits

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/knowledge-binding.py
+++ b/cogni-knowledge/scripts/knowledge-binding.py
@@ -477,9 +477,15 @@ def cmd_set_charter(args: argparse.Namespace) -> int:
                 open_themes.append(theme)
                 themes_added += 1
 
-    # Re-stamp framed_at only when the base was actually re-steered (a
-    # domain/audience/scope change); an open-themes-only update is not a re-frame.
-    if changed_charter:
+    # Re-stamp framed_at only when the base was actually re-steered AND the
+    # resulting charter still carries >=1 non-empty steering field — mirroring
+    # init's invariant (framed_at distinguishes a real charter from a skeleton).
+    # An open-themes-only update is not a re-frame, and clearing the last
+    # steering field (e.g. --charter-domain "") must not stamp a fresh date onto
+    # what is now an effectively-unframed charter.
+    if changed_charter and (
+        charter.get("domain") or charter.get("audience") or charter.get("scope")
+    ):
         charter["framed_at"] = _today()
 
     written = _write_binding(knowledge_root, binding)
@@ -711,7 +717,7 @@ def main(argv: list[str]) -> int:
 
     p_upsert = sub.add_parser(
         "upsert-themes",
-        help="Merge question-node theme-lineage records into topic_lineage.covered_themes[] (#409)",
+        help="Merge question-node theme-lineage records into topic_lineage.covered_themes[]",
     )
     p_upsert.add_argument("--knowledge-root", required=True)
     p_upsert.add_argument(
@@ -725,7 +731,7 @@ def main(argv: list[str]) -> int:
 
     p_setchar = sub.add_parser(
         "set-charter",
-        help="In-place charter re-frame on an existing base (#451; partial field "
+        help="In-place charter re-frame on an existing base (partial field "
              "update + union-merge into open_themes[])",
     )
     p_setchar.add_argument("--knowledge-root", required=True)

--- a/cogni-knowledge/tests/test_knowledge_binding.sh
+++ b/cogni-knowledge/tests/test_knowledge_binding.sh
@@ -280,6 +280,55 @@ echo "$OUT11" | grep -q 'knowledge_slug mismatch' \
   && green "PASS: set-charter refuses on --knowledge-slug mismatch" \
   || { red "FAIL: set-charter slug-mismatch guard wrong"; echo "$OUT11"; errors=$((errors+1)); }
 
+# 12. Clearing the last steering field must NOT re-stamp framed_at — mirrors
+#     init's invariant (framed_at stamped only when a steering field is
+#     non-empty), so a cleared charter stays distinguishable from a fresh one.
+#     A dedicated base whose ONLY steering field is domain.
+KBCLR="$WORK/kbclr"; mkdir -p "$KBCLR/.cogni-wiki"
+echo '{"name":"C","slug":"c","schema_version":"0.0.5"}' > "$KBCLR/.cogni-wiki/config.json"
+BINDING_CLR="$KBCLR/.cogni-knowledge/binding.json"
+python3 "$SCRIPT" init \
+  --knowledge-root "$KBCLR" --knowledge-slug clear-kb \
+  --knowledge-title "Clear KB" --wiki-path "$KBCLR" \
+  --charter-domain 'EU AI Act' >/dev/null
+# Freeze framed_at to a known-past date so a (wrong) re-stamp would be visible.
+python3 -c "
+import json
+b = json.load(open('$BINDING_CLR'))
+b['charter']['framed_at'] = '2025-03-03'
+json.dump(b, open('$BINDING_CLR','w'))
+"
+# Clear the only steering field — supplying an explicit empty string.
+python3 "$SCRIPT" set-charter --knowledge-root "$KBCLR" --charter-domain '' >/dev/null
+if python3 -c "
+import json
+b = json.load(open('$BINDING_CLR'))
+c = b['charter']
+assert c['domain'] == '', ('domain must clear', c)
+assert c['framed_at'] == '2025-03-03', ('clearing the last field must NOT re-stamp', c)
+print('OK')
+" | grep -q OK; then
+  green "PASS: set-charter clearing the last steering field does not re-stamp framed_at"
+else
+  red "FAIL: set-charter clearing case re-stamped framed_at"; errors=$((errors+1))
+fi
+
+# 12b. A subsequent non-empty re-steer DOES re-stamp (the common path stays).
+python3 "$SCRIPT" set-charter --knowledge-root "$KBCLR" \
+  --charter-domain 'EU AI Act high-risk' >/dev/null
+if python3 -c "
+import json
+b = json.load(open('$BINDING_CLR'))
+c = b['charter']
+assert c['domain'] == 'EU AI Act high-risk', c
+assert c['framed_at'] != '2025-03-03', ('a non-empty re-steer must re-stamp', c)
+print('OK')
+" | grep -q OK; then
+  green "PASS: set-charter non-empty re-steer still re-stamps framed_at"
+else
+  red "FAIL: set-charter non-empty re-steer failed to re-stamp"; errors=$((errors+1))
+fi
+
 # --- themes subcommand (#450): open MINUS covered at read time -------------
 # A fresh KB with a seed backlog, one of whose themes has been "researched"
 # (its theme_norm_key recorded in covered_themes[]). Display must hide the


### PR DESCRIPTION
Closes #454.

Two non-blocking polish nits deferred from #451 / PR #453, both in `scripts/knowledge-binding.py`'s charter subcommands.

## Summary
- Drop the internal issue refs from the two user-facing argparse `help=` strings — `#409` (upsert-themes) and `#451` (set-charter) — so `python3 knowledge-binding.py --help` carries no issue numbers (repo Contributing norm: provenance lives in git/CHANGELOG/references, not user-facing surfaces). Code comments and docstrings keep their refs.
- Fix `cmd_set_charter` so it re-stamps `framed_at` only when the resulting charter has ≥1 non-empty steering field, mirroring `init`'s invariant. Previously `set-charter --charter-domain ""` cleared the domain yet stamped `framed_at = today`, making a cleared charter indistinguishable from a freshly-framed one.
- Add a clearing-case unit test to `tests/test_knowledge_binding.sh` (clear-only → no stamp; subsequent non-empty → stamp).
- Bump `plugin.json` + `marketplace.json` 0.1.68 → 0.1.69 (patch).

## Scope
- Both nits are explicitly bundled on this single issue ("two deferred nits"), so both ship here — neither deferred.
- Only the two `help=` strings flagged in the issue are touched; the ~8 other `#NNN` refs in module comments / function docstrings are left in place per the issue.
- Nit 2 mirrors `init`'s exact invariant (`changed_charter and (domain or audience or scope)`); no behavioral change for the common case (re-steering with a non-empty value still re-stamps).

## Plan record
https://github.com/cogni-work/insight-wave/issues/454#issuecomment-4615618256

## Test plan
- [x] `bash cogni-knowledge/tests/test_knowledge_binding.sh` → ALL TESTS PASS (incl. new clearing-case + re-steer assertions).
- [x] `knowledge-binding.py set-charter --help` / `upsert-themes --help` show no `#NNN` refs.
- [x] Clearing the only steering field leaves `framed_at` unchanged; a non-empty re-steer still re-stamps.
- [x] `python3 scripts/check-breadcrumbs.py` exit 0 (no regression).
- [x] `plugin.json` and `marketplace.json` both read `0.1.69`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
