### PR TITLE
cogni-knowledge: down-weight analyst point-estimate spread in contradictor rubrics

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.71",
+      "version": "0.1.72",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/agents/source-contradictor.md
+++ b/cogni-knowledge/agents/source-contradictor.md
@@ -87,15 +87,16 @@ For each (new-claim, conflicting-page) where you detect tension, emit a finding 
 
 For each `contradiction` finding, set `severity`:
 
-- **`high`** — outright numeric or named-entity flip on a shared subject, with no scope qualifier separating the two assertions. Examples:
+- **`high`** — outright numeric or named-entity flip on a shared subject, with no scope qualifier separating the two assertions. The flip must be on an incompatible **categorical** fact — a single authoritative value such as a date, deadline, jurisdiction, or directional assertion — not two publishers' point-estimates of the same inherently-estimated quantity (see the estimate-divergence carve-out under `low`). Examples:
   - new source: "the deadline is 12 months", peer: "the deadline is 24 months" → high.
   - new source: "applies EU-wide", peer: "applies only in Germany" → high.
 - **`medium`** — scope shift or quantifier change on the same fact (`EU-wide` vs `Tier-1 member states`, `all member states` vs `most member states`, `mandatory` vs `recommended`). The factual core overlaps but the scope/strength differs.
 - **`low`** — soft tension, plausibly explained by date, context, or a missing qualifier. Surfaced for transparency; the operator may legitimately accept it.
+  - **Estimate divergence is always `low`.** When both sides are numeric point-estimates of the *same* metric (market size, CAGR, workforce gap, adoption rate, …) for the *same* scope and period, attributed to *different* independent publishers — e.g. one research house reports €12 bn and another €15 bn — this is expected analyst spread, not a contradiction. Score it `low` (never `medium` or `high`) and name it in the `note`, e.g. `"competing analyst point-estimates of the same metric — normal spread"`. Reserve a numeric `high` for an incompatible categorical claim, not for two publishers sizing the same quantity differently. (A *single* publisher revising its own earlier figure is different — that is a real revision, scored on its merits.)
 
 **Discipline:**
 
-- Default to `low` on doubt. Promote to `medium` only when scope overlap is clearly established. Promote to `high` only when the same entity/quantity flips.
+- Default to `low` on doubt. Promote to `medium` only when scope overlap is clearly established. Promote to `high` only when the same entity/quantity flips on an incompatible categorical claim — never when two independent publishers report different point-estimates of the same metric (that is expected spread, scored `low`).
 - **Emit ONE finding per (new-claim, conflicting-page) pair, not per claim** — when a new claim contradicts multiple claims on the same conflicting page, pick the most severe one (highest-severity match wins; ties broken by `claim_id` lexical order) and record only that pair; summarise the others in the `note`. This keeps the de-dup key `(new_claim_id, conflicting_page, conflicting_claim_id)` unambiguous.
 - A single new claim will rarely contradict more than 2 pages cleanly; if you find yourself emitting more, your bar is too loose — re-read with conservative discipline.
 

--- a/cogni-knowledge/agents/wiki-contradictor.md
+++ b/cogni-knowledge/agents/wiki-contradictor.md
@@ -105,15 +105,16 @@ For each (sentence, cited_page, claim) where you detect tension, emit a finding 
 
 For each `contradiction` finding, set `severity`:
 
-- **`high`** — outright numeric or named-entity flip on a shared subject, with no scope qualifier separating the two assertions. Examples:
+- **`high`** — outright numeric or named-entity flip on a shared subject, with no scope qualifier separating the two assertions. The flip must be on an incompatible **categorical** fact — a single authoritative value such as a date, deadline, jurisdiction, or directional assertion — not two publishers' point-estimates of the same inherently-estimated quantity (see the estimate-divergence carve-out under `low`). Examples:
   - synthesis: "the deadline is 12 months", cited source: "the deadline is 24 months" → high.
   - synthesis: "applies EU-wide", cited source: "applies only in Germany" → high.
 - **`medium`** — scope shift or quantifier change on the same fact (`EU-wide` vs `Tier-1 member states`, `all member states` vs `most member states`, `mandatory` vs `recommended`). The factual core overlaps but the scope/strength of the assertion differs.
 - **`low`** — soft tension, plausibly explained by date, context, or a missing qualifier. Surfaced for transparency but the operator may legitimately accept it.
+  - **Estimate divergence is always `low`.** When both sides are numeric point-estimates of the *same* metric (market size, CAGR, workforce gap, adoption rate, …) for the *same* scope and period, attributed to *different* independent publishers — e.g. one research house reports €12 bn and another €15 bn — this is expected analyst spread, not a contradiction. Score it `low` (never `medium` or `high`) and name it in the `note`, e.g. `"competing analyst point-estimates of the same metric — normal spread"`. Reserve a numeric `high` for an incompatible categorical claim, not for two publishers sizing the same quantity differently. (A *single* publisher revising its own earlier figure is different — that is a real revision, scored on its merits.)
 
 **Discipline:**
 
-- Default to `low` on doubt. Promote to `medium` only when scope overlap is clearly established. Promote to `high` only when the same entity/quantity flips.
+- Default to `low` on doubt. Promote to `medium` only when scope overlap is clearly established. Promote to `high` only when the same entity/quantity flips on an incompatible categorical claim — never when two independent publishers report different point-estimates of the same metric (that is expected spread, scored `low`).
 - **Emit ONE finding per (sentence, cited-page) pair, not per claim** — holds for distilled pages too. When a sentence contradicts multiple claims on the same page, pick the most severe one (highest-severity match wins; ties broken by `claim_id` lexical order) and record only that pair. The other contradicting claims are summarised in the `note` (e.g. `"synthesis asserts 12-month EU-wide deadline; cited source has 24-month transition (clm-004) AND Germany-only scope (clm-007)"`). This keeps the future de-dup key `(synthesis_excerpt, conflicting_page, conflicting_claim_id)` unambiguous.
 - A single sentence will rarely contradict more than 2 cited pages cleanly; if you find yourself emitting more, your bar is too loose — re-read with conservative discipline.
 


### PR DESCRIPTION
Closes #466.

## Summary
- Add a publisher-attributed estimate-divergence carve-out to the `low` severity tier in both `source-contradictor` (ingest-time, Step 4.6) and `wiki-contradictor` (finalize, Step 10.6) rubrics: when both sides are numeric point-estimates of the *same* metric/quantity for the same period from *different* publishers, score `low` (expected analyst spread), not `high`.
- Reinforce each rubric's discipline line so `high` stays reserved for incompatible categorical/directional flips (conflicting date, opposite directional assertion, mutually exclusive fact) — never two research houses' sizing of the same market.
- Keep both rubrics symmetric (the wiki variant keeps its minor "of the assertion" wording in the `medium` tier).
- Bump `plugin.json` 0.1.71 → 0.1.72 and mirror in `marketplace.json`.

## Scope decisions
- **Chosen: approach (b)** — a severity down-weight, prose-only, in the two agents' rubrics. This is the smallest slice that fixes the signal-to-noise problem the issue reports (14 ingest + 2 finalize findings, 6 high-severity, dominated by analyst spread). The kind vocabulary stays closed: estimate divergences still count as `contradiction` + `low`, so `contradiction-ingest-store.py` count invariants and the unchanged schema 0.1.0 hold. No script, schema, test, or SKILL.md change is needed.
- **Deferred: approach (a)** — a first-class `estimate_divergence` kind. Genuinely larger, separate concern with a 9+ file blast radius (store-script KINDS tuple + invariant assertions, both agents' closed-vocab declarations, three contract test suites, two SKILL.md display blocks, references/inverted-pipeline.md, plus a synchronized schema bump across all fragment writers). Should follow real-run data showing whether the `low` down-weight is sufficient, rather than ship speculatively. Filed as a follow-up.

## Test plan
- [x] Breadcrumb guard (`scripts/check-breadcrumbs.py`) clean on both agents — rationale stated semantically, no `#466` / version-tag breadcrumb.
- [x] Vocabulary stays closed — no new `kind` value introduced (`grep -c estimate_divergence` = 0 in both agents).
- [x] Carve-out present in each `low` tier; discipline lines symmetric across the two agents.
- [x] `tests/test_source_contradictor_contract.sh` + `tests/test_contradictor_contract.sh` — ALL PASS (no regression on the unchanged closed vocabulary).
- [x] `plugin.json` reads 0.1.72; `marketplace.json` mirrors it.

Resolution plan: https://github.com/cogni-work/insight-wave/issues/466#issuecomment-4620440851

🤖 Generated with [Claude Code](https://claude.com/claude-code)
