### PR TITLE
cogni-wiki: fix unreachable ../raw/ source paths + harden raw-citation validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -304,7 +304,7 @@
     {
       "name": "cogni-wiki",
       "source": "./cogni-wiki",
-      "version": "0.0.54",
+      "version": "0.0.55",
       "maturity": "incubating",
       "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions surface at ingest, and knowledge compounds. Based on Karpathy's LLM Wiki pattern.",
       "keywords": [

--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions surface at ingest, and knowledge compounds. Based on Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-wiki/CLAUDE.md
+++ b/cogni-wiki/CLAUDE.md
@@ -136,11 +136,11 @@ type: concept | entity | summary | decision | interview | meeting | learning | s
 tags: [tag1, tag2]
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
-sources: [../raw/paper-xyz.pdf, https://..., wiki://other-slug]
+sources: [../../raw/paper-xyz.pdf, https://..., wiki://other-slug]
 ---
 ```
 
-The `synthesis` type (introduced in v0.0.23) is reserved for LLM-derived answers that `wiki-query --file-back yes` files back into the wiki. Synthesis pages cite their wiki provenance via `wiki://<slug>` entries in `sources:` rather than `../raw/` paths; `wiki-lint` enforces this contract.
+The `synthesis` type (introduced in v0.0.23) is reserved for LLM-derived answers that `wiki-query --file-back yes` files back into the wiki. Synthesis pages cite their wiki provenance via `wiki://<slug>` entries in `sources:` rather than `../../raw/` paths; `wiki-lint` enforces this contract.
 
 The `interview` and `meeting` types (introduced in v0.0.24) carry the consulting-domain shapes that drive `wiki-ingest`'s body-template dispatch. `customer-call` and `retro` are deliberately **not** distinct types — they are scaffold variants distinguished by the `tags:` field (`tag:customer-call` swaps `interview.md` → `customer-call.md`; `tag:retro` swaps `learning.md` → `retro.md`), so the enum stays small while `wiki-query` can still slice by use case. See `skills/wiki-ingest/references/page-frontmatter.md` for the full schema and `skills/wiki-ingest/references/templates/README.md` for the type→template map.
 

--- a/cogni-wiki/README.md
+++ b/cogni-wiki/README.md
@@ -59,7 +59,7 @@ type: concept
 tags: [llms, safety, karpathy]
 created: 2026-04-12
 updated: 2026-04-12
-sources: [../raw/bai-et-al-2022.pdf]
+sources: [../../raw/bai-et-al-2022.pdf]
 ---
 ```
 

--- a/cogni-wiki/skills/wiki-health/SKILL.md
+++ b/cogni-wiki/skills/wiki-health/SKILL.md
@@ -139,7 +139,7 @@ This skill is **report-only**. It writes the log line and nothing else. Auto-fix
 | Missing required frontmatter | `wiki-health` | Schema check — deterministic |
 | Invalid `type:` value | `wiki-health` | Schema check — deterministic |
 | Filename / `id:` mismatch | `wiki-health` | Schema check — deterministic |
-| Missing `../raw/` source file | `wiki-health` | Filesystem check — deterministic |
+| Missing `../../raw/` source file | `wiki-health` | Filesystem check — deterministic |
 | Broken `wiki://` source | `wiki-health` | Structural — target page either exists or doesn't |
 | Stub page (body < 50 chars) | `wiki-health` | Length check — deterministic |
 | `entries_count` drift | `wiki-health` | Counter vs filesystem — deterministic |

--- a/cogni-wiki/skills/wiki-health/references/checks.md
+++ b/cogni-wiki/skills/wiki-health/references/checks.md
@@ -10,7 +10,7 @@ This file is the canonical list of what `health.py` checks. Every check here is 
 | `missing_frontmatter` | One of `id`, `title`, `type`, `created`, `updated` is missing or empty | `wiki-update` to add the field |
 | `id_mismatch` | Frontmatter `id: x` but filename is `y.md` | Rename the file or fix the frontmatter |
 | `invalid_type` | Frontmatter `type:` value not in `{concept, entity, summary, decision, interview, meeting, learning, synthesis, note, source}` | `wiki-update` to pick a valid type |
-| `missing_source` | `sources: [../raw/foo.pdf]` where `raw/foo.pdf` does not exist | Restore the source or remove the reference |
+| `missing_source` | `sources: [../../raw/foo.pdf]` where `raw/foo.pdf` does not exist | Restore the source or remove the reference |
 | `broken_wiki_source` | `sources: [wiki://other-slug]` where `wiki/<type>/other-slug.md` does not exist | `wiki-update` to fix the slug, or re-run `wiki-query --file-back` to regenerate the synthesis after the missing page is created |
 | `read_error` | Page file unreadable (permission, encoding, IO) | OS-level — investigate filesystem |
 

--- a/cogni-wiki/skills/wiki-health/scripts/health.py
+++ b/cogni-wiki/skills/wiki-health/scripts/health.py
@@ -17,7 +17,7 @@ Detects:
         - Missing required frontmatter fields
         - Filename / id mismatches
         - Invalid type values
-        - Missing ../raw/ source files
+        - Missing ../../raw/ source files
         - Broken wiki:// sources (target page does not exist)
         - Read errors
     Warnings (structural debt only — semantic warnings live in wiki-lint):

--- a/cogni-wiki/skills/wiki-health/scripts/health.py
+++ b/cogni-wiki/skills/wiki-health/scripts/health.py
@@ -192,14 +192,42 @@ def main() -> None:
         sources = fm.get("sources", [])
         if isinstance(sources, list):
             for src in sources:
-                if isinstance(src, str) and src.startswith("../raw/"):
-                    rel = src[len("../raw/") :]
-                    if not (raw_dir / rel).exists():
+                if isinstance(src, str) and (
+                    src.startswith("../") or src.startswith("./")
+                ):
+                    # Relative-path raw-source citation. Resolve from the page's
+                    # ACTUAL on-disk location rather than decoding the literal
+                    # `../raw/` prefix by convention — pages live two levels deep
+                    # (wiki/<type>/<slug>.md) since schema 0.0.5, so a `../raw/`
+                    # citation resolves to the non-existent wiki/raw/ instead of
+                    # <wiki-root>/raw/. The correct form is `../../raw/`. The old
+                    # string-strip check passed regardless of depth as long as
+                    # raw/<tail> existed, so a depth-wrong (unreachable) citation
+                    # shipped "health clean". Resolving from page_path.parent
+                    # catches the depth bug regardless of the literal string.
+                    resolved = (page_path.parent / src).resolve()
+                    in_raw = resolved == raw_dir or raw_dir in resolved.parents
+                    if not in_raw:
                         errors.append(
                             {
                                 "class": "missing_source",
                                 "page": slug,
-                                "message": f"source file not found: raw/{rel}",
+                                "message": (
+                                    f"raw source citation does not resolve under "
+                                    f"raw/: '{src}' from wiki/{ptype}/ points at "
+                                    f"{resolved} (use ../../raw/<file>)"
+                                ),
+                            }
+                        )
+                    elif not resolved.exists():
+                        errors.append(
+                            {
+                                "class": "missing_source",
+                                "page": slug,
+                                "message": (
+                                    f"source file not found: "
+                                    f"raw/{resolved.name} (cited as '{src}')"
+                                ),
                             }
                         )
                 elif isinstance(src, str) and src.startswith("wiki://"):

--- a/cogni-wiki/skills/wiki-ingest/SKILL.md
+++ b/cogni-wiki/skills/wiki-ingest/SKILL.md
@@ -239,14 +239,14 @@ tags: [{tag1}, {tag2}]
 created: {YYYY-MM-DD}
 updated: {YYYY-MM-DD}
 sources:
-  - ../raw/{source-filename}
+  - ../../raw/{source-filename}
 publisher_url: https://{publisher canonical URL, only if observable}
 ---
 ```
 
 **On `publisher_url`**: populate it only when the canonical URL is observable — do not fabricate. URL ingest → set it to the source URL (same one passed to WebFetch). File ingest with a URL printed on the PDF cover / in PDF metadata / in source text → use that URL. File ingest with no observable URL → omit the `publisher_url` key entirely (the field is optional). A guessed URL that 404s costs more credibility than an unlinked citation downstream; cogni-research will fall back to the wiki's `publisher_base_url` if set.
 
-**On `sources:` after auto-conversion.** When Step 2a converted the source, point `sources:` at the **original** (`../raw/{source-filename.docx}`), not the `.converted.md` cache file. The cache is a derived artefact — re-ingest can rebuild it from the original if a markitdown release improves extraction, and a pinned cache path would silently rot the citation chain.
+**On `sources:` after auto-conversion.** When Step 2a converted the source, point `sources:` at the **original** (`../../raw/{source-filename.docx}`), not the `.converted.md` cache file. The cache is a derived artefact — re-ingest can rebuild it from the original if a markitdown release improves extraction, and a pinned cache path would silently rot the citation chain.
 
 Body structure (the template selected in Step 4a sets the per-type heading shape inside `Details`; the four top-level sections below are constant):
 

--- a/cogni-wiki/skills/wiki-ingest/references/ingest-workflow.md
+++ b/cogni-wiki/skills/wiki-ingest/references/ingest-workflow.md
@@ -63,7 +63,7 @@ tags: [llms, safety, jailbreaking, long-context]
 created: 2026-04-12
 updated: 2026-04-12
 sources:
-  - ../raw/bai-et-al-2024-many-shot-jailbreaking.pdf
+  - ../../raw/bai-et-al-2024-many-shot-jailbreaking.pdf
 ---
 
 Many-shot jailbreaking exploits long context windows by stuffing hundreds of fake dialogue turns that prime the model toward a harmful completion.
@@ -88,7 +88,7 @@ Many-shot jailbreaking exploits long context windows by stuffing hundreds of fak
 
 ## Sources
 
-- [Bai et al. 2024 — Many-Shot Jailbreaking](../raw/bai-et-al-2024-many-shot-jailbreaking.pdf)
+- [Bai et al. 2024 — Many-Shot Jailbreaking](../../raw/bai-et-al-2024-many-shot-jailbreaking.pdf)
 ```
 
 ### Step 5: Update `wiki/index.md`
@@ -324,7 +324,7 @@ tags: [onboarding, customer-success, acme]
 created: 2026-04-22
 updated: 2026-04-22
 sources:
-  - ../raw/interview-pm-onboarding-2026-04-22.md
+  - ../../raw/interview-pm-onboarding-2026-04-22.md
 ---
 
 40-minute interview with `[[priya-rao]]` on `[[customer-onboarding]]` friction in Acme's CS org; surfaced three repeatable failure modes.
@@ -372,7 +372,7 @@ Follow-up to the Q1 churn analysis. We picked Priya because her team owns the da
 
 ## Sources
 
-- [Interview transcript — Acme PM onboarding](../raw/interview-pm-onboarding-2026-04-22.md)
+- [Interview transcript — Acme PM onboarding](../../raw/interview-pm-onboarding-2026-04-22.md)
 ```
 
 The interviewee link to `[[priya-rao]]` is required per the template; if the page doesn't exist, Step 4a's stub-first rule files `wiki/<type>/priya-rao.md` (frontmatter only, one-line summary) before writing this page.
@@ -513,7 +513,7 @@ tags: [customer-call, acme, q2]
 created: 2026-04-22
 updated: 2026-04-22
 sources:
-  - ../raw/discovery-acme-q2-2026-04-22.docx
+  - ../../raw/discovery-acme-q2-2026-04-22.docx
 ---
 
 …body filled per customer-call.md scaffold…

--- a/cogni-wiki/skills/wiki-ingest/references/page-frontmatter.md
+++ b/cogni-wiki/skills/wiki-ingest/references/page-frontmatter.md
@@ -13,7 +13,7 @@ tags: [<tag1>, <tag2>, ...]           # Optional. Short, lowercase, kebab-case
 created: YYYY-MM-DD                   # REQUIRED. Set at page creation, never changed
 updated: YYYY-MM-DD                   # REQUIRED. Set at every edit
 sources:                              # Optional but strongly encouraged
-  - ../raw/<filename>                 # Relative path from wiki/<type>/ to raw/ file (the same `../raw/` form works from every per-type dir)
+  - ../../raw/<filename>                 # Relative path from wiki/<type>/ to raw/ file (the same `../../raw/` form works from every per-type dir)
   - https://<url>                     # Or a stable external URL
   - wiki://<other-page-slug>          # Or a wiki-internal reference (synthesis pages)
 publisher_url: https://<url>          # Optional. Canonical URL at the publisher
@@ -87,7 +87,7 @@ See `./templates/README.md` for authoring conventions and per-template required 
 
 ### `sources` (optional but strongly encouraged)
 
-- Relative paths to files under `<wiki-root>/raw/` — always `../raw/filename` from the page's location in the per-type page dirs
+- Relative paths to files under `<wiki-root>/raw/` — always `../../raw/filename` from the page's location in the per-type page dirs
 - Or stable URLs
 - Or `wiki://<slug>` for wiki-internal references — used by `type: synthesis` pages to cite the wiki pages they were derived from. `wiki-lint` validates that each `wiki://<slug>` target page exists (a missing target is a `broken_wiki_source` error).
 - A page with no sources is flagged `warn` by `wiki-lint` unless its `type` is `decision` or `note`. A `type: synthesis` page with no `wiki://` source is flagged `synthesis_no_wiki_source` (warn) — synthesis pages must cite their wiki provenance.
@@ -95,9 +95,9 @@ See `./templates/README.md` for authoring conventions and per-template required 
 ### `publisher_url` (optional)
 
 - A single canonical `https://` URL pointing to where the publication lives on the publisher's website.
-- Used by **cogni-research wiki-researcher** to build clickable bibliography entries for wiki-sourced citations. Without it, citations to pages that were ingested from local PDFs (e.g. `sources: [../raw/foo.pdf]`) can only be linked via the wiki instance's `publisher_base_url` fallback — a publisher landing page rather than a per-document permalink.
+- Used by **cogni-research wiki-researcher** to build clickable bibliography entries for wiki-sourced citations. Without it, citations to pages that were ingested from local PDFs (e.g. `sources: [../../raw/foo.pdf]`) can only be linked via the wiki instance's `publisher_base_url` fallback — a publisher landing page rather than a per-document permalink.
 - When `sources:` already contains an `https://` URL, that URL is assumed to be the publisher URL and `publisher_url` is redundant (but harmless — explicit wins on read).
-- When `sources:` contains only local paths (`../raw/...`), add `publisher_url` if you know the canonical URL of the original publication. If you don't, leave it off — the wiki instance's `publisher_base_url` (see `.cogni-wiki/config.json`) still gives downstream citations a honest landing-page link.
+- When `sources:` contains only local paths (`../../raw/...`), add `publisher_url` if you know the canonical URL of the original publication. If you don't, leave it off — the wiki instance's `publisher_base_url` (see `.cogni-wiki/config.json`) still gives downstream citations a honest landing-page link.
 - Never fabricate. An empty field is fine; a guessed URL is not.
 
 ### `related` (optional)
@@ -121,7 +121,7 @@ tags: [llms, knowledge-management, karpathy, compounding]
 created: 2026-04-12
 updated: 2026-04-12
 sources:
-  - ../raw/karpathy-llm-wiki-gist.md
+  - ../../raw/karpathy-llm-wiki-gist.md
   - https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
 publisher_url: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
 related:
@@ -133,7 +133,7 @@ status: stable
 
 ## Synthesis page example
 
-A `type: synthesis` page filed back by `wiki-query` looks like this — note `wiki://`-prefixed sources rather than `../raw/` paths:
+A `type: synthesis` page filed back by `wiki-query` looks like this — note `wiki://`-prefixed sources rather than `../../raw/` paths:
 
 ```yaml
 ---

--- a/cogni-wiki/skills/wiki-ingest/references/templates/customer-call.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/customer-call.md
@@ -57,4 +57,4 @@ _(What stands in the way of a yes / a renewal / an expansion? Be specific — "p
 
 ## Sources
 
-- [{{call notes / transcript / recording}}](../raw/{{source-filename}})
+- [{{call notes / transcript / recording}}](../../raw/{{source-filename}})

--- a/cogni-wiki/skills/wiki-ingest/references/templates/decision.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/decision.md
@@ -54,4 +54,4 @@ _(What signal would trigger reopening this decision? E.g. "if customer churn on 
 
 ## Sources
 
-- [{{deciding meeting or doc}}](../raw/{{source-filename}})
+- [{{deciding meeting or doc}}](../../raw/{{source-filename}})

--- a/cogni-wiki/skills/wiki-ingest/references/templates/default.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/default.md
@@ -24,4 +24,4 @@ _(Distil the source under `##` subheadings the source itself suggests — e.g. m
 
 ## Sources
 
-- [{{source title}}](../raw/{{source-filename}})
+- [{{source title}}](../../raw/{{source-filename}})

--- a/cogni-wiki/skills/wiki-ingest/references/templates/interview.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/interview.md
@@ -50,4 +50,4 @@ _(Group the interview by the questions or themes the source surfaces. One `###` 
 
 ## Sources
 
-- [{{transcript or notes}}](../raw/{{source-filename}})
+- [{{transcript or notes}}](../../raw/{{source-filename}})

--- a/cogni-wiki/skills/wiki-ingest/references/templates/learning.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/learning.md
@@ -47,4 +47,4 @@ _(Counter-examples, edge cases, or contexts where the lesson would mislead. With
 
 ## Sources
 
-- [{{primary source if any}}](../raw/{{source-filename}})
+- [{{primary source if any}}](../../raw/{{source-filename}})

--- a/cogni-wiki/skills/wiki-ingest/references/templates/meeting.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/meeting.md
@@ -55,4 +55,4 @@ _(One `###` heading per topic. Capture the substance, not the chronology. Quote 
 
 ## Sources
 
-- [{{meeting notes / recording / chat log}}](../raw/{{source-filename}})
+- [{{meeting notes / recording / chat log}}](../../raw/{{source-filename}})

--- a/cogni-wiki/skills/wiki-ingest/references/templates/retro.md
+++ b/cogni-wiki/skills/wiki-ingest/references/templates/retro.md
@@ -58,4 +58,4 @@ _(If a learning here repeats a pattern from prior retros, cite the prior `[[retr
 
 ## Sources
 
-- [{{retro notes / board snapshot}}](../raw/{{source-filename}})
+- [{{retro notes / board snapshot}}](../../raw/{{source-filename}})

--- a/cogni-wiki/skills/wiki-ingest/scripts/batch_builder.py
+++ b/cogni-wiki/skills/wiki-ingest/scripts/batch_builder.py
@@ -202,7 +202,7 @@ def discover_orphans(wiki_root: Path) -> list:
             for s in sources:
                 if not isinstance(s, str):
                     continue
-                # Paths in sources are typically ../raw/foo.pdf — we only
+                # Paths in sources are typically ../../raw/foo.pdf — we only
                 # care about the filename tail for orphan detection.
                 cited.add(s.rstrip("/").split("/")[-1])
     orphans = []
@@ -571,7 +571,7 @@ def build_entries_from_stubs(
     entries = []
     for stub in stubs:
         source = stub["source"]
-        # Stub sources: if the frontmatter pointed at "../raw/foo.pdf" we keep
+        # Stub sources: if the frontmatter pointed at "../../raw/foo.pdf" we keep
         # it as-is (that is already a wiki-root-relative path). If we fell
         # back to the page path itself, normalise the same way as above.
         if not (source.startswith("http://") or source.startswith("https://") or source.startswith("../") or source.startswith("./")):

--- a/cogni-wiki/skills/wiki-lint/references/severity-tiers.md
+++ b/cogni-wiki/skills/wiki-lint/references/severity-tiers.md
@@ -50,7 +50,7 @@ An error means the wiki's contract is broken and a reader (human or LLM) might m
 | **Filename–id mismatch** | Frontmatter `id: x` but filename is `y.md` | Rename the file or fix the frontmatter |
 | **Missing required frontmatter** | `id`, `title`, `type`, `created`, or `updated` missing | `wiki-update` to add the field |
 | **Invalid type** | `type:` value is not one of the allowed values | `wiki-update` to pick a valid type |
-| **Missing source file** | `sources: [../raw/foo.pdf]` where `raw/foo.pdf` doesn't exist | Either restore the source or remove the reference |
+| **Missing source file** | `sources: [../../raw/foo.pdf]` where `raw/foo.pdf` doesn't exist | Either restore the source or remove the reference |
 | **Broken wiki source** | `sources: [wiki://other-slug]` where `wiki/<type>/other-slug.md` does not exist | `wiki-update` to fix the slug, or re-run `wiki-query --file-back` to regenerate the synthesis after the missing page is created |
 | **Duplicate slug** | Two pages with the same `id` frontmatter (shouldn't be possible if filenames are unique, but check) | Rename one |
 

--- a/cogni-wiki/skills/wiki-lint/scripts/lint_wiki.py
+++ b/cogni-wiki/skills/wiki-lint/scripts/lint_wiki.py
@@ -296,7 +296,7 @@ def main() -> None:
                 )
             # Synthesis pages must cite at least one wiki:// source. Empty
             # sources is already covered by the no_sources warning above; this
-            # catches the case where sources are present but only ../raw/ or URL
+            # catches the case where sources are present but only ../../raw/ or URL
             # entries — a synthesis without wiki provenance is suspicious.
             # Per-source target validation (missing raw file, broken wiki://
             # target) is owned by health.py as of v0.0.31.

--- a/cogni-wiki/skills/wiki-setup/references/SCHEMA.md.template
+++ b/cogni-wiki/skills/wiki-setup/references/SCHEMA.md.template
@@ -49,7 +49,7 @@ tags: [tag1, tag2]
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 sources:                         # Optional — relative paths or URLs
-  - ../raw/paper-xyz.pdf
+  - ../../raw/paper-xyz.pdf
   - https://example.com/article
 ---
 ```
@@ -73,7 +73,7 @@ The `type:` value MUST match the directory the page lives in (e.g. `type: concep
 ## Linking
 
 - Use `[[page-slug]]` for links to other wiki pages — slug-only, no path. The script layer resolves the slug to its per-type directory.
-- Use standard markdown links for external URLs and raw sources: `[label](../raw/file.pdf)`
+- Use standard markdown links for external URLs and raw sources: `[label](../../raw/file.pdf)`
 - Every `[[link]]` should be backed by an actual file under one of the per-type directories or `wiki/audits/`; the `wiki-lint` skill reports broken links
 
 ## Forward → reverse link contract

--- a/cogni-wiki/skills/wiki-update/SKILL.md
+++ b/cogni-wiki/skills/wiki-update/SKILL.md
@@ -70,7 +70,7 @@ Use the Edit tool (not Write) to preserve unchanged content byte-for-byte. For e
 - If the update adds a source, append it to the `sources:` list — never replace existing sources unless the old source is being explicitly retracted
 - If the update changes the page `type`, say so in the diff and justify the retype
 
-**Citation rule**: every new factual claim the update adds must link to a source. Either an inline `[../raw/file.pdf]` reference or a `[[wikilink]]` to another page (which in turn must cite a source). If the user cannot produce a source, the update stops. Unsourced claims erode the provenance chain that distinguishes this wiki from unverifiable notes — every page traces to raw/, and that contract holds only when updates also cite their evidence.
+**Citation rule**: every new factual claim the update adds must link to a source. Either an inline `[../../raw/file.pdf]` reference or a `[[wikilink]]` to another page (which in turn must cite a source). If the user cannot produce a source, the update stops. Unsourced claims erode the provenance chain that distinguishes this wiki from unverifiable notes — every page traces to raw/, and that contract holds only when updates also cite their evidence.
 
 ### 5. Sweep related pages (when `--related-sweep yes`)
 

--- a/cogni-wiki/skills/wiki-update/references/update-discipline.md
+++ b/cogni-wiki/skills/wiki-update/references/update-discipline.md
@@ -14,9 +14,9 @@ The user asks: "Reconcile these two pages."
 
 ### Step 1: Read both pages
 
-`[[rlhf-overview]]` frontmatter: `type: concept`, `sources: [../raw/ouyang-et-al-2022-instructgpt.pdf]`. Body defines RLHF as "Reinforcement Learning from Human Feedback — using human-generated preference labels to train a reward model."
+`[[rlhf-overview]]` frontmatter: `type: concept`, `sources: [../../raw/ouyang-et-al-2022-instructgpt.pdf]`. Body defines RLHF as "Reinforcement Learning from Human Feedback — using human-generated preference labels to train a reward model."
 
-`[[constitutional-ai]]` frontmatter: `type: concept`, `sources: [../raw/bai-et-al-2022-constitutional-ai.pdf]`. Body says "Constitutional AI replaces RLHF's human labels with AI-generated critiques, making the 'feedback' in RLHF come from a separate critic model rather than humans."
+`[[constitutional-ai]]` frontmatter: `type: concept`, `sources: [../../raw/bai-et-al-2022-constitutional-ai.pdf]`. Body says "Constitutional AI replaces RLHF's human labels with AI-generated critiques, making the 'feedback' in RLHF come from a separate critic model rather than humans."
 
 ### Step 2: Diagnose the contradiction
 
@@ -85,9 +85,9 @@ Current `[[rlhf-overview]]` claims "Reward-model quality saturates around 1B par
 >   "Reward-model quality saturates around 1B parameters, beyond which additional scale yields no measurable gains."
 >
 > **Proposed**:
->   "Earlier work suggested reward-model quality saturates around 1B parameters, but Chen et al. 2024 [../raw/chen-et-al-2024-rlhf-scaling.pdf] show the saturation claim was measurement noise — quality continues to improve (with diminishing returns) to at least 70B."
+>   "Earlier work suggested reward-model quality saturates around 1B parameters, but Chen et al. 2024 [../../raw/chen-et-al-2024-rlhf-scaling.pdf] show the saturation claim was measurement noise — quality continues to improve (with diminishing returns) to at least 70B."
 >
-> **Sources to add**: `../raw/chen-et-al-2024-rlhf-scaling.pdf`
+> **Sources to add**: `../../raw/chen-et-al-2024-rlhf-scaling.pdf`
 >
 > **Why**: preserves the historical claim (with attribution to the earlier era), adds the refinement with citation. The original source remains cited so readers can trace both positions.
 

--- a/cogni-wiki/tests/README.md
+++ b/cogni-wiki/tests/README.md
@@ -56,6 +56,7 @@ For pure LLM skills (no scripts to execute), regression coverage is limited to *
 | `test_source_page_type.sh` | `wiki-health` and `wiki-lint` accept the additive `type: source` page type added in v0.0.44 (#270) — a planted `wiki/sources/<slug>.md` page raises neither `invalid_type` nor `type_directory_mismatch`. Unblocks cogni-knowledge PR #269 milestone 6 `knowledge-ingest`. |
 | `test_index_summary_clamp.sh` | `wiki_index_update.py --max-summary N` clamps an over-long `--summary` on a WORD boundary with `…` via `_wikilib.clamp_summary` (v0.0.47, #324) — output words are an exact prefix of the input (no mid-word "…Sonderka"), German ä/ö/ü survive, codepoint-counted. No flag → verbatim passthrough (backward-compat for every other caller). |
 | `test_question_page_type.sh` | `wiki-health` and `wiki-lint` accept the additive `type: question` page type added in v0.0.50 (#407) — a planted `wiki/questions/<slug>.md` page raises neither `invalid_type` nor `type_directory_mismatch`. Unblocks cogni-knowledge #407 `knowledge-ingest` Step 4.5 (research-question nodes). |
+| `test_health_raw_citation_depth.sh` | `wiki-health` resolves relative raw-source citations from the page's actual on-disk location, not by decoding the literal `../raw/` prefix. A depth-wrong `../raw/<existing>` from a per-type dir is flagged `missing_source` (pages live two levels deep, so it points at the non-existent `wiki/raw/`); the depth-correct `../../raw/<existing>` is clean; a depth-correct citation to an absent file is flagged. Guards the per-type-dir raw-path fix. |
 
 ```sh
 bash tests/test_wiki_from_research_flags.sh
@@ -66,6 +67,7 @@ bash tests/test_batch_builder_metadata_config.sh
 bash tests/test_source_page_type.sh
 bash tests/test_index_summary_clamp.sh
 bash tests/test_question_page_type.sh
+bash tests/test_health_raw_citation_depth.sh
 ```
 
 The SKILL.md tests do not assert anything about LLM-driven behaviour — only that the contract surface that orchestrators (`cogni-knowledge:knowledge-report` / `cogni-knowledge:knowledge-query`) depend on remains intact. The script-level tests execute the actual code path and assert observable behaviour.

--- a/cogni-wiki/tests/fixtures/legacy-wiki/raw/decision-log.md
+++ b/cogni-wiki/tests/fixtures/legacy-wiki/raw/decision-log.md
@@ -1,4 +1,4 @@
 # Decision log (raw)
 
-Stub raw source so the `../raw/decision-log.md` reference in the decision
+Stub raw source so the `../../raw/decision-log.md` reference in the decision
 fixture page resolves cleanly under health.py's `missing_source` check.

--- a/cogni-wiki/tests/fixtures/legacy-wiki/wiki/pages/adopt-schema-version-0-0-5.md
+++ b/cogni-wiki/tests/fixtures/legacy-wiki/wiki/pages/adopt-schema-version-0-0-5.md
@@ -6,7 +6,7 @@ tags: [schema, migration]
 created: 2026-04-01
 updated: 2026-04-01
 sources:
-  - ../raw/decision-log.md
+  - ../../raw/decision-log.md
 ---
 
 # Adopt schema_version 0.0.5

--- a/cogni-wiki/tests/test_health_raw_citation_depth.sh
+++ b/cogni-wiki/tests/test_health_raw_citation_depth.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# test_health_raw_citation_depth.sh — assert wiki-health resolves raw-source
+# citations from the page's ACTUAL on-disk location, not by decoding the
+# literal `../raw/` prefix.
+#
+# Regression guard for the bug where pages live two levels deep
+# (wiki/<type>/<slug>.md since schema 0.0.5) but the citation convention
+# stayed `../raw/<file>` — which resolves to the non-existent `wiki/raw/`
+# instead of `<wiki-root>/raw/`. The correct form is `../../raw/<file>`.
+# The old check stripped the literal `../raw/` prefix and looked under
+# raw/<tail>, so a depth-wrong (unreachable) citation passed "health clean".
+#
+# Three cases, one wiki run (each page distinguished by the `page` field):
+#   1. depth-wrong  `../raw/<existing>`   -> MUST flag  missing_source
+#   2. depth-right  `../../raw/<existing>` -> MUST be clean (no missing_source)
+#   3. depth-right but absent file `../../raw/<nope>` -> MUST flag missing_source
+#
+# bash 3.2 + python3 stdlib only. Exits non-zero on any failure.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURES="$PLUGIN_ROOT/tests/fixtures"
+HEALTH="$PLUGIN_ROOT/skills/wiki-health/scripts/health.py"
+WORKDIR="$(mktemp -d)"
+WIKI="$WORKDIR/test-wiki"
+
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+red() { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+fail() { red "FAIL: $1"; exit 1; }
+
+assert_success_json() {
+  local label="$1" out="$2" ok
+  ok=$(printf '%s' "$out" | python3 -c 'import json, sys; d=json.loads(sys.stdin.read()); print("yes" if d.get("success") else "no")' 2>/dev/null || echo "parse-error")
+  if [ "$ok" != "yes" ]; then
+    red "FAIL ($label): expected success:true"
+    printf '%s\n' "$out"
+    exit 1
+  fi
+}
+
+# missing_source raised for a given page? prints "yes"/"no"
+missing_source_for() {
+  local out="$1" page="$2"
+  printf '%s' "$out" | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read())['data']
+page = '$page'
+for ent in d.get('errors', []) or []:
+    if ent.get('class') == 'missing_source' and ent.get('page') == page:
+        print('yes'); break
+else:
+    print('no')
+"
+}
+
+# ---------- prepare a migrated 0.0.5 fixture wiki ----------
+cp -R "$FIXTURES/legacy-wiki" "$WIKI"
+python3 "$PLUGIN_ROOT/skills/wiki-setup/scripts/migrate_layout.py" \
+  --wiki-root "$WIKI" --apply >/dev/null
+green "fixture migrated to per-type-dirs layout (0.0.5)"
+
+# ---------- plant a real raw source + three notes pages ----------
+TODAY=$(date +%Y-%m-%d)
+mkdir -p "$WIKI/raw" "$WIKI/wiki/notes"
+echo "raw source body for the depth regression test" > "$WIKI/raw/depth-test-source.md"
+
+plant() {  # $1 = slug, $2 = source citation
+  cat > "$WIKI/wiki/notes/$1.md" <<EOF
+---
+id: $1
+title: Depth test $1
+type: note
+created: $TODAY
+updated: $TODAY
+sources: [$2]
+---
+
+Body long enough to clear the stub-page threshold so the only finding under
+test is the raw-source citation resolution behaviour, padding padding padding.
+EOF
+}
+
+plant "depth-wrong"        "../raw/depth-test-source.md"
+plant "depth-right"        "../../raw/depth-test-source.md"
+plant "depth-right-absent" "../../raw/does-not-exist.md"
+green "planted raw/depth-test-source.md + 3 notes pages (wrong / right / right-absent)"
+
+# ---------- run health once ----------
+OUT=$(python3 "$HEALTH" --wiki-root "$WIKI")
+assert_success_json "health.py" "$OUT"
+green "health.py: success"
+
+# ---------- 1) depth-wrong ../raw/ MUST be flagged ----------
+[ "$(missing_source_for "$OUT" depth-wrong)" = "yes" ] \
+  || fail "depth-wrong '../raw/depth-test-source.md' was NOT flagged missing_source (the #459 regression)"
+green "depth-wrong ../raw/ citation correctly flagged missing_source"
+
+# ---------- 2) depth-right ../../raw/ (file exists) MUST be clean ----------
+[ "$(missing_source_for "$OUT" depth-right)" = "no" ] \
+  || fail "depth-correct '../../raw/depth-test-source.md' was wrongly flagged missing_source"
+green "depth-correct ../../raw/ citation (existing file) is clean"
+
+# ---------- 3) depth-right but absent file MUST be flagged ----------
+[ "$(missing_source_for "$OUT" depth-right-absent)" = "yes" ] \
+  || fail "absent '../../raw/does-not-exist.md' was NOT flagged missing_source"
+green "depth-correct ../../raw/ citation to an absent file correctly flagged missing_source"
+
+green "ALL TESTS PASS"


### PR DESCRIPTION
Closes #459.

## Summary
- Pages live two levels deep at `wiki/<type>/<slug>.md` (schema 0.0.5+), but the `sources:` / body raw-citation convention stayed `../raw/<file>`, which resolves to the nonexistent `wiki/raw/`. Corrected to `../../raw/` across the emit instruction (`wiki-ingest` SKILL.md Step 4b), the `page-frontmatter.md` schema + examples, all 7 per-type body templates, the `ingest-workflow.md` worked examples, and `SCHEMA.md.template` (copied into every new wiki). Since all per-type pages sit at the same depth, `../../raw/` is uniformly correct — so the previously-false "works from every per-type dir" assertion is now true.
- Hardened `health.py`'s `missing_source` check to resolve each relative raw citation from the page's **actual on-disk location** (`(page_path.parent / src).resolve()`, required to land inside `raw/` and exist) instead of decoding the literal `../raw/` prefix by convention. A depth-wrong path is now caught regardless of its string form — closing the gap where defect 1 shipped "health clean".
- Patch bump `cogni-wiki` 0.0.54 → 0.0.55 (plugin.json + marketplace.json).

## Two defects, one root (both fixed)
1. **Emit:** `wiki-ingest` wrote a depth-wrong `../raw/` citation → now `../../raw/`.
2. **Validation:** `wiki-health`/`wiki-lint` never validated raw citations against the page's real location → `health.py` now does.

## Behavior note
Existing already-ingested pages still carrying depth-wrong `../raw/` citations will now be **correctly flagged** as `missing_source` — that is the intended surfacing of latent breakage, not a regression. URL-cited pages and the `cogni-knowledge` inverted pipeline (URLs + fetch-cache, no `raw/`) are unaffected.

## Tests
- `tests/test_lint_health_partition.sh`, `tests/test_source_page_type.sh`, `tests/test_lint_fix.sh` — all pass (no regression).
- Focused functional check of the new logic: depth-wrong `../raw/foo.md` → flagged; correct `../../raw/foo.md` (file exists) → clean; correct depth but missing file → flagged.

## Scope decisions
- **Included:** the relative-depth correctness fix (the reporter's accepted fallback) + the validation-gap fix.
- **Deferred (follow-ups):** the depth-independent `raw://<filename>` scheme (the reporter's preferred design — a new convention beyond bug-fix scope), body `## Sources` markdown-link target validation, and the open question of converging the cogni-wiki hand-ingest vs cogni-knowledge pipeline provenance models.

Resolution plan record: https://github.com/cogni-work/insight-wave/issues/459#issuecomment-4620844845

🤖 Generated with [Claude Code](https://claude.com/claude-code)
