### PR TITLE
cogni-wiki: protect curated per-theme lead-ins in index inserts (contract + test)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -304,7 +304,7 @@
     {
       "name": "cogni-wiki",
       "source": "./cogni-wiki",
-      "version": "0.0.54",
+      "version": "0.0.56",
       "maturity": "incubating",
       "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions surface at ingest, and knowledge compounds. Based on Karpathy's LLM Wiki pattern.",
       "keywords": [

--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.54",
+  "version": "0.0.56",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions surface at ingest, and knowledge compounds. Based on Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-wiki/skills/wiki-setup/references/SCHEMA.md.template
+++ b/cogni-wiki/skills/wiki-setup/references/SCHEMA.md.template
@@ -115,6 +115,31 @@ The `compose`, `verify`, and `finalize` prefixes (v0.0.45+) mark the write-side 
 
 Grouped under `##` category headings. The `wiki-ingest` skill maintains this file.
 
+### Curated entry point (Knowledge Portal)
+
+`index.md` doubles as the **single human entry point** — the one file a reader
+(or a fresh session) opens first. Beyond the auto-maintained bullet lists, it
+may carry **curated editorial prose**: an orienting intro before the first
+`##` heading, and a short **per-theme lead-in paragraph** directly under each
+`## <theme>` heading that frames why the theme matters and what to read first.
+A useful portal shape reads top-down as scope → syntheses → questions →
+thematic clusters → notes, so the knowledge (not the bookkeeping scaffold) is
+foregrounded.
+
+**Protected lead-in guarantee.** The deterministic inserter
+(`wiki_index_update.py`) treats any non-bullet prose between a `## <theme>`
+heading and that section's first `- [[slug]]` bullet as a **protected curated
+lead-in**: new auto-bullets are inserted *below* it (alphabetised within the
+bullet block), and the lead-in is preserved verbatim — never overwritten or
+reordered. This mirrors the "preserve the human tail" discipline
+`question-store.py` applies to a page's `## Notes` section, inverted to
+preserve the *lead*. So a curated portal and the deterministic catalog
+coexist in one file. (Regression-locked by `tests/test_index_leadin_preserve.sh`.)
+
+The auto-generated machine-facing surfaces (`context_brief.md`,
+`open_questions.md`, `log.md`) remain separate files; the portal links out to
+them rather than inlining them.
+
 ## Golden rules
 
 1. **Claude writes the wiki; the user curates the raw sources.**

--- a/cogni-wiki/tests/README.md
+++ b/cogni-wiki/tests/README.md
@@ -56,6 +56,7 @@ For pure LLM skills (no scripts to execute), regression coverage is limited to *
 | `test_source_page_type.sh` | `wiki-health` and `wiki-lint` accept the additive `type: source` page type added in v0.0.44 (#270) — a planted `wiki/sources/<slug>.md` page raises neither `invalid_type` nor `type_directory_mismatch`. Unblocks cogni-knowledge PR #269 milestone 6 `knowledge-ingest`. |
 | `test_index_summary_clamp.sh` | `wiki_index_update.py --max-summary N` clamps an over-long `--summary` on a WORD boundary with `…` via `_wikilib.clamp_summary` (v0.0.47, #324) — output words are an exact prefix of the input (no mid-word "…Sonderka"), German ä/ö/ü survive, codepoint-counted. No flag → verbatim passthrough (backward-compat for every other caller). |
 | `test_question_page_type.sh` | `wiki-health` and `wiki-lint` accept the additive `type: question` page type added in v0.0.50 (#407) — a planted `wiki/questions/<slug>.md` page raises neither `invalid_type` nor `type_directory_mismatch`. Unblocks cogni-knowledge #407 `knowledge-ingest` Step 4.5 (research-question nodes). |
+| `test_index_leadin_preserve.sh` | `wiki_index_update.py` preserves a curated per-theme lead-in paragraph (the prose between a `## <theme>` heading and its first `- [[slug]]` bullet) when inserting an auto-bullet — for both a populated section (bullet inserts alphabetically below the lead-in) and an empty-bullet section (the first bullet lands below the lead-in). Asserts the lead-in is byte-identical and no duplicate heading is created. Locks the script-side enabler for the single curated Knowledge Portal `index.md`. |
 
 ```sh
 bash tests/test_wiki_from_research_flags.sh
@@ -66,6 +67,7 @@ bash tests/test_batch_builder_metadata_config.sh
 bash tests/test_source_page_type.sh
 bash tests/test_index_summary_clamp.sh
 bash tests/test_question_page_type.sh
+bash tests/test_index_leadin_preserve.sh
 ```
 
 The SKILL.md tests do not assert anything about LLM-driven behaviour — only that the contract surface that orchestrators (`cogni-knowledge:knowledge-report` / `cogni-knowledge:knowledge-query`) depend on remains intact. The script-level tests execute the actual code path and assert observable behaviour.

--- a/cogni-wiki/tests/test_index_leadin_preserve.sh
+++ b/cogni-wiki/tests/test_index_leadin_preserve.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# test_index_leadin_preserve.sh — lock the curated-portal guarantee:
+# wiki_index_update.py MUST preserve a curated per-theme lead-in paragraph
+# (the prose between a `## <theme>` heading and its first `- [[slug]]` bullet)
+# when it inserts a new auto-bullet under that heading.
+#
+# This is the script-side enabler for the "single curated Knowledge Portal
+# index.md" consolidation: a curated index can only be safe if the
+# deterministic inserter never clobbers the editorial lead-in. It mirrors the
+# "preserve the human tail" discipline cogni-knowledge/scripts/question-store.py
+# uses for `## Notes` — inverted here to preserve the LEAD.
+#
+# Two section states are exercised:
+#   1. POPULATED section — lead-in + existing bullets; new bullet inserts
+#      alphabetically among the bullets, lead-in untouched.
+#   2. EMPTY-BULLET section — lead-in but no bullets yet; the first bullet
+#      lands BELOW the lead-in, lead-in untouched.
+# Both also assert no duplicate `## <theme>` heading is created.
+#
+# bash 3.2 + python3 stdlib only. Exits non-zero on any failure.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+UPDATE="$PLUGIN_ROOT/skills/wiki-ingest/scripts/wiki_index_update.py"
+WORKDIR="$(mktemp -d)"
+WIKI="$WORKDIR/test-wiki"
+INDEX="$WIKI/wiki/index.md"
+
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+red() { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+fail() { red "FAIL: $1"; printf -- '----- index.md -----\n'; cat "$INDEX" 2>/dev/null; exit 1; }
+
+LEADIN_SYN="The verified answers this base produces. Start here, then follow the evidence."
+LEADIN_Q="The research questions this base answers; each links to the sources that answer it."
+
+# ---------- seed a curated portal-shaped index ----------
+mkdir -p "$WIKI/wiki"
+cat > "$INDEX" <<EOF
+# Test Base — Knowledge Portal
+
+> One entry point.
+
+## Syntheses
+
+$LEADIN_SYN
+
+- [[alpha-synthesis]] — first synthesis
+- [[omega-synthesis]] — last synthesis
+
+## Questions
+
+$LEADIN_Q
+EOF
+
+green "seeded curated portal index (## Syntheses w/ lead-in + 2 bullets; ## Questions w/ lead-in, no bullets)"
+
+# ---------- helper: count occurrences of a heading ----------
+count_heading() { grep -c "^## $1\$" "$INDEX" || true; }
+# ---------- helper: literal-substring presence ----------
+has_line() { grep -qF "$1" "$INDEX"; }
+
+# =====================================================================
+# CASE 1 — populated section: insert a bullet that sorts BETWEEN the two.
+# =====================================================================
+python3 "$UPDATE" --wiki-root "$WIKI" --slug "mid-synthesis" \
+  --summary "middle synthesis" --category "Syntheses" >/dev/null
+
+has_line "$LEADIN_SYN" \
+  || fail "Case 1: curated ## Syntheses lead-in was lost after insert"
+green "Case 1: lead-in preserved byte-for-byte"
+
+[ "$(count_heading Syntheses)" = "1" ] \
+  || fail "Case 1: duplicate ## Syntheses heading created (count=$(count_heading Syntheses))"
+green "Case 1: exactly one ## Syntheses heading"
+
+# alphabetical order among bullets: alpha < mid < omega
+ORDER=$(grep -oE '\[\[(alpha|mid|omega)-synthesis\]\]' "$INDEX" | tr '\n' ' ')
+[ "$ORDER" = "[[alpha-synthesis]] [[mid-synthesis]] [[omega-synthesis]] " ] \
+  || fail "Case 1: bullets not alphabetised (got: $ORDER)"
+green "Case 1: new bullet inserted alphabetically (alpha < mid < omega)"
+
+# lead-in must still sit ABOVE the first bullet under ## Syntheses
+python3 - "$INDEX" <<'PY' || exit 1
+import sys
+text = open(sys.argv[1], encoding="utf-8").read().splitlines()
+in_syn = False
+seen_leadin = False
+for ln in text:
+    if ln.strip() == "## Syntheses":
+        in_syn = True; continue
+    if in_syn and ln.startswith("## "):
+        break
+    if in_syn and ln.startswith("The verified answers"):
+        seen_leadin = True
+    if in_syn and ln.startswith("- [[") and not seen_leadin:
+        print("FAIL: a bullet precedes the curated lead-in under ## Syntheses")
+        sys.exit(1)
+sys.exit(0 if seen_leadin else 1)
+PY
+green "Case 1: lead-in still precedes the bullet block"
+
+# =====================================================================
+# CASE 2 — empty-bullet section: first bullet lands BELOW the lead-in.
+# =====================================================================
+python3 "$UPDATE" --wiki-root "$WIKI" --slug "first-question" \
+  --summary "the first question" --category "Questions" >/dev/null
+
+has_line "$LEADIN_Q" \
+  || fail "Case 2: curated ## Questions lead-in was lost after first-bullet insert"
+green "Case 2: lead-in preserved on empty-bullet section"
+
+[ "$(count_heading Questions)" = "1" ] \
+  || fail "Case 2: duplicate ## Questions heading created (count=$(count_heading Questions))"
+green "Case 2: exactly one ## Questions heading"
+
+has_line "[[first-question]]" \
+  || fail "Case 2: the new bullet was not inserted under ## Questions"
+
+# lead-in must precede the new bullet under ## Questions
+python3 - "$INDEX" <<'PY' || exit 1
+import sys
+text = open(sys.argv[1], encoding="utf-8").read().splitlines()
+in_q = False
+seen_leadin = False
+for ln in text:
+    if ln.strip() == "## Questions":
+        in_q = True; continue
+    if in_q and ln.startswith("## "):
+        break
+    if in_q and ln.startswith("The research questions"):
+        seen_leadin = True
+    if in_q and ln.startswith("- [[first-question]]"):
+        if not seen_leadin:
+            print("FAIL: the first bullet precedes the curated lead-in under ## Questions")
+            sys.exit(1)
+        sys.exit(0)
+sys.exit(1)
+PY
+green "Case 2: first bullet lands below the lead-in"
+
+green "ALL TESTS PASS"


### PR DESCRIPTION
Refs #461. (Phase 1 — the issue stays open; portal-content authoring is the remaining half.)

## Summary
Phase 1 of the single curated "Knowledge Portal" `index.md` consolidation: the **script-side enabler** that makes a curated index safe to adopt.

- **Add `tests/test_index_leadin_preserve.sh`** — proves `wiki_index_update.py` preserves a curated **per-theme lead-in** (the prose between a `## <theme>` heading and its first `- [[slug]]` bullet) when inserting an auto-bullet: for a **populated** section the bullet inserts alphabetically *below* the lead-in, and for an **empty-bullet** section the first bullet lands *below* the lead-in. Asserts the lead-in is byte-identical and no duplicate heading is created.
- **Document the contract** in `wiki-setup/references/SCHEMA.md.template` `## Index format` — the curated portal shape (scope → syntheses → questions → thematic clusters → notes) and the **protected-lead-in guarantee**, mirroring the "preserve the human tail" discipline `question-store.py` uses for `## Notes` (inverted to preserve the *lead*).
- **No code change to `wiki_index_update.py`** — its `_split_sections`/`_join_sections` model already preserves prose lead-ins on both insert paths (`_insert_alphabetised` splice + the empty-section branch). This is a **verification + contract slice**: the test ratchets the behaviour so it cannot silently regress.
- **Bump** cogni-wiki `0.0.54 → 0.0.56` (plugin.json + marketplace.json; 0.0.55 is claimed by the open #459 PR).

## Why a verification-only slice
A curated single-entry portal is only safe if the deterministic inserter never clobbers the editorial lead-in. The writer already behaves correctly — so the right minimal increment is to **lock** that behaviour with a regression test and **state** it in the format contract, rather than refactor a load-bearing script. Zero behaviour change for existing flat indexes.

## Scope decisions
- **In:** the regression test (both section states), the SCHEMA format-contract update, and the version bump.
- **Deferred to follow-up issues:**
  - Multi-project **duplicate-heading hardening** — `_create_category` appends a new `## <Category>` at EOF, so multi-project bases accumulate duplicate `## Syntheses`/`## Notes` headings + a stale header count (the snag the author observed). Best fixed and reviewed standalone since it changes a script every cogni-wiki and cogni-knowledge index write depends on.
  - Route `type: question` nodes to a dedicated **Questions section** (taxonomy decision in `knowledge-ingest` Step 4.5.3 `--category`).
  - **Portal-content authoring** for `wiki/index.md` (maintainer-judgement structure on a live base).
  - **cogni-knowledge `knowledge-finalize`/`-ingest`** caller integration with the curated headings.

## Test plan
- [ ] `bash cogni-wiki/tests/test_index_leadin_preserve.sh` exits 0.
- [ ] Full `cogni-wiki/tests/` suite passes (22/22), incl. sibling `test_index_summary_clamp.sh` / `test_index_placeholder_selfclean.sh` (no regression).
- [ ] `plugin.json` and `marketplace.json` both show cogni-wiki `0.0.56`.

Resolution plan record: https://github.com/cogni-work/insight-wave/issues/461#issuecomment-4621067547

🤖 Generated with [Claude Code](https://claude.com/claude-code)
