### PR TITLE
cogni-wiki: non-destructive --move-slug index relocation mode (#438 Part A)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -304,7 +304,7 @@
     {
       "name": "cogni-wiki",
       "source": "./cogni-wiki",
-      "version": "0.0.54",
+      "version": "0.0.57",
       "maturity": "incubating",
       "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions surface at ingest, and knowledge compounds. Based on Karpathy's LLM Wiki pattern.",
       "keywords": [

--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.54",
+  "version": "0.0.57",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions surface at ingest, and knowledge compounds. Based on Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-wiki/CLAUDE.md
+++ b/cogni-wiki/CLAUDE.md
@@ -173,6 +173,7 @@ The advisory lock at `<wiki-root>/.cogni-wiki/.lock` is **retained as defence-in
 | File | Write operation | Locked call site |
 |------|-----------------|------------------|
 | `wiki/index.md` | Insert/update entry line | `wiki_index_update.py::update_index` (line 335) |
+| `wiki/index.md` | Relocate an entry line between headings (`--move-slug`) | `wiki_index_update.py::move_slug` |
 | `wiki/<type>/<target>.md` | Backlink append into an *existing* page (slug → path resolved via `_wikilib.build_slug_index`) | `backlink_audit.py::apply_plan` |
 | `.cogni-wiki/config.json` | `entries_count` bump (and any future counters) | `config_bump.py::main` (line 105) |
 | `.cogni-wiki/last-resweep.json` | Sweep summary write at end of `wiki-claims-resweep` aggregate phase | `resweep_planner.py::phase_aggregate` |

--- a/cogni-wiki/skills/wiki-ingest/scripts/wiki_index_update.py
+++ b/cogni-wiki/skills/wiki-ingest/scripts/wiki_index_update.py
@@ -353,6 +353,90 @@ def update_index(index_path: Path, slug: str, summary: str, category: str) -> di
     }
 
 
+def move_slug(index_path: Path, slug: str, to_category: str) -> dict:
+    """Relocate an existing `[[slug]]` entry from its current heading to
+    `to_category`, keeping it alphabetised. Non-destructive and idempotent.
+
+    Contract (issue #438 Part A):
+    - Find the slug line via `_find_slug_line_globally`. Missing slug → fail.
+    - If the line already sits directly under a heading matching `to_category`,
+      return ``action: "noop"`` (idempotent — a second call is a no-op).
+    - Otherwise remove the line from its source section, re-insert it
+      alphabetised under `to_category` (reusing `_insert_alphabetised` /
+      `_create_category`), and drop the source heading **only** when nothing
+      but blank lines remains under it — the same empty-heading discipline
+      `strip_seed_placeholder` uses, so a curated per-theme prose lead-in
+      under the source heading is preserved.
+    - Never adds or drops a wikilink — only the line's *summary text* moves
+      with it, verbatim.
+
+    A distinct mode from `update_index`: Case A there updates a slug line *in
+    place and ignores the category*, which is exactly why a relocation needs
+    its own entry point rather than overloading the insert/update path every
+    current caller depends on.
+    """
+    if not index_path.is_file():
+        fail(f"index.md not found at {index_path}")
+
+    try:
+        text = index_path.read_text(encoding="utf-8")
+    except OSError as e:
+        fail(f"could not read index.md: {e}")
+        return {}
+
+    sections = _split_sections(text)
+    sec_idx, line_idx = _find_slug_line_globally(sections, slug)
+    if sec_idx == -1:
+        fail(f"slug not found in index: {slug}")
+        return {}
+
+    heading, body = sections[sec_idx]
+
+    # Idempotent no-op: already directly under the target heading.
+    if heading is not None and _heading_matches_category(heading, to_category):
+        return {
+            "action": "noop",
+            "category": HEADING_RE.match(heading).group(2).strip(),
+            "slug": slug,
+            "index_path": str(index_path),
+        }
+
+    moved_line = body[line_idx]
+    new_body = body[:line_idx] + body[line_idx + 1:]
+    sections[sec_idx] = (heading, new_body)
+
+    # Drop the source heading only when no non-blank content remains under it
+    # (mirrors strip_seed_placeholder; preserves a curated lead-in if present).
+    source_heading_dropped = False
+    if heading is not None and not any(ln.strip() for ln in new_body):
+        del sections[sec_idx]
+        source_heading_dropped = True
+
+    # Re-insert alphabetised under the target category (Case B / Case C).
+    category_created = False
+    placed = False
+    for i, (h, b) in enumerate(sections):
+        if h is not None and _heading_matches_category(h, to_category):
+            sections[i] = (h, _insert_alphabetised(b, moved_line, slug))
+            placed = True
+            break
+    if not placed:
+        sections = _create_category(sections, to_category, moved_line)
+        category_created = True
+
+    new_text = _join_sections(sections)
+    atomic_write(index_path, new_text)
+    return {
+        "action": "moved",
+        "category": to_category.strip(),
+        "category_created": category_created,
+        "source_heading_dropped": source_heading_dropped,
+        "line": moved_line,
+        "slug": slug,
+        "index_path": str(index_path),
+    }
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Insert/update a page's entry in wiki/index.md, preserving alphabetical order."
@@ -361,6 +445,8 @@ def main() -> None:
     parser.add_argument("--slug", help="Slug of the page whose line we're adding/updating (slug mode)")
     parser.add_argument("--summary", help="One-sentence summary shown after the slug wikilink (slug mode)")
     parser.add_argument("--category", help="Category heading text without the leading ##/### (slug mode)")
+    parser.add_argument("--move-slug", help="Slug of an existing entry to relocate to --to-category (move mode)")
+    parser.add_argument("--to-category", help="Target category heading for --move-slug (move mode)")
     parser.add_argument(
         "--max-summary",
         type=int,
@@ -387,6 +473,27 @@ def main() -> None:
 
     if not (wiki_root / "wiki").is_dir():
         fail(f"wiki/ not found under {wiki_root}")
+
+    # Move mode (#438): relocate an existing entry between headings. Mutually
+    # exclusive with slug-mode (--slug/--summary/--category) and --reflow-only
+    # so the three write paths never overlap.
+    if args.move_slug:
+        if args.reflow_only:
+            fail("--move-slug cannot be combined with --reflow-only")
+        if args.slug or args.summary or args.category:
+            fail("--move-slug is mutually exclusive with --slug/--summary/--category")
+        if not (args.to_category and args.to_category.strip()):
+            fail("--move-slug requires a non-empty --to-category")
+        if not index_path.is_file():
+            fail(f"index.md not found at {index_path}")
+        mv_slug = args.move_slug.strip().lower()
+        if not re.match(r"^[a-z0-9][a-z0-9\-]*$", mv_slug):
+            fail(f"invalid slug: {args.move_slug!r} (expected kebab-case: [a-z0-9][a-z0-9-]*)")
+        to_category = args.to_category.strip()
+        with _wiki_lock(wiki_root):
+            result = move_slug(index_path, mv_slug, to_category)
+        ok(result)
+        return
 
     if args.reflow_only:
         if not index_path.is_file():

--- a/cogni-wiki/skills/wiki-ingest/scripts/wiki_index_update.py
+++ b/cogni-wiki/skills/wiki-ingest/scripts/wiki_index_update.py
@@ -81,6 +81,29 @@ SLUG_LINE_RE_TEMPLATE = r"^(\s*-\s*\[\[){slug}(\]\])"
 SEED_PLACEHOLDER_LINE = "_No pages yet. Run `wiki-ingest` to add your first source._"
 SEED_CATEGORY_HEADING = "Categories"
 
+# Slug grammar shared by slug-mode (--slug) and move-mode (--move-slug), kept as
+# one constant so the kebab-case contract can't drift between the two paths.
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9\-]*$")
+
+
+def _validate_slug(slug: str, raw: str) -> None:
+    """Fail unless `slug` is kebab-case. `raw` is the user-supplied form, shown
+    verbatim in the error so the message points at exactly what they typed."""
+    if not SLUG_RE.match(slug):
+        fail(f"invalid slug: {raw!r} (expected kebab-case: [a-z0-9][a-z0-9-]*)")
+
+
+def _read_index_text(index_path: Path) -> str:
+    """Read index.md, failing cleanly if it's absent or unreadable. Shared by
+    update_index and move_slug so the existence/IO-error contract is identical."""
+    if not index_path.is_file():
+        fail(f"index.md not found at {index_path}")
+    try:
+        return index_path.read_text(encoding="utf-8")
+    except OSError as e:
+        fail(f"could not read index.md: {e}")
+        return ""  # unreachable — fail() exits; keeps the type checker happy
+
 
 def _split_sections(text: str) -> list:
     """Split index.md into a list of (heading_line_or_None, lines_under_it).
@@ -292,14 +315,7 @@ def reflow_categories(text: str) -> tuple:
 
 def update_index(index_path: Path, slug: str, summary: str, category: str) -> dict:
     """Do the actual edit. Pure function of (file contents, args)."""
-    if not index_path.is_file():
-        fail(f"index.md not found at {index_path}")
-
-    try:
-        text = index_path.read_text(encoding="utf-8")
-    except OSError as e:
-        fail(f"could not read index.md: {e}")
-        return {}
+    text = _read_index_text(index_path)
 
     # #306: shed the wiki-setup seed placeholder on the first real insert/update
     # so script-level callers stop inheriting the dead `## Categories` /
@@ -375,14 +391,7 @@ def move_slug(index_path: Path, slug: str, to_category: str) -> dict:
     its own entry point rather than overloading the insert/update path every
     current caller depends on.
     """
-    if not index_path.is_file():
-        fail(f"index.md not found at {index_path}")
-
-    try:
-        text = index_path.read_text(encoding="utf-8")
-    except OSError as e:
-        fail(f"could not read index.md: {e}")
-        return {}
+    text = _read_index_text(index_path)
 
     sections = _split_sections(text)
     sec_idx, line_idx = _find_slug_line_globally(sections, slug)
@@ -487,8 +496,7 @@ def main() -> None:
         if not index_path.is_file():
             fail(f"index.md not found at {index_path}")
         mv_slug = args.move_slug.strip().lower()
-        if not re.match(r"^[a-z0-9][a-z0-9\-]*$", mv_slug):
-            fail(f"invalid slug: {args.move_slug!r} (expected kebab-case: [a-z0-9][a-z0-9-]*)")
+        _validate_slug(mv_slug, args.move_slug)
         to_category = args.to_category.strip()
         with _wiki_lock(wiki_root):
             result = move_slug(index_path, mv_slug, to_category)
@@ -521,8 +529,7 @@ def main() -> None:
         fail("--slug, --summary, --category are required (or pass --reflow-only)")
 
     slug = args.slug.strip().lower()
-    if not re.match(r"^[a-z0-9][a-z0-9\-]*$", slug):
-        fail(f"invalid slug: {args.slug!r} (expected kebab-case: [a-z0-9][a-z0-9-]*)")
+    _validate_slug(slug, args.slug)
 
     summary = args.summary.strip()
     if not summary:

--- a/cogni-wiki/skills/wiki-ingest/scripts/wiki_index_update.py
+++ b/cogni-wiki/skills/wiki-ingest/scripts/wiki_index_update.py
@@ -385,6 +385,11 @@ def move_slug(index_path: Path, slug: str, to_category: str) -> dict:
       under the source heading is preserved.
     - Never adds or drops a wikilink — only the line's *summary text* moves
       with it, verbatim.
+    - Duplicate slugs: `_find_slug_line_globally` returns the **first** match,
+      so if a slug somehow appears under two headings only the first occurrence
+      relocates. That is intentional — duplicate slugs are a separate defect
+      `wiki-health` / `wiki-lint` already surface, and this mode does not try to
+      reconcile them.
 
     A distinct mode from `update_index`: Case A there updates a slug line *in
     place and ignores the category*, which is exactly why a relocation needs

--- a/cogni-wiki/tests/README.md
+++ b/cogni-wiki/tests/README.md
@@ -56,6 +56,7 @@ For pure LLM skills (no scripts to execute), regression coverage is limited to *
 | `test_source_page_type.sh` | `wiki-health` and `wiki-lint` accept the additive `type: source` page type added in v0.0.44 (#270) — a planted `wiki/sources/<slug>.md` page raises neither `invalid_type` nor `type_directory_mismatch`. Unblocks cogni-knowledge PR #269 milestone 6 `knowledge-ingest`. |
 | `test_index_summary_clamp.sh` | `wiki_index_update.py --max-summary N` clamps an over-long `--summary` on a WORD boundary with `…` via `_wikilib.clamp_summary` (v0.0.47, #324) — output words are an exact prefix of the input (no mid-word "…Sonderka"), German ä/ö/ü survive, codepoint-counted. No flag → verbatim passthrough (backward-compat for every other caller). |
 | `test_question_page_type.sh` | `wiki-health` and `wiki-lint` accept the additive `type: question` page type added in v0.0.50 (#407) — a planted `wiki/questions/<slug>.md` page raises neither `invalid_type` nor `type_directory_mismatch`. Unblocks cogni-knowledge #407 `knowledge-ingest` Step 4.5 (research-question nodes). |
+| `test_index_move_slug.sh` | `wiki_index_update.py --move-slug <slug> --to-category <cat>` non-destructively relocates an existing index entry between headings: alphabetised under the target, summary preserved verbatim, source heading dropped only when drained empty (a curated prose lead-in keeps it), idempotent (2nd call → `noop`), `[[wikilink]]` set-membership unchanged, and mutually exclusive with slug-mode / `--reflow-only`. Part A of the question-anchored index migration. |
 
 ```sh
 bash tests/test_wiki_from_research_flags.sh
@@ -66,6 +67,7 @@ bash tests/test_batch_builder_metadata_config.sh
 bash tests/test_source_page_type.sh
 bash tests/test_index_summary_clamp.sh
 bash tests/test_question_page_type.sh
+bash tests/test_index_move_slug.sh
 ```
 
 The SKILL.md tests do not assert anything about LLM-driven behaviour — only that the contract surface that orchestrators (`cogni-knowledge:knowledge-report` / `cogni-knowledge:knowledge-query`) depend on remains intact. The script-level tests execute the actual code path and assert observable behaviour.

--- a/cogni-wiki/tests/test_index_move_slug.sh
+++ b/cogni-wiki/tests/test_index_move_slug.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# test_index_move_slug.sh — assert wiki_index_update.py's `--move-slug` mode
+# (issue #438 Part A): non-destructive, idempotent relocation of an existing
+# index.md entry between category headings.
+#
+# Models the real migration shape: question-node slugs live only under the old
+# additive `## Research questions` heading; per-theme sections hold *source*
+# slugs. The migration relocates each question node into its theme section and
+# drops `## Research questions` once it is drained.
+#
+# Covers:
+#   1. Relocate — a question node moves into its theme section, alphabetised,
+#      summary text preserved verbatim; a still-populated source heading stays.
+#   2. Empty-heading drop — draining the last bullet drops the source heading
+#      (mirrors strip_seed_placeholder's empty-heading discipline).
+#   3. Idempotency — a second identical `--move-slug` is action:"noop", file
+#      byte-identical.
+#   4. Drift safety — the set of `[[wikilinks]]` is unchanged by a move.
+#   5. Mutual exclusivity — `--move-slug` with `--slug` or `--reflow-only` fails.
+#   6. Lead-in preservation — a source heading that still carries curated prose
+#      (no bullets left) is NOT dropped.
+#
+# bash 3.2 + python3 stdlib only. Exits non-zero on any failure.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+UPDATE="$PLUGIN_ROOT/skills/wiki-ingest/scripts/wiki_index_update.py"
+WORKDIR="$(mktemp -d)"
+WIKI="$WORKDIR/test-wiki"
+INDEX="$WIKI/wiki/index.md"
+
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+red() { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+fail() { red "FAIL: $1"; printf -- '----- index.md -----\n'; cat "$INDEX" 2>/dev/null; exit 1; }
+
+count_heading() { grep -c "^## $1\$" "$INDEX" || true; }
+has_line() { grep -qF "$1" "$INDEX"; }
+wikilink_set() { grep -oE '\[\[[a-z0-9][a-z0-9-]*\]\]' "$INDEX" | sort -u; }
+
+seed_index() {
+  mkdir -p "$WIKI/wiki"
+  cat > "$INDEX" <<'EOF'
+# Test Base — Knowledge Portal
+
+## Market Shifts
+- [[market-source-a]] — a market analysis source
+- [[market-source-b]] — another market source
+
+## Research questions
+- [[sq-adoption-barriers]] — what blocks adoption
+- [[sq-market-demand-drivers]] — what drives demand
+EOF
+}
+
+# =====================================================================
+# CASE 1 + 2a + 4 — relocate one question node into its theme section.
+# =====================================================================
+seed_index
+BEFORE_SET=$(wikilink_set)
+
+python3 "$UPDATE" --wiki-root "$WIKI" --move-slug "sq-market-demand-drivers" \
+  --to-category "Market Shifts" >/dev/null
+
+# moved bullet (summary verbatim) now lives under ## Market Shifts, alphabetised
+python3 - "$INDEX" <<'PY' || exit 1
+import sys
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+in_ms = False
+slugs = []
+for ln in lines:
+    if ln.strip() == "## Market Shifts":
+        in_ms = True; continue
+    if in_ms and ln.startswith("## "):
+        break
+    if in_ms and ln.startswith("- [["):
+        slugs.append(ln)
+joined = "\n".join(slugs)
+assert "- [[sq-market-demand-drivers]] — what drives demand" in joined, "moved bullet missing/altered under ## Market Shifts"
+# alphabetised by slug: market-source-a < market-source-b < sq-market-demand-drivers
+order = [l.split("[[")[1].split("]]")[0] for l in slugs]
+assert order == sorted(order), f"not alphabetised: {order}"
+PY
+green "Case 1: question node relocated into theme section, alphabetised, verbatim"
+
+[ "$(count_heading "Research questions")" = "1" ] \
+  || fail "Case 2a: ## Research questions dropped while it still has a bullet"
+green "Case 2a: non-empty source heading retained"
+
+AFTER_SET=$(wikilink_set)
+[ "$BEFORE_SET" = "$AFTER_SET" ] || fail "Case 4: wikilink set changed across move (drift)"
+green "Case 4: WIKILINK set-membership unchanged across move"
+
+# =====================================================================
+# CASE 2b — empty-heading drop: drain the last bullet out of ## Research questions.
+# =====================================================================
+python3 "$UPDATE" --wiki-root "$WIKI" --move-slug "sq-adoption-barriers" \
+  --to-category "Adoption" >/dev/null
+[ "$(count_heading "Research questions")" = "0" ] \
+  || fail "Case 2b: drained ## Research questions heading was not dropped"
+green "Case 2b: drained source heading dropped"
+
+# =====================================================================
+# CASE 3 — idempotency: a second identical move is a noop, file byte-identical.
+# =====================================================================
+seed_index
+python3 "$UPDATE" --wiki-root "$WIKI" --move-slug "sq-adoption-barriers" --to-category "Adoption" >/dev/null
+SNAP=$(cat "$INDEX")
+OUT=$(python3 "$UPDATE" --wiki-root "$WIKI" --move-slug "sq-adoption-barriers" --to-category "Adoption")
+ACTION=$(printf '%s' "$OUT" | python3 -c "import sys,json;print(json.load(sys.stdin)['data']['action'])")
+[ "$ACTION" = "noop" ] || fail "Case 3: second move returned action=$ACTION (expected noop)"
+[ "$SNAP" = "$(cat "$INDEX")" ] || fail "Case 3: noop move mutated the file"
+green "Case 3: second move is a noop and byte-identical"
+
+# =====================================================================
+# CASE 5 — mutual exclusivity.
+# =====================================================================
+seed_index
+if python3 "$UPDATE" --wiki-root "$WIKI" --move-slug "x" --to-category "Y" --reflow-only >/dev/null 2>&1; then
+  fail "Case 5: --move-slug + --reflow-only did not fail"
+fi
+green "Case 5a: --move-slug + --reflow-only rejected"
+if python3 "$UPDATE" --wiki-root "$WIKI" --move-slug "x" --to-category "Y" --slug "z" --summary "s" --category "C" >/dev/null 2>&1; then
+  fail "Case 5: --move-slug + --slug did not fail"
+fi
+green "Case 5b: --move-slug + --slug/--summary/--category rejected"
+
+# =====================================================================
+# CASE 6 — lead-in preservation: a source heading with curated prose but no
+# bullets left is NOT dropped.
+# =====================================================================
+mkdir -p "$WIKI/wiki"
+cat > "$INDEX" <<'EOF'
+# Test Base
+
+## Syntheses
+
+The verified answers this base produces.
+
+- [[only-synthesis]] — the one synthesis
+
+## Adoption
+- [[other-page]] — placeholder
+EOF
+python3 "$UPDATE" --wiki-root "$WIKI" --move-slug "only-synthesis" --to-category "Adoption" >/dev/null
+[ "$(count_heading "Syntheses")" = "1" ] \
+  || fail "Case 6: ## Syntheses dropped despite a curated lead-in remaining"
+has_line "The verified answers this base produces." \
+  || fail "Case 6: curated lead-in lost"
+green "Case 6: source heading with curated lead-in preserved"
+
+green "ALL TESTS PASS"


### PR DESCRIPTION
Refs #438 (Part A). (The issue stays open — Part B and the live-base migration run are the remaining halves.)

## Summary
Part A of migrating already-finalized wikis off the old two-grouping `index.md` layout (per-theme source sections + a separate `## Research questions`). Re-ingest can't relocate those entries because `wiki_index_update.py` Case A updates a slug line **in place and ignores `--category`** — so a dedicated relocation mode is required.

- **New `wiki_index_update.py --move-slug <slug> --to-category <cat>`** (locked, idempotent, non-destructive):
  - `noop` when the entry already sits under a heading matching `--to-category`.
  - else remove the line, re-insert it **alphabetised** under the target (reusing `_insert_alphabetised`/`_create_category`), and drop the source heading **only** when nothing but blank lines remains — the same empty-heading discipline `strip_seed_placeholder` uses, so a curated per-theme prose lead-in is preserved.
  - never adds/drops a wikilink — only the line's **summary text** moves, verbatim. `atomic_write`; `action ∈ {moved, noop}`.
- **Additive + mutually exclusive** with slug-mode (`--slug/--summary/--category`) and `--reflow-only`, validated in `main()` mirroring the existing `--reflow-only` early-return pattern. **Case A insert/update semantics are untouched — every current caller (cogni-trends, cogni-workspace, cogni-knowledge, cogni-wiki wiki-ingest) is byte-identical.**
- **New `tests/test_index_move_slug.sh`** — relocate, empty-heading drop, idempotent `noop` (byte-identical), `[[wikilink]]` set-membership drift proxy, mutual exclusivity, and curated-lead-in preservation.
- **Bump** cogni-wiki `0.0.54 → 0.0.57` (plugin.json + marketplace.json; forks from main, jumps past 0.0.55/0.0.56 claimed by the open #459/#461 PRs).

## Scope decisions
- **In:** the locked `--move-slug` mode, its test, the version bump (Part A — the dependency root).
- **Deferred (follow-ups):**
  - **Part B** — cogni-knowledge `scripts/migrate-question-index.py` one-shot driver (globs `wiki/questions/*.md`, reads `theme_label:`, calls `--move-slug` per node). It *depends on this mode landing first*; file as a cogni-knowledge follow-up once this merges.
  - **Migration action** — running the Part B driver against the live `.alpha/eu-ai-act-sme` base (and any other base carrying a `## Research questions` index section). A real user-wiki mutation and maintainer step, not part of any code PR.

## Test plan
- [ ] `bash cogni-wiki/tests/test_index_move_slug.sh` exits 0.
- [ ] Full `cogni-wiki/tests/` suite passes (22/22), incl. the existing slug-mode/reflow tests (`test_index_summary_clamp.sh`, `test_index_placeholder_selfclean.sh`) — no regression.
- [ ] slug-mode and `--reflow-only` behave exactly as before; `--move-slug` combined with either fails with a clear error.
- [ ] cogni-wiki version reads `0.0.57` in plugin.json and marketplace.json.

Resolution plan record: https://github.com/cogni-work/insight-wave/issues/438#issuecomment-4621248325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
