### PR TITLE
cogni-wiki: single-instance portal headings (duplicate-heading hardening)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -304,7 +304,7 @@
     {
       "name": "cogni-wiki",
       "source": "./cogni-wiki",
-      "version": "0.0.60",
+      "version": "0.0.61",
       "maturity": "incubating",
       "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions surface at ingest, and knowledge compounds. Based on Karpathy's LLM Wiki pattern.",
       "keywords": [

--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions surface at ingest, and knowledge compounds. Based on Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-wiki/skills/wiki-ingest/scripts/wiki_index_update.py
+++ b/cogni-wiki/skills/wiki-ingest/scripts/wiki_index_update.py
@@ -133,12 +133,21 @@ def _join_sections(sections: list) -> str:
     return "\n".join(out_lines) + "\n"
 
 
+def _heading_to_key(heading_line: str) -> str:
+    """Normalised comparison key for a heading line — the HEADING_RE-captured
+    text (or the raw line if it isn't a heading), folded with `.strip().lower()`.
+
+    The single source of truth for "are these the same heading", shared by
+    `_heading_matches_category` and `collapse_duplicate_headings` so the two
+    paths can't drift on what counts as a match.
+    """
+    m = HEADING_RE.match(heading_line)
+    return (m.group(2) if m else heading_line).strip().lower()
+
+
 def _heading_matches_category(heading_line: str, category: str) -> bool:
     """Match `## Foo` or `### Foo` against category="Foo" (case-insensitive)."""
-    m = HEADING_RE.match(heading_line)
-    if not m:
-        return False
-    return m.group(2).strip().lower() == category.strip().lower()
+    return _heading_to_key(heading_line) == category.strip().lower()
 
 
 def _slug_line_regex(slug: str) -> re.Pattern:
@@ -239,9 +248,9 @@ def _create_category(sections: list, category: str, new_line: str) -> list:
 def collapse_duplicate_headings(sections: list) -> list:
     """Merge duplicate `## <heading>` sections into the first occurrence.
 
-    Two sections are "the same heading" when their HEADING_RE-captured text,
-    normalised with `.strip().lower()`, is equal — the same key
-    `_heading_matches_category` compares against. The FIRST occurrence survives
+    Two sections are "the same heading" when their `_heading_to_key` value is
+    equal — the same normalised key `_heading_matches_category` compares
+    against, so collapse and dispatch agree. The FIRST occurrence survives
     and keeps its body verbatim, including any **curated lead-in** (the
     protected prose between a heading and its first `- [[slug]]` bullet, per the
     #461 Phase-1 contract). Each later duplicate's `- [[slug]]` bullets are
@@ -266,8 +275,7 @@ def collapse_duplicate_headings(sections: list) -> list:
         if heading is None:
             result.append((heading, list(body)))
             continue
-        m = HEADING_RE.match(heading)
-        key = (m.group(2) if m else heading).strip().lower()
+        key = _heading_to_key(heading)
         if key not in first_idx:
             first_idx[key] = len(result)
             result.append((heading, list(body)))
@@ -276,9 +284,7 @@ def collapse_duplicate_headings(sections: list) -> list:
         changed = True
         tgt_heading, tgt_body = result[first_idx[key]]
         existing_slugs = {
-            _extract_slug_from_line(ln)
-            for ln in tgt_body
-            if _extract_slug_from_line(ln)
+            slug for ln in tgt_body if (slug := _extract_slug_from_line(ln))
         }
         for line in body:
             slug = _extract_slug_from_line(line)

--- a/cogni-wiki/skills/wiki-ingest/scripts/wiki_index_update.py
+++ b/cogni-wiki/skills/wiki-ingest/scripts/wiki_index_update.py
@@ -236,6 +236,62 @@ def _create_category(sections: list, category: str, new_line: str) -> list:
     return sections
 
 
+def collapse_duplicate_headings(sections: list) -> list:
+    """Merge duplicate `## <heading>` sections into the first occurrence.
+
+    Two sections are "the same heading" when their HEADING_RE-captured text,
+    normalised with `.strip().lower()`, is equal — the same key
+    `_heading_matches_category` compares against. The FIRST occurrence survives
+    and keeps its body verbatim, including any **curated lead-in** (the
+    protected prose between a heading and its first `- [[slug]]` bullet, per the
+    #461 Phase-1 contract). Each later duplicate's `- [[slug]]` bullets are
+    folded into the survivor via `_insert_alphabetised` (skipping a slug the
+    survivor already carries, so the fold is idempotent and never creates a
+    duplicate bullet line), and the duplicate's heading shell is dropped. A
+    later duplicate's own non-bullet prose is discarded — first lead-in wins;
+    a machine-created duplicate from `_create_category` carries only
+    `["", bullet, ""]`, so it has no lead-in to lose.
+
+    Pure function. Returns the input list unchanged when every heading is unique
+    (no-op on a clean index). The preamble section (heading is None) is never
+    merged. This keeps a multi-project portal `index.md` single-instance: a
+    second `## <theme>` block created when a prior insert fell through to Case C
+    against a heading that didn't case/whitespace-match is collapsed on the next
+    write rather than persisting on disk.
+    """
+    first_idx: dict = {}
+    result: list = []
+    changed = False
+    for heading, body in sections:
+        if heading is None:
+            result.append((heading, list(body)))
+            continue
+        m = HEADING_RE.match(heading)
+        key = (m.group(2) if m else heading).strip().lower()
+        if key not in first_idx:
+            first_idx[key] = len(result)
+            result.append((heading, list(body)))
+            continue
+        # Duplicate heading: fold its bullets into the first occurrence's body.
+        changed = True
+        tgt_heading, tgt_body = result[first_idx[key]]
+        existing_slugs = {
+            _extract_slug_from_line(ln)
+            for ln in tgt_body
+            if _extract_slug_from_line(ln)
+        }
+        for line in body:
+            slug = _extract_slug_from_line(line)
+            if slug and slug not in existing_slugs:
+                tgt_body = _insert_alphabetised(tgt_body, line, slug)
+                existing_slugs.add(slug)
+        result[first_idx[key]] = (tgt_heading, tgt_body)
+        # Drop the duplicate heading shell — do not append it to `result`.
+    if not changed:
+        return sections
+    return result
+
+
 def strip_seed_placeholder(text: str) -> str:
     """Remove the wiki-setup seed placeholder from index.md text (#306).
 
@@ -324,6 +380,10 @@ def update_index(index_path: Path, slug: str, summary: str, category: str) -> di
 
     new_line = f"- [[{slug}]] — {summary}"
     sections = _split_sections(text)
+    # #485 Phase 1: keep portal `## <theme>` sections single-instance — fold any
+    # pre-existing duplicate heading into its first occurrence before dispatch,
+    # so Case B always finds the merged section and Case C never adds a third.
+    sections = collapse_duplicate_headings(sections)
 
     # Case A: slug already has a line somewhere — update it in place.
     sec_idx, line_idx = _find_slug_line_globally(sections, slug)
@@ -399,6 +459,10 @@ def move_slug(index_path: Path, slug: str, to_category: str) -> dict:
     text = _read_index_text(index_path)
 
     sections = _split_sections(text)
+    # #485 Phase 1: collapse any duplicate `## <theme>` heading before locating
+    # the slug, so a relocation against a portal that already drifted into two
+    # same-theme sections operates on the merged (single-instance) section.
+    sections = collapse_duplicate_headings(sections)
     sec_idx, line_idx = _find_slug_line_globally(sections, slug)
     if sec_idx == -1:
         fail(f"slug not found in index: {slug}")

--- a/cogni-wiki/skills/wiki-setup/references/SCHEMA.md.template
+++ b/cogni-wiki/skills/wiki-setup/references/SCHEMA.md.template
@@ -136,6 +136,15 @@ reordered. This mirrors the "preserve the human tail" discipline
 preserve the *lead*. So a curated portal and the deterministic catalog
 coexist in one file. (Regression-locked by `tests/test_index_leadin_preserve.sh`.)
 
+**Single-instance heading guarantee.** Each `## <theme>` heading is
+single-instance. When multiple projects or ingests write into one portal,
+`wiki_index_update.py` collapses any duplicate `## <theme>` section into the
+first occurrence at write time — the later section's bullets are merged
+alphabetically into the first (its curated lead-in preserved verbatim) and the
+duplicate heading shell is dropped — so a reader never sees the same theme split
+across two competing sections. (Regression-locked by
+`tests/test_index_duplicate_heading.sh`.)
+
 The auto-generated machine-facing surfaces (`context_brief.md`,
 `open_questions.md`, `log.md`) remain separate files; the portal links out to
 them rather than inlining them.

--- a/cogni-wiki/tests/test_index_duplicate_heading.sh
+++ b/cogni-wiki/tests/test_index_duplicate_heading.sh
@@ -137,4 +137,76 @@ if ! diff -q "$BEFORE" "$INDEX" >/dev/null 2>&1; then
 fi
 green "Case 2: idempotent re-run — single heading, index unchanged"
 
+# =====================================================================
+# CASE 3 — the SAME slug present in BOTH duplicate sections collapses to
+# exactly one bullet (the dedup "skip a slug the survivor already carries"
+# branch, asserted directly rather than transitively).
+# =====================================================================
+cat > "$INDEX" <<EOF
+# Test Base — Knowledge Portal
+
+> One entry point.
+
+## Syntheses
+
+$LEADIN_SYN
+
+- [[dup-synthesis]] — first copy
+
+## Syntheses
+
+- [[dup-synthesis]] — second copy
+- [[tail-synthesis]] — only in the second section
+EOF
+
+# An insert of an unrelated slug triggers the collapse.
+python3 "$UPDATE" --wiki-root "$WIKI" --slug "head-synthesis" \
+  --summary "sorts first" --category "Syntheses" >/dev/null
+
+[ "$(count_heading Syntheses)" = "1" ] \
+  || fail "Case 3: ## Syntheses not collapsed (count=$(count_heading Syntheses))"
+[ "$(count_bullet "[[dup-synthesis]]")" = "1" ] \
+  || fail "Case 3: slug in both sections not deduped (count=$(count_bullet "[[dup-synthesis]]"))"
+has_line "[[tail-synthesis]]" \
+  || fail "Case 3: distinct bullet from the second section was dropped"
+has_line "$LEADIN_SYN" \
+  || fail "Case 3: the survivor's curated lead-in was lost"
+green "Case 3: a slug duplicated across both sections survives exactly once"
+
+# =====================================================================
+# CASE 4 — move_slug() collapses a drifted portal before relocating, so the
+# move operates on the merged (single-instance) target section.
+# =====================================================================
+cat > "$INDEX" <<EOF
+# Test Base — Knowledge Portal
+
+> One entry point.
+
+## Syntheses
+
+$LEADIN_SYN
+
+- [[alpha-synthesis]] — first synthesis
+
+## Drafts
+
+- [[beta-synthesis]] — to be relocated into Syntheses
+
+## Syntheses
+
+- [[omega-synthesis]] — last synthesis
+EOF
+
+python3 "$UPDATE" --wiki-root "$WIKI" --move-slug "beta-synthesis" \
+  --to-category "Syntheses" >/dev/null
+
+[ "$(count_heading Syntheses)" = "1" ] \
+  || fail "Case 4: move_slug did not collapse the duplicate (count=$(count_heading Syntheses))"
+ORDER=$(grep -oE '\[\[(alpha|beta|omega)-synthesis\]\]' "$INDEX" | tr '\n' ' ')
+[ "$ORDER" = "[[alpha-synthesis]] [[beta-synthesis]] [[omega-synthesis]] " ] \
+  || fail "Case 4: relocated bullet not alphabetised into the merged section (got: $ORDER)"
+has_line "$LEADIN_SYN" \
+  || fail "Case 4: the survivor's curated lead-in was lost during move+collapse"
+green "Case 4: move_slug collapses first, then relocates into the merged section"
+
 green "ALL TESTS PASS"

--- a/cogni-wiki/tests/test_index_duplicate_heading.sh
+++ b/cogni-wiki/tests/test_index_duplicate_heading.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# test_index_duplicate_heading.sh — lock the single-instance portal guarantee:
+# wiki_index_update.py MUST collapse a duplicate `## <theme>` section into the
+# first occurrence at write time, so a multi-project Knowledge Portal index.md
+# never shows the same theme split across two competing sections.
+#
+# This is the #485 Phase-1 hardening on top of the #461 lead-in contract
+# (test_index_leadin_preserve.sh). The collapse runs inside update_index() (and
+# move_slug()) before the insert/relocate dispatch, so it is a free side-effect
+# of any slug-mode insert/update or --move-slug call.
+#
+# Invariants asserted:
+#   1. A pre-existing duplicate `## Syntheses` is collapsed to ONE heading on
+#      the next insert; the FIRST section's curated lead-in survives verbatim.
+#   2. Bullets from BOTH original sections survive, merged once and alphabetised
+#      (the inserted bullet lands among them in slug order).
+#   3. An unrelated section (## Sources) is left untouched.
+#   4. Idempotent: a re-run produces no second heading and no bullet churn.
+#
+# bash 3.2 + python3 stdlib only. Exits non-zero on any failure.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+UPDATE="$PLUGIN_ROOT/skills/wiki-ingest/scripts/wiki_index_update.py"
+WORKDIR="$(mktemp -d)"
+WIKI="$WORKDIR/test-wiki"
+INDEX="$WIKI/wiki/index.md"
+
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+red() { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+fail() { red "FAIL: $1"; printf -- '----- index.md -----\n'; cat "$INDEX" 2>/dev/null; exit 1; }
+
+LEADIN_SYN="The verified answers this base produces. Start here, then follow the evidence."
+
+count_heading() { grep -c "^## $1\$" "$INDEX" || true; }
+count_bullet()  { grep -cF "$1" "$INDEX" || true; }
+has_line()      { grep -qF "$1" "$INDEX"; }
+
+# ---------- seed a portal index that has DRIFTED into two ## Syntheses ----------
+# The first section is curated (lead-in + a bullet); the second is the
+# machine-shaped duplicate a prior Case-C insert would have appended.
+mkdir -p "$WIKI/wiki"
+cat > "$INDEX" <<EOF
+# Test Base — Knowledge Portal
+
+> One entry point.
+
+## Syntheses
+
+$LEADIN_SYN
+
+- [[alpha-synthesis]] — first synthesis
+
+## Sources
+
+- [[some-source]] — an unrelated source bullet that must stay put
+
+## Syntheses
+
+- [[omega-synthesis]] — last synthesis
+EOF
+
+green "seeded a drifted portal (two ## Syntheses sections + an unrelated ## Sources)"
+
+# =====================================================================
+# CASE 1 — an insert under Syntheses collapses the duplicate first.
+# mid-synthesis sorts BETWEEN alpha and omega.
+# =====================================================================
+python3 "$UPDATE" --wiki-root "$WIKI" --slug "mid-synthesis" \
+  --summary "middle synthesis" --category "Syntheses" >/dev/null
+
+[ "$(count_heading Syntheses)" = "1" ] \
+  || fail "Case 1: ## Syntheses not collapsed to single instance (count=$(count_heading Syntheses))"
+green "Case 1: exactly one ## Syntheses heading after collapse"
+
+has_line "$LEADIN_SYN" \
+  || fail "Case 1: the first section's curated lead-in was lost during collapse"
+green "Case 1: curated lead-in preserved byte-for-byte"
+
+# all three slugs present, each exactly once
+for s in alpha-synthesis mid-synthesis omega-synthesis; do
+  has_line "[[$s]]" || fail "Case 1: bullet [[$s]] missing after collapse"
+  [ "$(count_bullet "[[$s]]")" = "1" ] \
+    || fail "Case 1: bullet [[$s]] duplicated (count=$(count_bullet "[[$s]]"))"
+done
+green "Case 1: bullets from both sections merged, each present exactly once"
+
+# alphabetical order among the merged Syntheses bullets: alpha < mid < omega
+ORDER=$(grep -oE '\[\[(alpha|mid|omega)-synthesis\]\]' "$INDEX" | tr '\n' ' ')
+[ "$ORDER" = "[[alpha-synthesis]] [[mid-synthesis]] [[omega-synthesis]] " ] \
+  || fail "Case 1: merged bullets not alphabetised (got: $ORDER)"
+green "Case 1: merged bullets alphabetised (alpha < mid < omega)"
+
+# the unrelated ## Sources section is untouched
+[ "$(count_heading Sources)" = "1" ] \
+  || fail "Case 1: unrelated ## Sources heading disturbed (count=$(count_heading Sources))"
+has_line "[[some-source]]" \
+  || fail "Case 1: unrelated [[some-source]] bullet was dropped"
+green "Case 1: unrelated ## Sources section left untouched"
+
+# lead-in must still sit ABOVE the first bullet under ## Syntheses
+python3 - "$INDEX" <<'PY' || exit 1
+import sys
+text = open(sys.argv[1], encoding="utf-8").read().splitlines()
+in_syn = False
+seen_leadin = False
+for ln in text:
+    if ln.strip() == "## Syntheses":
+        in_syn = True; continue
+    if in_syn and ln.startswith("## "):
+        break
+    if in_syn and ln.startswith("The verified answers"):
+        seen_leadin = True
+    if in_syn and ln.startswith("- [[") and not seen_leadin:
+        print("FAIL: a bullet precedes the curated lead-in under ## Syntheses")
+        sys.exit(1)
+sys.exit(0 if seen_leadin else 1)
+PY
+green "Case 1: lead-in still precedes the merged bullet block"
+
+# =====================================================================
+# CASE 2 — idempotency: a re-run adds no second heading and no bullet churn.
+# =====================================================================
+BEFORE="$WORKDIR/before.md"
+cp "$INDEX" "$BEFORE"
+python3 "$UPDATE" --wiki-root "$WIKI" --slug "mid-synthesis" \
+  --summary "middle synthesis" --category "Syntheses" >/dev/null
+
+[ "$(count_heading Syntheses)" = "1" ] \
+  || fail "Case 2: re-run created a second ## Syntheses heading"
+if ! diff -q "$BEFORE" "$INDEX" >/dev/null 2>&1; then
+  fail "Case 2: idempotent re-run mutated index.md (Case-A update should be a no-op)"
+fi
+green "Case 2: idempotent re-run — single heading, index unchanged"
+
+green "ALL TESTS PASS"


### PR DESCRIPTION
Refs #485 (Phase 1 of the multi-phase Knowledge Portal umbrella).

## Summary
- Add a pure `collapse_duplicate_headings(sections)` helper to `wiki_index_update.py` that folds any duplicate `## <theme>` section into the FIRST occurrence: later same-heading bullets are merged alphabetically into the first section's bullet block via the existing `_insert_alphabetised` (skipping a slug the survivor already carries, so the fold is idempotent and never creates a duplicate bullet), and the duplicate heading shells are dropped. No-op when every heading is unique (a clean index passes through unchanged).
- The FIRST occurrence's curated lead-in (the protected prose between a heading and its first `- [[slug]]` bullet, per the #461 Phase-1 / PR #476 contract) survives verbatim; machine-created duplicates from `_create_category` carry no lead-in, so they lose only their heading shell, not their bullets.
- Wired into `update_index` (right after `_split_sections`, before the Case A/B/C dispatch) and `move_slug` (right after its `_split_sections`), both already inside the existing `_wiki_lock` critical section — so the collapse is a free side-effect of any slug-mode insert/update or `--move-slug` call.
- Regression test `tests/test_index_duplicate_heading.sh` seeds a drifted portal (two `## Syntheses` sections — first curated, second machine-shaped — plus an unrelated `## Sources`) and asserts a single surviving heading, the curated lead-in preserved, all bullets merged exactly once and alphabetised, the unrelated section untouched, and idempotency on re-run.
- Document the single-instance invariant in `SCHEMA.md.template`'s Knowledge Portal section.
- Bump cogni-wiki 0.0.60 → 0.0.61 in `plugin.json` and mirror in root `marketplace.json`.

## Scope decisions
- **In:** the prevention guard (collapse on write) + test + SCHEMA line + version bump — a bounded, testable change to `wiki_index_update.py` only.
- **Deferred** (the umbrella issue #485 stays open to track these — this PR uses `Refs`, not `Closes`):
  - **Phase 2** — `type: question` routing under the theme_label portal section (may be partly landed via `knowledge-ingest` Step 4.5.3 + the #484 migrate driver; confirm whether a migration gap remains before filing).
  - **Phase 3** — portal-content authoring of curated per-theme lead-ins (editorial/SME, not code).
  - **Phase 4** — cogni-knowledge `knowledge-finalize` portal-shape integration (architectural, cross-plugin).
  - **Optional** — a wiki-lint `--fix=portal_heading_dedup` REPAIR fixer for already-duplicated bases. This PR ships *prevention*; repairing pre-existing duplicates via the `reflow_categories` / wiki-lint path is a separate change because it widens an existing wiki-lint surface, so `reflow_categories` is deliberately left untouched here.

## Test plan
- [x] `bash cogni-wiki/tests/test_index_duplicate_heading.sh` → `ALL TESTS PASS` (single surviving heading, lead-in preserved, bullets merged once + alphabetised, unrelated section untouched, idempotent re-run).
- [x] `bash cogni-wiki/tests/test_index_leadin_preserve.sh` still passes (the #461 lead-in regression — collapse must not disturb the single-section lead-in path).
- [x] `bash cogni-wiki/tests/test_index_move_slug.sh` still passes (move_slug now collapses first).
- [x] `test_index_placeholder_selfclean.sh`, `test_index_summary_clamp.sh`, `test_lint_fix.sh` still pass (no regression from the `update_index` change).
- [x] `python3 -c "import ast; ast.parse(...)"` parses clean.
- [x] cogni-wiki version `0.0.61` mirrored in `plugin.json` and `marketplace.json`.
