### PR TITLE
cogni-knowledge: one Python SSOT for the wiki-scripts resolve probe + self-resolve test

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/_knowledge_lib.py
+++ b/cogni-knowledge/scripts/_knowledge_lib.py
@@ -1551,7 +1551,7 @@ def load_wiki_coverage_findings(project_path) -> list:
 _NUMERIC_VERSION_RE = re.compile(r"^[0-9]+(\.[0-9]+)*$")
 
 
-def resolve_wiki_scripts(skill: str) -> Path:
+def resolve_wiki_scripts(skill: str, base_dir: "Path | None" = None) -> Path:
     """Locate `cogni-wiki/skills/<skill>/scripts/`, the single Python definition
     of the shell `resolve_wiki_scripts <skill>` probe in the knowledge-* SKILLs.
 
@@ -1569,9 +1569,15 @@ def resolve_wiki_scripts(skill: str) -> Path:
          `<repo-root>/../cogni-wiki/*/skills/<skill>/scripts` (a non-numeric
          dir name — a branch/`main` checkout — never outranks a real semver).
 
+    `base_dir` is a TEST-ONLY injection seam: when None (the production default)
+    <repo-root> is derived from this file's location, so every real caller is
+    byte-identical to the no-arg form; a test passes an explicit synthetic root
+    to exercise the versioned-cache ranking branch hermetically (the real
+    sibling checkout would otherwise short-circuit branch 1 in the monorepo).
+
     Raises FileNotFoundError when neither branch resolves.
     """
-    repo_root = Path(__file__).resolve().parents[2]
+    repo_root = Path(base_dir) if base_dir is not None else Path(__file__).resolve().parents[2]
     sib = repo_root / "cogni-wiki" / "skills" / skill / "scripts"
     if sib.is_dir():
         return sib

--- a/cogni-knowledge/scripts/_knowledge_lib.py
+++ b/cogni-knowledge/scripts/_knowledge_lib.py
@@ -1541,3 +1541,54 @@ def load_wiki_coverage_findings(project_path) -> list:
         msg = messages.get(sid) or f"sub-question {sid} ({verdict})"
         out.append({"class": _COVERAGE_GAP_CLASS[verdict], "id": f"sq:{sid}", "message": msg})
     return out
+
+
+# A dotted-numeric version dir name, e.g. `0.1.74` — mirrors the shell probe's
+# `case "$ver" in ''|*[!0-9.]*) continue` numeric guard so a branch/`main`
+# checkout dir never outranks a real semver. Slightly stricter than the shell
+# case (rejects empty/leading/trailing/doubled `.` segments too), which only
+# matters for malformed dirs and lets the sort key skip an empty-segment guard.
+_NUMERIC_VERSION_RE = re.compile(r"^[0-9]+(\.[0-9]+)*$")
+
+
+def resolve_wiki_scripts(skill: str) -> Path:
+    """Locate `cogni-wiki/skills/<skill>/scripts/`, the single Python definition
+    of the shell `resolve_wiki_scripts <skill>` probe in the knowledge-* SKILLs.
+
+    Generalises the per-skill wiki-scripts lookup so a standalone, operator-run
+    Python driver (e.g. migrate-question-index.py) self-resolves the dir without
+    carrying its own copy of the ranking rule. The locked-writer scripts
+    (question-store.py, concept-store.py) deliberately keep requiring
+    `--wiki-scripts-dir` from the orchestrator and never call this.
+
+    Probe order (highest-priority first):
+      1. Sibling checkout — `<repo-root>/cogni-wiki/skills/<skill>/scripts`,
+         where <repo-root> is two levels up from this file
+         (scripts/ -> cogni-knowledge/ -> <repo-root>).
+      2. Versioned-cache install — newest NUMERIC version dir matching
+         `<repo-root>/../cogni-wiki/*/skills/<skill>/scripts` (a non-numeric
+         dir name — a branch/`main` checkout — never outranks a real semver).
+
+    Raises FileNotFoundError when neither branch resolves.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    sib = repo_root / "cogni-wiki" / "skills" / skill / "scripts"
+    if sib.is_dir():
+        return sib
+
+    candidates: "list[tuple[tuple[int, ...], Path]]" = []
+    for d in (repo_root.parent / "cogni-wiki").glob(f"*/skills/{skill}/scripts"):
+        if not d.is_dir():
+            continue
+        ver = d.parents[2].name  # the <semver> segment
+        if _NUMERIC_VERSION_RE.match(ver):
+            # Sort key: `0.0.9 < 0.0.16`. The regex guarantees every segment is a
+            # non-empty digit run, so no empty-segment filter is needed.
+            candidates.append((tuple(int(p) for p in ver.split(".")), d))
+    if candidates:
+        return max(candidates)[1]
+
+    raise FileNotFoundError(
+        f"cogni-wiki {skill} scripts not found — install cogni-wiki, run "
+        f"from inside the monorepo, or pass --wiki-scripts-dir"
+    )

--- a/cogni-knowledge/scripts/migrate-question-index.py
+++ b/cogni-knowledge/scripts/migrate-question-index.py
@@ -55,14 +55,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _knowledge_lib import (  # noqa: E402
     _FRONTMATTER_RE,
     _unquote_scalar,
+    resolve_wiki_scripts,
 )
 
-# A dotted-numeric version dir name, e.g. `0.1.74` — mirrors the shell probe's
-# `case "$ver" in ''|*[!0-9.]*) continue` numeric guard so a branch/`main`
-# checkout dir never outranks a real semver. Slightly stricter than the shell
-# case (rejects empty/leading/trailing/doubled `.` segments too), which only
-# matters for malformed dirs and lets the sort key skip an empty-segment guard.
-_NUMERIC_VERSION_RE = re.compile(r"^[0-9]+(\.[0-9]+)*$")
 _THEME_LABEL_RE = re.compile(r"^theme_label[ \t]*:[ \t]*(.+?)[ \t]*$")
 
 
@@ -70,40 +65,6 @@ def _emit(success: bool, data: "dict | None" = None, error: str = "") -> int:
     payload = {"success": bool(success), "data": data or {}, "error": error or ""}
     print(json.dumps(payload, indent=2, ensure_ascii=False))
     return 0 if success else 1
-
-
-def resolve_wiki_ingest_scripts() -> Path:
-    """Locate `cogni-wiki/skills/wiki-ingest/scripts/`, mirroring the shell
-    `resolve_wiki_scripts wiki-ingest` probe in knowledge-ingest/SKILL.md.
-
-    Probe order:
-      1. Sibling checkout — `<repo-root>/cogni-wiki/skills/wiki-ingest/scripts`,
-         where <repo-root> is three levels up from this file
-         (scripts/ -> cogni-knowledge/ -> <repo-root>).
-      2. Versioned-cache install — newest NUMERIC version dir matching
-         `<repo-root>/../cogni-wiki/*/skills/wiki-ingest/scripts`.
-    """
-    repo_root = Path(__file__).resolve().parents[2]
-    sib = repo_root / "cogni-wiki" / "skills" / "wiki-ingest" / "scripts"
-    if sib.is_dir():
-        return sib
-
-    candidates: "list[tuple[tuple[int, ...], Path]]" = []
-    for d in (repo_root.parent / "cogni-wiki").glob("*/skills/wiki-ingest/scripts"):
-        if not d.is_dir():
-            continue
-        ver = d.parents[2].name  # the <semver> segment
-        if _NUMERIC_VERSION_RE.match(ver):
-            # Sort key: `0.0.9 < 0.0.16`. The regex guarantees every segment is a
-            # non-empty digit run, so no empty-segment filter is needed.
-            candidates.append((tuple(int(p) for p in ver.split(".")), d))
-    if candidates:
-        return max(candidates)[1]
-
-    raise FileNotFoundError(
-        "cogni-wiki wiki-ingest scripts not found — install cogni-wiki, run "
-        "from inside the monorepo, or pass --wiki-scripts-dir"
-    )
 
 
 def theme_label_from_frontmatter(page_text: str) -> str:
@@ -139,7 +100,7 @@ def cmd_migrate(args: argparse.Namespace) -> int:
             scripts_dir = Path(args.wiki_scripts_dir).expanduser().resolve()
         else:
             try:
-                scripts_dir = resolve_wiki_ingest_scripts()
+                scripts_dir = resolve_wiki_scripts("wiki-ingest")
             except FileNotFoundError as exc:
                 return _emit(False, error=str(exc))
         update_script = scripts_dir / "wiki_index_update.py"

--- a/cogni-knowledge/tests/test_knowledge_lib.sh
+++ b/cogni-knowledge/tests/test_knowledge_lib.sh
@@ -789,6 +789,21 @@ def assert_resolve_wiki_scripts():
     if sib.is_dir():
         got = kl.resolve_wiki_scripts("wiki-ingest")
         assert got.resolve() == sib.resolve(), f"got={got!r} expected sibling={sib!r}"
+    # Versioned-cache ranking branch (hermetic, via the base_dir test seam):
+    # no sibling checkout under <base> forces fall-through to branch 2, where
+    # the NEWEST numeric version dir must win and a non-numeric `main` checkout
+    # must be excluded by _NUMERIC_VERSION_RE — the branch the real-layout case
+    # above can never reach (the live sibling short-circuits branch 1).
+    base = work / "wiki-version-fixture" / "insight-wave"  # synthetic <repo-root>
+    cache = base.parent / "cogni-wiki"  # <repo-root>.parent/cogni-wiki/*/skills/...
+    for ver in ("0.0.9", "0.0.16", "0.1.2", "main"):
+        (cache / ver / "skills" / "wiki-ingest" / "scripts").mkdir(parents=True, exist_ok=True)
+    # No <base>/cogni-wiki/skills/wiki-ingest/scripts → branch 1 misses.
+    assert not (base / "cogni-wiki" / "skills" / "wiki-ingest" / "scripts").exists()
+    got = kl.resolve_wiki_scripts("wiki-ingest", base_dir=base)
+    expected = cache / "0.1.2" / "skills" / "wiki-ingest" / "scripts"
+    assert got.resolve() == expected.resolve(), f"version ranking: got={got!r} expected={expected!r}"
+    assert got.parents[2].name == "0.1.2", f"non-numeric 'main' must not win: {got!r}"
 
 
 check("tokenization_primitives", assert_tokenization_primitives)

--- a/cogni-knowledge/tests/test_knowledge_lib.sh
+++ b/cogni-knowledge/tests/test_knowledge_lib.sh
@@ -768,6 +768,29 @@ def assert_extract_page_frontmatter():
     assert kl.extract_page_content_hash("# just a body\n") == ""
 
 
+def assert_resolve_wiki_scripts():
+    # The single Python definition of the wiki-scripts resolve probe (#488),
+    # shared by the standalone migrate-question-index.py driver so it is no
+    # longer a second independent copy of the bash ranking rule.
+    # Negative case (hermetic, always on): an unknown skill matches neither the
+    # sibling checkout nor any versioned-cache dir → FileNotFoundError, and the
+    # message carries the skill name + the --wiki-scripts-dir escape hatch.
+    try:
+        kl.resolve_wiki_scripts("__nonexistent_skill__")
+        assert False, "expected FileNotFoundError for an unknown skill"
+    except FileNotFoundError as exc:
+        assert "__nonexistent_skill__" in str(exc), str(exc)
+        assert "--wiki-scripts-dir" in str(exc), str(exc)
+    # Real-layout case (guarded by the same sibling-exists precondition the
+    # migrate test uses): in the dev monorepo the sibling checkout exists, so
+    # resolve_wiki_scripts("wiki-ingest") returns exactly that dir.
+    repo_root = scripts.parent.parent  # scripts/ -> cogni-knowledge/ -> repo-root
+    sib = repo_root / "cogni-wiki" / "skills" / "wiki-ingest" / "scripts"
+    if sib.is_dir():
+        got = kl.resolve_wiki_scripts("wiki-ingest")
+        assert got.resolve() == sib.resolve(), f"got={got!r} expected sibling={sib!r}"
+
+
 check("tokenization_primitives", assert_tokenization_primitives)
 check("norm_key", assert_norm_key)
 check("theme_norm_key", assert_theme_norm_key)
@@ -796,6 +819,7 @@ check("parse_answer_claims_with_id", assert_parse_answer_claims_with_id)
 check("parse_answer_records", assert_parse_answer_records)
 check("writer_quality_normalizers", assert_writer_quality_normalizers)
 check("extract_page_frontmatter", assert_extract_page_frontmatter)
+check("resolve_wiki_scripts", assert_resolve_wiki_scripts)
 PY
 )
 
@@ -841,6 +865,7 @@ grade digit_anchor_tokens     "digit_anchor_tokens — Artikel/Article 99 → {9
 grade parse_crossmerge_records "parse_crossmerge_records — merge: slug|survivor|absorbed, whitespace strip, wrong-arity/empty-field dropped, comments, CRLF, ''→[] (#345)"
 grade writer_quality_normalizers "writer-quality normalizers (#309 P2) — normalize_tone/prose_density/citation_format/target_words + CITATION_FAMILY, valid passthrough, unknown→safe default, wikilink→ieee"
 grade extract_page_frontmatter "ingest-integrity frontmatter parsers (#413/#421) — extract_page_id_and_url id+sources, extract_page_content_hash quoted/unquoted-comment/absent/no-frontmatter→'' (shared by sweep + Phase-3 guard)"
+grade resolve_wiki_scripts    "resolve_wiki_scripts (#488) — single Python SSOT for the wiki-scripts probe (sibling checkout, else newest numeric version dir); unknown skill→FileNotFoundError naming the skill + --wiki-scripts-dir; real sibling layout resolves to the in-repo dir"
 
 if [ $errors -gt 0 ]; then
   red "$errors case(s) failed."

--- a/cogni-knowledge/tests/test_migrate_question_index.sh
+++ b/cogni-knowledge/tests/test_migrate_question_index.sh
@@ -201,6 +201,53 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 4: self-resolve path — NO --wiki-scripts-dir. Exercises the driver's
+# resolve_wiki_scripts("wiki-ingest") probe (now _knowledge_lib.resolve_wiki_scripts)
+# against the in-repo sibling checkout, which the lines 33-36 WSD guard above
+# already proved exists. Tests 2/3 always pass --wiki-scripts-dir, so this is
+# the only case that fires the probe end-to-end.
+#
+# A fresh wiki fixture (a legacy flat `## Research questions` heading) gives the
+# self-resolve run a relocatable bullet, so success means the probe resolved AND
+# the move ran to completion against the resolved wiki_index_update.py.
+# ---------------------------------------------------------------------------
+WIKI2="$WORK/wiki-root-2"
+mkdir -p "$WIKI2/wiki/questions" "$WIKI2/.cogni-wiki"
+cat > "$WIKI2/wiki/index.md" <<'EOF'
+# Index
+
+## Research questions
+
+- [[records-of-processing-scope]] — What is in scope for the records of processing.
+EOF
+cat > "$WIKI2/wiki/questions/records-of-processing-scope.md" <<'EOF'
+---
+id: records-of-processing-scope
+title: "Records of processing scope"
+type: question
+tags: [question]
+theme_label: "Compliance Scope"
+---
+
+## Findings
+EOF
+
+OUT=$(python3 "$SCRIPT" --wiki-root "$WIKI2")
+echo "$OUT" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d['success'] is True, d
+assert d['data']['dry_run'] is False, d
+actions = {m['slug']: m['action'] for m in d['data']['moved']}
+assert actions.get('records-of-processing-scope') == 'moved', d
+print('OK')
+" | grep -q OK && green "PASS: self-resolve (no --wiki-scripts-dir) probes the sibling checkout and relocates the node" \
+  || { red "FAIL: self-resolve output assertion (probe or move failed)"; errors=$((errors + 1)); }
+
+assert_grep '## Compliance Scope' "$WIKI2/wiki/index.md" "self-resolve run created the theme_label heading"
+assert_not_grep '## Research questions' "$WIKI2/wiki/index.md" "self-resolve run dropped the empty flat heading"
+
+# ---------------------------------------------------------------------------
 if [ "$errors" -eq 0 ]; then
   green "ALL PASS"
   exit 0


### PR DESCRIPTION
Closes #488.

Follow-up from review of #486 — the two non-blocking items deferred from that PR.

## Summary
- Add `resolve_wiki_scripts(skill: str) -> Path` to `scripts/_knowledge_lib.py` as the single Python definition of the "sibling checkout first, else newest numeric version dir" probe (generalized from the wiki-ingest-only port, so a future `__main__` shell-out is trivial to add). The numeric-version guard regex moves to the lib alongside it.
- `scripts/migrate-question-index.py` now imports `resolve_wiki_scripts` from `_knowledge_lib` and drops its own `resolve_wiki_ingest_scripts()` copy + the duplicate `_NUMERIC_VERSION_RE`; the no-`--wiki-scripts-dir` branch calls `resolve_wiki_scripts("wiki-ingest")`. Behavior and the JSON envelope are unchanged.
- `tests/test_knowledge_lib.sh`: a unit case (unknown-skill → FileNotFoundError naming the skill + `--wiki-scripts-dir`; the in-repo sibling layout resolves).
- `tests/test_migrate_question_index.sh`: a Test 4 that runs the driver **without** `--wiki-scripts-dir` against the in-repo sibling checkout and asserts it relocates a node end-to-end — exercising the self-resolve branch the existing three cases skip (dry-run / explicit override).
- Version bump `0.1.74 → 0.1.75` in `plugin.json` and `marketplace.json`.

## Scope decisions
- **IN:** the issue author's explicit lower-effort alternative — move/generalize the Python probe into `_knowledge_lib.py` so it is no longer a second independent copy for Python callers (item 1's core complaint), plus full coverage of the self-resolve path (item 2). Self-contained to `scripts/` + `tests/`.
- **OUT (deferred):** the full bash-to-python shell-out unification — rewriting the bash `resolve_wiki_scripts` probes in `knowledge-ingest`/`knowledge-finalize` SKILL.md to shell out to a new `_knowledge_lib.py` `__main__`, and rewriting the `test_resolve_wiki_scripts.sh` byte-identity contract test to validate the delegation shape. That touches the live ingest/finalize runtime path and is the genuinely higher-risk concern. The new lib function is shaped (`skill` param) so adding the `__main__` CLI later is additive.
- **OUT (deferred):** optional driver-skip-branch test coverage (`unreadable_page`, `unparseable_output`, `move_failed`) the issue marks OPTIONAL.

## Test plan
- [x] `bash tests/test_knowledge_lib.sh` — passes, including the new `resolve_wiki_scripts` case.
- [x] `bash tests/test_migrate_question_index.sh` — all existing cases plus the new self-resolve case pass.
- [x] `bash tests/test_resolve_wiki_scripts.sh` — still passes unchanged (bash byte-identity contract untouched).
- [x] Full cogni-knowledge suite (45 test scripts) — all pass; breadcrumb guard clean.
- [x] `plugin.json` and `marketplace.json` both read `0.1.75`.

Plan record: https://github.com/cogni-work/insight-wave/issues/488#issuecomment-4625059799
