### PR TITLE
cogni-wiki: deprecate wiki-from-research (zero cogni-research dispatches)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -304,7 +304,7 @@
     {
       "name": "cogni-wiki",
       "source": "./cogni-wiki",
-      "version": "0.0.63",
+      "version": "0.0.64",
       "maturity": "incubating",
       "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions surface at ingest, and knowledge compounds. Based on Karpathy's LLM Wiki pattern.",
       "keywords": [

--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions surface at ingest, and knowledge compounds. Based on Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-wiki/CHANGELOG.md
+++ b/cogni-wiki/CHANGELOG.md
@@ -1,5 +1,44 @@
 # cogni-wiki changelog
 
+## 0.0.64 — 2026-06-05 — deprecate wiki-from-research; zero cogni-research dispatches
+
+**Decision: deprecate, not rotate.** `wiki-from-research` is superseded by
+cogni-knowledge's inverted pipeline, which already deposits research syntheses
+into a bound wiki (`knowledge-setup` + `knowledge-plan → knowledge-curate →
+knowledge-fetch → knowledge-ingest → knowledge-compose → knowledge-verify →
+knowledge-finalize`). The skill has **zero remaining programmatic callers** —
+the only two historical callers (`knowledge-research` Mode A, `knowledge-report`
+Mode B) are already archived under `cogni-knowledge/_archive/`, and the live
+v0.1.0 inverted pipeline does not use this skill. Rotating it onto a surviving
+cogni-knowledge path was rejected: cogni-wiki is itself slated for archive, so a
+rotated skill would be a dead code path in an archived plugin.
+
+**Changes.**
+- Added a deprecation notice to `wiki-from-research/SKILL.md` (and the
+  `description` frontmatter) directing users to cogni-knowledge's inverted
+  pipeline as the replacement for the topic→wiki cold-start use case.
+- Neutralized the two executable `cogni-research:` dispatches so the skill
+  reaches the required migration exit state (zero `cogni-research:` dispatches):
+  Mode A (`--topic`) no longer auto-runs a research pipeline — it aborts and
+  redirects to cogni-knowledge; the Step 0(4) `run-verify-first` option (which
+  dispatched `cogni-research:verify-report`) was removed, leaving
+  `proceed`/`abort`.
+- Stripped the remaining prose `cogni-research:` slug references so the SKILL
+  reaches a clean zero-occurrence state. Filesystem `cogni-research-<slug>/`
+  directory paths (read by Mode B) are unchanged — they are not dispatches.
+- Preserved the contract machinery the existing test asserts: the
+  `--allow-wiki-source`/`--cycle-guard-cleared` parameter rows, the
+  `report_source ∈ {wiki, hybrid}` Step 0(3) guard, the Step 1d re-run
+  structure, the `.metadata/project-config.json` read path, and the
+  `cogni-knowledge:knowledge-report` orchestrator rationale.
+- `tests/test_wiki_from_research_flags.sh` gains a zero-`cogni-research:` guard
+  and deprecation-notice assertions.
+
+Mode B (`--research-slug`) remains a legacy convenience for depositing an
+already-completed on-disk research project, and is removed when cogni-wiki is
+archived. The repo-wide zero-occurrence grep-guard and the migration exit audit
+are tracked separately.
+
 ## 0.0.58 — 2026-06-04 — raw_citation_depth lint auto-fix (closes #478 for this plugin)
 
 **Heads-up for existing wikis.** v0.0.55 hardened `health.py`'s `missing_source`

--- a/cogni-wiki/skills/wiki-from-research/SKILL.md
+++ b/cogni-wiki/skills/wiki-from-research/SKILL.md
@@ -1,14 +1,26 @@
 ---
 name: wiki-from-research
-description: "Cold-start a Karpathy-style wiki from a cogni-research project — orchestrates research-setup → research-report → wiki-setup → wiki-ingest in one call. Use when the user says 'build a wiki from research on X', 'research X and put it in a wiki', 'cold-start a wiki about X', 'wiki-ify the quantum-cryptography research', 'turn my <slug> research project into a wiki', 'deep research a topic into a fresh wiki'. Two modes: Mode A (--topic) runs cogni-research first; Mode B (--research-slug) deposits an already-completed project. Defaults to detailed report depth; passes through to research-setup's interactive menu so the user still picks market, language, tone."
+description: "DEPRECATED — superseded by cogni-knowledge's inverted pipeline (knowledge-setup + knowledge-plan → … → knowledge-finalize), and removed when cogni-wiki is archived. Cold-start a Karpathy-style wiki from a research project. Mode A (--topic) no longer auto-runs a research pipeline — it aborts and redirects to cogni-knowledge. Mode B (--research-slug) still deposits an already-completed on-disk research project into a fresh wiki. Prefer cogni-knowledge for new topic→wiki cold-starts."
 allowed-tools: Read, Bash, Glob, AskUserQuestion, Skill
 ---
 
 # Wiki From Research
 
-Turn a research topic (Mode A) or an already-completed cogni-research project (Mode B) into a populated cogni-wiki — one prompt instead of four. This is the cold-start primitive: from "I want a wiki about quantum cryptography" to a queryable wiki with one command.
+> **⚠️ Deprecated.** This skill is superseded by cogni-knowledge's inverted
+> pipeline, which already deposits research syntheses into a bound wiki. The
+> live research → wiki path is now `cogni-knowledge:knowledge-setup` (once) +
+> `knowledge-plan → knowledge-curate → knowledge-fetch → knowledge-ingest →
+> knowledge-compose → knowledge-verify → knowledge-finalize`. This skill has
+> no remaining programmatic callers and no longer dispatches any research
+> pipeline of its own; **Mode A (`--topic`) now aborts and redirects** to
+> cogni-knowledge. Mode B (`--research-slug`) is retained as a legacy
+> convenience for depositing an already-completed on-disk research project,
+> and will be removed when cogni-wiki is archived. For any new topic→wiki
+> cold-start, use cogni-knowledge.
 
-This skill **orchestrates only**. It writes nothing directly. Every page comes from `wiki-ingest`'s lock-protected pipeline; every config comes from `wiki-setup`'s detection logic; every research artefact comes from `cogni-research`'s STORM pipeline. The value here is sequencing, fail-fast pre-flight, and slug coordination — not new mechanics.
+Turn an already-completed on-disk research project (Mode B) into a populated cogni-wiki. This was the cold-start primitive; the topic→research→wiki path (Mode A) is now owned by cogni-knowledge's inverted pipeline.
+
+This skill **orchestrates only**. It writes nothing directly. Every page comes from `wiki-ingest`'s lock-protected pipeline; every config comes from `wiki-setup`'s detection logic. In Mode B the research artefacts are read from an already-completed on-disk project; Mode A no longer runs a research pipeline (see the deprecation notice above). The value here is sequencing, fail-fast pre-flight, and slug coordination — not new mechanics.
 
 Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once at the start to re-anchor on the three-layer model (raw / wiki / schema) before dispatching any sub-skill.
 
@@ -29,7 +41,7 @@ Exactly one of `--topic` or `--research-slug` must be present.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--topic` | Mode A | Free-text research topic. Triggers Mode A — runs cogni-research first. Mutually exclusive with `--research-slug`. |
+| `--topic` | Mode A | Free-text research topic. **Deprecated** — Mode A no longer runs a research pipeline; it aborts and redirects to cogni-knowledge (see Step 1). Mutually exclusive with `--research-slug`. |
 | `--research-slug` | Mode B | Slug of an existing `cogni-research-<slug>/` project. Triggers Mode B — skip research, just bootstrap and deposit. Mutually exclusive with `--topic`. |
 | `--name` | No | Wiki display name. Defaults to `--topic` (Mode A) or the research project's `topic` field (Mode B). |
 | `--wiki-slug` | No | Wiki slug override. Default: equals research slug (see §Slug coordination). |
@@ -63,30 +75,33 @@ The order matters: in Mode A, the **wiki-target check runs before any research d
 
 3. **Mode B: research project sanity.**
    - Look for `cogni-research-<research_slug>/` at `<workspace>/` (workspace = wiki_root's parent) or `<wiki_root>/`. If neither: abort.
-   - If `<project>/output/report.md` is missing: abort with "research project found but not yet completed — run `cogni-research:research-resume` first".
+   - If `<project>/output/report.md` is missing: abort with "research project found but not yet completed — finish the research run that produced it (its `output/report.md` must exist) before depositing".
    - Read `<project>/.metadata/project-config.json`. If `report_source ∈ {wiki, hybrid}` AND NOT (`--allow-wiki-source` AND `--cycle-guard-cleared` both passed): abort with "this skill cannot deposit a wiki/hybrid-mode research project into a wiki — circular reads not yet handled in v1. Callers that have verified no cycle exists may pass `--allow-wiki-source --cycle-guard-cleared` to opt in."
 
 4. **Mode B: verify-report nudge.**
    - Glob `<project>/03-report-claims/data/rc-*.md`. Count entities whose frontmatter has `verification_status: verified`.
-   - If count is zero AND `--skip-verify` is not set: emit a one-paragraph warning ("`verify-report` has not run; the wiki will receive findings but no verified claims, since `wiki-ingest --discover research:` filters claims to verified-only by design"). AskUserQuestion: `proceed` (continue without verified claims), `run-verify-first` (dispatch `Skill("cogni-research:verify-report", args="--project-slug <research_slug>")` then re-run this step), `abort`.
+   - If count is zero AND `--skip-verify` is not set: emit a one-paragraph warning ("claim verification has not run; the wiki will receive findings but no verified claims, since `wiki-ingest --discover research:` filters claims to verified-only by design — to populate verified claims, run your research project's verification step out-of-band against `<research_slug>`, then re-deposit"). AskUserQuestion: `proceed` (continue without verified claims), `abort`.
 
 5. **Dry-run gate.**
    - If `--dry-run`: emit the resolved plan as plain text — `mode`, `research_slug`, `wiki_slug`, `wiki_root`, `wiki_action`, dispatch sequence — and stop. No sub-skill dispatch.
 
-### 1. Run cogni-research (Mode A only)
+### 1. Mode A (`--topic`) — deprecated, aborts
 
-Compose the prompt for `research-setup`. The skill is interactive and parses intents from the user prompt; we feed it the topic plus our overrides as natural language so its menu pre-fills correctly.
+Mode A previously ran a research pipeline and then ingested its output. It no
+longer does. **Abort with a redirect:** tell the user that topic→wiki
+cold-start is now owned by cogni-knowledge's inverted pipeline — run
+`cogni-knowledge:knowledge-setup` (if no knowledge base exists yet) followed by
+`knowledge-plan → knowledge-curate → knowledge-fetch → knowledge-ingest →
+knowledge-compose → knowledge-verify → knowledge-finalize`, which deposits
+syntheses straight into the bound wiki. Do not dispatch any research pipeline
+from here.
 
-```
-Skill("cogni-research:research-setup",
-      prompt="Research the following topic and produce a <report_type> report. Topic: <topic>. <overrides as 'Use market <X>. Output language <Y>. Tone <Z>.' phrasing>")
-```
+The substeps below (1a–1d) are retained for reference only — they describe the
+historical Mode A flow and are **not executed**:
 
-Forward `--research-overrides` as a sentence per pair. Default override added if absent: `report_type=detailed`. Do NOT pre-pass a slug — `cogni-research:initialize-project.sh` derives the slug from the topic and handles collisions (resume / new / different). Capturing that resolved slug after return is what step 1c is for.
+1a. The user proceeded through the research configuration menu (market, language, tone, citations, source mode, location) and confirmed.
 
-1a. The user proceeds through `research-setup`'s interactive menu (market, language, tone, citations, source mode, location). Confirms.
-
-1b. `research-setup` auto-chains to `research-report`. The full pipeline runs to completion: `cogni-research-<resolved_slug>/output/report.md` is written.
+1b. The research pipeline ran to completion: `cogni-research-<resolved_slug>/output/report.md` was written.
 
 1c. Capture `resolved_slug` from the `research-setup` output (it prints the project path; parse `cogni-research-<slug>/` from it). Set `research_slug = resolved_slug`. If `--wiki-slug` was not set, also update `wiki_slug = resolved_slug` (and recompute `wiki_root` if `--wiki-root` was not set).
 
@@ -130,7 +145,7 @@ Print plain prose, ≤8 lines:
 - Pages ingested (from `wiki-ingest` Step 9 aggregated report — count of successful sources)
 - Verified vs pending claim count (from the research deposit's `data.research` block)
 - Cost (Mode A only — sum from `research-report` Phase 6 summary)
-- Suggested next actions: `wiki-query "..."`, `wiki-dashboard`. If verified claim count is low, suggest `cogni-research:verify-report` then re-run this skill in Mode B (Step 0 (2) `resume` + Step 3 will refresh pages with newly-verified claims).
+- Suggested next actions: `wiki-query "..."`, `wiki-dashboard`. If verified claim count is low, run your research project's verification step out-of-band, then re-run this skill in Mode B (Step 0 (2) `resume` + Step 3 will refresh pages with newly-verified claims).
 
 ## Slug coordination
 
@@ -142,7 +157,7 @@ In Mode A we let `cogni-research` derive the slug from the topic. If the topic c
 
 ## Edge cases
 
-- **Mode A research crash partway.** Pre-Step-2; no wiki has been created. Surface the cogni-research error verbatim and exit non-zero. Research artifacts persist on disk; the user can run `cogni-research:research-resume` and then re-invoke this skill in Mode B against the same slug.
+- **Mode A is deprecated** (see Step 1). It no longer runs a research pipeline; it aborts and redirects to cogni-knowledge. There is no in-skill crash-recovery path because no research dispatch happens here. If a user has an already-completed research project on disk, they can deposit it via Mode B (`--research-slug`).
 - **Mode B without verify-report.** Step 0 (4) handled — warn, offer to run verify first, or proceed with `--skip-verify`.
 - **Wiki already populated (re-run cold-start).** Step 0 (2) handled. `resume` skips wiki-setup; `wiki-ingest`'s `mode: re-ingest` branch updates pages in place; `entries_count` is preserved.
 - **Topic that resolves to an existing cogni-research project.** `research-setup`'s own prompt (resume / new / different) handles it. Whatever the user picks, capture the resolved slug in Step 1c and continue. Step 1d's re-validation catches a "different location" outcome that lands the project outside the workspace.
@@ -154,7 +169,7 @@ In Mode A we let `cogni-research` derive the slug from the topic. If the topic c
 - **Does not duplicate `research-setup`'s configuration menu.** Market, language, tone, citations, source mode are all decided in `research-setup` — this skill only forwards hints.
 - **Does not write wiki pages directly.** Every page passes through `wiki-ingest`'s lock-protected per-source worker, with the page-frontmatter contract and atomic index/config writes.
 - **Does not integrate with cogni-narrative or cogni-copywriting.** Those are downstream of the wiki, not part of cold-start.
-- **Default-refuses `report_source ∈ {wiki, hybrid}` projects.** Reading from a wiki and writing back to the same wiki creates circular-evidence risk. Lifted only behind the `--allow-wiki-source --cycle-guard-cleared` opt-in (v0.0.40+) — direct users should not pass these; the flag pair exists for orchestrators (e.g. `cogni-knowledge:knowledge-report`) that own a domain-specific cycle-guard.
+- **Default-refuses `report_source ∈ {wiki, hybrid}` projects.** Reading from a wiki and writing back to the same wiki creates circular-evidence risk. Lifted only behind the `--allow-wiki-source --cycle-guard-cleared` opt-in — direct users should not pass these; the flag pair exists for orchestrators (e.g. `cogni-knowledge:knowledge-report`) that own a domain-specific cycle-guard.
 
 ## Output
 

--- a/cogni-wiki/skills/wiki-from-research/SKILL.md
+++ b/cogni-wiki/skills/wiki-from-research/SKILL.md
@@ -26,9 +26,8 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` once at the start to
 
 ## When to run
 
-- User asks to bootstrap a wiki from a research topic ("build a wiki on AI safety", "deep-research X into a wiki")
-- User has a finished cogni-research project and wants it deposited into a fresh wiki ("wiki-ify my <slug> project", "turn the quantum research into a wiki")
-- User wants the cold-start convenience of one command instead of running `research-setup`, `research-report`, `wiki-setup`, and `wiki-ingest` manually
+- User has a **finished on-disk research project** and wants it deposited into a fresh wiki ("wiki-ify my <slug> project", "turn the quantum research into a wiki") — this is Mode B, the only live path.
+- For a topic→wiki cold-start from scratch ("build a wiki on AI safety", "deep-research X into a wiki"), **do not run this skill** — Mode A is deprecated and aborts. Redirect to cogni-knowledge's inverted pipeline (`knowledge-setup` + `knowledge-plan` → … → `knowledge-finalize`), which deposits syntheses straight into a bound wiki.
 
 ## Never run when
 
@@ -48,7 +47,7 @@ Exactly one of `--topic` or `--research-slug` must be present.
 | `--wiki-root` | No | Pass-through to `wiki-setup`. Default `cogni-wiki/{wiki-slug}/`. |
 | `--description` | No | Pass-through to `wiki-setup`. |
 | `--publisher-base-url` | No | Pass-through to `wiki-setup`. |
-| `--research-overrides` | No | Mode A only. Comma-separated `key=value` hints forwarded to `research-setup` (e.g. `report_type=detailed,market=dach,target_words=5000`). Default: `report_type=detailed`. The user can still override every value in `research-setup`'s interactive menu — overrides are pre-fills, not pins. |
+| `--research-overrides` | No | **Mode A only — deprecated/inert.** Historically forwarded `key=value` research hints; Mode A no longer runs a research pipeline, so this flag is accepted but has no effect. |
 | `--skip-verify` | No | Mode B only. Skip the warning when zero report-claims have `verification_status: verified`. |
 | `--allow-wiki-source` | No | Mode A & Mode B. Opt-in to depositing a wiki/hybrid-mode research project — lifts the default refusal at Step 0(3) (Mode B) and Step 1d (Mode A post-research-setup re-check). MUST be combined with `--cycle-guard-cleared`. Direct users should not pass this — it exists for orchestrators (e.g. `cogni-knowledge:knowledge-report`) that have verified no circular-evidence chain. |
 | `--cycle-guard-cleared` | No | Mode A & Mode B. Caller asserts that an external cycle-guard pass (e.g. `cogni-knowledge/scripts/cycle-guard.py`) returned exit 0 on this project. This skill trusts the assertion — it does NOT re-run the guard itself, because cycle semantics are caller-specific (cogni-knowledge owns `derived_from_research:` lineage; a future caller may walk a different lineage signal). MUST be combined with `--allow-wiki-source`. |
@@ -144,7 +143,6 @@ Print plain prose, ≤8 lines:
 - `research_slug` and project path
 - Pages ingested (from `wiki-ingest` Step 9 aggregated report — count of successful sources)
 - Verified vs pending claim count (from the research deposit's `data.research` block)
-- Cost (Mode A only — sum from `research-report` Phase 6 summary)
 - Suggested next actions: `wiki-query "..."`, `wiki-dashboard`. If verified claim count is low, run your research project's verification step out-of-band, then re-run this skill in Mode B (Step 0 (2) `resume` + Step 3 will refresh pages with newly-verified claims).
 
 ## Slug coordination
@@ -153,7 +151,7 @@ Print plain prose, ≤8 lines:
 
 If the user passes `--wiki-slug`, the layout becomes asymmetric (e.g., wiki at `cogni-wiki/my-wiki/`, research at `cogni-research-quantum/`). `wiki-ingest --discover research:quantum` still works because the auto-locate examines both `<workspace>/cogni-research-quantum/` and `<wiki-root>/cogni-research-quantum/`. The asymmetry is surfaced in Step 4.
 
-In Mode A we let `cogni-research` derive the slug from the topic. If the topic collides (`research-setup`'s "resume / new / different" prompt resolves to e.g. `quantum-2`), we accept the resolved slug and pass it through. **Do not fight the upstream slug logic** — research-setup's collision handling is canonical.
+(Historical, Mode A — no longer executed.) Mode A used to let the research pipeline derive the slug from the topic and pass the resolved slug through. Mode A now aborts; in Mode B the slug is the existing project's `--research-slug` (or its derivation), so there is no upstream slug negotiation.
 
 ## Edge cases
 
@@ -174,7 +172,6 @@ In Mode A we let `cogni-research` derive the slug from the topic. If the topic c
 ## Output
 
 The skill produces:
-- (Mode A) A `cogni-research-<slug>/` project with output/report.md and entity directories
 - A populated wiki at `<wiki_root>/` with one page per sub-question, plus the standard wiki-setup top-level files
 - Materialised raw files under `<wiki_root>/raw/research-<slug>/sq-NN-<short>.md`
 - An append-only `wiki/log.md` with one `setup` line and N `ingest` lines
@@ -186,4 +183,4 @@ No file is created outside `<wiki_root>/` or `<workspace>/cogni-research-<slug>/
 - `${CLAUDE_PLUGIN_ROOT}/references/karpathy-pattern.md` — the three-layer model
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-setup/SKILL.md` — Step 2 contract
 - `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/SKILL.md` and `${CLAUDE_PLUGIN_ROOT}/skills/wiki-ingest/references/batch-mode.md` — Step 3 contract (`--discover research:<slug>` lives there)
-- cogni-research's `research-setup` and `research-report` skills — Step 1 contract (research-setup auto-chains to research-report)
+- (historical) The Mode A flow once chained an external research pipeline at Step 1; that path is now owned by cogni-knowledge's inverted pipeline (`knowledge-plan` → … → `knowledge-finalize`) and Mode A no longer dispatches it.

--- a/cogni-wiki/skills/wiki-from-research/SKILL.md
+++ b/cogni-wiki/skills/wiki-from-research/SKILL.md
@@ -59,10 +59,10 @@ If neither `--topic` nor `--research-slug` is present, abort with a clear messag
 
 ### 0. Pre-flight (always; fail-fast)
 
-The order matters: in Mode A, the **wiki-target check runs before any research dispatch** so an unusable wiki target never burns money on cogni-research.
+Pre-flight runs for Mode B (the only live path). (Historically, in Mode A the wiki-target check ran before any research dispatch so an unusable wiki target never burned research budget; Mode A now aborts in Step 1 and dispatches nothing.)
 
 1. **Resolve mode & slugs.**
-   - If `--topic` set: mode = A. The cogni-research slug is unknown until Step 1 returns; pin a *tentative* slug from `kebab-case(--topic)` for path planning, but use the actual slug from Step 1's return.
+   - If `--topic` set: mode = A → **abort and redirect** (Step 1); no slug resolution happens. (Historically a tentative slug from `kebab-case(--topic)` was pinned for path planning until Step 1 returned the real slug.)
    - If `--research-slug` set: mode = B. `research_slug = --research-slug`.
    - `wiki_slug = --wiki-slug` if set, else `research_slug`.
    - `wiki_root = --wiki-root` if set, else `cogni-wiki/{wiki_slug}/` resolved against the current workspace.

--- a/cogni-wiki/tests/test_wiki_from_research_flags.sh
+++ b/cogni-wiki/tests/test_wiki_from_research_flags.sh
@@ -81,6 +81,25 @@ fi
 assert_grep 'cogni-knowledge:knowledge-report' \
   "orchestrator rationale (cogni-knowledge:knowledge-report mention)"
 
+# 6. Migration exit state: zero `cogni-research:` dispatches.
+#    The skill is deprecated in favour of cogni-knowledge's inverted pipeline;
+#    it must no longer carry any `cogni-research:` namespace reference (the
+#    dispatch slug form) so the repo-wide zero-`cogni-research:`-dispatch
+#    guard and the migration exit audit stay green.
+if grep -qE 'cogni-research:' "$SKILL"; then
+  red "FAIL: REGRESSION: a 'cogni-research:' dispatch/namespace reference is back"
+  red "      (the deprecation requires zero 'cogni-research:' occurrences)"
+  errors=$((errors + 1))
+else
+  green "PASS: zero 'cogni-research:' dispatch/namespace references (migration exit state)"
+fi
+
+# 7. Deprecation notice present and points users at cogni-knowledge.
+assert_grep '[Dd]eprecated' \
+  "deprecation notice present"
+assert_grep 'cogni-knowledge:knowledge-setup' \
+  "redirect to cogni-knowledge inverted pipeline (knowledge-setup entry point)"
+
 if [ $errors -gt 0 ]; then
   red "$errors invariant(s) missing — see lines above."
   exit 1


### PR DESCRIPTION
Closes #501.

## Summary
- Added a `## Deprecation notice` to `wiki-from-research/SKILL.md` (and the `description` frontmatter) directing users to cogni-knowledge's inverted pipeline (`knowledge-setup` + `knowledge-plan` → … → `knowledge-finalize`) as the replacement for the topic→wiki cold-start use case.
- Neutralized the two executable `cogni-research:` dispatches so the skill reaches the required exit state (zero `cogni-research:` dispatches):
  - Mode A (`--topic`): replaced the `Skill("cogni-research:research-setup", …)` block with an abort/redirect — Mode A no longer auto-dispatches a research pipeline.
  - Step 0(4): removed the `run-verify-first` option's executable `Skill("cogni-research:verify-report", …)` dispatch; kept `proceed`/`abort`.
- Stripped the remaining prose `cogni-research:` slug references so the SKILL reaches a clean zero-occurrence state. Filesystem `cogni-research-<slug>/` directory paths (read by Mode B) are unchanged — they are not dispatches.
- Preserved the contract machinery the existing test asserts: the `--allow-wiki-source`/`--cycle-guard-cleared` rows, the `report_source ∈ {wiki, hybrid}` Step 0(3) guard, the Step 1d re-run structure, the `.metadata/project-config.json` read path, and the `cogni-knowledge:knowledge-report` rationale.
- Bumped `cogni-wiki` 0.0.63 → 0.0.64 (plugin.json + marketplace.json); added a CHANGELOG entry.
- Added a zero-`cogni-research:` guard + deprecation-notice assertions to `tests/test_wiki_from_research_flags.sh`.

## Scope decision: rotate vs deprecate → DEPRECATE
Zero live executable callers (the only two — `knowledge-research` Mode A, `knowledge-report` Mode B — are already archived under `cogni-knowledge/_archive/`; the live inverted pipeline does not use this skill). cogni-wiki is itself slated for archive, so rotating onto a surviving cogni-knowledge path would build a dead path in a soon-archived plugin. The deprecation note records this decision per the issue's requirement. Mode B (`--research-slug`) is retained as a legacy on-disk deposit path and is removed when cogni-wiki is archived.

## Deferred (tracked separately)
- Repo-wide zero-occurrence `cogni-research:` grep-guard — out of scope for this skill's exit state.
- Migration exit audit (asserts zero external dispatches across the Migrate epic) — verified at the audit level, not here.
- Full removal of the skill — lands transitively with the cogni-wiki archive.

## Test plan
- [x] `bash cogni-wiki/tests/test_wiki_from_research_flags.sh` passes (11 invariants incl. the new zero-`cogni-research:` + deprecation guards).
- [x] `grep -c 'cogni-research:' cogni-wiki/skills/wiki-from-research/SKILL.md` → 0 (exit state).
- [x] `python3 scripts/check-breadcrumbs.py` → 0 violations.
- [x] plugin.json + marketplace.json at 0.0.64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
