### PR TITLE
cogni-narrative: decouple arc-inheritance from the cogni-research project layout

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,7 +28,7 @@
     {
       "name": "cogni-narrative",
       "source": "./cogni-narrative",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "maturity": "preview",
       "description": "Story arc engine for insight-wave. Transforms structured research and portfolio output into executive narratives via 11 arc frameworks (Corporate Visions, JTBD Portfolio, Strategic Foresight, Trend Panorama, Smarter Service + 6) and 8 narrative techniques. Includes review scoring (0–100, A–F) and derivative formats (executive brief, talking points, one-pager). Bilingual EN/DE.",
       "keywords": [

--- a/cogni-narrative/.claude-plugin/plugin.json
+++ b/cogni-narrative/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-narrative",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Story arc engine for insight-wave. Transforms structured research and portfolio output into executive narratives via 11 arc frameworks (Corporate Visions, JTBD Portfolio, Strategic Foresight, Trend Panorama, Smarter Service + 6) and 8 narrative techniques. Includes review scoring (0–100, A–F) and derivative formats (executive brief, talking points, one-pager). Bilingual EN/DE.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-narrative/CLAUDE.md
+++ b/cogni-narrative/CLAUDE.md
@@ -84,11 +84,11 @@ Arc auto-detection: the narrative skill analyzes input content structure and pro
 ## Pipeline Position
 
 ```
-cogni-research → cogni-narrative → cogni-copywriting → cogni-visual
-  (research)       (compose)         (polish)           (visualize)
+cogni-knowledge → cogni-narrative → cogni-copywriting → cogni-visual
+  (research)        (compose)         (polish)           (visualize)
 ```
 
-- **Upstream**: Research output from cogni-research; TIPS dimension data from cogni-trends
+- **Upstream**: Research syntheses from cogni-knowledge (inverted-pipeline output; legacy cogni-research projects still work via the same `.metadata/` arc probe); TIPS dimension data from cogni-trends
 - **Citation bridge**: `bridge-citations.py` converts `[Source: Publisher](URL)` inline citations into per-source markdown files before Phase 1 loads them
 - **Downstream**: cogni-copywriting detects `arc_id` frontmatter and applies arc-aware polishing; cogni-visual transforms narratives into slides, journey maps, web pages, storyboards
 

--- a/cogni-narrative/README.md
+++ b/cogni-narrative/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-The story arc engine for the insight-wave ecosystem — transforms structured research and portfolio output into executive-grade narratives using 11 arc frameworks (Corporate Visions, JTBD Portfolio, Strategic Foresight, Trend Panorama, and seven more) and 8 narrative techniques, with review scoring (0–100, A–F) and derivative formats (executive brief, talking points, one-pager), sitting between cogni-research and cogni-copywriting in the pipeline and feeding cogni-visual, cogni-sales, and cogni-marketing downstream. Bilingual EN/DE.
+The story arc engine for the insight-wave ecosystem — transforms structured research and portfolio output into executive-grade narratives using 11 arc frameworks (Corporate Visions, JTBD Portfolio, Strategic Foresight, Trend Panorama, and seven more) and 8 narrative techniques, with review scoring (0–100, A–F) and derivative formats (executive brief, talking points, one-pager), sitting between cogni-knowledge and cogni-copywriting in the pipeline and feeding cogni-visual, cogni-sales, and cogni-marketing downstream. Bilingual EN/DE.
 
 ## Why this exists
 
@@ -151,7 +151,7 @@ cogni-narrative/
 | Plugin | Required | Purpose |
 |--------|----------|---------|
 | cogni-trends | No | Provides trend-scout output for the `trend-panorama` arc |
-| cogni-research | No | Provides research reports as narrative input |
+| cogni-knowledge | No | Provides research syntheses (inverted-pipeline output) as narrative input |
 | cogni-portfolio | No | jtbd-portfolio arc reads portfolio entity files |
 | cogni-copywriting | No | Arc-aware executive polish (downstream) |
 | cogni-visual | No | Slide decks and visual assets from narrative output (downstream) |

--- a/cogni-narrative/skills/narrative/SKILL.md
+++ b/cogni-narrative/skills/narrative/SKILL.md
@@ -28,7 +28,7 @@ Transform input markdown files into a structured executive narrative using one o
 | `--arc-id` | No | Explicit arc selection; overrides auto-detection |
 | `--language` | No | Output language: `en` (default) or `de`. Fallback chain: explicit parameter > project metadata > workspace preference (`.workspace-config.json`) > content detection > `en` |
 | `--output-path` | No | Output file path; defaults to `insight-summary.md` in source directory |
-| `--project-path` | No | Research project root; enables arc inheritance from `.metadata/project-config.json` (Phase 1 step 8) and loading entity data beyond source path. When omitted, Phase 1 step 8 probes `<source-path>/..` and `<source-path>/../..` to auto-detect a cogni-research project root |
+| `--project-path` | No | Research/knowledge project root; enables arc inheritance from the project's `.metadata/` (`plan.json` for a cogni-knowledge project, or `project-config.json` for a legacy cogni-research project — Phase 1 step 8) and loading entity data beyond source path. When omitted, Phase 1 step 8 probes `<source-path>/..` and `<source-path>/../..` to auto-detect the project root |
 | `--research-question` | No | Original research question for narrative hook framing |
 | `--target-length` | No | Target total word count as a single number (e.g., `2500`). System applies +/-15% band to derive the acceptable range. Default: `1675` (yields ~1,424-1,926 words). Recommended: 800-4,000 — outside this range, arc rhetorical structure may not scale well |
 | `--content-map` | No | YAML map of content category keys to file/directory paths for additional context |
@@ -114,7 +114,7 @@ The quality of each phase depends on the previous one. In particular, Phases 3 a
 
 ### Phase 0.5: Citation Bridge (conditional)
 
-Source content from upstream research tools (e.g., cogni-research) may use `[Source: Publisher](URL)` inline citations. These need to be converted into per-source markdown files before Phase 1 can load them as citable references.
+Source content from upstream research/knowledge tools (e.g., cogni-knowledge, or legacy cogni-research) may use `[Source: Publisher](URL)` inline citations. These need to be converted into per-source markdown files before Phase 1 can load them as citable references.
 
 **Detection:** Scan the first 500 lines of the source content for the pattern `[Source: ...](...)`. If present, run the bridge. If not, skip to Phase 1.
 
@@ -149,17 +149,19 @@ After running the bridge, redirect `--source-path` to the `narrative-input/` dir
 5. If `--research-question` provided, store it for hook construction.
 6. Parse `--target-length` if provided (single integer). Compute the acceptable range: `total_lower = target * 0.85`, `total_upper = target * 1.15`. If omitted, default to `target = 1675` (range 1424-1926). Store `target_length`, `total_lower`, `total_upper`.
 7. Build a mental CONTENT_REGISTRY: list of loaded files with titles, word counts, key sections, category tags.
-8. **Resolve arc inheritance from a source cogni-research project.** Probe up to three candidate roots in order — `--project-path` (when provided), then `<source-path>/..` (handles `--source-path <project>/output/`), then `<source-path>/../..` (handles `--source-path <project>/output/report.md`). First candidate with a readable `.metadata/project-config.json` wins; the jq call returns empty on missing file, so no separate existence check:
+8. **Resolve arc inheritance from a source research/knowledge project.** The upstream producer is a cogni-knowledge inverted-pipeline project (or a legacy cogni-research project). Probe up to three candidate roots in order — `--project-path` (when provided), then `<source-path>/..` (handles `--source-path <project>/output/`), then `<source-path>/../..` (handles `--source-path <project>/output/report.md`). For each candidate, read the story-arc id from either project-metadata file — `.metadata/plan.json` (cogni-knowledge inverted pipeline) or `.metadata/project-config.json` (legacy cogni-research). The first candidate+file yielding a non-empty `story_arc_id` wins; jq returns empty on a missing file, so no separate existence check is needed and a project that carries no arc (e.g. a cogni-knowledge wiki deposit) simply falls through:
 
    ```bash
    for CANDIDATE in "${PROJECT_PATH:+$PROJECT_PATH}" "${SOURCE_PATH}/.." "${SOURCE_PATH}/../.."; do
      [[ -z "$CANDIDATE" ]] && continue
-     ARC=$(jq -r '.story_arc_id // empty' "$CANDIDATE/.metadata/project-config.json" 2>/dev/null)
-     [[ -n "$ARC" ]] && { PROJECT_ROOT="$CANDIDATE"; INHERITED_ARC="$ARC"; break; }
+     for CFG in plan.json project-config.json; do
+       ARC=$(jq -r '.story_arc_id // empty' "$CANDIDATE/.metadata/$CFG" 2>/dev/null)
+       [[ -n "$ARC" ]] && { PROJECT_ROOT="$CANDIDATE"; INHERITED_ARC="$ARC"; break 2; }
+     done
    done
    ```
 
-   If `INHERITED_ARC` is set AND not `standard-research`, store as `inherited_arc_id` for Phase 2 and log: `Inheriting story_arc_id="<INHERITED_ARC>" from <PROJECT_ROOT>`. Otherwise skip silently. Mirrors `cogni-visual:enrich-report` Phase 0's parent-of-source-path detection with a narrower scope (only `.metadata/project-config.json` is checked).
+   If `INHERITED_ARC` is set AND not `standard-research`, store as `inherited_arc_id` for Phase 2 and log: `Inheriting story_arc_id="<INHERITED_ARC>" from <PROJECT_ROOT>`. Otherwise skip silently. The probe is layout-agnostic — it reads whichever `.metadata/` project-metadata file is present, so it works against a cogni-knowledge project, a legacy cogni-research project, or a bare source path with no project root. Mirrors `cogni-visual:enrich-report` Phase 0's parent-of-source-path detection with a narrower scope (only the `.metadata/` project-metadata files are checked).
 
 **Before moving on,** make sure you can answer: How many files loaded? What are the 2-3 dominant themes? What is the approximate total word count? If you can't answer these, you haven't internalized the source material yet.
 

--- a/cogni-narrative/skills/narrative/SKILL.md
+++ b/cogni-narrative/skills/narrative/SKILL.md
@@ -175,12 +175,12 @@ The arc registry contains the detection algorithm, keyword sets, and content-typ
 
 **Selection priority:**
 1. If `--arc-id` provided, use it directly. `detection_reason = "explicit --arc-id parameter"`.
-2. If `inherited_arc_id` was resolved in Phase 1 step 8, use it. `detection_reason = "inherited from source research project: <PROJECT_ROOT>"`.
+2. If `inherited_arc_id` was resolved in Phase 1 step 8, use it. `detection_reason = "inherited from source research/knowledge project: <PROJECT_ROOT>"`.
 3. If `narrative-config.json` contains `content_type`, apply detection algorithm from arc-registry. `detection_reason = "content_type mapping from narrative-config.json"`.
 4. If none of the above, analyze loaded content for keyword density using detection algorithm. `detection_reason = "keyword density analysis"`.
 5. Fallback: `corporate-visions`. `detection_reason = "default fallback"`.
 
-Present selected arc to user for confirmation using AskUserQuestion. Show the detected arc with detection reason and offer alternatives. For priority-2 picks, label the prompt "Inherited from source research project — preserves the long-form report's arc". Accept user confirmation or override.
+Present selected arc to user for confirmation using AskUserQuestion. Show the detected arc with detection reason and offer alternatives. For priority-2 picks, label the prompt "Inherited from source research/knowledge project — preserves the long-form report's arc". Accept user confirmation or override.
 
 Store: `arc_id`, `arc_display_name`, `detection_reason`
 


### PR DESCRIPTION
Closes #502.

## Summary
Decouple cogni-narrative's arc-inheritance from the legacy cogni-research project layout. No runtime dispatch is added or removed — cogni-narrative never dispatched `cogni-research:`; this closes the *structural + documentation* coupling so the Migrate epic's grep-guard passes and narrative keeps working against cogni-knowledge output.

- **Probe made layout-agnostic** (`narrative/SKILL.md` Phase 1 step 8): reads `story_arc_id` from `.metadata/plan.json` (cogni-knowledge inverted pipeline) **or** `.metadata/project-config.json` (legacy cogni-research), keeping the existing candidate-root probe order. A cogni-knowledge project carries no `story_arc_id`, so the probe falls through silently — **behavior-preserving** for both producers.
- **Prose updated** to name cogni-knowledge as the upstream producer: the `--project-path` row, the citation-bridge note, `README.md` dependency table + pitch line, and `CLAUDE.md` data-flow (legacy cogni-research still works via the same probe).
- **Version** bumped 0.11.1 → 0.11.2 (plugin.json + marketplace.json).

## Why deprecate-not-rewrite the coupling
cogni-knowledge inverted-pipeline projects write `.metadata/plan.json` (not the legacy `project-config.json`) and do not carry a `story_arc_id` at all. The pre-change probe therefore already no-op'd gracefully against cogni-knowledge output; this PR makes that forward-compatible (it will inherit an arc if cogni-knowledge ever stamps one) and corrects the prose that still named cogni-research as the producer.

## Test plan
- [x] Probe bash verified to run clean against missing metadata files (graceful no-op, `break 2` works).
- [x] No narrative test suite to break (no `tests/` dir; no arc-inheritance fixtures).
- [x] `grep -c 'cogni-research:' cogni-narrative/skills/narrative/SKILL.md` → 0.
- [x] `python3 scripts/check-breadcrumbs.py` → 0 violations.
- [x] plugin.json + marketplace.json at 0.11.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
