### PR TITLE
cogni-portfolio: confirm zero cogni-research/cogni-wiki dispatch and close out

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -117,7 +117,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.50",
+      "version": "0.9.51",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
       "keywords": [

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.50",
+  "version": "0.9.51",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -202,7 +202,7 @@ cogni-portfolio/
 | cogni-marketing | No | Customer narratives from portfolio-communicate are auto-discovered by marketing-setup for voice/messaging enrichment |
 | cogni-claims | No | Claim verification for research-backed assertions via portfolio-verify |
 | cogni-trends | No | Bidirectional TIPS integration via trends-bridge |
-| cogni-research | No | Pitch arcs (technology-futures, strategic-foresight, trend-panorama, theme-thesis) in portfolio-communicate draw on cogni-research output for evidence |
+| cogni-knowledge | No | Pitch arcs (technology-futures, strategic-foresight, trend-panorama, theme-thesis) in portfolio-communicate draw on cogni-knowledge research syntheses for evidence |
 | cogni-workspace | No | Theme selection for portfolio-dashboard via pick-theme |
 | cogni-consulting | No | Lean Canvas extraction via portfolio-canvas (canvases from business-model-hypothesis vision class) |
 | cogni-sales | No | Downstream consumer — why-change pitch builds on portfolio features and propositions |

--- a/cogni-portfolio/skills/portfolio-communicate/SKILL.md
+++ b/cogni-portfolio/skills/portfolio-communicate/SKILL.md
@@ -134,7 +134,7 @@ For the `pitch` use case, the output's `arc_id` controls which story structure c
 > - **Competitive Intelligence** (`competitive-intelligence`) — Landscape → Shifts → Positioning → Implications. Best for competitive positioning presentations.
 > - **Industry Transformation** (`industry-transformation`) — Forces → Friction → Evolution → Leadership. Best for industry conferences and thought leadership.
 
-If the user explicitly passed `--arc-id` on invocation, skip the picker and use that value. Still validate it against the four supported arcs above — reject unsupported arcs (`technology-futures`, `strategic-foresight`, `trend-panorama`, `theme-thesis`) with the explanation from `templates-pitch.md` that those arcs need cogni-trends or cogni-research input and portfolio data alone is usually insufficient.
+If the user explicitly passed `--arc-id` on invocation, skip the picker and use that value. Still validate it against the four supported arcs above — reject unsupported arcs (`technology-futures`, `strategic-foresight`, `trend-panorama`, `theme-thesis`) with the explanation from `templates-pitch.md` that those arcs need cogni-trends or cogni-knowledge input and portfolio data alone is usually insufficient.
 
 Pass the chosen `arc_id` into Step 2 so `cogni-narrative/skills/narrative/references/story-arc/{arc-id}/arc-definition.md` is read for the right arc, and into Step 3 so the frontmatter and evidence mapping use the right arc elements.
 

--- a/cogni-portfolio/skills/portfolio-communicate/references/templates-pitch.md
+++ b/cogni-portfolio/skills/portfolio-communicate/references/templates-pitch.md
@@ -45,7 +45,7 @@ Pitches are spoken aloud to an audience, usually in a room where someone can imm
 | `competitive-intelligence` | Competitive positioning presentation | Competitors → Landscape/Shifts, Propositions → Positioning, Markets → Implications |
 | `industry-transformation` | Industry conference, thought leadership | Markets → Forces, Competitors → Friction, Features → Evolution, Products → Leadership |
 
-Other arcs (`technology-futures`, `strategic-foresight`, `trend-panorama`, `theme-thesis`) are better served by cogni-trends or cogni-research input — portfolio data alone is usually insufficient for these arcs.
+Other arcs (`technology-futures`, `strategic-foresight`, `trend-panorama`, `theme-thesis`) are better served by cogni-trends or cogni-knowledge input — portfolio data alone is usually insufficient for these arcs.
 
 ---
 


### PR DESCRIPTION
Closes #503.

## Summary
The lightweight confirm-and-close-out child for cogni-portfolio.

- **Confirmed zero live dispatches:** `grep -rInE 'cogni-(research|wiki):' cogni-portfolio/skills cogni-portfolio/agents` returns nothing. cogni-portfolio uses WebSearch directly — the roadmap's flag was a false positive.
- **Scrubbed the three docs-only `cogni-research` mentions** (bare, no colon — they would not trip the colon grep-guard, but cogni-research is being archived so they are corrected to name the surviving producer):
  - `README.md` dependency-table row → cogni-knowledge.
  - `skills/portfolio-communicate/SKILL.md` arc-rejection prose → "cogni-trends or cogni-knowledge input".
  - `skills/portfolio-communicate/references/templates-pitch.md` arc-guidance prose → same.
- **Version** bumped 0.9.50 → 0.9.51 (plugin.json + marketplace.json).

## Verification (exit state)
- [x] `grep -rInE 'cogni-(research|wiki):' cogni-portfolio/skills cogni-portfolio/agents` → 0 (no live dispatch).
- [x] `grep -rInE 'cogni-(research|wiki)' cogni-portfolio --include='*.md' | grep -vE 'cogni-(research|wiki)-'` → 0 (no remaining bare mentions).
- [x] `python3 scripts/check-breadcrumbs.py` → 0 violations.
- [x] plugin.json + marketplace.json at 0.9.51.

cogni-portfolio is now auditable as checked (not skipped) and closed out of the Migrate epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
