### PR TITLE
cogni-knowledge: vendor remaining standalone cogni-wiki scripts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-claims-resweep/scripts/extract_page_claims.py
+++ b/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-claims-resweep/scripts/extract_page_claims.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""
+extract_page_claims.py — deterministic claim candidate extraction from wiki page prose.
+
+Walks <wiki-root>/wiki/pages/, parses each page's frontmatter and body, and emits
+claim candidates that the wiki-claims-resweep skill submits to cogni-claims for
+re-verification.
+
+Boundary: this script is **read-only** and **never** makes network calls. It reads
+markdown, parses frontmatter, and prints JSON. WebFetch happens later, inside the
+cogni-claims:claim-verifier agent that the SKILL dispatches.
+
+Extraction rule (deterministic, no LLM):
+    For each inline-link `[text](http(s)://...)` and each bare `http(s)://...` URL
+    in the page body, take the containing sentence as the claim statement and the
+    URL as the source. Sentences are split on `.`, `!`, `?` followed by whitespace
+    and on blank lines. Markdown link syntax is stripped from the rendered claim.
+    Sentences shorter than MIN_CLAIM_CHARS are dropped (heuristically reduces
+    list-item / heading noise). Identical (statement, url) pairs dedupe.
+
+Page selection (mode is mutually exclusive):
+    --all          Every page that has a non-empty `sources:` frontmatter.
+    --page <slug>  Single-page sweep.
+    --stale-only   Pages whose `updated:` date is older than STALE_PAGE_DAYS
+                   (mirrors wiki-lint's threshold; status=draft uses
+                   STALE_DRAFT_DAYS).
+
+Refusal: pages where any extracted claim's source URL points back into the same
+wiki tree (relative wikilink or path under <wiki-root>) are dropped from that
+page's claim list and counted in `circular_skipped`. Pattern from PRs #198/#199.
+
+Output contract:
+    {
+      "success": true,
+      "data": {
+        "wiki_root": "...",
+        "mode": "all|page|stale-only",
+        "pages": [
+          {
+            "slug": "...",
+            "title": "...",
+            "page_path": "wiki/pages/<slug>.md",
+            "updated": "YYYY-MM-DD",
+            "age_days": <int|null>,
+            "claims": [
+              {"statement": "...", "source_url": "https://...",
+               "source_title": "...", "line": <int>}
+            ],
+            "circular_skipped": <int>
+          }
+        ],
+        "stats": {
+          "pages_scanned": <int>,
+          "pages_with_claims": <int>,
+          "total_claims": <int>,
+          "total_unique_sources": <int>,
+          "circular_skipped": <int>,
+          "pages_skipped_no_sources": <int>
+        }
+      },
+      "error": ""
+    }
+
+stdlib-only, Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "wiki-ingest" / "scripts"))
+from _wikilib import (  # noqa: E402
+    build_slug_index,
+    fail,
+    fail_if_pre_migration,
+    is_audit_slug,
+    iter_pages,
+    ok,
+    parse_frontmatter,
+    split_frontmatter,
+)
+
+
+STALE_DRAFT_DAYS = 180
+STALE_PAGE_DAYS = 365
+
+MIN_CLAIM_CHARS = 30
+MAX_CLAIMS_PER_PAGE = 50
+
+INLINE_LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^)\s]+)\)")
+BARE_URL_RE = re.compile(r"(?<![\(\[\"'])\bhttps?://[^\s)\]<>\"']+")
+SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z\[(])|\n\s*\n")
+# Permissive: strips ANY [[…]] syntax from claim text, not just valid slugs.
+# Intentionally different from `_wikilib.WIKILINK_RE` which only matches valid
+# slugs — the strict regex would miss hand-edited brackets, leaving litter in
+# the extracted claim sentence.
+WIKILINK_STRIP_RE = re.compile(r"\[\[[^\]]+\]\]")
+MD_LINK_STRIP_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _unquote(s: str) -> str:
+    s = s.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
+        return s[1:-1]
+    return s
+
+
+def parse_date(s: str):
+    try:
+        return dt.datetime.strptime(s.strip(), "%Y-%m-%d").date()
+    except (ValueError, AttributeError):
+        return None
+
+
+def split_body(text: str) -> str:
+    return split_frontmatter(text)[1]
+
+
+def strip_markdown(s: str) -> str:
+    """Render claim text as plain prose: drop markdown link syntax, wikilinks,
+    code-fences, and squash whitespace. Keep the link's anchor text."""
+    s = MD_LINK_STRIP_RE.sub(r"\1", s)
+    s = WIKILINK_STRIP_RE.sub("", s)
+    s = s.replace("`", "")
+    s = s.lstrip("-*> \t").strip()
+    s = WHITESPACE_RE.sub(" ", s)
+    return s.strip()
+
+
+def is_circular_source(url: str, wiki_root: Path) -> bool:
+    """A URL is circular if it points back into this wiki: a relative path
+    starting with `wiki/` or an absolute path under <wiki-root>. Outside
+    URLs (http/https) are always non-circular."""
+    if url.startswith(("http://", "https://")):
+        return False
+    if url.startswith("wiki/") or url.startswith("../wiki/") or url.startswith("./wiki/"):
+        return True
+    try:
+        resolved = (wiki_root / url).resolve()
+        wiki_pages = (wiki_root / "wiki").resolve()
+        return str(resolved).startswith(str(wiki_pages))
+    except (OSError, ValueError):
+        return False
+
+
+def extract_claims_from_body(body: str, wiki_root: Path) -> tuple[list[dict], int]:
+    """Return (claims, circular_skipped_count)."""
+    claims: list[dict] = []
+    circular = 0
+    seen: set = set()
+
+    sentences = SENTENCE_SPLIT_RE.split(body)
+    line_offsets: list[int] = []
+    cursor = 0
+    for sent in sentences:
+        line_offsets.append(body[:cursor].count("\n") + 1)
+        cursor += len(sent) + 1
+
+    for idx, raw_sent in enumerate(sentences):
+        sent = raw_sent.strip()
+        if not sent:
+            continue
+
+        urls: list[tuple[str, str]] = []
+        for m in INLINE_LINK_RE.finditer(sent):
+            urls.append((m.group(2), m.group(1).strip()))
+        for m in BARE_URL_RE.finditer(sent):
+            url = m.group(0).rstrip(".,;:!?")
+            if not any(url == u for u, _ in urls):
+                urls.append((url, ""))
+
+        if not urls:
+            continue
+
+        statement = strip_markdown(sent)
+        if len(statement) < MIN_CLAIM_CHARS:
+            continue
+
+        for url, anchor_text in urls:
+            if is_circular_source(url, wiki_root):
+                circular += 1
+                continue
+            key = (statement, url)
+            if key in seen:
+                continue
+            seen.add(key)
+            claims.append({
+                "statement": statement,
+                "source_url": url,
+                "source_title": anchor_text or url,
+                "line": line_offsets[idx] if idx < len(line_offsets) else 0,
+            })
+            if len(claims) >= MAX_CLAIMS_PER_PAGE:
+                return claims, circular
+    return claims, circular
+
+
+def find_wiki_root(start: Path) -> Path:
+    current = start.resolve()
+    while True:
+        if (current / ".cogni-wiki" / "config.json").is_file():
+            return current
+        if current.parent == current:
+            fail(f"not inside a cogni-wiki (no .cogni-wiki/config.json at or above {start})")
+        current = current.parent
+
+
+def select_pages(wiki_root: Path, mode: str, page_arg: str | None,
+                 days_override: int | None) -> list[Path]:
+    today = dt.date.today()
+    all_paths = sorted(
+        path for slug, path, _ptype in iter_pages(wiki_root)
+        if not is_audit_slug(slug)
+    )
+
+    if mode == "page":
+        slug_index = build_slug_index(wiki_root)
+        entry = slug_index.get(page_arg)
+        if entry is None:
+            fail(f"page not found: {page_arg}")
+        target = entry[0]
+        return [target]
+
+    if mode == "stale-only":
+        out: list[Path] = []
+        for path in all_paths:
+            try:
+                fm = parse_frontmatter(path.read_text(encoding="utf-8"))
+            except OSError:
+                continue
+            updated = parse_date(_unquote(fm.get("updated", "")))
+            if not updated:
+                continue
+            age = (today - updated).days
+            status = _unquote(fm.get("status", "")).lower()
+            threshold = days_override if days_override is not None else (
+                STALE_DRAFT_DAYS if status == "draft" else STALE_PAGE_DAYS
+            )
+            if age > threshold:
+                out.append(path)
+        return out
+
+    return all_paths  # mode == "all"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract claim candidates from wiki pages (deterministic, no network).")
+    parser.add_argument("--wiki-root", help="Override auto-detected wiki root.")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--all", action="store_true", help="Every page with non-empty sources (default).")
+    group.add_argument("--page", metavar="SLUG", help="Single-page sweep.")
+    group.add_argument("--stale-only", action="store_true",
+                       help="Only pages older than STALE_PAGE_DAYS (or --days).")
+    parser.add_argument("--days", type=int, default=None,
+                        help="Override staleness threshold (used with --stale-only).")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    wiki_root = Path(args.wiki_root).resolve() if args.wiki_root else find_wiki_root(Path.cwd())
+    if not (wiki_root / ".cogni-wiki" / "config.json").is_file():
+        fail(f"not a cogni-wiki: {wiki_root}/.cogni-wiki/config.json not found")
+    fail_if_pre_migration(wiki_root)
+
+    if args.page:
+        mode = "page"
+    elif args.stale_only:
+        mode = "stale-only"
+    else:
+        mode = "all"
+
+    if args.days is not None and mode != "stale-only":
+        fail("--days requires --stale-only")
+
+    selected = select_pages(wiki_root, mode, args.page, args.days)
+
+    today = dt.date.today()
+    pages_out: list[dict] = []
+    pages_skipped_no_sources = 0
+    total_circular = 0
+    unique_sources: set = set()
+
+    for path in selected:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        fm = parse_frontmatter(text)
+        sources = fm.get("sources", [])
+        if isinstance(sources, list) and not sources:
+            pages_skipped_no_sources += 1
+            continue
+        if not isinstance(sources, list):
+            pages_skipped_no_sources += 1
+            continue
+
+        body = split_body(text)
+        claims, circular = extract_claims_from_body(body, wiki_root)
+        total_circular += circular
+        if not claims:
+            continue
+
+        updated = parse_date(_unquote(fm.get("updated", "")))
+        age = (today - updated).days if updated else None
+
+        for c in claims:
+            unique_sources.add(c["source_url"])
+
+        pages_out.append({
+            "slug": path.stem,
+            "title": _unquote(fm.get("title", "")) or path.stem,
+            "page_path": str(path.relative_to(wiki_root)),
+            "updated": _unquote(fm.get("updated", "")),
+            "age_days": age,
+            "claims": claims,
+            "circular_skipped": circular,
+        })
+
+    ok({
+        "wiki_root": str(wiki_root),
+        "mode": mode,
+        "pages": pages_out,
+        "stats": {
+            "pages_scanned": len(selected),
+            "pages_with_claims": len(pages_out),
+            "total_claims": sum(len(p["claims"]) for p in pages_out),
+            "total_unique_sources": len(unique_sources),
+            "circular_skipped": total_circular,
+            "pages_skipped_no_sources": pages_skipped_no_sources,
+        },
+    })
+
+
+if __name__ == "__main__":
+    main()

--- a/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-claims-resweep/scripts/resweep_planner.py
+++ b/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-claims-resweep/scripts/resweep_planner.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""
+resweep_planner.py — workspace materialiser and report aggregator for
+wiki-claims-resweep.
+
+Two phases, selected via --phase:
+
+    --phase plan       Read extract JSON (from --extract-file or stdin), create the
+                       per-day sweep workspace under <wiki-root>/raw/claims-resweep-
+                       <YYYY-MM-DD>/, write one claim-manifest markdown per page
+                       and index.json, then emit a dispatch plan on stdout. The
+                       SKILL hands each manifest to cogni-claims:claims (submit +
+                       verify).
+
+    --phase aggregate  Read verification results (from --results-file or stdin) +
+                       the workspace dir, write report.md alongside the manifests,
+                       and write/refresh <wiki-root>/.cogni-wiki/last-resweep.json
+                       (lock-wrapped — last-resweep.json is shared state per the
+                       Concurrency Invariant in cogni-wiki/CLAUDE.md). Emit summary
+                       stats on stdout.
+
+Boundary: this script writes only to (a) the per-day sweep workspace under
+`raw/claims-resweep-<date>/` (isolated, no lock needed) and (b) the lock-wrapped
+`.cogni-wiki/last-resweep.json`. It never touches the per-type page dirs, `wiki/index.md`,
+or `.cogni-wiki/config.json` — page mutations are out of scope (report-only by
+design; user runs wiki-update manually if they want stale markers).
+
+stdlib-only, Python 3.8+. Output contract for plan phase:
+
+    {
+      "success": true,
+      "data": {
+        "workspace": "<abs path>",
+        "workspace_rel": "raw/claims-resweep-<date>",
+        "sweep_date": "YYYY-MM-DD",
+        "plan": [
+          {
+            "slug": "<page-slug>",
+            "manifest": "raw/claims-resweep-<date>/<slug>-claims.md",
+            "claim_count": <int>,
+            "source_count": <int>
+          }
+        ],
+        "stats": {
+          "pages": <int>,
+          "total_claims": <int>,
+          "total_unique_sources": <int>
+        }
+      },
+      "error": ""
+    }
+
+For aggregate phase, output adds report_path, last_resweep_path, and per-status
+counts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "wiki-ingest" / "scripts"))
+from _wikilib import (  # noqa: E402
+    _wiki_lock,
+    atomic_write,
+    fail,
+    ok,
+)
+
+
+def _yaml_escape(s: str) -> str:
+    if any(c in s for c in ":#\n\"'"):
+        return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    return s
+
+
+def render_manifest(page: dict, sweep_date: str) -> str:
+    lines = [
+        "---",
+        f"page_slug: {page['slug']}",
+        f"page_title: {_yaml_escape(page.get('title', page['slug']))}",
+        f"sweep_date: {sweep_date}",
+        f"claim_count: {len(page['claims'])}",
+        f"source_count: {len({c['source_url'] for c in page['claims']})}",
+        f"page_updated: {page.get('updated', '')}",
+        "---",
+        "",
+        f"# Claims to re-verify — {page.get('title', page['slug'])}",
+        "",
+        f"Page: `{page.get('page_path') or page['slug']}`",
+        f"Sweep: {sweep_date}",
+        "",
+        "## Claims",
+        "",
+    ]
+    for i, c in enumerate(page["claims"], 1):
+        lines.append(f"### Claim {i}")
+        lines.append("")
+        lines.append(f"- **statement**: {c['statement']}")
+        lines.append(f"- **source_url**: {c['source_url']}")
+        lines.append(f"- **source_title**: {c.get('source_title', '')}")
+        lines.append(f"- **page_line**: {c.get('line', 0)}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def phase_plan(args) -> None:
+    extract = load_json(args.extract_file)
+    if not extract.get("success"):
+        fail(f"extract input not successful: {extract.get('error', 'unknown')}")
+    data = extract.get("data", {})
+    wiki_root = Path(data.get("wiki_root", "")).resolve()
+    if not wiki_root.is_dir():
+        fail(f"extract.wiki_root not a directory: {wiki_root}")
+    if not (wiki_root / ".cogni-wiki" / "config.json").is_file():
+        fail(f"extract.wiki_root is not a cogni-wiki: {wiki_root}")
+
+    pages = data.get("pages", []) or []
+    if not pages:
+        ok({
+            "workspace": "",
+            "workspace_rel": "",
+            "sweep_date": dt.date.today().isoformat(),
+            "plan": [],
+            "stats": {"pages": 0, "total_claims": 0, "total_unique_sources": 0},
+        })
+
+    sweep_date = args.date or dt.date.today().isoformat()
+    workspace = wiki_root / "raw" / f"claims-resweep-{sweep_date}"
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    plan: list[dict] = []
+    unique_sources: set = set()
+    for page in pages:
+        if not page.get("claims"):
+            continue
+        manifest_path = workspace / f"{page['slug']}-claims.md"
+        atomic_write(manifest_path, render_manifest(page, sweep_date))
+        for c in page["claims"]:
+            unique_sources.add(c["source_url"])
+        plan.append({
+            "slug": page["slug"],
+            "manifest": str(manifest_path.relative_to(wiki_root)),
+            "manifest_abs": str(manifest_path),
+            "claim_count": len(page["claims"]),
+            "source_count": len({c["source_url"] for c in page["claims"]}),
+            "page_path": page.get("page_path") or page["slug"],
+            "age_days": page.get("age_days"),
+        })
+
+    index_path = workspace / "index.json"
+    atomic_write(index_path, json.dumps({
+        "sweep_date": sweep_date,
+        "mode": data.get("mode", "all"),
+        "wiki_root": str(wiki_root),
+        "pages": [
+            {k: v for k, v in entry.items() if k != "manifest_abs"}
+            for entry in plan
+        ],
+        "stats": {
+            "pages": len(plan),
+            "total_claims": sum(p["claim_count"] for p in plan),
+            "total_unique_sources": len(unique_sources),
+        },
+    }, indent=2) + "\n")
+
+    ok({
+        "workspace": str(workspace),
+        "workspace_rel": f"raw/claims-resweep-{sweep_date}",
+        "sweep_date": sweep_date,
+        "plan": plan,
+        "stats": {
+            "pages": len(plan),
+            "total_claims": sum(p["claim_count"] for p in plan),
+            "total_unique_sources": len(unique_sources),
+        },
+    })
+
+
+def render_report(results: dict, plan_index: dict, sweep_date: str) -> str:
+    pages_results = results.get("pages", [])
+    totals = {"verified": 0, "deviated": 0, "source_unavailable": 0, "unverified": 0}
+    for p in pages_results:
+        for c in p.get("claims", []):
+            status = c.get("status", "unverified")
+            totals[status] = totals.get(status, 0) + 1
+
+    deviated_pages = [p["slug"] for p in pages_results
+                      if any(c.get("status") == "deviated" for c in p.get("claims", []))]
+    unavailable_pages = [p["slug"] for p in pages_results
+                         if any(c.get("status") == "source_unavailable" for c in p.get("claims", []))]
+
+    lines = [
+        "---",
+        f"sweep_date: {sweep_date}",
+        f"mode: {plan_index.get('mode', 'all')}",
+        f"total_pages: {len(pages_results)}",
+        f"total_claims: {sum(totals.values())}",
+        f"verified: {totals['verified']}",
+        f"deviated: {totals['deviated']}",
+        f"source_unavailable: {totals['source_unavailable']}",
+        f"unverified: {totals['unverified']}",
+        "---",
+        "",
+        f"# Wiki claims re-verify sweep — {sweep_date}",
+        "",
+        "Pages were not modified. Run `wiki-update` manually for any page where you want to add a `## Stale (date)` marker.",
+        "",
+        "## Summary",
+        "",
+        f"- Pages scanned: {len(pages_results)}",
+        f"- Total claims checked: {sum(totals.values())}",
+        f"- Verified: {totals['verified']}",
+        f"- Deviated: {totals['deviated']} (across {len(deviated_pages)} pages)",
+        f"- Source unavailable: {totals['source_unavailable']} (across {len(unavailable_pages)} pages)",
+        "",
+    ]
+
+    flagged = [p for p in pages_results
+               if any(c.get("status") in ("deviated", "source_unavailable") for c in p.get("claims", []))]
+    if flagged:
+        lines.append("## Pages with findings")
+        lines.append("")
+        for p in flagged:
+            lines.append(f"### {p['slug']}")
+            lines.append("")
+            for c in p.get("claims", []):
+                status = c.get("status", "unverified")
+                if status not in ("deviated", "source_unavailable"):
+                    continue
+                lines.append(f"- **status**: {status}")
+                lines.append(f"  - statement: {c.get('statement', '')}")
+                lines.append(f"  - source: {c.get('source_url', '')}")
+                for d in c.get("deviations", []) or []:
+                    lines.append(f"  - deviation: {d.get('type', '?')} ({d.get('severity', '?')}) — {d.get('explanation', '')}")
+                    excerpt = d.get("source_excerpt", "")
+                    if excerpt:
+                        lines.append(f"    excerpt: {excerpt[:200]}")
+            lines.append("")
+    else:
+        lines.append("No deviated or unavailable claims. Wiki citations are healthy as of this sweep.")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def phase_aggregate(args) -> None:
+    results = load_json(args.results_file)
+    if not results.get("success"):
+        fail(f"results input not successful: {results.get('error', 'unknown')}")
+    rdata = results.get("data", {})
+
+    workspace = Path(args.workspace).resolve()
+    if not workspace.is_dir():
+        fail(f"workspace not a directory: {workspace}")
+    index_path = workspace / "index.json"
+    if not index_path.is_file():
+        fail(f"workspace missing index.json: {index_path}")
+
+    plan_index = json.loads(index_path.read_text(encoding="utf-8"))
+    wiki_root = Path(plan_index.get("wiki_root", "")).resolve()
+    if not (wiki_root / ".cogni-wiki" / "config.json").is_file():
+        fail(f"index.wiki_root no longer a cogni-wiki: {wiki_root}")
+    sweep_date = plan_index.get("sweep_date", dt.date.today().isoformat())
+
+    report_path = workspace / "report.md"
+    atomic_write(report_path, render_report(rdata, plan_index, sweep_date))
+
+    deviated_pages = sorted({
+        p["slug"] for p in rdata.get("pages", [])
+        if any(c.get("status") == "deviated" for c in p.get("claims", []))
+    })
+    unavailable_pages = sorted({
+        p["slug"] for p in rdata.get("pages", [])
+        if any(c.get("status") == "source_unavailable" for c in p.get("claims", []))
+    })
+
+    last_resweep = {
+        "sweep_date": sweep_date,
+        "mode": plan_index.get("mode", "all"),
+        "deviated_pages": deviated_pages,
+        "unavailable_pages": unavailable_pages,
+        "report_path": str(report_path.relative_to(wiki_root)),
+    }
+    last_path = wiki_root / ".cogni-wiki" / "last-resweep.json"
+    with _wiki_lock(wiki_root):
+        atomic_write(last_path, json.dumps(last_resweep, indent=2) + "\n")
+
+    totals = {"verified": 0, "deviated": 0, "source_unavailable": 0, "unverified": 0}
+    for p in rdata.get("pages", []):
+        for c in p.get("claims", []):
+            status = c.get("status", "unverified")
+            totals[status] = totals.get(status, 0) + 1
+
+    ok({
+        "report_path": str(report_path.relative_to(wiki_root)),
+        "last_resweep_path": str(last_path.relative_to(wiki_root)),
+        "sweep_date": sweep_date,
+        "deviated_pages": deviated_pages,
+        "unavailable_pages": unavailable_pages,
+        "stats": {
+            "total_pages": len(rdata.get("pages", [])),
+            "total_claims": sum(totals.values()),
+            **totals,
+        },
+    })
+
+
+def load_json(path_arg: str | None) -> dict:
+    if not path_arg or path_arg == "-":
+        try:
+            return json.loads(sys.stdin.read())
+        except json.JSONDecodeError as e:
+            fail(f"stdin is not valid JSON: {e}")
+    p = Path(path_arg).expanduser()
+    if not p.is_file():
+        fail(f"file not found: {p}")
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        fail(f"{p}: invalid JSON ({e})")
+    return {}  # unreachable
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Materialise sweep workspace and aggregate verification results.")
+    parser.add_argument("--phase", choices=("plan", "aggregate"), required=True)
+    parser.add_argument("--extract-file", help="Path to extract_page_claims.py JSON output (or '-' for stdin). Plan phase.")
+    parser.add_argument("--results-file", help="Path to verification-results JSON (or '-' for stdin). Aggregate phase.")
+    parser.add_argument("--workspace", help="Sweep workspace dir (raw/claims-resweep-<date>). Aggregate phase.")
+    parser.add_argument("--date", help="Override sweep date (YYYY-MM-DD). Plan phase only.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.phase == "plan":
+        if not args.extract_file:
+            args.extract_file = "-"
+        phase_plan(args)
+    else:
+        if not args.workspace:
+            fail("--workspace is required for --phase aggregate")
+        if not args.results_file:
+            args.results_file = "-"
+        phase_aggregate(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-dashboard/scripts/build_graph.py
+++ b/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-dashboard/scripts/build_graph.py
@@ -1,0 +1,867 @@
+#!/usr/bin/env python3
+"""
+build_graph.py — two-pass graph layer for cogni-wiki (#221).
+
+Modes (--mode):
+  build (default)        Pass 1 (deterministic [[wikilink]] edges) + read Pass-2
+                         cache + Label Propagation communities + write HTML.
+  enumerate-candidates   List page pairs that need LLM evaluation (shared tags
+                         / type / body overlap), filtered by what's already
+                         covered by Pass-1 edges and what's already cached.
+                         The wiki-dashboard SKILL.md drives the LLM eval loop;
+                         scripts never call an LLM directly (mirrors
+                         lint_wiki.py's split with its SKILL.md Step 4).
+  record-judgement       Atomically write one cache file with the LLM's verdict
+                         for a single pair. Re-callable per pair so partial
+                         runs persist.
+
+Stdlib only. Self-contained HTML output (no CDN, no external resources). The
+inline JS renderer is documented under
+`skills/wiki-dashboard/references/graph-renderer.md`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import html
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "wiki-ingest" / "scripts"))
+from _wikilib import (  # noqa: E402
+    FRONTMATTER_RE,
+    WIKILINK_RE,
+    atomic_write,
+    build_slug_index,
+    emit_json,
+    fail_if_pre_migration,
+    is_audit_slug,
+    is_foundation_page,
+    iter_pages,
+    parse_frontmatter,
+    split_frontmatter,
+)
+
+
+EDGE_COLORS = {
+    "EXTRACTED": "#555555",
+    "INFERRED": "#FF5722",
+    "AMBIGUOUS": "#BDBDBD",
+}
+
+STOPWORDS = frozenset("""
+the a an of to and or in on at for with from by as is are was were be been being
+this that these those it its their there here have has had do does did not no
+but if then so than such which who whom whose what when where why how all any
+each few more most other some only own same can will just should now also into
+about above below over under between through during after before because while
+i you we they me him her us them my your our his she he page concept entity
+type tag tags title sources created updated wiki notes summary decision
+interview meeting learning synthesis note
+""".split())
+
+TOKEN_RE = re.compile(r"[a-z][a-z0-9\-]+")
+
+
+def page_body(text: str) -> str:
+    return split_frontmatter(text)[1]
+
+
+def tokenise(body: str) -> set:
+    """Lowercase token bag, stop-word filtered, dedup."""
+    return {t for t in TOKEN_RE.findall(body.lower()) if t not in STOPWORDS and len(t) >= 4}
+
+
+def page_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def pair_id(slug_a: str, slug_b: str) -> str:
+    """Deterministic pair identifier — sha256 of sorted-slug pair."""
+    a, b = sorted([slug_a, slug_b])
+    return hashlib.sha256(f"{a}|{b}".encode("utf-8")).hexdigest()
+
+
+def jaccard(a: set, b: set) -> float:
+    if not a and not b:
+        return 0.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union else 0.0
+
+
+def collect_pages(wiki_root: Path) -> list:
+    """Return [{slug, path, ptype, title, tags, body, body_tokens, fm, text, content_hash, foundation, audit}].
+
+    Audit slugs (lint-/health-) are surfaced with audit=True so callers can
+    skip them from edges and Pass-2 candidates without re-deriving the rule.
+    """
+    pages = []
+    for slug, path, ptype in iter_pages(wiki_root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        fm = parse_frontmatter(text)
+        title = fm.get("title", slug) if isinstance(fm.get("title", slug), str) else slug
+        tags_raw = fm.get("tags", [])
+        tags = [t for t in tags_raw if isinstance(t, str)] if isinstance(tags_raw, list) else []
+        body = page_body(text)
+        pages.append({
+            "slug": slug,
+            "path": path,
+            "ptype": fm.get("type", ptype) if isinstance(fm.get("type", ptype), str) else ptype,
+            "title": title,
+            "tags": set(tags),
+            "tags_list": tags,
+            "body": body,
+            "body_tokens": tokenise(body),
+            "fm": fm,
+            "text": text,
+            "content_hash": page_hash(text),
+            "foundation": is_foundation_page(fm),
+            "audit": is_audit_slug(slug),
+        })
+    return pages
+
+
+def build_pass1_edges(pages: list) -> list:
+    """Pass 1 — every [[slug]] target that resolves to an existing page becomes
+    one EXTRACTED edge. Self-loops and dangling targets dropped.
+
+    Output is deterministic (sorted by (src, tgt))."""
+    slugs = {p["slug"] for p in pages if not p["audit"]}
+    seen = set()
+    edges = []
+    for p in pages:
+        if p["audit"]:
+            continue
+        for target in WIKILINK_RE.findall(p["text"]):
+            if target == p["slug"] or target not in slugs:
+                continue
+            key = (p["slug"], target)
+            if key in seen:
+                continue
+            seen.add(key)
+            edges.append({
+                "from": p["slug"],
+                "to": target,
+                "type": "EXTRACTED",
+                "confidence": 1.0,
+                "relationship": "",
+            })
+    edges.sort(key=lambda e: (e["from"], e["to"]))
+    return edges
+
+
+def cache_path(wiki_root: Path, slug_a: str, slug_b: str) -> Path:
+    return wiki_root / ".cogni-wiki" / "graph-cache" / f"{pair_id(slug_a, slug_b)}.json"
+
+
+def read_cache_entry(p: Path) -> dict:
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def cache_hit(entry: dict, page_a_hash: str, page_b_hash: str, model_id: str) -> bool:
+    """Hit only when both page hashes AND model_id match; otherwise the cached
+    judgement is stale (page edited or model rotated)."""
+    if not entry:
+        return False
+    a, b = sorted([page_a_hash, page_b_hash])
+    cached_a, cached_b = sorted([entry.get("page_a_hash", ""), entry.get("page_b_hash", "")])
+    return cached_a == a and cached_b == b and entry.get("model_id", "") == model_id
+
+
+def build_pass2_edges(pages: list, wiki_root: Path, model_id: str) -> list:
+    """Read every cache entry that's a fresh hit and translate to edges.
+
+    INFERRED if confidence >= 0.7, else AMBIGUOUS. `unrelated` cache entries
+    don't produce edges. Stale entries (page hash mismatch / model mismatch)
+    are silently ignored — they stay on disk so re-running with the original
+    model is still a no-op."""
+    by_slug = {p["slug"]: p for p in pages}
+    cache_dir = wiki_root / ".cogni-wiki" / "graph-cache"
+    if not cache_dir.is_dir():
+        return []
+    edges = []
+    for cache_file in sorted(cache_dir.glob("*.json")):
+        entry = read_cache_entry(cache_file)
+        slug_a = entry.get("slug_a")
+        slug_b = entry.get("slug_b")
+        if not slug_a or not slug_b:
+            continue
+        if slug_a not in by_slug or slug_b not in by_slug:
+            continue
+        if not cache_hit(entry, by_slug[slug_a]["content_hash"], by_slug[slug_b]["content_hash"], model_id):
+            continue
+        if entry.get("judgement") != "related":
+            continue
+        confidence = float(entry.get("confidence", 0.0) or 0.0)
+        edge_type = "INFERRED" if confidence >= 0.7 else "AMBIGUOUS"
+        edges.append({
+            "from": slug_a,
+            "to": slug_b,
+            "type": edge_type,
+            "confidence": confidence,
+            "relationship": entry.get("relationship", "") or "",
+        })
+    edges.sort(key=lambda e: (e["from"], e["to"]))
+    return edges
+
+
+def label_propagation(node_ids: list, adj: dict, max_iter: int = 30) -> dict:
+    """Deterministic Label Propagation Algorithm — simpler than Louvain (~60 LOC),
+    seeded by sorted-slug initialisation, lower-id-wins tie-break.
+
+    Sufficient for colour clustering on 100–1000-page wikis. Faithful Louvain
+    can replace this in a follow-up PR if community-quality ever matters more
+    than render speed (see references/graph-renderer.md §"Communities").
+    """
+    sorted_ids = sorted(node_ids)
+    labels = {n: i for i, n in enumerate(sorted_ids)}
+    for _ in range(max_iter):
+        changed = False
+        for n in sorted_ids:
+            neighbour_labels = Counter(labels[m] for m in adj.get(n, ()) if m in labels)
+            if not neighbour_labels:
+                continue
+            best = max(neighbour_labels.items(), key=lambda kv: (kv[1], -kv[0]))[0]
+            if labels[n] != best:
+                labels[n] = best
+                changed = True
+        if not changed:
+            break
+    # Compact community ids to 0..K-1 in deterministic order.
+    remap = {}
+    next_id = 0
+    out = {}
+    for n in sorted_ids:
+        lab = labels[n]
+        if lab not in remap:
+            remap[lab] = next_id
+            next_id += 1
+        out[n] = remap[lab]
+    return out
+
+
+def hsl_palette(n: int) -> list:
+    """Generate `n` perceptually-spaced HSL colours via golden-ratio hue stepping."""
+    if n <= 0:
+        return []
+    golden = 0.61803398875
+    out = []
+    h = 0.137
+    for _ in range(n):
+        out.append(f"hsl({int(h * 360)}, 65%, 55%)")
+        h = (h + golden) % 1.0
+    return out
+
+
+def preview(body: str, n: int = 220) -> str:
+    s = " ".join(body.split())
+    return s[:n] + ("…" if len(s) > n else "")
+
+
+def build_graph_data(pages: list, edges: list) -> dict:
+    """Assemble the inline graph data: per-node {id,label,type,tags,preview,
+    community,degree}; per-edge {from,to,type,relationship,confidence}.
+
+    Drops audit slugs. Foundation pages stay as nodes (they're domain knowledge),
+    but Pass-2 enumeration skips foundation×foundation pairs separately.
+    """
+    visible = [p for p in pages if not p["audit"]]
+    node_ids = [p["slug"] for p in visible]
+    edges_visible = [e for e in edges if e["from"] in node_ids and e["to"] in node_ids]
+    adj = defaultdict(set)
+    for e in edges_visible:
+        adj[e["from"]].add(e["to"])
+        adj[e["to"]].add(e["from"])
+    communities = label_propagation(node_ids, adj)
+    palette = hsl_palette(max(1, len(set(communities.values()))))
+
+    nodes = []
+    for p in sorted(visible, key=lambda x: x["slug"]):
+        comm = communities.get(p["slug"], 0)
+        nodes.append({
+            "id": p["slug"],
+            "label": p["title"],
+            "type": p["ptype"],
+            "tags": sorted(p["tags_list"]),
+            "preview": preview(p["body"]),
+            "community": comm,
+            "color": palette[comm % len(palette)],
+            "foundation": p["foundation"],
+            "degree": len(adj.get(p["slug"], ())),
+        })
+
+    edge_data = []
+    for e in edges_visible:
+        edge_data.append({
+            "from": e["from"],
+            "to": e["to"],
+            "type": e["type"],
+            "color": EDGE_COLORS.get(e["type"], "#999"),
+            "confidence": round(float(e.get("confidence", 1.0)), 3),
+            "relationship": e.get("relationship", ""),
+        })
+
+    return {
+        "nodes": nodes,
+        "edges": edge_data,
+        "community_count": len(set(communities.values())),
+    }
+
+
+# ---------------------------------------------------------------------------
+# HTML renderer — vanilla canvas, self-contained, zero external resources.
+# Documented in skills/wiki-dashboard/references/graph-renderer.md.
+# ---------------------------------------------------------------------------
+
+STYLE = """
+* { box-sizing: border-box; }
+body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, sans-serif;
+       background: #0f1115; color: #e6e8eb; overflow: hidden; }
+#header { position: fixed; top: 0; left: 0; right: 0; padding: 10px 16px;
+          background: rgba(15,17,21,0.92); border-bottom: 1px solid #20242c;
+          display: flex; gap: 12px; align-items: center; z-index: 10; }
+#header h1 { font-size: 14px; margin: 0; font-weight: 600; letter-spacing: 0.02em; }
+#header .meta { color: #8a93a3; font-size: 12px; }
+#search { padding: 5px 9px; border-radius: 6px; border: 1px solid #2a2f3a;
+          background: #181c25; color: #e6e8eb; font-size: 13px; width: 220px; }
+#search:focus { outline: none; border-color: #4a90e2; }
+#legend { display: flex; gap: 10px; font-size: 11px; color: #8a93a3; }
+.legend-item { display: flex; align-items: center; gap: 4px; }
+.legend-swatch { width: 14px; height: 3px; border-radius: 1px; }
+#canvas { position: fixed; top: 44px; left: 0; right: 0; bottom: 0; cursor: grab; }
+#canvas:active { cursor: grabbing; }
+#panel { position: fixed; top: 44px; right: 0; bottom: 0; width: 340px;
+         background: #181c25; border-left: 1px solid #20242c; padding: 18px;
+         overflow-y: auto; transform: translateX(100%); transition: transform 0.18s ease; z-index: 9; }
+#panel.open { transform: translateX(0); }
+#panel h2 { margin: 0 0 4px; font-size: 16px; }
+#panel .ptype { display: inline-block; font-size: 10px; text-transform: uppercase;
+                background: #2a2f3a; color: #c9d1d9; padding: 2px 7px; border-radius: 3px;
+                margin-bottom: 10px; }
+#panel .tags { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 12px; }
+#panel .tag { font-size: 11px; background: #2a2f3a; color: #aab2bf;
+              padding: 2px 7px; border-radius: 999px; }
+#panel .preview { font-size: 13px; color: #c9d1d9; line-height: 1.5; margin-bottom: 14px; }
+#panel h3 { font-size: 11px; text-transform: uppercase; color: #8a93a3;
+            margin: 14px 0 6px; letter-spacing: 0.05em; }
+#panel ul { margin: 0; padding-left: 18px; font-size: 13px; }
+#panel li { margin: 3px 0; }
+#panel li button { background: none; border: none; color: #79b0ff;
+                   cursor: pointer; padding: 0; font: inherit; text-align: left; }
+#panel li button:hover { text-decoration: underline; }
+#panel .relationship { color: #8a93a3; font-size: 11px; }
+#panel .close { position: absolute; top: 12px; right: 12px; background: none;
+                border: none; color: #8a93a3; font-size: 20px; cursor: pointer; }
+#stats { position: fixed; bottom: 10px; left: 10px; font-size: 11px;
+         color: #8a93a3; background: rgba(15,17,21,0.85); padding: 5px 9px;
+         border-radius: 4px; }
+footer { position: fixed; bottom: 10px; right: 10px; font-size: 10px; color: #4a5160; }
+"""
+
+
+def render_html(graph_data: dict, config: dict, stats: dict) -> str:
+    """Self-contained HTML — inline CSS + inline canvas-renderer JS + inline data.
+
+    The data shape kept lean intentionally: full markdown is NOT inlined per
+    node (would balloon a 200-page wiki to 5–10 MB). 220-char preview only;
+    the user opens the source page from the dashboard if they want more.
+    """
+    generated_at = dt.datetime.now().strftime("%Y-%m-%d %H:%M")
+    data_json = json.dumps(graph_data, ensure_ascii=False, separators=(",", ":"))
+    cfg_safe = {
+        "name": config.get("name", "cogni-wiki"),
+        "slug": config.get("slug", ""),
+    }
+    edge_legend = (
+        f'<span class="legend-item"><span class="legend-swatch" style="background:{EDGE_COLORS["EXTRACTED"]}"></span>extracted</span>'
+        f'<span class="legend-item"><span class="legend-swatch" style="background:{EDGE_COLORS["INFERRED"]}"></span>inferred</span>'
+        f'<span class="legend-item"><span class="legend-swatch" style="background:{EDGE_COLORS["AMBIGUOUS"]}"></span>ambiguous</span>'
+    )
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Wiki Graph — {html.escape(cfg_safe["name"])}</title>
+<style>{STYLE}</style>
+</head>
+<body>
+<div id="header">
+  <h1>{html.escape(cfg_safe["name"])} <span class="meta">/ {html.escape(cfg_safe["slug"])}</span></h1>
+  <input id="search" type="text" placeholder="search nodes…" autocomplete="off">
+  <div id="legend">{edge_legend}</div>
+</div>
+<canvas id="canvas"></canvas>
+<div id="panel">
+  <button class="close" type="button" onclick="closePanel()">&times;</button>
+  <div id="panel-body"></div>
+</div>
+<div id="stats">{stats["nodes"]} nodes · {stats["edges_pass1"]} extracted · {stats["edges_pass2"]} inferred · {stats["communities"]} communities</div>
+<footer>Generated by cogni-wiki v0.0.34 · {generated_at}</footer>
+<script>
+const GRAPH = {data_json};
+{INLINE_JS}
+</script>
+</body>
+</html>
+"""
+
+
+# Inline force-directed canvas renderer. Self-contained: no external libs.
+# Verlet-style integration with Coulomb-like repulsion and Hooke spring on edges.
+INLINE_JS = r"""
+(function () {
+  const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
+  const search = document.getElementById('search');
+  const panel = document.getElementById('panel');
+  const panelBody = document.getElementById('panel-body');
+
+  const nodes = GRAPH.nodes.map(n => ({
+    ...n,
+    x: 0, y: 0, vx: 0, vy: 0,
+    visible: true,
+  }));
+  const edges = GRAPH.edges;
+  const idx = new Map(nodes.map((n, i) => [n.id, i]));
+
+  // Initial layout — concentric rings by community for cleaner cold start.
+  const W = window.innerWidth;
+  const H = window.innerHeight - 44;
+  const byCom = new Map();
+  for (const n of nodes) {
+    if (!byCom.has(n.community)) byCom.set(n.community, []);
+    byCom.get(n.community).push(n);
+  }
+  let comIdx = 0;
+  const totalCom = byCom.size;
+  for (const [com, group] of byCom) {
+    const cx = W / 2 + Math.cos((comIdx / totalCom) * Math.PI * 2) * Math.min(W, H) * 0.25;
+    const cy = H / 2 + Math.sin((comIdx / totalCom) * Math.PI * 2) * Math.min(W, H) * 0.25;
+    for (let i = 0; i < group.length; i++) {
+      const t = (i / Math.max(1, group.length)) * Math.PI * 2;
+      const r = 30 + 8 * Math.sqrt(group.length);
+      group[i].x = cx + Math.cos(t) * r + (Math.random() - 0.5) * 4;
+      group[i].y = cy + Math.sin(t) * r + (Math.random() - 0.5) * 4;
+    }
+    comIdx++;
+  }
+
+  // Adjacency for highlight + neighbours panel.
+  const neighbours = new Map(nodes.map(n => [n.id, []]));
+  for (const e of edges) {
+    if (neighbours.has(e.from)) neighbours.get(e.from).push({ id: e.to, type: e.type, relationship: e.relationship, dir: 'out' });
+    if (neighbours.has(e.to)) neighbours.get(e.to).push({ id: e.from, type: e.type, relationship: e.relationship, dir: 'in' });
+  }
+
+  // Pan + zoom.
+  let zoom = 1, panX = 0, panY = 0;
+  let dragging = null, dragOffsetX = 0, dragOffsetY = 0;
+  let panning = false, panStartX = 0, panStartY = 0;
+  let selected = null;
+
+  function resize() {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight - 44;
+  }
+  resize();
+  window.addEventListener('resize', resize);
+
+  function worldToScreen(x, y) { return [x * zoom + panX, y * zoom + panY]; }
+  function screenToWorld(x, y) { return [(x - panX) / zoom, (y - panY) / zoom]; }
+
+  // Force simulation step.
+  function tick() {
+    const REPULSE = 1800;
+    const SPRING = 0.012;
+    const SPRING_LEN = 90;
+    const GRAVITY = 0.0008;
+    const DAMP = 0.82;
+    const cx = canvas.width / 2 / zoom - panX / zoom;
+    const cy = canvas.height / 2 / zoom - panY / zoom;
+    for (let i = 0; i < nodes.length; i++) {
+      const a = nodes[i];
+      if (!a.visible) continue;
+      let fx = (cx - a.x) * GRAVITY;
+      let fy = (cy - a.y) * GRAVITY;
+      for (let j = 0; j < nodes.length; j++) {
+        if (i === j) continue;
+        const b = nodes[j];
+        if (!b.visible) continue;
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        const d2 = dx * dx + dy * dy + 1;
+        const f = REPULSE / d2;
+        fx += dx * f;
+        fy += dy * f;
+      }
+      a.fx = fx; a.fy = fy;
+    }
+    for (const e of edges) {
+      const a = nodes[idx.get(e.from)];
+      const b = nodes[idx.get(e.to)];
+      if (!a || !b || !a.visible || !b.visible) continue;
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const d = Math.sqrt(dx * dx + dy * dy) + 0.01;
+      const stretch = (d - SPRING_LEN) * SPRING;
+      const fx = (dx / d) * stretch;
+      const fy = (dy / d) * stretch;
+      a.fx += fx; a.fy += fy;
+      b.fx -= fx; b.fy -= fy;
+    }
+    for (const n of nodes) {
+      if (!n.visible || n === dragging) continue;
+      n.vx = (n.vx + n.fx) * DAMP;
+      n.vy = (n.vy + n.fy) * DAMP;
+      n.x += n.vx;
+      n.y += n.vy;
+    }
+  }
+
+  function nodeRadius(n) {
+    return 5 + Math.min(14, Math.sqrt(n.degree + 1) * 2.5);
+  }
+
+  function draw() {
+    ctx.fillStyle = '#0f1115';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.save();
+    ctx.translate(panX, panY);
+    ctx.scale(zoom, zoom);
+    // Edges first.
+    for (const e of edges) {
+      const a = nodes[idx.get(e.from)];
+      const b = nodes[idx.get(e.to)];
+      if (!a || !b || !a.visible || !b.visible) continue;
+      const dim = selected && selected.id !== a.id && selected.id !== b.id;
+      ctx.strokeStyle = dim ? '#1f242d' : e.color;
+      ctx.lineWidth = dim ? 0.5 : (e.type === 'EXTRACTED' ? 1.0 : 0.7);
+      ctx.beginPath();
+      ctx.moveTo(a.x, a.y);
+      ctx.lineTo(b.x, b.y);
+      ctx.stroke();
+    }
+    // Nodes on top.
+    for (const n of nodes) {
+      if (!n.visible) continue;
+      const r = nodeRadius(n);
+      const isSel = selected && selected.id === n.id;
+      const dim = selected && !isSel && !(neighbours.get(selected.id) || []).some(x => x.id === n.id);
+      ctx.fillStyle = dim ? '#2a2f3a' : n.color;
+      ctx.strokeStyle = isSel ? '#fff' : (n.foundation ? '#ffe066' : '#0f1115');
+      ctx.lineWidth = isSel ? 2.5 : (n.foundation ? 1.4 : 1);
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+      if (zoom > 0.6 && (isSel || n.degree >= 2)) {
+        ctx.fillStyle = dim ? '#3a4150' : '#e6e8eb';
+        ctx.font = '11px -apple-system, sans-serif';
+        ctx.fillText(n.label, n.x + r + 3, n.y + 3);
+      }
+    }
+    ctx.restore();
+  }
+
+  function loop() {
+    tick();
+    draw();
+    requestAnimationFrame(loop);
+  }
+
+  function nodeAt(sx, sy) {
+    const [wx, wy] = screenToWorld(sx, sy);
+    for (let i = nodes.length - 1; i >= 0; i--) {
+      const n = nodes[i];
+      if (!n.visible) continue;
+      const dx = n.x - wx, dy = n.y - wy;
+      if (dx * dx + dy * dy <= (nodeRadius(n) + 2) ** 2) return n;
+    }
+    return null;
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
+  }
+
+  function renderPanel(n) {
+    const tagsHtml = n.tags.map(t => `<span class="tag">${escapeHtml(t)}</span>`).join('');
+    const out = (neighbours.get(n.id) || []).filter(x => x.dir === 'out');
+    const inn = (neighbours.get(n.id) || []).filter(x => x.dir === 'in');
+    const fmtNeighbour = x => {
+      const target = nodes[idx.get(x.id)];
+      const lbl = target ? target.label : x.id;
+      const rel = x.relationship ? ` <span class="relationship">— ${escapeHtml(x.relationship)}</span>` : '';
+      return `<li><button onclick="selectById('${escapeHtml(x.id).replace(/'/g, "&#39;")}')">${escapeHtml(lbl)}</button> <span class="relationship">[${x.type.toLowerCase()}]</span>${rel}</li>`;
+    };
+    panelBody.innerHTML = `
+      <h2>${escapeHtml(n.label)}</h2>
+      <span class="ptype">${escapeHtml(n.type || '?')}</span>
+      ${tagsHtml ? `<div class="tags">${tagsHtml}</div>` : ''}
+      <div class="preview">${escapeHtml(n.preview || '(no preview)')}</div>
+      ${out.length ? `<h3>Outbound (${out.length})</h3><ul>${out.map(fmtNeighbour).join('')}</ul>` : ''}
+      ${inn.length ? `<h3>Inbound (${inn.length})</h3><ul>${inn.map(fmtNeighbour).join('')}</ul>` : ''}
+      ${!out.length && !inn.length ? `<div class="relationship">No connections.</div>` : ''}
+    `;
+    panel.classList.add('open');
+  }
+
+  function selectNode(n) {
+    selected = n;
+    if (n) renderPanel(n);
+  }
+
+  window.selectById = function (id) {
+    const n = nodes[idx.get(id)];
+    if (n) selectNode(n);
+  };
+  window.closePanel = function () {
+    panel.classList.remove('open');
+    selected = null;
+  };
+
+  canvas.addEventListener('mousedown', (ev) => {
+    const n = nodeAt(ev.clientX, ev.clientY - 44);
+    if (n) {
+      dragging = n;
+      const [wx, wy] = screenToWorld(ev.clientX, ev.clientY - 44);
+      dragOffsetX = wx - n.x;
+      dragOffsetY = wy - n.y;
+    } else {
+      panning = true;
+      panStartX = ev.clientX - panX;
+      panStartY = ev.clientY - panY;
+    }
+  });
+  canvas.addEventListener('mousemove', (ev) => {
+    if (dragging) {
+      const [wx, wy] = screenToWorld(ev.clientX, ev.clientY - 44);
+      dragging.x = wx - dragOffsetX;
+      dragging.y = wy - dragOffsetY;
+      dragging.vx = 0; dragging.vy = 0;
+    } else if (panning) {
+      panX = ev.clientX - panStartX;
+      panY = ev.clientY - panStartY;
+    }
+  });
+  canvas.addEventListener('mouseup', (ev) => {
+    if (dragging) {
+      // If barely moved → treat as click.
+      if (Math.abs(dragging.vx) < 0.5 && Math.abs(dragging.vy) < 0.5) {
+        selectNode(dragging);
+      }
+    } else if (panning) {
+      const moved = Math.abs(ev.clientX - panX - panStartX) + Math.abs(ev.clientY - panY - panStartY);
+      if (moved < 3) {
+        // Background click.
+        closePanel();
+      }
+    }
+    dragging = null;
+    panning = false;
+  });
+  canvas.addEventListener('wheel', (ev) => {
+    ev.preventDefault();
+    const factor = ev.deltaY < 0 ? 1.12 : 1 / 1.12;
+    const [wx, wy] = screenToWorld(ev.clientX, ev.clientY - 44);
+    zoom = Math.max(0.2, Math.min(4, zoom * factor));
+    const [sx, sy] = worldToScreen(wx, wy);
+    panX += ev.clientX - sx;
+    panY += (ev.clientY - 44) - sy;
+  }, { passive: false });
+
+  search.addEventListener('input', () => {
+    const q = search.value.trim().toLowerCase();
+    if (!q) {
+      for (const n of nodes) n.visible = true;
+      return;
+    }
+    const matched = new Set();
+    for (const n of nodes) {
+      if (n.id.toLowerCase().includes(q) || n.label.toLowerCase().includes(q) ||
+          n.tags.some(t => t.toLowerCase().includes(q))) {
+        matched.add(n.id);
+      }
+    }
+    // Include direct neighbours so the matched subgraph stays connected on screen.
+    const expanded = new Set(matched);
+    for (const id of matched) for (const x of (neighbours.get(id) || [])) expanded.add(x.id);
+    for (const n of nodes) n.visible = expanded.has(n.id);
+  });
+
+  loop();
+})();
+"""
+
+
+def cmd_build(args, wiki_root: Path, config: dict) -> None:
+    pages = collect_pages(wiki_root)
+    edges_pass1 = build_pass1_edges(pages)
+    edges_pass2 = build_pass2_edges(pages, wiki_root, args.model)
+    all_edges = edges_pass1 + edges_pass2
+    graph_data = build_graph_data(pages, all_edges)
+    stats = {
+        "nodes": len(graph_data["nodes"]),
+        "edges_pass1": len(edges_pass1),
+        "edges_pass2": len(edges_pass2),
+        "communities": graph_data["community_count"],
+    }
+    output = Path(args.output).expanduser().resolve() if args.output else wiki_root / "wiki-graph.html"
+    html_text = render_html(graph_data, config, stats)
+    try:
+        atomic_write(output, html_text)
+    except OSError as exc:
+        emit_json(False, error=f"could not write output: {exc}")
+        sys.exit(1)
+    emit_json(True, data={
+        "output": str(output),
+        "nodes": stats["nodes"],
+        "edges_pass1": stats["edges_pass1"],
+        "edges_pass2": stats["edges_pass2"],
+        "communities": stats["communities"],
+    })
+
+
+def cmd_enumerate(args, wiki_root: Path, config: dict) -> None:
+    pages = collect_pages(wiki_root)
+    edges_pass1 = build_pass1_edges(pages)
+    pass1_pairs = {tuple(sorted([e["from"], e["to"]])) for e in edges_pass1}
+    by_slug = {p["slug"]: p for p in pages if not p["audit"]}
+    slugs = sorted(by_slug.keys())
+    candidates = []
+    for i in range(len(slugs)):
+        for j in range(i + 1, len(slugs)):
+            a = by_slug[slugs[i]]
+            b = by_slug[slugs[j]]
+            key = (slugs[i], slugs[j])
+            if key in pass1_pairs:
+                continue
+            if a["foundation"] and b["foundation"]:
+                continue
+            shared = len(a["tags"] & b["tags"])
+            same_type = a["ptype"] == b["ptype"]
+            overlap = jaccard(a["body_tokens"], b["body_tokens"])
+            include = (
+                shared >= 1
+                or (same_type and overlap >= 0.20)
+                or overlap >= 0.35
+            )
+            if not include:
+                continue
+            cpath = cache_path(wiki_root, a["slug"], b["slug"])
+            if cpath.is_file():
+                entry = read_cache_entry(cpath)
+                if cache_hit(entry, a["content_hash"], b["content_hash"], args.model):
+                    continue
+            pid = pair_id(a["slug"], b["slug"])
+            candidates.append({
+                "pair_id": pid,
+                "slug_a": a["slug"],
+                "slug_b": b["slug"],
+                "shared_tags": shared,
+                "same_type": same_type,
+                "body_overlap": round(overlap, 3),
+                "page_a_preview": preview(a["body"]),
+                "page_b_preview": preview(b["body"]),
+            })
+    # Deterministic order: sort by pair_id (stable across runs and resumable).
+    candidates.sort(key=lambda c: c["pair_id"])
+    if args.limit and args.limit > 0:
+        candidates = candidates[: args.limit]
+    emit_json(True, data={
+        "candidates": candidates,
+        "count": len(candidates),
+        "model_id": args.model,
+    })
+
+
+def cmd_record(args, wiki_root: Path, config: dict) -> None:
+    if not args.pair_id or not args.slug_a or not args.slug_b:
+        emit_json(False, error="record-judgement requires --pair-id, --slug-a, --slug-b")
+        sys.exit(1)
+    if args.judgement not in {"related", "unrelated"}:
+        emit_json(False, error="--judgement must be 'related' or 'unrelated'")
+        sys.exit(1)
+    expected = pair_id(args.slug_a, args.slug_b)
+    if expected != args.pair_id:
+        emit_json(False, error=f"pair_id mismatch: expected {expected} for ({args.slug_a},{args.slug_b})")
+        sys.exit(1)
+    pages = collect_pages(wiki_root)
+    by_slug = {p["slug"]: p for p in pages}
+    if args.slug_a not in by_slug or args.slug_b not in by_slug:
+        emit_json(False, error="one or both slugs do not exist in the wiki")
+        sys.exit(1)
+    a, b = sorted([args.slug_a, args.slug_b])
+    pa_hash = by_slug[a]["content_hash"]
+    pb_hash = by_slug[b]["content_hash"]
+    entry = {
+        "pair_id": args.pair_id,
+        "slug_a": a,
+        "slug_b": b,
+        "page_a_hash": pa_hash,
+        "page_b_hash": pb_hash,
+        "model_id": args.model,
+        "judgement": args.judgement,
+        "confidence": float(args.confidence),
+        "relationship": args.relationship or "",
+        "evaluated_at": dt.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+    }
+    cpath = cache_path(wiki_root, args.slug_a, args.slug_b)
+    try:
+        atomic_write(cpath, json.dumps(entry, ensure_ascii=False, indent=2) + "\n")
+    except OSError as exc:
+        emit_json(False, error=f"could not write cache entry: {exc}")
+        sys.exit(1)
+    emit_json(True, data={"cache_path": str(cpath), "judgement": args.judgement})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Two-pass graph layer for cogni-wiki (#221)")
+    parser.add_argument("--wiki-root", required=True)
+    parser.add_argument("--mode", choices=["build", "enumerate-candidates", "record-judgement"], default="build")
+    parser.add_argument("--output", default=None, help="Override HTML output path (build mode)")
+    parser.add_argument("--model", default="sonnet", help="Model id for cache key (default: sonnet)")
+    parser.add_argument("--limit", type=int, default=50, help="Max candidates to emit (enumerate mode)")
+    parser.add_argument("--pair-id", default=None, help="Pair sha256 identifier (record mode)")
+    parser.add_argument("--slug-a", default=None)
+    parser.add_argument("--slug-b", default=None)
+    parser.add_argument("--judgement", default="related", choices=["related", "unrelated"])
+    parser.add_argument("--confidence", type=float, default=0.0)
+    parser.add_argument("--relationship", default="")
+    args = parser.parse_args()
+
+    wiki_root = Path(args.wiki_root).expanduser().resolve()
+    config_path = wiki_root / ".cogni-wiki" / "config.json"
+    if not config_path.is_file():
+        emit_json(False, error=f"not a cogni-wiki: {config_path} missing")
+        sys.exit(1)
+    fail_if_pre_migration(wiki_root)
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        emit_json(False, error=f"config.json unreadable: {exc}")
+        sys.exit(1)
+
+    if args.mode == "build":
+        cmd_build(args, wiki_root, config)
+    elif args.mode == "enumerate-candidates":
+        cmd_enumerate(args, wiki_root, config)
+    elif args.mode == "record-judgement":
+        cmd_record(args, wiki_root, config)
+
+
+if __name__ == "__main__":
+    main()

--- a/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-dashboard/scripts/render_dashboard.py
+++ b/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-dashboard/scripts/render_dashboard.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""
+render_dashboard.py — generate a self-contained HTML dashboard for a cogni-wiki.
+
+Usage:
+    render_dashboard.py --wiki-root <path> [--output <path>]
+
+Output contract:
+    Writes the HTML file to --output (default: <wiki-root>/wiki-dashboard.html).
+    Prints a JSON summary to stdout:
+    {"success": true, "data": {"output": "<path>", "pages": N, ...}, "error": ""}
+
+Design constraints:
+    - stdlib only
+    - No network calls
+    - Single HTML file with inlined CSS, no JS
+    - Idempotent (same bytes on repeat runs, modulo the generated-at timestamp)
+    - Bash 3.2 / Python 3.8+ compatible
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "wiki-ingest" / "scripts"))
+from _wikilib import (  # noqa: E402
+    PAGE_TYPE_DIRS,
+    VALID_TYPES,
+    WIKILINK_RE,
+    fail,
+    fail_if_pre_migration,
+    is_audit_slug,
+    iter_pages,
+    ok,
+    parse_frontmatter,
+)
+
+
+VALID_TYPES_ORDERED = list(PAGE_TYPE_DIRS.keys())
+TYPE_COLORS = {
+    "concept": "#2563eb",
+    "entity": "#059669",
+    "summary": "#d97706",
+    "decision": "#dc2626",
+    "interview": "#0d9488",
+    "meeting": "#9333ea",
+    "learning": "#7c3aed",
+    "synthesis": "#0891b2",
+    "note": "#64748b",
+    "question": "#be123c",
+}
+
+
+def e(s) -> str:
+    return html.escape(str(s or ""))
+
+
+STYLE = """
+* { box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  margin: 0;
+  color: #111827;
+  background: #f9fafb;
+  line-height: 1.5;
+}
+main { max-width: 1100px; margin: 0 auto; padding: 32px 24px 64px; }
+header h1 { margin: 0 0 4px; font-size: 28px; letter-spacing: -0.02em; }
+header .slug { color: #6b7280; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; }
+header .desc { color: #374151; margin: 8px 0 0; }
+.meta { color: #6b7280; font-size: 13px; margin-top: 4px; }
+section { background: #fff; border: 1px solid #e5e7eb; border-radius: 10px; padding: 20px 22px; margin: 20px 0; }
+section h2 { margin: 0 0 14px; font-size: 16px; text-transform: uppercase; letter-spacing: 0.05em; color: #374151; }
+.stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 12px; }
+.stat { background: #f3f4f6; border-radius: 8px; padding: 14px 16px; }
+.stat .num { font-size: 26px; font-weight: 600; color: #111827; }
+.stat .lbl { font-size: 12px; color: #6b7280; margin-top: 2px; }
+.bar-row { display: flex; align-items: center; gap: 10px; margin: 6px 0; font-size: 14px; }
+.bar-row .type-lbl { width: 90px; color: #374151; }
+.bar-row .bar-container { flex: 1; background: #f3f4f6; height: 18px; border-radius: 4px; overflow: hidden; }
+.bar-row .bar { height: 100%; }
+.bar-row .count { width: 40px; text-align: right; color: #6b7280; font-variant-numeric: tabular-nums; }
+.tags { display: flex; flex-wrap: wrap; gap: 8px 10px; }
+.tag { background: #eef2ff; color: #4338ca; padding: 3px 10px; border-radius: 999px; font-size: 13px; }
+.activity { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; color: #374151; white-space: pre-wrap; max-height: 240px; overflow: auto; }
+.pages-list { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 6px 16px; }
+.pages-list .entry { font-size: 13px; color: #111827; }
+.pages-list .entry .type-tag { font-size: 10px; text-transform: uppercase; color: #fff; padding: 1px 6px; border-radius: 3px; margin-right: 6px; vertical-align: middle; }
+.pages-list .entry .links { color: #6b7280; font-variant-numeric: tabular-nums; }
+.pages-list .entry.orphan { color: #b45309; }
+footer { color: #9ca3af; font-size: 12px; margin-top: 24px; text-align: center; }
+"""
+
+
+def build_html(ctx: dict) -> str:
+    pages = ctx["pages"]
+    stats = ctx["stats"]
+    type_counts = ctx["type_counts"]
+    tag_counts = ctx["tag_counts"]
+    recent_log = ctx["recent_log"]
+    orphans = ctx["orphans"]
+    inbound_counts = ctx["inbound_counts"]
+    cfg = ctx["config"]
+
+    # Type bars
+    max_type = max(type_counts.values()) if type_counts else 1
+    bars = []
+    for t in VALID_TYPES_ORDERED:
+        n = type_counts.get(t, 0)
+        pct = (n / max_type * 100) if max_type else 0
+        color = TYPE_COLORS.get(t, "#9ca3af")
+        bars.append(
+            f'<div class="bar-row"><span class="type-lbl">{e(t)}</span>'
+            f'<div class="bar-container"><div class="bar" style="width:{pct:.1f}%;background:{color}"></div></div>'
+            f'<span class="count">{n}</span></div>'
+        )
+    type_bars_html = "\n".join(bars)
+
+    # Tag cloud
+    top_tags = tag_counts.most_common(30)
+    if top_tags:
+        max_tag = top_tags[0][1]
+        min_tag = top_tags[-1][1]
+        tag_spans = []
+        for tag, n in top_tags:
+            if max_tag == min_tag:
+                size = 14
+            else:
+                size = 12 + int(((n - min_tag) / (max_tag - min_tag)) * 12)
+            tag_spans.append(f'<span class="tag" style="font-size:{size}px">{e(tag)} · {n}</span>')
+        tags_html = '<div class="tags">' + "".join(tag_spans) + "</div>"
+    else:
+        tags_html = '<div class="meta">No tags yet.</div>'
+
+    # Recent activity
+    activity_html = f'<div class="activity">{e(chr(10).join(recent_log)) or "No activity yet."}</div>'
+
+    # Most-linked pages
+    most_linked = sorted(inbound_counts.items(), key=lambda kv: (-kv[1], kv[0]))[:10]
+    if most_linked:
+        ml_html = '<ul style="margin:0;padding-left:20px;font-size:14px">' + "".join(
+            f'<li>{e(slug)} <span class="meta">— {n} inbound</span></li>' for slug, n in most_linked
+        ) + "</ul>"
+    else:
+        ml_html = '<div class="meta">No inbound links yet.</div>'
+
+    # Orphans
+    if orphans:
+        orph_html = '<ul style="margin:0;padding-left:20px;font-size:14px;color:#b45309">' + "".join(
+            f"<li>{e(slug)}</li>" for slug in orphans
+        ) + "</ul>"
+    else:
+        orph_html = '<div class="meta">No orphan pages — every page has at least one inbound link. ✓</div>'
+
+    # Full index grouped by type
+    grouped: dict = {t: [] for t in VALID_TYPES_ORDERED}
+    grouped["_other"] = []
+    for p in pages:
+        t = p["type"] if p["type"] in VALID_TYPES else "_other"
+        grouped[t].append(p)
+
+    sections = []
+    for t in VALID_TYPES_ORDERED + ["_other"]:
+        items = grouped[t]
+        if not items:
+            continue
+        entries = []
+        for p in sorted(items, key=lambda x: x["title"].lower()):
+            inbound = inbound_counts.get(p["slug"], 0)
+            orphan_cls = " orphan" if inbound == 0 else ""
+            color = TYPE_COLORS.get(p["type"], "#9ca3af")
+            entries.append(
+                f'<div class="entry{orphan_cls}">'
+                f'<span class="type-tag" style="background:{color}">{e(p["type"] or "?")}</span>'
+                f'{e(p["title"])} '
+                f'<span class="links">· {inbound}↵</span>'
+                f"</div>"
+            )
+        label = t if t != "_other" else "other"
+        sections.append(
+            f'<h3 style="margin:18px 0 6px;font-size:13px;text-transform:uppercase;color:#6b7280">{e(label)} ({len(items)})</h3>'
+            f'<div class="pages-list">{"".join(entries)}</div>'
+        )
+    index_html = "".join(sections) or '<div class="meta">No pages yet.</div>'
+
+    generated_at = dt.datetime.now().strftime("%Y-%m-%d %H:%M")
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Wiki Dashboard — {e(cfg.get('name', 'cogni-wiki'))}</title>
+<style>{STYLE}</style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>{e(cfg.get("name", "cogni-wiki"))}</h1>
+    <div class="slug">{e(cfg.get("slug", ""))}</div>
+    <p class="desc">{e(cfg.get("description", ""))}</p>
+    <div class="meta">Created {e(cfg.get("created", "?"))} · generated {e(generated_at)}</div>
+  </header>
+
+  <section>
+    <h2>At a glance</h2>
+    <div class="stats">
+      <div class="stat"><div class="num">{stats['pages']}</div><div class="lbl">pages</div></div>
+      <div class="stat"><div class="num">{stats['raw']}</div><div class="lbl">raw sources</div></div>
+      <div class="stat"><div class="num">{stats['links']}</div><div class="lbl">internal links</div></div>
+      <div class="stat"><div class="num">{stats['tags']}</div><div class="lbl">unique tags</div></div>
+      <div class="stat"><div class="num">{stats['orphans']}</div><div class="lbl">orphans</div></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Pages by type</h2>
+    {type_bars_html}
+  </section>
+
+  <section>
+    <h2>Tag cloud</h2>
+    {tags_html}
+  </section>
+
+  <section>
+    <h2>Most-linked pages</h2>
+    {ml_html}
+  </section>
+
+  <section>
+    <h2>Orphan pages</h2>
+    {orph_html}
+  </section>
+
+  <section>
+    <h2>Recent activity</h2>
+    {activity_html}
+  </section>
+
+  <section>
+    <h2>Full index</h2>
+    {index_html}
+  </section>
+
+  <footer>Generated by cogni-wiki · Karpathy-pattern compounding knowledge base</footer>
+</main>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render a cogni-wiki dashboard as self-contained HTML")
+    parser.add_argument("--wiki-root", required=True)
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    wiki_root = Path(args.wiki_root).expanduser().resolve()
+    config_path = wiki_root / ".cogni-wiki" / "config.json"
+    raw_dir = wiki_root / "raw"
+    log_path = wiki_root / "wiki" / "log.md"
+
+    if not config_path.is_file():
+        fail(f"not a cogni-wiki: {config_path} missing")
+    fail_if_pre_migration(wiki_root)
+
+    try:
+        with config_path.open(encoding="utf-8") as f:
+            config = json.load(f)
+    except Exception as exc:
+        fail(f"config.json unreadable: {exc}")
+        return
+
+    pages: list = []
+    type_counts: Counter = Counter()
+    tag_counts: Counter = Counter()
+    inbound_counts: Counter = Counter()
+    total_links = 0
+
+    for slug, path, ptype_dir in iter_pages(wiki_root):
+        if is_audit_slug(slug):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        fm = parse_frontmatter(text)
+        title = fm.get("title", slug) or slug
+        ptype = fm.get("type", "") or ptype_dir
+        tags = fm.get("tags", []) if isinstance(fm.get("tags", []), list) else []
+        type_counts[ptype] += 1
+        for t in tags:
+            if isinstance(t, str):
+                tag_counts[t] += 1
+        links = WIKILINK_RE.findall(text)
+        total_links += len(links)
+        for target in links:
+            inbound_counts[target] += 1
+        pages.append({"slug": slug, "title": title, "type": ptype, "tags": tags})
+
+    existing_slugs = {p["slug"] for p in pages}
+    orphans = sorted(
+        slug for slug in existing_slugs if inbound_counts.get(slug, 0) == 0
+    )
+
+    raw_count = 0
+    if raw_dir.is_dir():
+        raw_count = sum(1 for _ in raw_dir.glob("*") if _.is_file())
+
+    recent_log: list = []
+    if log_path.is_file():
+        try:
+            log_lines = log_path.read_text(encoding="utf-8").splitlines()
+            recent_log = [
+                line for line in log_lines if line.startswith("## [")
+            ][-20:]
+        except OSError:
+            recent_log = []
+
+    stats = {
+        "pages": len(pages),
+        "raw": raw_count,
+        "links": total_links,
+        "tags": len(tag_counts),
+        "orphans": len(orphans),
+    }
+
+    output = Path(args.output).expanduser().resolve() if args.output else wiki_root / "wiki-dashboard.html"
+    html_text = build_html(
+        {
+            "config": config,
+            "pages": pages,
+            "stats": stats,
+            "type_counts": type_counts,
+            "tag_counts": tag_counts,
+            "recent_log": recent_log,
+            "orphans": orphans,
+            "inbound_counts": inbound_counts,
+        }
+    )
+
+    try:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(html_text, encoding="utf-8")
+    except OSError as exc:
+        fail(f"could not write output: {exc}")
+        return
+
+    ok(
+        {
+            "output": str(output),
+            "pages": len(pages),
+            "raw": raw_count,
+            "links": total_links,
+            "tags": len(tag_counts),
+            "orphans": len(orphans),
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-ingest/scripts/_wiki_research.py
+++ b/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-ingest/scripts/_wiki_research.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+_wiki_research.py — shared helpers for reading cogni-research projects from
+cogni-wiki scripts.
+
+Both `wiki-ingest/scripts/batch_builder.py` (discovery → research mode) and
+`wiki-refresh/scripts/refresh_planner.py` (stale-page refresh loop) need the
+same primitives:
+
+  - resolve a research project from a slug or absolute path,
+  - read the sub-question manifest,
+  - read a single cogni-research entity file,
+  - unquote YAML scalars and strip wikilink syntax,
+  - parse ISO dates.
+
+Lifting them here removes the byte-for-byte duplication CLAUDE.md called out
+under §"wiki-refresh stale-page loop" ("The entity-loading helpers in
+refresh_planner.py mirror those in batch_builder.py — known tech debt").
+
+stdlib-only.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+# `parse_frontmatter` and `fail` live in `_wikilib`. Importing them keeps this
+# module self-contained for callers who only need the research helpers.
+from _wikilib import fail, parse_frontmatter, split_frontmatter
+
+
+def unquote(s: str) -> str:
+    """Strip surrounding single or double quotes from a YAML scalar."""
+    s = s.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
+        return s[1:-1]
+    return s
+
+
+def strip_wikilink(ref: str) -> str:
+    """`[[01-contexts/data/ctx-foo-12345678]]` → `ctx-foo-12345678`.
+
+    Tolerant of surrounding quotes — cogni-research's create-entity.py emits
+    quoted wikilinks because YAML treats `[[…]]` as a flow-sequence start
+    otherwise. The frontmatter parser keeps the quotes verbatim.
+    """
+    inner = unquote(ref)
+    if inner.startswith("[[") and inner.endswith("]]"):
+        inner = inner[2:-2]
+    return inner.rsplit("/", 1)[-1]
+
+
+def parse_date(s: str):
+    """ISO `YYYY-MM-DD` → `date`; returns `None` on any parse failure."""
+    try:
+        return dt.datetime.strptime(s.strip(), "%Y-%m-%d").date()
+    except (ValueError, AttributeError):
+        return None
+
+
+def read_research_entity(path: Path) -> "tuple[dict, str]":
+    """Read a cogni-research entity .md → (frontmatter dict, body text).
+
+    cogni-research entities use the same YAML-subset shape as wiki pages
+    (top-level scalars + `- ` list items), so `_wikilib.parse_frontmatter`
+    handles the shapes that matter here.
+    """
+    text = path.read_text(encoding="utf-8")
+    fm, body = split_frontmatter(text)
+    return fm, body.lstrip("\n")
+
+
+def locate_research_project(slug_or_path: str, wiki_root: Path, override: str | None) -> Path:
+    """Resolve a research slug or path to a project directory.
+
+    Lookup order:
+      1. `override` if given (must point at the project dir directly).
+      2. `slug_or_path` itself if it contains a path separator (relative to
+         cwd, then absolute).
+      3. Legacy prefixed naming (pre-v0.7 cogni-research):
+         `<workspace>/cogni-research-<slug>/` then
+         `<wiki_root>/cogni-research-<slug>/`.
+      4. v0.7.x+ naming (no `cogni-research-` prefix): `<slug>/` for
+         --slug-named projects, `<slug>-<date>/` for derived slugs. Probed
+         under both `wiki_root.parent` and `wiki_root`. Each candidate is
+         verified by the presence of `.metadata/project-config.json` so a
+         neighbour dir that happens to share a prefix isn't accepted.
+    On failure: emits the candidates checked so the user can correct the
+    layout, then `fail()`s (which exits — `return Path()` is unreachable).
+    """
+    if override:
+        project = Path(override).resolve()
+        if not project.is_dir():
+            fail(f"--research-root not a directory: {project}")
+        return project
+
+    if "/" in slug_or_path or slug_or_path.startswith("."):
+        candidate = Path(slug_or_path).resolve()
+        if candidate.is_dir():
+            return candidate
+        fail(f"--research path not found: {candidate}")
+
+    legacy_candidates = [
+        wiki_root.parent / f"cogni-research-{slug_or_path}",
+        wiki_root / f"cogni-research-{slug_or_path}",
+    ]
+    for c in legacy_candidates:
+        if c.is_dir():
+            return c.resolve()
+
+    # v0.7.x+ fallback. cogni-research's initialize-project.sh creates
+    # `<slug>/` (when --slug is set) or `<slug>-<date>/` (when the slug is
+    # derived). Verify each candidate carries .metadata/project-config.json.
+    for base in [wiki_root.parent, wiki_root]:
+        exact = base / slug_or_path
+        if exact.is_dir() and (exact / ".metadata" / "project-config.json").is_file():
+            return exact.resolve()
+        for cand in sorted(base.glob(f"{slug_or_path}-*")):
+            if cand.is_dir() and (cand / ".metadata" / "project-config.json").is_file():
+                return cand.resolve()
+
+    suffix_examples = [
+        f"{wiki_root.parent / slug_or_path}",
+        f"{wiki_root.parent / slug_or_path}-<date>",
+        f"{wiki_root / slug_or_path}",
+        f"{wiki_root / slug_or_path}-<date>",
+    ]
+    fail(
+        "cogni-research project not found. Tried legacy-prefixed: "
+        + ", ".join(str(c) for c in legacy_candidates)
+        + ". Also tried v0.7.x+ shapes: "
+        + ", ".join(suffix_examples)
+        + ". Pass --research-root to override."
+    )
+    return Path()  # unreachable
+
+
+def load_sub_questions(project: Path) -> "list[dict]":
+    """Read all `00-sub-questions/data/sq-*.md` → list ordered by section_index.
+
+    Each entry: `{id, query, parent_topic, section_index, status}` — the
+    minimum surface both batch_builder (synthesis materialisation) and
+    refresh_planner (stale-page matching) consume.
+    """
+    sq_dir = project / "00-sub-questions" / "data"
+    if not sq_dir.is_dir():
+        fail(f"sub-questions dir missing: {sq_dir}")
+    items: list = []
+    for path in sorted(sq_dir.glob("sq-*.md")):
+        text = path.read_text(encoding="utf-8")
+        fm = parse_frontmatter(text)
+        if not fm.get("query"):
+            continue
+        try:
+            section_index = int(fm.get("section_index", 0))
+        except (TypeError, ValueError):
+            section_index = 0
+        items.append({
+            "id": unquote(fm.get("dc:identifier") or path.stem),
+            "query": unquote(fm["query"]),
+            "parent_topic": unquote(fm.get("parent_topic", "")),
+            "section_index": section_index,
+            "status": unquote(fm.get("status", "")),
+        })
+    items.sort(key=lambda x: (x["section_index"], x["id"]))
+    return items
+
+
+def find_wiki_root(start: Path) -> Path:
+    """Walk up from `start` looking for `.cogni-wiki/config.json`."""
+    current = start.resolve()
+    while True:
+        if (current / ".cogni-wiki" / "config.json").is_file():
+            return current
+        if current.parent == current:
+            fail(
+                f"not inside a cogni-wiki (no .cogni-wiki/config.json at or above {start})"
+            )
+        current = current.parent

--- a/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-ingest/scripts/convert_to_md.py
+++ b/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-ingest/scripts/convert_to_md.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""
+convert_to_md.py — convert a non-markdown source file to markdown for ingest.
+
+Issue #208: wiki-ingest's Step 2 today only handles `.md` files in `raw/`,
+PDFs (via the Read tool's pages parameter), URLs (via WebFetch), and pasted
+text. Multi-format consulting sources (`.docx` interviews, `.pptx` decks,
+`.xlsx` models, `.html` web archives, `.epub` training material) require
+manual pre-conversion before the user can ingest them.
+
+This helper closes that gap with stdlib-first detection plus an optional
+shell-out to `markitdown` when available. The original under `raw/` is
+preserved verbatim — the converted markdown is written alongside as
+`<source-stem>.converted.md` so the ground-truth source remains the file
+referenced by `sources:` frontmatter; re-ingest can re-convert if a future
+markitdown release improves extraction.
+
+cogni-wiki stays stdlib-only by default. markitdown is an optional
+dependency that enables richer extraction for binary office formats; its
+absence is not an error for the formats stdlib can handle (`.md`, `.pdf`,
+`.html`, `.txt`).
+
+Usage:
+    convert_to_md.py --source raw/report.docx
+    convert_to_md.py --source raw/page.html --no-markitdown
+    convert_to_md.py --source raw/notes.md            # no-op, returns source path
+    convert_to_md.py --source raw/report.docx --force # ignore the cache
+
+Output contract (stdout, single-line JSON):
+    {
+      "success": true,
+      "data": {
+        "source_path": "raw/report.docx",
+        "converted_path": "raw/report.converted.md",
+        "backend": "markitdown",
+        "cached": false
+      },
+      "error": ""
+    }
+
+Backends:
+  - noop-markdown          source is already `.md` / `.markdown` — `converted_path` == `source_path`
+  - noop-pdf               source is `.pdf` — wiki-ingest Step 2 handles PDFs via the Read tool
+  - stdlib-passthrough     source is `.txt` — copied verbatim into the converted file
+  - stdlib-html            source is `.html` / `.htm` — tags stripped via `html.parser`
+  - markitdown             shelled out to the `markitdown` CLI when installed
+  - cache-hit              `<source>.converted.md` is newer than the source — re-used unchanged
+
+Idempotency: a converted file whose mtime is newer than (or equal to) the
+source's mtime is treated as up-to-date and re-used without invoking the
+backend. `--force` overrides. The PDF and markdown no-ops are always
+idempotent because they never write a converted file.
+
+stdlib-only (Python 3.8+, macOS / Linux). markitdown is optional.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import List
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _wikilib import atomic_write  # noqa: E402
+
+
+MARKDOWN_EXTS = {".md", ".markdown"}
+PDF_EXTS = {".pdf"}
+TEXT_EXTS = {".txt"}
+HTML_EXTS = {".html", ".htm"}
+# Formats markitdown handles when available; stdlib has no fallback for these.
+MARKITDOWN_ONLY_EXTS = {
+    ".docx", ".doc",
+    ".pptx", ".ppt",
+    ".xlsx", ".xls",
+    ".epub",
+    ".rst",
+    ".csv", ".tsv",
+    ".json", ".xml",
+    ".yaml", ".yml",
+    ".ipynb",
+}
+
+
+def fail(msg: str, **extra) -> None:
+    print(json.dumps({"success": False, "data": dict(extra), "error": msg}))
+    sys.exit(1)
+
+
+def ok(**data) -> None:
+    print(json.dumps({"success": True, "data": data, "error": ""}))
+    sys.exit(0)
+
+
+class _HTMLToText(HTMLParser):
+    """Stdlib-only HTML→text fallback. Coarse — preserves heading levels and
+    paragraph breaks; drops attributes, scripts, and styles. Good enough for
+    web-archive ingest when markitdown isn't installed."""
+
+    _SKIP_TAGS = {"script", "style", "noscript", "head"}
+    _BLOCK_TAGS = {"p", "li", "tr", "div", "section", "article", "blockquote"}
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._chunks: List[str] = []
+        self._skip_depth = 0
+        self._heading: int = 0  # active heading level, 0 if none
+
+    def handle_starttag(self, tag, attrs):
+        if tag in self._SKIP_TAGS:
+            self._skip_depth += 1
+            return
+        if len(tag) == 2 and tag[0] == "h" and tag[1].isdigit():
+            self._heading = int(tag[1])
+            self._chunks.append("\n\n" + "#" * self._heading + " ")
+            return
+        if tag == "br":
+            self._chunks.append("\n")
+            return
+        if tag in self._BLOCK_TAGS:
+            self._chunks.append("\n\n")
+            return
+
+    def handle_endtag(self, tag):
+        if tag in self._SKIP_TAGS:
+            if self._skip_depth > 0:
+                self._skip_depth -= 1
+            return
+        if len(tag) == 2 and tag[0] == "h" and tag[1].isdigit():
+            self._heading = 0
+            self._chunks.append("\n\n")
+            return
+        if tag in self._BLOCK_TAGS:
+            self._chunks.append("\n\n")
+
+    def handle_data(self, data):
+        if self._skip_depth == 0:
+            self._chunks.append(data)
+
+    def text(self) -> str:
+        raw = "".join(self._chunks)
+        # Collapse runs of >2 newlines to exactly 2 (paragraph break).
+        out_lines: List[str] = []
+        blank_run = 0
+        for line in raw.splitlines():
+            stripped = line.strip()
+            if stripped:
+                out_lines.append(stripped)
+                blank_run = 0
+            else:
+                blank_run += 1
+                if blank_run == 1:
+                    out_lines.append("")
+        return "\n".join(out_lines).strip() + "\n"
+
+
+def _converted_path_for(source: Path) -> Path:
+    # Sit alongside the source so frontmatter-relative paths still resolve.
+    # `<stem>.converted.md` keeps the original extension visible in the name.
+    return source.with_suffix(source.suffix + ".converted.md")
+
+
+def _is_cache_fresh(source: Path, converted: Path) -> bool:
+    if not converted.is_file():
+        return False
+    try:
+        return converted.stat().st_mtime >= source.stat().st_mtime
+    except OSError:
+        return False
+
+
+def _convert_html_stdlib(source: Path) -> str:
+    raw = source.read_text(encoding="utf-8", errors="replace")
+    parser = _HTMLToText()
+    parser.feed(raw)
+    parser.close()
+    return parser.text()
+
+
+def _convert_via_markitdown(source: Path) -> str:
+    # markitdown's CLI prints the converted markdown to stdout.
+    # We pass the input as a positional argument so it works for binary formats.
+    proc = subprocess.run(
+        ["markitdown", str(source)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"markitdown exited {proc.returncode}: {proc.stderr.strip() or '<no stderr>'}"
+        )
+    return proc.stdout
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert a non-markdown source to markdown for wiki-ingest"
+    )
+    parser.add_argument("--source", required=True, help="Path to the source file under raw/")
+    parser.add_argument(
+        "--no-markitdown",
+        action="store_true",
+        help="Skip the markitdown CLI even if installed (use stdlib backends only)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-run conversion even if the cached .converted.md is newer than the source",
+    )
+    args = parser.parse_args()
+
+    source = Path(args.source).expanduser()
+    if not source.is_file():
+        fail(f"source not found: {source}", source_path=str(source))
+
+    ext = source.suffix.lower()
+
+    if ext in MARKDOWN_EXTS:
+        ok(
+            source_path=str(source),
+            converted_path=str(source),
+            backend="noop-markdown",
+            cached=False,
+        )
+        return
+
+    if ext in PDF_EXTS:
+        # PDFs are read by wiki-ingest Step 2 via the Read tool's pages param.
+        # We deliberately do not invoke markitdown here — the existing pipeline
+        # is fine for consulting workloads (per issue #208 non-goals).
+        ok(
+            source_path=str(source),
+            converted_path=str(source),
+            backend="noop-pdf",
+            cached=False,
+        )
+        return
+
+    converted = _converted_path_for(source)
+
+    if not args.force and _is_cache_fresh(source, converted):
+        ok(
+            source_path=str(source),
+            converted_path=str(converted),
+            backend="cache-hit",
+            cached=True,
+        )
+        return
+
+    have_markitdown = (not args.no_markitdown) and bool(shutil.which("markitdown"))
+
+    backend: str
+    content: str
+
+    try:
+        if ext in TEXT_EXTS and not have_markitdown:
+            content = source.read_text(encoding="utf-8", errors="replace")
+            backend = "stdlib-passthrough"
+        elif ext in HTML_EXTS and not have_markitdown:
+            content = _convert_html_stdlib(source)
+            backend = "stdlib-html"
+        elif have_markitdown and ext in (TEXT_EXTS | HTML_EXTS | MARKITDOWN_ONLY_EXTS):
+            content = _convert_via_markitdown(source)
+            backend = "markitdown"
+        elif ext in MARKITDOWN_ONLY_EXTS:
+            fail(
+                f"format {ext!r} requires markitdown — install with `pip install markitdown` "
+                f"or convert {source.name} to markdown manually",
+                source_path=str(source),
+                backend="unsupported",
+            )
+            return
+        else:
+            fail(
+                f"unsupported source extension {ext!r}",
+                source_path=str(source),
+                backend="unsupported",
+            )
+            return
+    except RuntimeError as e:
+        fail(str(e), source_path=str(source), backend="markitdown-error")
+        return
+    except OSError as e:
+        fail(f"could not read source: {e}", source_path=str(source))
+        return
+
+    atomic_write(converted, content)
+
+    ok(
+        source_path=str(source),
+        converted_path=str(converted),
+        backend=backend,
+        cached=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-ingest/scripts/wiki_queue.py
+++ b/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-ingest/scripts/wiki_queue.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+"""
+wiki_queue.py — persistent ingest queue for cogni-wiki (T3.1, v0.0.35+).
+
+Issue #212 Tier 3 spine: a file-based queue under `<wiki-root>/.cogni-wiki/queue/`
+that decouples *when* an ingest fires from *who* is at the keyboard, without
+breaking the Karpathy invariant ("source N+1 must see source N's just-written
+page"). Single-worker semantics by construction: `--next` refuses to advance
+while any job sits in `running/`, so a queue-driven ingest stays strictly
+sequential. The decoupling is in scheduling, not in concurrency.
+
+Five operations, one dispatcher:
+
+    --enqueue   --source <s> [--type T] [--tags ...] [--title ...]
+                [--auto-backlinks K] [--no-convert] [--priority N]
+                [--scheduled-at ISO]
+                Write a fresh job under pending/. No LLM. Logs `queue | enqueued`.
+
+    --next      Atomic pending → running pick. Emits the job payload (or
+                action: "noop", reason: "queue_empty" | "running_busy"
+                | "all_scheduled_future"). Refuses to pick while running/ is
+                non-empty. Stamps started_at on the picked job. No LLM.
+
+    --complete  --job-id <id> --success | --failure --error <msg>
+                Move running/<id>.json → done/ or failed/ atomically; stamp
+                finished_at and (on failure) last_error. On failure, append
+                a `queue | failed` line to wiki/log.md. No LLM.
+
+    --status    [--limit N]
+                Read-only counts + oldest pending + running_started_at +
+                last N failures (default 5). No LLM.
+
+    --retry     --job-id <id> [--scheduled-at ISO]
+                Move failed/<id>.json → pending/<id>.json; increment attempts;
+                clear last_error; optionally rewrite scheduled_at. Logs
+                `queue | retried`. No LLM.
+
+Concurrency contract:
+
+    Every state-dir transition (rename + stamp) is wrapped in
+    `_wiki_lock(wiki_root)` from `_wikilib.py` so two `--next` calls from
+    separate sessions cannot pick the same job. Job-file *bodies* are unique
+    by construction (one writer per job_id) and don't need additional
+    locking. The slow LLM-driven ingest itself runs **outside** the queue
+    lock between `--next` and `--complete`, so the lock window stays small.
+
+`os.rename` between `pending/`, `running/`, `done/`, `failed/` is POSIX-atomic
+because all four dirs are siblings under `.cogni-wiki/queue/`, on the same
+filesystem by construction (we created them).
+
+Output: standard `{success, data, error}` JSON on stdout via `_wikilib.emit_json`.
+Exits 0 on `success: true` (including action: "noop" for --next), non-zero
+on `success: false` so scheduled drainers (T3.2) treat empty/busy as quiet
+no-ops while genuine failures still page.
+
+stdlib-only. Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _wikilib import (  # noqa: E402
+    _wiki_lock,
+    atomic_write,
+    emit_json,
+    fail,
+    fail_if_pre_migration,
+)
+
+
+JOB_VERSION = 1
+QUEUE_STATES = ("pending", "running", "done", "failed")
+DEFAULT_PRIORITY = 50
+DEFAULT_FAILURES_LIMIT = 5
+ID_RE = re.compile(r"^\d{10}-[0-9a-f]{8}$")
+ISO_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+def now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_iso(s: str) -> dt.datetime:
+    return dt.datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=dt.timezone.utc)
+
+
+def queue_root(wiki_root: Path) -> Path:
+    return wiki_root / ".cogni-wiki" / "queue"
+
+
+def state_dir(wiki_root: Path, state: str) -> Path:
+    return queue_root(wiki_root) / state
+
+
+def ensure_queue_dirs(wiki_root: Path) -> None:
+    """Lazy-create the four state dirs on first use. Cheap, idempotent."""
+    for state in QUEUE_STATES:
+        state_dir(wiki_root, state).mkdir(parents=True, exist_ok=True)
+
+
+def make_job_id(source: str) -> str:
+    """{enqueued_at_unix:010d}-{sha1(source + nanos)[:8]} — lex-sortable, unique."""
+    enqueued = int(time.time())
+    nanos = time.time_ns()
+    digest = hashlib.sha1(f"{source}|{nanos}".encode("utf-8")).hexdigest()[:8]
+    return f"{enqueued:010d}-{digest}"
+
+
+def find_job(wiki_root: Path, job_id: str) -> tuple[str, Path] | tuple[None, None]:
+    """Locate `<id>.json` across all four state dirs. Returns (state, path) or (None, None)."""
+    for state in QUEUE_STATES:
+        p = state_dir(wiki_root, state) / f"{job_id}.json"
+        if p.is_file():
+            return state, p
+    return None, None
+
+
+def read_job(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_job(path: Path, job: dict) -> None:
+    atomic_write(path, json.dumps(job, ensure_ascii=False, indent=2) + "\n")
+
+
+def append_log(wiki_root: Path, line: str) -> None:
+    """Append a `## [date] queue | …` line to wiki/log.md. Append-only,
+    no read-modify-write — same pattern every other operation log line uses."""
+    log_path = wiki_root / "wiki" / "log.md"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    today = dt.date.today().isoformat()
+    with open(log_path, "a", encoding="utf-8") as f:
+        f.write(f"## [{today}] queue | {line}\n")
+
+
+# ---------------------------------------------------------------------------
+# enqueue
+# ---------------------------------------------------------------------------
+
+
+def cmd_enqueue(args, wiki_root: Path) -> None:
+    if not args.source:
+        fail("--enqueue requires --source")
+    if args.priority is not None and not (0 <= args.priority <= 100):
+        fail(f"--priority must be in [0, 100] (got {args.priority})")
+    if args.scheduled_at and not ISO_RE.match(args.scheduled_at):
+        fail(f"--scheduled-at must be ISO 8601 UTC (YYYY-MM-DDTHH:MM:SSZ); got {args.scheduled_at!r}")
+    if args.auto_backlinks is not None and args.auto_backlinks < 0:
+        fail(f"--auto-backlinks must be >= 0 (got {args.auto_backlinks})")
+
+    ensure_queue_dirs(wiki_root)
+
+    enqueued = now_iso()
+    scheduled = args.scheduled_at or enqueued
+    job_id = make_job_id(args.source)
+    job = {
+        "version": JOB_VERSION,
+        "id": job_id,
+        "source": args.source,
+        "type": args.type,
+        "tags": args.tags or [],
+        "title": args.title,
+        "auto_backlinks": args.auto_backlinks,
+        "no_convert": bool(args.no_convert),
+        "priority": args.priority if args.priority is not None else DEFAULT_PRIORITY,
+        "attempts": 0,
+        "last_error": None,
+        "enqueued_at": enqueued,
+        "scheduled_at": scheduled,
+        "started_at": None,
+        "finished_at": None,
+    }
+
+    target = state_dir(wiki_root, "pending") / f"{job_id}.json"
+    with _wiki_lock(wiki_root):
+        if target.exists():
+            # Astronomically unlikely (sha1 + nanos), but be honest about it.
+            fail(f"job id collision: {job_id} already exists")
+        write_job(target, job)
+        append_log(wiki_root, f"enqueued {job_id} source={args.source}")
+
+    emit_json(True, {"action": "enqueued", "job": job, "path": str(target)})
+
+
+# ---------------------------------------------------------------------------
+# next
+# ---------------------------------------------------------------------------
+
+
+def _list_pending_sorted(wiki_root: Path) -> list[Path]:
+    """Sort pending/ jobs by (-priority, enqueued_at). The id prefix is the
+    Unix-second timestamp, so lex-ordering on id resolves ties to FIFO."""
+    pending = state_dir(wiki_root, "pending")
+    if not pending.is_dir():
+        return []
+    paths = sorted(pending.glob("*.json"))
+    if not paths:
+        return []
+    decorated = []
+    for p in paths:
+        try:
+            job = read_job(p)
+        except (OSError, json.JSONDecodeError):
+            continue
+        priority = int(job.get("priority", DEFAULT_PRIORITY))
+        decorated.append((-priority, p.stem, p, job))
+    decorated.sort(key=lambda t: (t[0], t[1]))
+    return [(p, job) for _, _, p, job in decorated]
+
+
+def cmd_next(args, wiki_root: Path) -> None:
+    ensure_queue_dirs(wiki_root)
+
+    with _wiki_lock(wiki_root):
+        running_dir = state_dir(wiki_root, "running")
+        running_jobs = list(running_dir.glob("*.json"))
+        if running_jobs:
+            emit_json(True, {
+                "action": "noop",
+                "reason": "running_busy",
+                "running_count": len(running_jobs),
+            })
+            return
+
+        candidates = _list_pending_sorted(wiki_root)
+        if not candidates:
+            emit_json(True, {"action": "noop", "reason": "queue_empty"})
+            return
+
+        # Pick the first candidate whose scheduled_at <= now.
+        now = dt.datetime.now(dt.timezone.utc)
+        picked_path = None
+        picked_job = None
+        for path, job in candidates:
+            scheduled_raw = job.get("scheduled_at") or job.get("enqueued_at")
+            try:
+                scheduled = parse_iso(scheduled_raw)
+            except (TypeError, ValueError):
+                # Treat unparseable as "ready now"; better than skipping forever.
+                scheduled = now
+            if scheduled <= now:
+                picked_path, picked_job = path, job
+                break
+
+        if picked_path is None:
+            emit_json(True, {
+                "action": "noop",
+                "reason": "all_scheduled_future",
+                "pending_count": len(candidates),
+            })
+            return
+
+        # Stamp started_at, then atomic move pending → running.
+        picked_job["started_at"] = now_iso()
+        target = running_dir / picked_path.name
+        # os.rename across sibling dirs of .cogni-wiki/queue/ is POSIX-atomic
+        # because all four state dirs live on the same filesystem (we created
+        # them under one root). See man 2 rename: atomic when target name is
+        # fresh, which is the case here — the same id only ever lives in one
+        # of pending/running/done/failed.
+        write_job(picked_path, picked_job)
+        os.rename(str(picked_path), str(target))
+
+    emit_json(True, {"action": "pick", "job": picked_job, "path": str(target)})
+
+
+# ---------------------------------------------------------------------------
+# complete
+# ---------------------------------------------------------------------------
+
+
+def cmd_complete(args, wiki_root: Path) -> None:
+    if not args.job_id:
+        fail("--complete requires --job-id")
+    if bool(args.success) == bool(args.failure):
+        fail("--complete requires exactly one of --success or --failure")
+    if args.failure and not args.error:
+        fail("--complete --failure requires --error <msg>")
+
+    ensure_queue_dirs(wiki_root)
+
+    src_path = state_dir(wiki_root, "running") / f"{args.job_id}.json"
+    target_state = "done" if args.success else "failed"
+    target_path = state_dir(wiki_root, target_state) / f"{args.job_id}.json"
+
+    with _wiki_lock(wiki_root):
+        if not src_path.is_file():
+            # Locate the actual current state for a useful error.
+            actual_state, _ = find_job(wiki_root, args.job_id)
+            if actual_state is None:
+                fail(f"job {args.job_id!r} not found in any queue state")
+            else:
+                fail(f"job {args.job_id!r} is in {actual_state}/, not running/ — cannot complete")
+            return
+
+        job = read_job(src_path)
+        job["finished_at"] = now_iso()
+        if args.failure:
+            job["last_error"] = args.error
+        write_job(src_path, job)
+        os.rename(str(src_path), str(target_path))
+
+        if args.failure:
+            # Truncate very long error messages so log.md stays greppable.
+            err_short = (args.error or "").splitlines()[0][:200]
+            append_log(wiki_root, f"failed {args.job_id} error={err_short}")
+
+    emit_json(True, {
+        "action": "completed",
+        "outcome": target_state,
+        "job": job,
+        "path": str(target_path),
+    })
+
+
+# ---------------------------------------------------------------------------
+# retry
+# ---------------------------------------------------------------------------
+
+
+def cmd_retry(args, wiki_root: Path) -> None:
+    if not args.job_id:
+        fail("--retry requires --job-id")
+    if args.scheduled_at and not ISO_RE.match(args.scheduled_at):
+        fail(f"--scheduled-at must be ISO 8601 UTC; got {args.scheduled_at!r}")
+
+    ensure_queue_dirs(wiki_root)
+
+    src_path = state_dir(wiki_root, "failed") / f"{args.job_id}.json"
+    target_path = state_dir(wiki_root, "pending") / f"{args.job_id}.json"
+
+    with _wiki_lock(wiki_root):
+        if not src_path.is_file():
+            actual_state, _ = find_job(wiki_root, args.job_id)
+            if actual_state is None:
+                fail(f"job {args.job_id!r} not found in any queue state")
+            else:
+                fail(f"job {args.job_id!r} is in {actual_state}/, not failed/ — cannot retry")
+            return
+
+        job = read_job(src_path)
+        job["attempts"] = int(job.get("attempts", 0)) + 1
+        job["last_error"] = None
+        job["started_at"] = None
+        job["finished_at"] = None
+        if args.scheduled_at:
+            job["scheduled_at"] = args.scheduled_at
+        write_job(src_path, job)
+        os.rename(str(src_path), str(target_path))
+        append_log(wiki_root, f"retried {args.job_id} from=failed attempts={job['attempts']}")
+
+    emit_json(True, {"action": "retried", "job": job, "path": str(target_path)})
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+def _count_done_recent(wiki_root: Path, days: int = 30) -> int:
+    """Count done/<id>.json files whose id-timestamp prefix is within `days`.
+    The id prefix is the Unix second at enqueue time — close enough to
+    "recent finish" for a status-block bucket without re-reading every body."""
+    done = state_dir(wiki_root, "done")
+    if not done.is_dir():
+        return 0
+    cutoff = int(time.time()) - days * 86400
+    n = 0
+    for p in done.glob("*.json"):
+        m = ID_RE.match(p.stem)
+        if not m:
+            continue
+        try:
+            ts = int(p.stem.split("-", 1)[0])
+        except ValueError:
+            continue
+        if ts >= cutoff:
+            n += 1
+    return n
+
+
+def _oldest_pending(wiki_root: Path) -> tuple[str | None, str | None]:
+    """(oldest_id, oldest_enqueued_at_iso) for the lex-smallest pending id."""
+    pending = state_dir(wiki_root, "pending")
+    if not pending.is_dir():
+        return None, None
+    paths = sorted(pending.glob("*.json"))
+    if not paths:
+        return None, None
+    try:
+        job = read_job(paths[0])
+    except (OSError, json.JSONDecodeError):
+        return paths[0].stem, None
+    return job.get("id", paths[0].stem), job.get("enqueued_at")
+
+
+def _next_scheduled_at(wiki_root: Path) -> str | None:
+    """Soonest scheduled_at across pending jobs (None if pending is empty)."""
+    pending = state_dir(wiki_root, "pending")
+    if not pending.is_dir():
+        return None
+    soonest = None
+    for p in sorted(pending.glob("*.json")):
+        try:
+            job = read_job(p)
+        except (OSError, json.JSONDecodeError):
+            continue
+        when = job.get("scheduled_at") or job.get("enqueued_at")
+        if when and (soonest is None or when < soonest):
+            soonest = when
+    return soonest
+
+
+def _running_started_at(wiki_root: Path) -> str | None:
+    """started_at of the oldest job currently in running/, or None."""
+    running = state_dir(wiki_root, "running")
+    if not running.is_dir():
+        return None
+    paths = sorted(running.glob("*.json"))
+    if not paths:
+        return None
+    try:
+        job = read_job(paths[0])
+    except (OSError, json.JSONDecodeError):
+        return None
+    return job.get("started_at")
+
+
+def _recent_failures(wiki_root: Path, limit: int) -> list[dict]:
+    failed = state_dir(wiki_root, "failed")
+    if not failed.is_dir():
+        return []
+    paths = sorted(failed.glob("*.json"), reverse=True)[:limit]
+    out = []
+    for p in paths:
+        try:
+            job = read_job(p)
+        except (OSError, json.JSONDecodeError):
+            continue
+        out.append({
+            "id": job.get("id", p.stem),
+            "source": job.get("source"),
+            "last_error": job.get("last_error"),
+            "attempts": job.get("attempts", 0),
+            "finished_at": job.get("finished_at"),
+        })
+    return out
+
+
+def cmd_status(args, wiki_root: Path) -> None:
+    qroot = queue_root(wiki_root)
+    if not qroot.is_dir():
+        emit_json(True, {
+            "available": False,
+            "pending": 0, "running": 0, "done_recent": 0, "failed": 0,
+        })
+        return
+
+    counts = {}
+    for state in QUEUE_STATES:
+        d = state_dir(wiki_root, state)
+        counts[state] = len(list(d.glob("*.json"))) if d.is_dir() else 0
+
+    oldest_id, oldest_at = _oldest_pending(wiki_root)
+    data = {
+        "available": True,
+        "pending": counts["pending"],
+        "running": counts["running"],
+        "done_recent": _count_done_recent(wiki_root),
+        "done_total": counts["done"],
+        "failed": counts["failed"],
+        "oldest_pending_id": oldest_id,
+        "oldest_pending_enqueued_at": oldest_at,
+        "next_scheduled_at": _next_scheduled_at(wiki_root),
+        "running_started_at": _running_started_at(wiki_root),
+        "recent_failures": _recent_failures(wiki_root, args.limit or DEFAULT_FAILURES_LIMIT),
+    }
+    emit_json(True, data)
+
+
+# ---------------------------------------------------------------------------
+# dispatcher
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Persistent ingest queue for cogni-wiki (T3.1)",
+    )
+    parser.add_argument("--wiki-root", required=True, help="Absolute path to the wiki root")
+
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--enqueue", action="store_true", help="Add a job to pending/")
+    mode.add_argument("--next", dest="next_", action="store_true", help="Pick the next pending job")
+    mode.add_argument("--complete", action="store_true", help="Move a running/ job to done/ or failed/")
+    mode.add_argument("--retry", action="store_true", help="Move a failed/ job back to pending/")
+    mode.add_argument("--status", action="store_true", help="Read-only status JSON")
+
+    # --enqueue flags
+    parser.add_argument("--source", help="Source path or URL (--enqueue)")
+    parser.add_argument("--type", help="Page type override (--enqueue)")
+    parser.add_argument("--tags", help="Comma-separated tag list (--enqueue)")
+    parser.add_argument("--title", help="Title override (--enqueue)")
+    parser.add_argument("--auto-backlinks", type=int, help="Auto-backlinks K (--enqueue)")
+    parser.add_argument("--no-convert", action="store_true", help="Skip Step 2a auto-conversion (--enqueue)")
+    parser.add_argument("--priority", type=int, help="Priority 0-100, higher is picked first (--enqueue, default 50)")
+    parser.add_argument("--scheduled-at", help="ISO 8601 UTC YYYY-MM-DDTHH:MM:SSZ (--enqueue, --retry)")
+
+    # --complete / --retry flags
+    parser.add_argument("--job-id", help="Job id (--complete, --retry)")
+    parser.add_argument("--success", action="store_true", help="--complete outcome: success")
+    parser.add_argument("--failure", action="store_true", help="--complete outcome: failure")
+    parser.add_argument("--error", help="Error message (--complete --failure)")
+
+    # --status flags
+    parser.add_argument("--limit", type=int, help="Max recent failures to return (--status)")
+
+    args = parser.parse_args()
+
+    # Normalise --tags → list (strip whitespace, drop empties).
+    if isinstance(args.tags, str):
+        args.tags = [t.strip() for t in args.tags.split(",") if t.strip()]
+
+    wiki_root = Path(args.wiki_root).expanduser().resolve()
+    if not (wiki_root / ".cogni-wiki" / "config.json").is_file():
+        fail(f"not a cogni-wiki: {wiki_root}/.cogni-wiki/config.json not found")
+    fail_if_pre_migration(wiki_root)
+
+    if args.enqueue:
+        cmd_enqueue(args, wiki_root)
+    elif args.next_:
+        cmd_next(args, wiki_root)
+    elif args.complete:
+        cmd_complete(args, wiki_root)
+    elif args.retry:
+        cmd_retry(args, wiki_root)
+    elif args.status:
+        cmd_status(args, wiki_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-prefill/scripts/prefill_foundations.py
+++ b/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-prefill/scripts/prefill_foundations.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""
+prefill_foundations.py — copy curated foundation pages into a wiki's
+`wiki/concepts/` directory.
+
+Issue #224 / cogni-wiki Tier 2 item #4. Foundations are canonical concept
+pages (Porter's Five Forces, Jobs-to-be-Done, MECE, …) that every wiki
+re-derives today from whatever source the user happens to drop in `raw/`
+first. Pre-seeding them stops concept duplication for textbook material
+and gives downstream pages a stable target slug to link into.
+
+The plugin-side library lives at `${CLAUDE_PLUGIN_ROOT}/foundations/`. Each
+file is a `type: concept` page with `foundation: true` frontmatter and
+literal `{{PREFILL_DATE}}` placeholders for `created:` / `updated:`. This
+script substitutes today's ISO date at copy time, then never rewrites the
+page on idempotent re-runs.
+
+Output contract (standard {success, data, error} JSON line on stdout):
+
+    {"success": true,
+     "data": {
+       "wiki_root": "<abs path>",
+       "filter": "all" | "consulting" | "product" | "strategy" | "list",
+       "available": [{"slug": "...", "title": "...", "tags": [...]}, ...],
+       "copied":   ["porters-five-forces", ...],
+       "skipped_existing": ["mece", ...],
+       "failed":   [{"slug": "...", "error": "..."}],
+       "entries_count_delta": N,
+       "dry_run": false
+     },
+     "error": ""}
+
+stdlib-only. Python 3.8+. Uses `_wikilib._wiki_lock` to serialise the
+existence-check + write loop against concurrent `wiki-ingest` runs sharing
+the same wiki root, and routes the `entries_count` bump through
+`config_bump.py --delta N` (the same locked code path every other writer
+uses).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "wiki-ingest" / "scripts"))
+from _wikilib import (  # noqa: E402
+    FRONTMATTER_RE,
+    _wiki_lock,
+    atomic_write,
+    emit_json,
+    fail,
+    fail_if_pre_migration,
+)
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+FOUNDATIONS_DIR = PLUGIN_ROOT / "foundations"
+CONFIG_BUMP_SCRIPT = (
+    PLUGIN_ROOT / "skills" / "wiki-ingest" / "scripts" / "config_bump.py"
+)
+
+# Filter sets are tag-based. A foundation belongs to set X iff its frontmatter
+# `tags:` contains the matching keyword. `all` accepts everything.
+FILTER_TAGS = {
+    "consulting": "consulting",
+    "product": "product",
+    "strategy": "strategy",
+}
+
+DATE_PLACEHOLDER = "{{PREFILL_DATE}}"
+
+
+def parse_minimal_frontmatter(text: str) -> dict:
+    """Extract `id`, `title`, `type`, and `tags` from a foundation file.
+
+    Foundation files are plugin-authored and follow a fixed shape, so we
+    only need a strict subset of YAML — same parser shape as
+    `_wikilib._parse_frontmatter_minimal` extended to handle the
+    `tags: [a, b]` inline list. Anything else falls through to an empty
+    list, which is fine for the filter logic.
+    """
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return {}
+    out: dict = {}
+    for line in m.group(1).splitlines():
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        if ":" not in line or line.startswith(" "):
+            continue
+        k, _, v = line.partition(":")
+        k = k.strip()
+        v = v.strip()
+        if k == "tags" and v.startswith("[") and v.endswith("]"):
+            inner = v[1:-1].strip()
+            if inner:
+                out[k] = [t.strip() for t in inner.split(",") if t.strip()]
+            else:
+                out[k] = []
+        else:
+            out[k] = v
+    return out
+
+
+def list_foundations(foundations_dir: Path) -> list:
+    """Return [{slug, title, tags, path}] for every *.md file under
+    `foundations/` other than README.md.
+    """
+    out: list = []
+    if not foundations_dir.is_dir():
+        return out
+    for path in sorted(foundations_dir.glob("*.md")):
+        if path.name.lower() == "readme.md":
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as e:
+            out.append({"slug": path.stem, "title": path.stem, "tags": [], "path": str(path), "_error": str(e)})
+            continue
+        fm = parse_minimal_frontmatter(text)
+        tags = fm.get("tags") if isinstance(fm.get("tags"), list) else []
+        out.append({
+            "slug": fm.get("id") or path.stem,
+            "title": fm.get("title") or path.stem,
+            "tags": tags,
+            "path": str(path),
+        })
+    return out
+
+
+def filter_foundations(items: list, flt: str) -> list:
+    if flt == "all":
+        return list(items)
+    tag = FILTER_TAGS.get(flt)
+    if tag is None:
+        return []
+    return [it for it in items if tag in (it.get("tags") or [])]
+
+
+def render_for_target(text: str, prefill_date: str) -> str:
+    """Substitute `{{PREFILL_DATE}}` placeholders with today's ISO date."""
+    return text.replace(DATE_PLACEHOLDER, prefill_date)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Prefill curated foundation concept pages into a wiki."
+    )
+    p.add_argument("--wiki-root", help="Path to the wiki root (required unless --list).")
+    p.add_argument(
+        "--filter",
+        default="all",
+        choices=["all", "consulting", "product", "strategy"],
+        help="Which subset to copy (default: all).",
+    )
+    p.add_argument(
+        "--list",
+        action="store_true",
+        help="Print the available foundations under the chosen --filter and exit. "
+             "No wiki is touched; --wiki-root is optional in this mode.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute the plan without writing any file or bumping entries_count.",
+    )
+    p.add_argument(
+        "--foundations-dir",
+        help="Override the plugin-side foundations directory (test hook).",
+    )
+    args = p.parse_args()
+
+    foundations_dir = Path(args.foundations_dir) if args.foundations_dir else FOUNDATIONS_DIR
+    if not foundations_dir.is_dir():
+        fail(f"foundations directory not found: {foundations_dir}")
+
+    available = list_foundations(foundations_dir)
+    selected = filter_foundations(available, args.filter)
+
+    if args.list:
+        emit_json(
+            True,
+            {
+                "wiki_root": str(Path(args.wiki_root).resolve()) if args.wiki_root else "",
+                "filter": args.filter,
+                "available": [
+                    {"slug": it["slug"], "title": it["title"], "tags": it["tags"]}
+                    for it in selected
+                ],
+                "copied": [],
+                "skipped_existing": [],
+                "failed": [],
+                "entries_count_delta": 0,
+                "dry_run": True,
+            },
+        )
+        return
+
+    if not args.wiki_root:
+        fail("--wiki-root is required unless --list is set")
+
+    wiki_root = Path(args.wiki_root).resolve()
+    if not (wiki_root / ".cogni-wiki" / "config.json").is_file():
+        fail(f"not a wiki: {wiki_root} (missing .cogni-wiki/config.json)")
+    fail_if_pre_migration(wiki_root)
+
+    concepts_dir = wiki_root / "wiki" / "concepts"
+    concepts_dir.mkdir(parents=True, exist_ok=True)
+
+    today = dt.date.today().isoformat()
+    copied: list = []
+    skipped: list = []
+    failed: list = []
+
+    # Existence check + write loop go inside the wiki lock so a concurrent
+    # `wiki-ingest` from another session can't sneak a same-slug page in
+    # between our check and our write. The lock is released before
+    # config_bump.py runs (it acquires its own).
+    with _wiki_lock(wiki_root):
+        for it in selected:
+            slug = it["slug"]
+            target = concepts_dir / f"{slug}.md"
+            if target.exists():
+                skipped.append(slug)
+                continue
+            try:
+                src_text = Path(it["path"]).read_text(encoding="utf-8")
+                rendered = render_for_target(src_text, today)
+                if not args.dry_run:
+                    atomic_write(target, rendered)
+                copied.append(slug)
+            except Exception as e:
+                failed.append({"slug": slug, "error": str(e)})
+
+    delta = 0 if args.dry_run else len(copied)
+    if delta > 0:
+        try:
+            cb = subprocess.run(
+                [
+                    sys.executable,
+                    str(CONFIG_BUMP_SCRIPT),
+                    "--wiki-root",
+                    str(wiki_root),
+                    "--key",
+                    "entries_count",
+                    "--delta",
+                    str(delta),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            try:
+                cb_json = json.loads(cb.stdout.strip().splitlines()[-1]) if cb.stdout.strip() else {}
+            except (ValueError, IndexError):
+                cb_json = {}
+            if cb.returncode != 0 or not cb_json.get("success"):
+                # The pages are already on disk; surface the bump failure but
+                # don't unwind. A follow-up `--fix=entries_count_drift` lint
+                # run reconciles the count.
+                failed.append({
+                    "slug": "(entries_count_bump)",
+                    "error": cb_json.get("error") or cb.stderr.strip() or "config_bump failed",
+                })
+                delta = 0
+        except OSError as e:
+            failed.append({"slug": "(entries_count_bump)", "error": str(e)})
+            delta = 0
+
+    emit_json(
+        True,
+        {
+            "wiki_root": str(wiki_root),
+            "filter": args.filter,
+            "available": [
+                {"slug": it["slug"], "title": it["title"], "tags": it["tags"]}
+                for it in selected
+            ],
+            "copied": copied,
+            "skipped_existing": skipped,
+            "failed": failed,
+            "entries_count_delta": delta,
+            "dry_run": bool(args.dry_run),
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-refresh/scripts/refresh_planner.py
+++ b/cogni-knowledge/scripts/vendor/cogni-wiki/skills/wiki-refresh/scripts/refresh_planner.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""
+refresh_planner.py — match stale wiki pages to cogni-research sub-questions
+and emit a refresh plan on stdout. The wiki-refresh skill consumes this
+plan: it materialises one refresh markdown per matched (page, sub-question)
+pair and dispatches wiki-update to apply each.
+
+Boundary: this script does NOT write to the wiki. It only reads and emits
+JSON. Materialisation lives in the SKILL.md (Step 5), which keeps the
+script idempotent and dry-run-safe.
+
+Match algorithm: Jaccard on token sets, page-side = title + tags + type,
+sub-question-side = query + parent_topic. Stopword-filtered, lightly
+suffix-stripped. Symmetric and deterministic. Threshold default 0.30.
+
+Stdlib-only, Python 3.8+. Output contract:
+
+    {
+      "success": true,
+      "data": {
+        "matches": [
+          {
+            "page": "<slug>",
+            "page_title": "...",
+            "page_age_days": <int>,
+            "page_type": "<type>",
+            "page_tags": [...],
+            "sub_question": "<sq-id>",
+            "sub_question_query": "...",
+            "sub_question_section_index": <int>,
+            "score": <float>,
+            "reasons": ["tag overlap: [...]", "title term: '<t>'", ...]
+          }
+        ],
+        "unmatched_pages": ["<slug>", ...],
+        "stats": {
+          "stale_pages_total": <int>,
+          "matched": <int>,
+          "below_threshold": <int>,
+          "sub_questions_total": <int>
+        }
+      },
+      "error": ""
+    }
+
+    On failure: {"success": false, "data": {}, "error": "..."} with exit 1.
+
+Note on duplication: lines 100–230 (frontmatter parser, wikilink stripper,
+entity loaders) mirror equivalent helpers in
+`cogni-wiki/skills/wiki-ingest/scripts/batch_builder.py`. The duplication
+is acknowledged tech debt — both targets share the same cogni-research
+entity contract (`schemas/{sub-question,context,source,report-claim}.schema.json`),
+and a schema change would touch both consumers anyway. Refactor is non-urgent
+(parallel to the `_wiki_lock` situation described in cogni-wiki/CLAUDE.md).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "wiki-ingest" / "scripts"))
+from _wikilib import (  # noqa: E402
+    fail,
+    fail_if_pre_migration,
+    is_audit_slug,
+    iter_pages,
+    ok,
+    parse_frontmatter,
+)
+from _wiki_research import (  # noqa: E402
+    find_wiki_root,
+    load_sub_questions,
+    locate_research_project,
+    parse_date,
+    unquote as _unquote,
+)
+
+
+# Staleness thresholds — must match cogni-wiki/skills/wiki-lint/scripts/lint_wiki.py
+STALE_DRAFT_DAYS = 180
+STALE_PAGE_DAYS = 365
+
+DEFAULT_THRESHOLD = 0.30
+
+SLUG_CLEAN_RE = re.compile(r"[^a-z0-9]+")
+TOKEN_SPLIT_RE = re.compile(r"[^a-z0-9]+")
+
+STOPWORDS = frozenset({
+    "a", "an", "the", "of", "in", "on", "for", "with", "and", "or", "to", "is", "are", "was", "were",
+    "be", "been", "being", "have", "has", "had", "do", "does", "did", "will", "would", "should", "can",
+    "could", "may", "might", "must", "what", "how", "why", "when", "where", "which", "who", "whom",
+    "this", "that", "these", "those", "it", "its", "their", "they", "them", "we", "us", "our",
+    "vs", "into", "from", "about", "as", "by", "if", "any", "all", "some", "more", "most",
+})
+
+
+def load_wiki_pages(wiki_root: Path) -> list[dict]:
+    """Return all wiki pages with parsed frontmatter and computed age."""
+    today = dt.date.today()
+    pages: list[dict] = []
+    for slug, path, _ptype_dir in iter_pages(wiki_root):
+        if is_audit_slug(slug):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        fm = parse_frontmatter(text)
+        title = _unquote(fm.get("title", "")) or slug
+        page_type = _unquote(fm.get("type", "")) or "summary"
+        tags = fm.get("tags", []) if isinstance(fm.get("tags"), list) else []
+        tags = [_unquote(t) for t in tags if isinstance(t, str)]
+        sources = fm.get("sources", []) if isinstance(fm.get("sources"), list) else []
+        sources = [_unquote(s) for s in sources if isinstance(s, str)]
+        status = _unquote(fm.get("status", "")).lower()
+        updated_str = _unquote(fm.get("updated", ""))
+        updated = parse_date(updated_str)
+        age_days = (today - updated).days if updated else None
+        pages.append({
+            "slug": slug,
+            "title": title,
+            "type": page_type,
+            "tags": tags,
+            "sources": sources,
+            "status": status,
+            "updated": updated_str,
+            "age_days": age_days,
+            "path": path,
+        })
+    return pages
+
+
+def filter_stale(pages: list[dict], days_override: int | None) -> list[dict]:
+    """Apply lint's staleness rule (or --days override) to the page list."""
+    out = []
+    for p in pages:
+        age = p.get("age_days")
+        if age is None:
+            # No valid `updated:` — lint flags as a frontmatter warning, not stale.
+            # Skip here; stale-by-age is the only signal this script consumes.
+            continue
+        if days_override is not None:
+            if age > days_override:
+                out.append(p)
+        else:
+            if p["status"] == "draft" and age > STALE_DRAFT_DAYS:
+                out.append(p)
+            elif age > STALE_PAGE_DAYS:
+                out.append(p)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer
+# ---------------------------------------------------------------------------
+
+
+def _stem(token: str) -> str:
+    """Mini suffix-stripper. Order matters: longest suffix first."""
+    if len(token) < 4:
+        return token
+    if token.endswith("ies") and len(token) > 4:
+        return token[:-3] + "y"
+    for suffix in ("ing", "ed", "es", "s"):
+        if token.endswith(suffix) and len(token) - len(suffix) >= 3:
+            return token[: -len(suffix)]
+    return token
+
+
+def tokenize(*parts: str) -> set:
+    text = " ".join(p for p in parts if p)
+    text = text.lower()
+    raw_tokens = TOKEN_SPLIT_RE.split(text)
+    out: set = set()
+    for t in raw_tokens:
+        if len(t) < 3:
+            continue
+        if t in STOPWORDS:
+            continue
+        out.add(_stem(t))
+    return out
+
+
+def jaccard(a: set, b: set) -> float:
+    if not a and not b:
+        return 0.0
+    union = a | b
+    if not union:
+        return 0.0
+    return len(a & b) / len(union)
+
+
+def explain_match(page: dict, sq: dict, page_tokens: set, sq_tokens: set) -> list[str]:
+    """Up to 3 human-readable reasons. Debuggability, not behavioural.
+
+    Deterministic — sorted token iteration so reruns produce identical reasons.
+    """
+    reasons: list[str] = []
+    page_tag_tokens = tokenize(" ".join(page["tags"]))
+    overlap_tags = sorted(t for t in page_tag_tokens if t in sq_tokens)
+    if overlap_tags:
+        reasons.append(f"tag overlap: {overlap_tags[:3]}")
+    title_tokens = tokenize(page["title"])
+    title_hits = sorted(t for t in title_tokens if t in sq_tokens)
+    if title_hits:
+        reasons.append(f"title term: '{title_hits[0]}'")
+    type_token = tokenize(page["type"])
+    if type_token and any(t in sq_tokens for t in type_token):
+        reasons.append("type match")
+    return reasons[:3]
+
+
+# ---------------------------------------------------------------------------
+# Match planner
+# ---------------------------------------------------------------------------
+
+
+def build_plan(
+    stale_pages: list[dict],
+    sub_questions: list[dict],
+    threshold: float,
+    force: bool,
+    limit: int | None,
+) -> dict:
+    matches: list[dict] = []
+    unmatched: list[str] = []
+    below_threshold = 0
+
+    sq_token_cache: dict = {}
+    for sq in sub_questions:
+        sq_token_cache[sq["id"]] = tokenize(sq["query"], sq["parent_topic"])
+
+    for page in stale_pages:
+        page_tokens = tokenize(page["title"], " ".join(page["tags"]), page["type"])
+        best: dict | None = None
+        for sq in sub_questions:
+            score = jaccard(page_tokens, sq_token_cache[sq["id"]])
+            if best is None or (score, -sq["section_index"], sq["id"]) > (
+                best["score"], -best["sub_question_section_index"], best["sub_question"]
+            ):
+                # Tie-break: higher score wins; on tie, lower section_index wins;
+                # on tie, lex sub-question id wins. We invert section_index so
+                # max-tuple compare picks the lower one.
+                best = {
+                    "score": score,
+                    "sub_question": sq["id"],
+                    "sub_question_query": sq["query"],
+                    "sub_question_section_index": sq["section_index"],
+                    "_sq_obj": sq,
+                    "_page_tokens": page_tokens,
+                }
+        if best is None:
+            unmatched.append(page["slug"])
+            continue
+        if best["score"] < threshold and not force:
+            below_threshold += 1
+            unmatched.append(page["slug"])
+            continue
+        reasons = explain_match(page, best["_sq_obj"], best["_page_tokens"], sq_token_cache[best["sub_question"]])
+        matches.append({
+            "page": page["slug"],
+            "page_title": page["title"],
+            "page_age_days": page["age_days"],
+            "page_type": page["type"],
+            "page_tags": page["tags"],
+            "sub_question": best["sub_question"],
+            "sub_question_query": best["sub_question_query"],
+            "sub_question_section_index": best["sub_question_section_index"],
+            "score": round(best["score"], 4),
+            "reasons": reasons,
+        })
+
+    # Sort matches by score desc for plan readability and --limit.
+    matches.sort(key=lambda m: (-m["score"], m["sub_question_section_index"], m["page"]))
+
+    if limit is not None and limit >= 0:
+        if len(matches) > limit:
+            dropped = matches[limit:]
+            matches = matches[:limit]
+            for m in dropped:
+                unmatched.append(m["page"])
+
+    return {
+        "matches": matches,
+        "unmatched_pages": sorted(set(unmatched)),
+        "stats": {
+            "stale_pages_total": len(stale_pages),
+            "matched": len(matches),
+            "below_threshold": below_threshold,
+            "sub_questions_total": len(sub_questions),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Match stale wiki pages to cogni-research sub-questions; emit refresh plan as JSON.",
+    )
+    parser.add_argument("--research-slug", required=True, help="cogni-research project slug or path.")
+    parser.add_argument("--research-root", help="Override auto-located project root.")
+    parser.add_argument("--wiki-root", help="Override auto-detected wiki root.")
+    parser.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD,
+                        help=f"Jaccard threshold for matching (default {DEFAULT_THRESHOLD}).")
+    parser.add_argument("--days", type=int, default=None,
+                        help="Override staleness threshold (collapses STALE_PAGE_DAYS+STALE_DRAFT_DAYS to N).")
+    parser.add_argument("--pages", help="Comma-separated page slug list; bypasses staleness filter.")
+    parser.add_argument("--limit", type=int, default=None, help="Cap matches at N after ranking.")
+    parser.add_argument("--force", action="store_true",
+                        help="With --pages: include sub-threshold matches.")
+    args = parser.parse_args()
+
+    if args.pages and args.days is not None:
+        fail("--pages and --days are mutually exclusive")
+    if args.threshold < 0.0 or args.threshold > 1.0:
+        fail(f"--threshold must be in [0.0, 1.0], got {args.threshold}")
+
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+
+    wiki_root = Path(args.wiki_root).resolve() if args.wiki_root else find_wiki_root(Path.cwd())
+    if not (wiki_root / ".cogni-wiki" / "config.json").is_file():
+        fail(f"not a cogni-wiki: {wiki_root}/.cogni-wiki/config.json not found")
+    fail_if_pre_migration(wiki_root)
+
+    project = locate_research_project(args.research_slug, wiki_root, args.research_root)
+    if not (project / "project-config.json").is_file():
+        fail(f"not a cogni-research project (missing project-config.json): {project}")
+
+    sub_questions = load_sub_questions(project)
+    if not sub_questions:
+        ok({
+            "matches": [],
+            "unmatched_pages": [],
+            "stats": {"stale_pages_total": 0, "matched": 0, "below_threshold": 0, "sub_questions_total": 0},
+        })
+
+    all_pages = load_wiki_pages(wiki_root)
+    if args.pages:
+        wanted = {s.strip() for s in args.pages.split(",") if s.strip()}
+        stale_pages = [p for p in all_pages if p["slug"] in wanted]
+        # Note: we do NOT filter by age here — explicit --pages bypasses staleness.
+        missing = wanted - {p["slug"] for p in stale_pages}
+        # Missing slugs are not fatal; they're surfaced via the SKILL's pre-flight,
+        # not here. The planner just doesn't include them.
+        del missing
+    else:
+        stale_pages = filter_stale(all_pages, args.days)
+
+    plan = build_plan(stale_pages, sub_questions, args.threshold, args.force, args.limit)
+    ok(plan)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #528.

## Summary
Vendor the 8 in-scope standalone cogni-wiki scripts as byte-faithful point-in-time copies into `cogni-knowledge/scripts/vendor/cogni-wiki/skills/<skill>/scripts/`, mirroring the existing Phase-7 layout that `resolve_wiki_scripts()` (`cogni-knowledge/scripts/_knowledge_lib.py:1685`) resolves vendored-first (Branch 0):

- `wiki-dashboard/scripts/{render_dashboard,build_graph}.py`
- `wiki-prefill/scripts/prefill_foundations.py`
- `wiki-ingest/scripts/{wiki_queue,convert_to_md}.py`
- `wiki-claims-resweep/scripts/{extract_page_claims,resweep_planner}.py`
- `wiki-refresh/scripts/refresh_planner.py`

Purely additive (9 new files, 0 modified logic). Patch-bumps cogni-knowledge `0.1.84 → 0.1.85` in plugin.json + marketplace.json. This unblocks the standalone knowledge skills (knowledge-dashboard / -resume / -refresh, etc.) to drop their `cogni-wiki:` dispatches in follow-up (#529/#530/#531).

## Scope decision — a 9th file beyond the issue's stated list
The issue marks `_wiki_research.py` **out of scope** (treating it as a standalone surface). But `wiki-refresh/scripts/refresh_planner.py` does `from _wiki_research import find_wiki_root, load_sub_questions, locate_research_project, parse_date, unquote`, and `_wiki_research.py` (180 lines, pure stdlib, imports only `_wikilib`) exists **nowhere** in cogni-knowledge today. A byte-faithful `refresh_planner.py` copy raises `ModuleNotFoundError` without it. So it is vendored alongside `refresh_planner.py` as a **required transitive engine import**, not as a new standalone surface. `batch_builder.py` / `migrate_layout.py` remain out of scope (no in-scope script imports them).

## Verification
- ✅ `diff` of each vendored file vs its `cogni-wiki/skills/...` source is empty (byte-identical).
- ✅ Import-resolution smoke test: all 9 vendored modules `exec_module` cleanly from their vendored locations — `refresh_planner` resolves `_wikilib` **and** `_wiki_research`; the dashboard pair, claims-resweep pair, `wiki_queue`/`convert_to_md`, and `prefill_foundations` resolve against the already-vendored `_wikilib.py` / `foundations/` / `config_bump.py`.
- ✅ `.py` source only — no `__pycache__/` or `*.pyc` introduced.

## Deferred to follow-up
- Flip the standalone knowledge skills to drop `cogni-wiki:` dispatches now that scripts resolve vendored-first (#529/#530/#531).
- Remove the pre-existing stray committed `_wikilib.cpython-314.pyc` under the vendored `wiki-ingest/scripts/__pycache__/` (separate hygiene cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
