### PR TITLE
feat(cogni-knowledge): add `direct` fetch_method to unblock local-source ingest (#533)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-claims",
       "source": "./cogni-claims",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "maturity": "preview",
       "description": "Claim verification and management system. Verifies sourced claims against cited URLs, detects deviations, guides users through resolution, and provides interactive cobrowsing recovery for unreachable sources.",
       "keywords": [
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-claims/.claude-plugin/plugin.json
+++ b/cogni-claims/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-claims",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Claim verification and management system. Verifies sourced claims against cited URLs, detects deviations, guides users through resolution, and provides interactive cobrowsing recovery for unreachable sources.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-claims/CLAUDE.md
+++ b/cogni-claims/CLAUDE.md
@@ -108,7 +108,7 @@ Sources that WebFetch cannot reach can be recovered interactively via `/claims c
 
 The source-inspector agent (used in inspect mode) opens sources in the user's browser via claude-in-chrome for visual evidence review.
 
-Source cache files record which method succeeded via `fetch_method`: `"webfetch"` or `"cobrowse_interactive"`. A third value, `"direct"`, exists in the shared vocabulary for a non-web (local) source whose bytes are already in hand — a local file, pasted text, a local PDF, or an interview note. cogni-claims itself never emits `direct` (it is a web-source verifier with no local-ingest path); the value is recognized here so the contract stays aligned with cogni-knowledge's fetch-cache, which writes `direct` for its standalone local-source ingest. A `direct` entry is always `status: ok` and carries no negative-cache reason.
+Source cache files record which method succeeded via `fetch_method`: `"webfetch"` or `"cobrowse_interactive"`. A third value, `"direct"`, exists in the shared vocabulary for a non-web (local) source whose bytes are already in hand — a local file, pasted text, a local PDF, or an interview note. cogni-claims itself never emits `direct` (it is a web-source verifier with no local-ingest path); the value is recognized here so the contract stays aligned with cogni-knowledge's fetch-cache, which writes `direct` for its standalone local-source ingest. A `direct` entry always records a successfully-held body and carries no negative-cache reason — cogni-knowledge writes it as `status: ok` (that cache's status vocabulary); the equivalent in cogni-claims' own source cache, whose statuses are `success`/`failed`, would be `status: success`.
 
 ### Interactive cobrowse recovery
 

--- a/cogni-claims/CLAUDE.md
+++ b/cogni-claims/CLAUDE.md
@@ -108,7 +108,7 @@ Sources that WebFetch cannot reach can be recovered interactively via `/claims c
 
 The source-inspector agent (used in inspect mode) opens sources in the user's browser via claude-in-chrome for visual evidence review.
 
-Source cache files record which method succeeded via `fetch_method`: `"webfetch"` or `"cobrowse_interactive"`.
+Source cache files record which method succeeded via `fetch_method`: `"webfetch"` or `"cobrowse_interactive"`. A third value, `"direct"`, exists in the shared vocabulary for a non-web (local) source whose bytes are already in hand — a local file, pasted text, a local PDF, or an interview note. cogni-claims itself never emits `direct` (it is a web-source verifier with no local-ingest path); the value is recognized here so the contract stays aligned with cogni-knowledge's fetch-cache, which writes `direct` for its standalone local-source ingest. A `direct` entry is always `status: ok` and carries no negative-cache reason.
 
 ### Interactive cobrowse recovery
 

--- a/cogni-claims/skills/claim-entity/references/workspace-conventions.md
+++ b/cogni-claims/skills/claim-entity/references/workspace-conventions.md
@@ -78,6 +78,8 @@ For failed fetches (WebFetch failed):
 }
 ```
 
+**`fetch_method` vocabulary.** `webfetch` (automated `WebFetch`) and `cobrowse_interactive` (user-assisted claude-in-chrome recovery) are the two values cogni-claims writes. The shared vocabulary also includes `direct` — a non-web source whose bytes are already in hand (a local file, pasted text, a local PDF, or an interview note), always paired with `status: success`/`ok` and no `error`. cogni-claims never emits `direct` (it verifies web sources only); it is documented here so the cache schema stays aligned with cogni-knowledge's fetch-cache, which writes `direct` for its standalone local-source ingest.
+
 Hash generation: Use the URL string to produce a short filesystem-safe hash. The claims-store.sh script provides this via `echo -n "$url" | shasum -a 256 | cut -c1-16`.
 
 Cache rules:

--- a/cogni-claims/skills/claim-entity/references/workspace-conventions.md
+++ b/cogni-claims/skills/claim-entity/references/workspace-conventions.md
@@ -78,7 +78,7 @@ For failed fetches (WebFetch failed):
 }
 ```
 
-**`fetch_method` vocabulary.** `webfetch` (automated `WebFetch`) and `cobrowse_interactive` (user-assisted claude-in-chrome recovery) are the two values cogni-claims writes. The shared vocabulary also includes `direct` — a non-web source whose bytes are already in hand (a local file, pasted text, a local PDF, or an interview note), always paired with `status: success`/`ok` and no `error`. cogni-claims never emits `direct` (it verifies web sources only); it is documented here so the cache schema stays aligned with cogni-knowledge's fetch-cache, which writes `direct` for its standalone local-source ingest.
+**`fetch_method` vocabulary.** `webfetch` (automated `WebFetch`) and `cobrowse_interactive` (user-assisted claude-in-chrome recovery) are the two values cogni-claims writes. The shared vocabulary also includes `direct` — a non-web source whose bytes are already in hand (a local file, pasted text, a local PDF, or an interview note), always paired with a success status (`status: success` in cogni-claims' own cache vocabulary, matching the `success`/`failed` examples above; cogni-knowledge writes the same entry as `status: ok`) and no `error`. cogni-claims never emits `direct` (it verifies web sources only); it is documented here so the cache schema stays aligned with cogni-knowledge's fetch-cache, which writes `direct` for its standalone local-source ingest.
 
 Hash generation: Use the URL string to produce a short filesystem-safe hash. The claims-store.sh script provides this via `echo -n "$url" | shasum -a 256 | cut -c1-16`.
 

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/references/fetch-cache-design.md
+++ b/cogni-knowledge/references/fetch-cache-design.md
@@ -29,9 +29,11 @@ One canonical cache per knowledge base, shared across all projects under that ba
 }
 ```
 
-`fetch_method ∈ {webfetch, cobrowse_interactive}`. These are the exact two values cogni-claims uses (`cogni-claims/CLAUDE.md:109`, `skills/claims/SKILL.md:317`) — kept aligned so a future shared verifier can read either cache's entries without translation. Adding a new value here requires an additive coordinated change in cogni-claims.
+`fetch_method ∈ {webfetch, cobrowse_interactive, direct}`. The first two are kept aligned with cogni-claims (`cogni-claims/CLAUDE.md:111`, `skills/claims/SKILL.md`) so a future shared verifier can read either cache's entries without translation. Adding a value here is an additive cross-plugin contract change, mirrored in the cogni-claims prose.
 
-`status ∈ {ok, unavailable}`. An unavailable entry is recorded for negative caching — repeated fetches against a known-dead URL within the freshness window short-circuit to the cached `unavailable` verdict.
+**`direct` — non-web sources.** `webfetch` and `cobrowse_interactive` are the two web-fetch outcomes (an automated `WebFetch`, or an interactive Claude-in-Chrome recovery). `direct` records a source whose bytes are already in hand and were never fetched over the network — a local file (`.docx`/`.html`/`.txt`), pasted text, a local PDF, or a local interview note. It is the honest provenance value for `knowledge-ingest-source`'s local-input path. A `direct` entry is always `status: ok` (the body exists by definition), so it never carries a `webfetch_*`/negative-cache `reason` — the negative-cache machinery is web-only.
+
+`status ∈ {ok, unavailable}`. An unavailable entry is recorded for negative caching — repeated fetches against a known-dead URL within the freshness window short-circuit to the cached `unavailable` verdict. `direct` entries are never `unavailable`.
 
 ## Cache-key choice: URL, not content
 
@@ -105,9 +107,9 @@ cogni-claims has its own URL→body cache at `cogni-claims/sources/{url-hash}.js
 |---|---|---|
 | Cache key | First 16 chars of sha256(url) | Full 64 chars of sha256(url) |
 | Lifecycle | Per-workspace | Per knowledge base |
-| Schema for `fetch_method` | `webfetch` / `cobrowse_interactive` | identical |
+| Schema for `fetch_method` | `webfetch` / `cobrowse_interactive` | superset: adds `direct` |
 
-The 64-char key was chosen because at scale (10k+ URLs across a long-lived knowledge base) the 16-char truncation has nontrivial collision risk. The two caches do not share storage — they have different lifecycles — but the `fetch_method` vocabulary is kept identical so a future absorbed verifier can interpret either format consistently. When cogni-claims is absorbed at v1.0, the truncated keys are the loose end to reconcile (widen cogni-claims to 64 chars, or accept that legacy 16-char entries lose addressability).
+The 64-char key was chosen because at scale (10k+ URLs across a long-lived knowledge base) the 16-char truncation has nontrivial collision risk. The two caches do not share storage — they have different lifecycles — but the **shared** `fetch_method` web values (`webfetch` / `cobrowse_interactive`) are kept identical so a future absorbed verifier can interpret either format consistently. cogni-knowledge additionally writes `direct` for non-web (local) sources, which cogni-claims — a web-source verifier with no local-ingest path — never emits; the value is documented on the cogni-claims side so an absorbed verifier recognizes it rather than treating it as unknown. When cogni-claims is absorbed at v1.0, the truncated keys are the loose end to reconcile (widen cogni-claims to 64 chars, or accept that legacy 16-char entries lose addressability).
 
 ## Why not put this upstream in cogni-wiki?
 

--- a/cogni-knowledge/scripts/fetch-cache.py
+++ b/cogni-knowledge/scripts/fetch-cache.py
@@ -46,11 +46,15 @@ from _knowledge_lib import (  # noqa: E402
 SCHEMA_VERSION = "0.1.0"
 FETCH_CACHE_DIRNAME = "fetch-cache"
 BINDING_DIRNAME = ".cogni-knowledge"
-# Matches cogni-claims' fetch_method enum (cogni-claims/CLAUDE.md:109,
-# skills/claims/SKILL.md:317) so a future shared verifier can read either
-# cache's entries without translation. Do not add new values without
-# coordinating an additive change there.
-VALID_FETCH_METHODS = {"webfetch", "cobrowse_interactive"}
+# Matches cogni-claims' fetch_method enum (cogni-claims/CLAUDE.md:111,
+# skills/claims/SKILL.md) so a future shared verifier can read either cache's
+# entries without translation. `webfetch` / `cobrowse_interactive` are the two
+# web-fetch outcomes; `direct` records a non-web source (a local file / pasted
+# text / local PDF / interview note) whose bytes are already in hand — it is
+# always paired with status `ok` and never carries a negative-cache `reason`.
+# Adding a value here is a cross-plugin contract change: keep it additive and
+# mirror it in the cogni-claims prose above.
+VALID_FETCH_METHODS = {"webfetch", "cobrowse_interactive", "direct"}
 VALID_STATUSES = {"ok", "unavailable"}
 # Closed vocabulary for unavailable-entry `reason`. Single source of truth
 # for the `webfetch_error_class` enum that `source-fetcher.md` Step 4

--- a/cogni-knowledge/tests/test_fetch_cache.sh
+++ b/cogni-knowledge/tests/test_fetch_cache.sh
@@ -389,6 +389,51 @@ else
   errors=$((errors + 1))
 fi
 
+# 11. store + fetch a `direct` (non-web / local) source — round-trips with no reason.
+KB3="$WORK/kb3"
+mkdir -p "$KB3/.cogni-knowledge"
+URL_LOCAL="file:///notes/interview-2026-06-06.txt"
+python3 "$SCRIPT" store \
+  --knowledge-root "$KB3" \
+  --url "$URL_LOCAL" \
+  --fetch-method direct \
+  --status ok \
+  --body "verbatim local interview note body" \
+  --publisher "local" >/dev/null
+FETCH_DIRECT=$(python3 "$SCRIPT" fetch --knowledge-root "$KB3" --url "$URL_LOCAL")
+if echo "$FETCH_DIRECT" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d['success'] is True, d
+e = d['data']['entry']
+assert e['fetch_method'] == 'direct', e
+assert e['status'] == 'ok', e
+assert e['body'] == 'verbatim local interview note body', e
+assert e.get('reason') in (None, ''), e
+print('OK')
+" | grep -q OK; then
+  green "PASS: store + fetch round-trip for a direct (non-web) source"
+else
+  red "FAIL: direct-source round-trip mismatch"
+  red "  got: $FETCH_DIRECT"
+  errors=$((errors + 1))
+fi
+
+# 12. an unknown fetch-method is still rejected by argparse choices.
+BAD_METHOD=$(python3 "$SCRIPT" store \
+  --knowledge-root "$KB3" \
+  --url "https://example.org/x" \
+  --fetch-method scrape \
+  --status ok \
+  --body "x" 2>&1 || true)
+if echo "$BAD_METHOD" | grep -q "invalid choice: 'scrape'"; then
+  green "PASS: unknown --fetch-method is rejected (closed vocabulary held)"
+else
+  red "FAIL: unknown --fetch-method was not rejected"
+  red "  got: $BAD_METHOD"
+  errors=$((errors + 1))
+fi
+
 if [ $errors -gt 0 ]; then
   red "$errors case(s) failed."
   exit 1


### PR DESCRIPTION
## What & why

Unblocks **#533** (`knowledge-ingest-source` — local file / paste / local PDF / interview note + `type:interview`). That issue carried `svc:blocked` on two dependencies; **#528** (vendor `convert_to_md.py` + `wiki_queue.py`) already merged, leaving **one** blocker: the fetch-cache `fetch_method` vocabulary was web-coupled (`{webfetch, cobrowse_interactive}`), so a non-web source could not be deposited honestly.

This is the **smallest shippable unblock** — it resolves the cross-plugin enum decision only. The local-ingest feature work itself follows as a separate PR.

## The decision

The issue weighed two options and **rejected the parallel non-web store** (forks the cache contract). This PR ratifies the recommended **additive `direct` method**:

- `direct` records a source whose bytes are already in hand (local file / pasted text / local PDF / interview note).
- Always `status: ok`; never carries a negative-cache `reason` (the negative-cache machinery is web-only).
- The only **enforced** `fetch_method` enum lives in cogni-knowledge's `fetch-cache.py`; cogni-claims only carries prose. cogni-claims is a web-source verifier with **no** local-ingest path, so it never *emits* `direct` — its docs are aligned so an absorbed verifier *recognizes* the value.

## Changes

**cogni-knowledge** (enforced enum + design doc) — `0.1.88 → 0.1.89`
- `scripts/fetch-cache.py` — `direct` in `VALID_FETCH_METHODS`; refreshed contract comment
- `references/fetch-cache-design.md` — enum statement, comparison-table row, `direct` semantics paragraph
- `tests/test_fetch_cache.sh` — `direct` round-trip + unknown-method-rejection cases

**cogni-claims** (prose contract alignment) — `0.10.1 → 0.10.2`
- `CLAUDE.md` + `claim-entity/.../workspace-conventions.md` — document `direct` as recognized-but-not-emitted
- (claims `SKILL.md` intentionally untouched — its only `fetch_method` mentions are cobrowse-recovery examples, not a method enumeration)

## Verification

- `bash cogni-knowledge/tests/test_fetch_cache.sh` — 18 cases green (incl. 2 new)
- `bash cogni-knowledge/tests/test_skill_contracts.sh` — ALL PASS
- `python3 scripts/check-breadcrumbs.py` — 0 violations
- Manual `store --fetch-method direct --status ok` → `fetch` round-trips `fetch_method: direct`; `direct` + stray `--reason` correctly rejected

## Follow-up (not in this PR)

After merge: remove `svc:blocked` from #533, mark its cogni-claims enum dependency satisfied, then pick up the local-ingest feature (multi-input handling, `convert_to_md`/`wiki_queue` wiring, `type:interview` page type + `source-ingester` `PAGE_TYPE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)