### PR TITLE
cogni-knowledge: pin vendored cogni-wiki source revision in vendor/README

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.91",
+      "version": "0.1.92",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/vendor/README.md
+++ b/cogni-knowledge/scripts/vendor/README.md
@@ -32,6 +32,14 @@ These files are not a fork. cogni-wiki remains the source of truth. To update th
 vendored engine, re-copy from `cogni-wiki/` and let `tests/test_vendored_engine_parity.sh`
 enforce byte-identity in CI — it fails if any vendored file drifts from its origin.
 
+Vendored-from: e356c998e2e14b9c4ead4979c187509b061a228f (2026-06-05)
+
+That is the cogni-wiki revision this tree mirrors — the last commit to touch the
+vendored origins (`cogni-wiki/skills/{wiki-ingest,wiki-lint,wiki-health}/scripts`
+and `cogni-wiki/foundations`). Re-stamp this line whenever the tree is re-copied.
+It is the durable provenance marker once cogni-wiki is archived and the parity
+test's origin comparisons skip silently.
+
 Only the runtime subset the knowledge-* skills actually invoke is vendored here;
 the remaining cogni-wiki scripts are re-homed with the standalone surface in a
 later phase.


### PR DESCRIPTION
Closes #535.

## Summary
- Add a `Vendored-from: e356c998e2e14b9c4ead4979c187509b061a228f (2026-06-05)` provenance line to `cogni-knowledge/scripts/vendor/README.md` under the `## Do not hand-edit` section, recording which cogni-wiki revision the vendored tree mirrors (the last commit to touch the vendored origins).
- Bump `cogni-knowledge` patch version 0.1.91 → 0.1.92 in `plugin.json` and mirror it in `marketplace.json` (repo version-management policy).

## Scope decisions
- **In scope (the issue's required deliverable):** record the source commit SHA + date in `vendor/README.md`. Delivered in full — this closes #535.
- **Why this matters now:** the drift test `tests/test_vendored_engine_parity.sh` SKIPS (does not fail) each origin comparison when `cogni-wiki/` is absent. Once cogni-wiki is archived (Epic C) and removed, git history becomes the only provenance — this in-tree line is the durable marker for a future re-sync or audit.
- **Out of scope (issue-optional):** the issue's optional "have the re-vendor step stamp it automatically." There is no re-vendor/copy script in `cogni-knowledge/scripts/` today (re-vendoring is a manual `cp`), so building auto-stamping tooling is separable new scope.

## Test plan
- [x] `cat cogni-knowledge/scripts/vendor/README.md` shows the `Vendored-from:` line (line 35).
- [x] `bash cogni-knowledge/tests/test_vendored_engine_parity.sh` passes (28 files byte-identical, README presence check still green).
- [x] `plugin.json` and the `cogni-knowledge` `marketplace.json` entry both show 0.1.92.

## Follow-up issues
- #551 — parity test should assert the `vendor/README` `Vendored-from:` SHA marker is present (newly-identified hardening, beyond #535's scope)
