### PR TITLE
cogni-trends: cut value-modeler uploaded-corpus off cogni-research

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -93,7 +93,7 @@
     {
       "name": "cogni-trends",
       "source": "./cogni-trends",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "maturity": "preview",
       "description": "Strategic trend scouting and TIPS reporting pipeline. Combines the Smarter Service Trendradar (4 dimensions) with TIPS (Trends, Implications, Possibilities, Solutions): trend-scout → value-modeler → trend-research → trend-synthesis and/or trend-booklet → verify-trend-report. Evidence-backed CxO reports and reusable industry catalogs across DE/FR/IT/PL/NL/ES + US/UK.",
       "keywords": [

--- a/cogni-trends/.claude-plugin/plugin.json
+++ b/cogni-trends/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-trends",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Strategic trend scouting and TIPS reporting pipeline. Combines the Smarter Service Trendradar (4 dimensions) with TIPS (Trends, Implications, Possibilities, Solutions): trend-scout → value-modeler → trend-research → trend-synthesis and/or trend-booklet → verify-trend-report. Evidence-backed CxO reports and reusable industry catalogs across DE/FR/IT/PL/NL/ES + US/UK.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-trends/CHANGELOG.md
+++ b/cogni-trends/CHANGELOG.md
@@ -1,5 +1,29 @@
 # cogni-trends changelog
 
+## 0.6.6 — 2026-06-08 — value-modeler Phase 2 uploaded-corpus site cut off cogni-research
+
+`value-modeler` Phase 2 (`references/workflow-phases/phase-2-solutions.md`) cuts its third and
+final solution-evidence site — **uploaded collateral (Step 2.6.A point 4)** — off the deprecated
+`cogni-research:local-researcher` dispatch. The unblocking capability (cogni-knowledge local-source
+ingest with honest non-web provenance) shipped in cogni-knowledge v0.1.99.
+
+- The per-ST `cogni-research:local-researcher` dispatch over
+  `cogni-portfolio/{portfolio_ref}/{vendor_source.case_study_uploads || "uploads/"}` is replaced by
+  reading the uploaded document corpus **natively** — enumerate the files and `Read` each directly,
+  synthesizing the outcome claim inline. No plugin dispatch and no binding required, mirroring the
+  vendor-wiki (Step 2.6.A point 5) and open-mode (Step 2.6.B) patterns.
+- Optional deposit-when-bound branch: when a knowledge base is bound, deposit each matching file via
+  `cogni-knowledge:knowledge-ingest-source --file <abspath>` (one invocation per file; stores with
+  honest `fetch_method: direct`) and read the resulting `wiki/sources/<slug>.md` page back. The
+  rejected alternative — forcing the local corpus through URL-only ingest or a synthetic `webfetch`
+  method — would lie about `fetch_method`, a cross-plugin contract with cogni-claims.
+
+The vendor-mode dispatch budget table and the `data-model.md` attribution prose
+(`case_study_uploads` field, `source: "uploads"` enum) are updated to match. Output shape
+(`vendor_references[]` with `source: "uploads"` / `source_ref: "uploads/{filename}"`) and the per-ST
+budget are unchanged — downstream writers are unaffected. **With this change there are zero
+`cogni-research:` runtime dispatches left in cogni-trends.** Part of the FMO Migrate epic (Epic B).
+
 ## 0.6.5 — 2026-06-06 — value-modeler Phase 2 evidence dispatch rerouted to cogni-knowledge
 
 `value-modeler` Phase 2 (`references/workflow-phases/phase-2-solutions.md`) no longer
@@ -18,8 +42,8 @@ The per-ST dispatch budget table and the `data-model.md` attribution prose (`sou
 `published_cases[]` preamble) are updated to match. Output shape (`vendor_references[]`,
 `published_cases[]`, per-ST mutual exclusivity) and all `source` field *values* are unchanged —
 downstream writers are unaffected. The uploaded-corpus `cogni-research:local-researcher` site
-(Step 2.6 point 4, `source: "uploads"`) is deliberately untouched; it is carved out to a separate
-follow-up gated on cogni-knowledge local-source ingest. Part of the FMO Migrate epic (Epic B).
+(Step 2.6.A point 4, `source: "uploads"`) is carved out to a separate follow-up gated on
+cogni-knowledge local-source ingest — landed in 0.6.6 above. Part of the FMO Migrate epic (Epic B).
 
 ## 0.6.4 — 2026-05-29 — Discoverability — manifest description compacted (closes #351 for this plugin)
 

--- a/cogni-trends/references/data-model.md
+++ b/cogni-trends/references/data-model.md
@@ -108,7 +108,7 @@ project in the workspace. When `study_mode` is `"open"`, this field is omitted.
 - `vendor_slug` (string, required): kebab-case vendor identifier for display resolution. When `trend-scout` Step 0.8c auto-populates `vendor_source`, this defaults to the same value as `portfolio_ref` (both reflect the connected portfolio's slug). Power users can manually override `vendor_slug` in `tips-project.json` when the published vendor brand differs from the portfolio slug (e.g., `portfolio_ref: "t-systems-corp"` with `vendor_slug: "t-systems"`).
 - `vendor_display_name` (string, required): Human-readable provider name for prose weaving (e.g., `"T-Systems"`).
 - `case_study_wiki` (string, optional): Path relative to workspace root pointing at a cogni-wiki instance to query for reference evidence.
-- `case_study_uploads` (string, optional): Path (relative to the portfolio project) to a directory of uploaded case study documents (PDF, DOCX, MD) for `local-researcher` dispatch. Defaults to the portfolio project's `uploads/` directory when omitted.
+- `case_study_uploads` (string, optional): Path (relative to the portfolio project) to a directory of uploaded case study documents (PDF, DOCX, MD) the vendor-mode pass `Read`s natively (optionally depositing each file via `cogni-knowledge:knowledge-ingest-source --file`, `fetch_method: direct`, when a base is bound). Defaults to the portfolio project's `uploads/` directory when omitted.
 
 ### trend-scout-output.json (Scout Output)
 
@@ -770,7 +770,7 @@ New fields (all optional, backward compatible — existing STs without these fie
   - `outcome_claim` (string, required): Short outcome statement suitable for CxO prose (1–2 sentences).
   - `roi_claim` (string, optional): Quantified ROI when available from portfolio evidence (e.g., `"€4.2M avoided OPEX"`).
   - `source` (string, required): Where the reference came from inside the portfolio — `"customers"` (a `named_customers[]` entry),
-    `"propositions"` (an `evidence[]` entry tagged vendor-authored), `"uploads"` (document corpus via `cogni-research:local-researcher`),
+    `"propositions"` (an `evidence[]` entry tagged vendor-authored), `"uploads"` (uploaded document corpus read natively, optionally deposited via `cogni-knowledge:knowledge-ingest-source`),
     or `"wiki"` (a `wiki-grounding.py rank` hit over the vendor's case-study wiki).
   - `source_ref` (string, required): Portfolio-relative path or entity ref with optional JSON Pointer. Must resolve inside `cogni-portfolio/{portfolio_ref}/`.
   - `portfolio_grounding_entry_ref` (string, required): `{feature_slug}--{market_slug}` key linking this reference back to one of the ST's `portfolio_grounding[]` entries.

--- a/cogni-trends/skills/value-modeler/references/workflow-phases/phase-2-solutions.md
+++ b/cogni-trends/skills/value-modeler/references/workflow-phases/phase-2-solutions.md
@@ -594,7 +594,7 @@ do not HALT. A misconfigured vendor project should still produce a report.
 
 | Mode | Dispatch budget per ST |
 |------|-----------------------|
-| vendor | max 2 `cogni-research:local-researcher` calls + max 2 `wiki-grounding.py rank` calls (+ `Read` of the ranked pages) + plain JSON reads (unbounded) |
+| vendor | max 4 `Read` calls of uploaded-corpus files (+ optional `cogni-knowledge:knowledge-ingest-source --file` deposit, one per file, when a base is bound) + max 2 `wiki-grounding.py rank` calls (+ `Read` of the ranked pages) + plain JSON reads (unbounded) |
 | open | max 1 native cogni-knowledge research pass (inline `WebSearch` + `WebFetch`, or `cogni-knowledge:knowledge-ingest-source` per URL) with ≤ 4 sub-queries |
 
 ### 2.6.A: Vendor Mode — Source References from the Portfolio Corpus
@@ -633,12 +633,20 @@ For each ST where the `solution_blueprint.building_blocks[]` contains any block 
    points). When the tag is absent on older projects, include only entries whose `source_url`
    is empty (portfolio-internal only) — never web-sourced evidence.
 
-4. **Uploaded collateral** — dispatch `cogni-research:local-researcher` once per ST against
-   `cogni-portfolio/{portfolio_ref}/{vendor_source.case_study_uploads || "uploads/"}`. Build
-   sub-questions from the ST name + lead building-block capability + investment theme name, e.g.:
+4. **Uploaded collateral** — read the uploaded document corpus natively (no plugin dispatch, no
+   binding required — mirrors the vendor-wiki and open-mode patterns below). Enumerate the files
+   under `cogni-portfolio/{portfolio_ref}/{vendor_source.case_study_uploads || "uploads/"}`
+   (`.pdf`, `.docx`, `.html`, `.txt`, `.md`) and `Read` each directly, synthesizing the outcome
+   claim inline against a sub-question built from the ST name + lead building-block capability +
+   investment theme name, e.g.:
    *"Which uploaded case studies describe an implementation of {ST.name} in {industry.subsector_en} and what outcome was reported?"*.
-   Limit to max 4 sub-questions per dispatch. Each matching file becomes a `vendor_references[]`
-   entry with `source: "uploads"` and `source_ref: "uploads/{filename}"`.
+   Limit to max 4 files read per ST. Optionally, when a knowledge base is bound, deposit each
+   matching file via `cogni-knowledge:knowledge-ingest-source --file <abspath>` — one invocation
+   per file (there is no bulk `--directory` mode; the local document stores with honest
+   `fetch_method: direct`, and the skill's own diff-before-write dedup makes a re-run idempotent)
+   — and read the resulting `wiki/sources/<slug>.md` page back instead of the raw file. Each
+   matching file becomes a `vendor_references[]` entry with `source: "uploads"` and
+   `source_ref: "uploads/{filename}"`.
 
 5. **Vendor wiki (optional)** — when `vendor_source.case_study_wiki` is set, rank that wiki
    natively with cogni-knowledge's re-homed discovery primitive (no plugin dispatch, no binding,


### PR DESCRIPTION
Closes #546.

Cuts the value-modeler Phase 2 vendor-mode **uploaded-corpus** evidence site off the deprecated `cogni-research:local-researcher` dispatch and onto the native inline-`Read` pattern already established in the same file, with an optional `cogni-knowledge:knowledge-ingest-source` deposit when a knowledge base is bound. With this change there are **zero `cogni-research:` runtime dispatches left in cogni-trends**. Dependency #533 (cogni-knowledge local-source ingest, `fetch_method: direct`) merged in v0.1.99, unblocking the honest-provenance path for non-URL local documents.

## Summary
- Replace the per-ST `cogni-research:local-researcher` uploaded-collateral dispatch (`phase-2-solutions.md` Step 2.6.A point 4) with: `Read` each file in `cogni-portfolio/{portfolio_ref}/{vendor_source.case_study_uploads || "uploads/"}` directly and synthesize the outcome claim inline — mirroring the vendor-wiki (point 5) and open-mode (Step 2.6.B) in-file patterns. No binding prerequisite for the default path.
- Add the **optional deposit-when-bound** branch: when a knowledge base is bound, deposit each matching file via `cogni-knowledge:knowledge-ingest-source --file <abspath>` (stores with honest `fetch_method: direct`; the skill's diff-before-write dedup makes a re-run idempotent) and read it back — one invocation per file (no bulk `--directory` mode).
- Update the vendor-mode dispatch budget table (`phase-2-solutions.md` ~L597) to drop the `cogni-research:local-researcher` calls.
- Update attribution prose in `data-model.md` (`case_study_uploads` field; `vendor_references[].source` enum `"uploads"`) to name the replacement path. The `source` value `"uploads"` and `source_ref` shape are unchanged — downstream writers unaffected.
- CHANGELOG `0.6.6` entry; patch-bump `plugin.json` + `marketplace.json` (0.6.5 → 0.6.6); flip the prior 0.6.5 carve-out note to reflect this cutover landing.

## Provenance honesty
The rejected alternative (forcing the local corpus through URL-only ingest or a synthetic `webfetch` method) would lie about `fetch_method`, a cross-plugin contract with cogni-claims. The default inline-`Read` path carries no synthetic provenance; the optional deposit path uses the `direct` method shipped specifically for this in #533.

## Test plan
- [x] `grep cogni-research:` over `cogni-trends/skills` + `cogni-trends/references` returns zero **runtime dispatch** hits (only two `verify-report` prose analogies remain).
- [x] `local-researcher` no longer appears in skills/references.
- [x] `source: "uploads"` / `source_ref: "uploads/{filename}"` output shape preserved.
- [x] `plugin.json` = `0.6.6`; marketplace `cogni-trends` entry = `0.6.6`; both JSON valid.
- [x] Breadcrumb guard: 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
