### PR TITLE
cogni-knowledge: standalone knowledge-update + knowledge-prefill skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/skills/knowledge-prefill/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-prefill/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: knowledge-prefill
+description: "Seed a cogni-knowledge base with curated foundation concept pages — Porter's Five Forces, Jobs-to-be-Done, MECE, Pyramid Principle, OODA, SWOT, BCG Matrix, Value Chain, Lean Canvas, Wardley Mapping, Double Diamond. Wraps the vendored prefill_foundations.py engine (resolved vendored-first), so a Karpathy base is prefillable with no cogni-wiki plugin installed. Foundations carry `foundation: true`; knowledge-update refuses to edit them without --force. Use this skill whenever the user says 'prefill the knowledge base', 'seed canonical concepts', 'add foundations', 'knowledge prefill', 'pre-fill consulting frameworks', or wants to opt into the canonical foundation pages knowledge-setup deliberately skips."
+allowed-tools: Read, Bash, AskUserQuestion
+---
+
+# Knowledge Prefill
+
+Seed a bound knowledge base with curated `foundation: true` concept pages so canonical material like Porter's Five Forces, Jobs-to-be-Done, and MECE has a stable target slug from day one. This is the standalone analog of `cogni-wiki:wiki-prefill`, computed **natively on the vendored `prefill_foundations.py` engine** (resolved vendored-first via `resolve_wiki_scripts()`), so a Karpathy base is prefillable with no `cogni-wiki` plugin installed. It **does not dispatch `cogni-wiki:wiki-prefill`**.
+
+**Why this is a deliberate opt-in.** `knowledge-setup` intentionally passes `--skip-prefill-prompt` to `cogni-wiki:wiki-setup` — a cogni-knowledge base has its own opinionated domain seeding (the first `knowledge-plan` → … → `knowledge-finalize` run seeds the base domain-specifically), and layering the generic canonical foundations on top would clutter it. `knowledge-prefill` is the **native opt-in** so a user who skipped foundations at setup time — or who wants the textbook concepts as stable link targets later — can add them without installing cogni-wiki.
+
+Read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` once at the start of a session so you remember the wiki-engine boundary — cogni-knowledge runs the prefill on the **vendored** engine, it does not dispatch `cogni-wiki:wiki-prefill`.
+
+## When to run
+
+- User explicitly asks to prefill, seed, or pre-load foundations / canonical concepts / consulting frameworks into the bound base
+- A base set up with `--skip-prefill-prompt` (the cogni-knowledge default) and the user now wants the canonical foundations as stable link targets
+- An existing base has accumulated duplicate pages for canonical material and the user wants to establish the foundation slugs
+
+## Never run when
+
+- The target directory has no `.cogni-knowledge/binding.json` — offer `knowledge-setup` instead.
+- The user wants to add a non-canonical concept — that is the inverted pipeline's / `knowledge-ingest-source`'s job; foundations are reserved for textbook material that needs no per-base synthesis.
+
+## How it relates to neighbours
+
+- `knowledge-setup` deliberately skips the canonical foundations (`--skip-prefill-prompt`); this skill is the opt-in that adds them later.
+- `knowledge-update` refuses to edit the `foundation: true` pages this skill seeds without `--force` — they are terminal.
+- `knowledge-lint` skips orphan / no-sources / staleness warnings on foundations and surfaces their count.
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--knowledge-slug` | Yes | Slug of the knowledge base to prefill. Resolves to `cogni-knowledge/<slug>/` unless `--knowledge-root` overrides. |
+| `--knowledge-root` | No | Override the default knowledge-base directory. |
+| `--filter` | No | One of `all` (default), `consulting`, `product`, `strategy`. Limits the copy to foundations tagged with the matching keyword. |
+| `--list` | No | Print the available foundations under the chosen `--filter` and exit. No page is written. Use to review the set before committing. |
+| `--dry-run` | No | Compute the plan without writing any page or bumping `entries_count`. Pair with `--filter` to preview the subset. |
+
+## Workflow
+
+### 0. Pre-flight
+
+**Required engine.** This skill runs the prefill on the **vendored** wiki-prefill engine — cogni-knowledge ships a byte-identical copy in-tree under `scripts/vendor/cogni-wiki/`, so a bound base is prefillable without cogni-wiki installed. The `cogni-wiki` install is only a fallback layout. Probe both so the skill aborts cleanly here rather than failing mid-skill:
+
+```
+# vendored-first: the in-tree wiki-prefill scripts are self-contained
+test -d "${CLAUDE_PLUGIN_ROOT}/scripts/vendor/cogni-wiki/skills/wiki-prefill/scripts" && WIKI_OK=yes || WIKI_OK=no
+
+# fallback: an installed cogni-wiki sibling / marketplace cache (legacy layout)
+if [ "$WIKI_OK" = "no" ]; then
+  probe_plugin() {
+    local plugin="$1" skill="$2"
+    test -f "${CLAUDE_PLUGIN_ROOT}/../${plugin}/skills/${skill}/SKILL.md" && return 0
+    for d in "${CLAUDE_PLUGIN_ROOT}/../../${plugin}/"*/skills/"${skill}"/SKILL.md; do
+      [ -f "$d" ] && return 0
+    done
+    return 1
+  }
+  probe_plugin cogni-wiki wiki-setup && WIKI_OK=yes || WIKI_OK=no
+fi
+```
+
+If `WIKI_OK` is `no`, abort:
+
+> cogni-knowledge's vendored wiki-prefill scripts are missing and no `cogni-wiki`
+> install was found. Reinstall cogni-knowledge, then retry.
+
+This probe is the early-abort gate only — Step 2's `resolve_wiki_scripts` is the authoritative resolver for the actual `prefill_foundations.py` path; keep the two vendored-first precedences in sync.
+
+### 1. Resolve the knowledge root and read the binding
+
+1. Resolve `knowledge_root`:
+   - If `--knowledge-root` is set, use it.
+   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the current working directory).
+
+2. Read the binding:
+   ```bash
+   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py read \
+       --knowledge-root <knowledge_root>
+   ```
+   On `success: false`, abort and offer `knowledge-setup`. Do not auto-create.
+
+3. Extract from the binding: `knowledge_slug`, `knowledge_title`, `wiki_path`.
+
+4. Validate the binding's `knowledge_slug` matches `--knowledge-slug`. Mismatch → abort.
+
+(`--list` mode is the only exception — it touches no wiki, so the binding read is informational. You may still run it to confirm the base before listing.)
+
+### 2. Run the prefill natively (vendored `prefill_foundations.py`)
+
+Resolve the vendored `wiki-prefill` scripts dir vendored-first (the same `resolve_wiki_scripts` posture `knowledge-lint` / `knowledge-health` use), then invoke `prefill_foundations.py` directly — no `Skill` dispatch:
+
+```bash
+. "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-wiki-scripts.sh"
+WIKI_PREFILL_SCRIPTS=$(resolve_wiki_scripts wiki-prefill prefill_foundations.py) \
+  || abort "cogni-knowledge's vendored wiki-prefill scripts are missing and no cogni-wiki install was found. Reinstall cogni-knowledge, then retry."
+```
+
+The vendored engine derives its `FOUNDATIONS_DIR` and `CONFIG_BUMP_SCRIPT` from its own in-tree location, so no `--foundations-dir` override is needed — the foundations library ships alongside the vendored scripts.
+
+Build the invocation from the parameters. **Default is a wet apply** (idempotent — existing foundation slugs are skipped):
+
+```bash
+python3 "${WIKI_PREFILL_SCRIPTS}/prefill_foundations.py" --wiki-root "<wiki_path>" --filter <filter>
+```
+
+Map the user's flags through verbatim:
+
+- `--filter=<all|consulting|product|strategy>` → pass `--filter <value>` (the engine validates the choice; `all` copies every foundation).
+- `--list` → pass `--list` (read-only; enumerates the plugin-side library without touching the wiki).
+- `--dry-run` → pass `--dry-run` (computes the plan without writing or bumping `entries_count`).
+
+Parse the JSON envelope `{success, data, error}`. On `success: false`, surface `error` and stop. Otherwise capture `data.available[]`, `data.copied[]`, `data.skipped_existing[]`, `data.failed[]`, and `data.entries_count_delta`.
+
+### 3. Append to the log
+
+On a wet apply (not `--list` / `--dry-run`), append one line to `<wiki_path>/wiki/log.md`:
+
+```
+## [{YYYY-MM-DD}] prefill   | filter={filter} — copied N foundations
+```
+
+### 4. Report to the user
+
+In ≤5 sentences:
+
+- Which foundations were copied and how many were skipped (already existed).
+- Where the pages live (`<wiki_path>/wiki/concepts/<slug>.md`).
+- Reminder: `knowledge-update` refuses to edit `foundation: true` pages without `--force` — they are terminal by design.
+- Suggested next action: run the inverted pipeline (`knowledge-plan` → …) to add domain-specific knowledge that links into the foundations.
+
+## Edge cases
+
+- **`--list` with no wiki.** The engine enumerates the plugin-side library without a wiki root; the binding read is informational in this mode.
+- **`config_bump.py` failure.** The page writes stay on disk; `entries_count` drift is reconcilable via `knowledge-lint --fix=entries_count_drift`.
+- **Slug collision with a non-foundation page.** The slug is silently skipped, no overwrite.
+
+## Out of scope
+
+- Does NOT dispatch `cogni-wiki:wiki-prefill` — the prefill is computed natively on the vendored engine.
+- Does NOT add domain-specific pages — that is the inverted pipeline / `knowledge-ingest-source`.
+- Does NOT write to the binding.
+
+## Output
+
+- N new files under `<wiki_path>/wiki/concepts/` (one per copied foundation), one appended `wiki/log.md` line, and a locked `entries_count` bump (on a wet apply). Read-only under `--list` / `--dry-run`.
+
+## References
+
+- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` — delegation boundary (prefill computed natively on the vendored engine)
+- `${CLAUDE_PLUGIN_ROOT}/scripts/vendor/cogni-wiki/skills/wiki-prefill/scripts/prefill_foundations.py` — the vendored prefill engine invoked in Step 2
+- `${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py --help`

--- a/cogni-knowledge/skills/knowledge-prefill/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-prefill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: knowledge-prefill
-description: "Seed a cogni-knowledge base with curated foundation concept pages — Porter's Five Forces, Jobs-to-be-Done, MECE, Pyramid Principle, OODA, SWOT, BCG Matrix, Value Chain, Lean Canvas, Wardley Mapping, Double Diamond. Wraps the vendored prefill_foundations.py engine (resolved vendored-first), so a Karpathy base is prefillable with no cogni-wiki plugin installed. Foundations carry `foundation: true`; knowledge-update refuses to edit them without --force. Use this skill whenever the user says 'prefill the knowledge base', 'seed canonical concepts', 'add foundations', 'knowledge prefill', 'pre-fill consulting frameworks', or wants to opt into the canonical foundation pages knowledge-setup deliberately skips."
+description: "Seed a cogni-knowledge base with curated foundation concept pages (Porter's Five Forces, Jobs-to-be-Done, MECE, Pyramid Principle, OODA, SWOT, BCG Matrix, Value Chain, Lean Canvas, Wardley Mapping, Double Diamond) on the vendored prefill engine, so a Karpathy base is prefillable with no cogni-wiki plugin installed. Use this skill whenever the user says 'prefill the knowledge base', 'seed canonical concepts', 'add foundations', 'knowledge prefill', or 'pre-fill consulting frameworks'."
 allowed-tools: Read, Bash, AskUserQuestion
 ---
 
@@ -21,7 +21,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` once at the start
 ## Never run when
 
 - The target directory has no `.cogni-knowledge/binding.json` — offer `knowledge-setup` instead.
-- The user wants to add a non-canonical concept — that is the inverted pipeline's / `knowledge-ingest-source`'s job; foundations are reserved for textbook material that needs no per-base synthesis.
+- The user wants to add a single non-canonical concept — route that to `knowledge-ingest-source` (one source into the base), or, for a full topic, to the inverted pipeline (`knowledge-plan`); foundations are reserved for textbook material that needs no per-base synthesis.
 
 ## How it relates to neighbours
 

--- a/cogni-knowledge/skills/knowledge-update/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: knowledge-update
-description: "Manually curate a single page in a cogni-knowledge base — revise an existing wiki page when knowledge has changed, showing the diff before writing, requiring a source citation for every new claim, and sweeping related pages for now-stale statements the update contradicts. This is the standalone analog of cogni-wiki:wiki-update, resolved against the bound wiki via the binding manifest so a Karpathy base is curatable with no cogni-wiki plugin installed. Use this skill whenever the user says 'update the knowledge base', 'update page X', 'revise the wiki', 'knowledge update', 'the base is out of date on X', 'fix the contradictions from the lint report', 'retire that page', or when a single-source ingest collides with an existing page (knowledge-ingest-source hands control here for diff-before-write)."
+description: "Manually curate a single page in a cogni-knowledge base — revise an existing wiki page when knowledge has changed. Shows the diff before writing, requires a source citation for every new claim, and sweeps related pages for now-stale statements the update contradicts. The standalone analog of cogni-wiki:wiki-update, resolved against the bound wiki via the binding manifest so a Karpathy base is curatable with no cogni-wiki plugin installed. Use this skill whenever the user says 'update the knowledge base', 'update page X', 'revise the wiki', 'knowledge update', 'the base is out of date on X', 'fix the contradictions from the lint report', 'retire that page', or when a single-source ingest collides with an existing page."
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 
@@ -15,7 +15,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` once at the start
 ## When to run
 
 - User explicitly asks to update, revise, retire, or fix a page in the bound base
-- `knowledge-ingest-source` detected that a single source collides with an existing page and handed control here for diff-before-write (the named endpoint for that cross-skill handoff)
+- `knowledge-ingest-source` detected that a single source collides with an existing page and handed control here for diff-before-write (the intended endpoint for that cross-skill handoff)
 - `knowledge-lint` reported a contradiction or `claim_drift` the user wants reconciled
 - User says "the base says X but actually Y — fix it"
 
@@ -30,7 +30,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` once at the start
 
 ## How it relates to neighbours
 
-- `knowledge-ingest-source` *adds* one source page (with its own diff-before-write dedup on a covering collision); `knowledge-update` *refines* an existing page. The collision handoff flows ingest-source → here.
+- `knowledge-ingest-source` *adds* one source page (with its own diff-before-write dedup on a covering collision); `knowledge-update` *refines* an existing page. The collision handoff is intended to flow ingest-source → here (the sibling's covering-collision branch still names `cogni-wiki:wiki-update` directly; rewiring it to name this skill is a tracked follow-up).
 - `knowledge-lint` *audits* hygiene (stale/drift/reverse links) and repairs the mechanical classes; `knowledge-update` is where a human-judged semantic fix (a contradiction, a refined claim) lands. Run lint to find what is stale; run update to fix what needs prose judgment.
 - `knowledge-prefill` seeds the `foundation: true` pages this skill refuses to edit without `--force`.
 
@@ -50,13 +50,13 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` once at the start
 
 ### 0. Pre-flight
 
-No engine to resolve — the update is pure-LLM, `Edit`-driven. The only pre-flight is the binding (Step 1): the wiki root and the page both resolve from `.cogni-knowledge/binding.json`, never from a cwd walk (the divergence from `cogni-wiki:wiki-update`, which walks upward from the current directory).
+No engine to resolve — the update is pure-LLM, `Edit`-driven. The only pre-flight is the binding (Step 1): the **wiki root** (`wiki_path`) and the target page both resolve from `.cogni-knowledge/binding.json`, never from a cwd walk of the wiki tree (the divergence from `cogni-wiki:wiki-update`, which walks upward from the current directory to find the wiki). The `--knowledge-root` default in Step 1 is only how the **binding file** is located on disk — it is not a wiki-tree walk.
 
 ### 1. Resolve the knowledge root and read the binding
 
 1. Resolve `knowledge_root`:
    - If `--knowledge-root` is set, use it.
-   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the current working directory).
+   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the current working directory). This locates the **binding file**, not the wiki — `wiki_path` is then read from the binding (sub-step 3 below), so the wiki root itself never comes from a cwd walk.
 
 2. Read the binding:
    ```bash
@@ -89,7 +89,7 @@ State in plain prose:
 4. **What will be deleted** — if anything is being removed, say so explicitly.
 5. **What the diff looks like** — show the before/after as a unified diff.
 
-Show this to the user. For autonomous runs, still emit the synthesis in the response but proceed without waiting for explicit confirmation.
+Show this to the user. For autonomous runs, still emit the synthesis in the response but proceed without waiting for explicit confirmation. Treat a run as autonomous when the dispatch is non-interactive — no `AskUserQuestion`-capable session, or an explicit autonomous / `--yes` flag was passed; otherwise wait for the user's confirmation before writing.
 
 This is the **diff-before-write** discipline — the cogni-knowledge equivalent of `git diff` + manual inspection before commit.
 

--- a/cogni-knowledge/skills/knowledge-update/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-update/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: knowledge-update
+description: "Manually curate a single page in a cogni-knowledge base — revise an existing wiki page when knowledge has changed, showing the diff before writing, requiring a source citation for every new claim, and sweeping related pages for now-stale statements the update contradicts. This is the standalone analog of cogni-wiki:wiki-update, resolved against the bound wiki via the binding manifest so a Karpathy base is curatable with no cogni-wiki plugin installed. Use this skill whenever the user says 'update the knowledge base', 'update page X', 'revise the wiki', 'knowledge update', 'the base is out of date on X', 'fix the contradictions from the lint report', 'retire that page', or when a single-source ingest collides with an existing page (knowledge-ingest-source hands control here for diff-before-write)."
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+# Knowledge Update
+
+Revise one page in a bound knowledge base because knowledge has changed, a contradiction was reported, or a new source refines a claim. This is the **manual single-page curation** half of the compounding loop — the inverted pipeline *adds* (ingest → distill → compose → finalize), and `knowledge-update` *refines*. Together they keep a Karpathy base live.
+
+This is the standalone analog of `cogni-wiki:wiki-update`, computed **natively** against the bound wiki — it resolves the wiki root from `.cogni-knowledge/binding.json` and edits the page directly with the `Edit` tool, so a base is curatable with no `cogni-wiki` plugin installed. It **does not dispatch `cogni-wiki:wiki-update`**.
+
+Read `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` once at the start of a session so you remember the wiki-engine boundary — cogni-knowledge curates the page natively (the update logic is pure-LLM, Edit-driven; there is no engine script to resolve), it does not delegate to `cogni-wiki:wiki-update`.
+
+## When to run
+
+- User explicitly asks to update, revise, retire, or fix a page in the bound base
+- `knowledge-ingest-source` detected that a single source collides with an existing page and handed control here for diff-before-write (the named endpoint for that cross-skill handoff)
+- `knowledge-lint` reported a contradiction or `claim_drift` the user wants reconciled
+- User says "the base says X but actually Y — fix it"
+
+## Never run when
+
+- The target directory has no `.cogni-knowledge/binding.json` — offer `knowledge-setup` instead.
+- The target page does not exist — offer `knowledge-ingest-source` instead.
+- The user wants to append a new claim with no source — stop and ask for the source first.
+- The change is cosmetic only (a typo fix) — just `Edit` the page directly and bump its `updated:` field; you do not need this skill's full discipline.
+- The target page has `foundation: true` in frontmatter (seeded by `knowledge-prefill`) and the user did **not** pass `--force`. Foundations are terminal pages — canonical textbook concepts (Porter's Five Forces, Jobs-to-be-Done, MECE, …) whose authority derives from the upstream source URL, not per-base synthesis. Stop and surface the refusal verbatim:
+  > Page `{slug}` is a foundation (canonical concept seeded by `knowledge-prefill`). Updates require `--force` to preserve the terminal-page contract. Consider `knowledge-ingest-source` for a base-specific page that links into [[{slug}]] instead.
+
+## How it relates to neighbours
+
+- `knowledge-ingest-source` *adds* one source page (with its own diff-before-write dedup on a covering collision); `knowledge-update` *refines* an existing page. The collision handoff flows ingest-source → here.
+- `knowledge-lint` *audits* hygiene (stale/drift/reverse links) and repairs the mechanical classes; `knowledge-update` is where a human-judged semantic fix (a contradiction, a refined claim) lands. Run lint to find what is stale; run update to fix what needs prose judgment.
+- `knowledge-prefill` seeds the `foundation: true` pages this skill refuses to edit without `--force`.
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--knowledge-slug` | Yes | Slug of the knowledge base. Resolves to `cogni-knowledge/<slug>/` unless `--knowledge-root` overrides. |
+| `--knowledge-root` | No | Override the default knowledge-base directory. |
+| `--page` | Yes | Slug of the page to update, or a fuzzy title that resolves to one slug. |
+| `--reason` | Yes | Why the update is happening: `new-source`, `contradiction`, `refinement`, `retype`, `retire`. |
+| `--source` | Conditional | Required when `--reason new-source` — a URL or a path to a file the new claim is grounded in. |
+| `--related-sweep` | No | `yes` (default) / `no` — whether to check related pages for stale statements the update contradicts. |
+| `--force` | No | Override the `foundation: true` refusal in "Never run when". Required when the target is a foundation and the upstream canonical source has genuinely shifted. No effect on non-foundation pages. |
+
+## Workflow
+
+### 0. Pre-flight
+
+No engine to resolve — the update is pure-LLM, `Edit`-driven. The only pre-flight is the binding (Step 1): the wiki root and the page both resolve from `.cogni-knowledge/binding.json`, never from a cwd walk (the divergence from `cogni-wiki:wiki-update`, which walks upward from the current directory).
+
+### 1. Resolve the knowledge root and read the binding
+
+1. Resolve `knowledge_root`:
+   - If `--knowledge-root` is set, use it.
+   - Otherwise, `knowledge_root = cogni-knowledge/<knowledge-slug>/` (relative to the current working directory).
+
+2. Read the binding:
+   ```bash
+   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py read \
+       --knowledge-root <knowledge_root>
+   ```
+   On `success: false`, abort and offer `knowledge-setup`. Do not auto-create.
+
+3. Extract from the binding: `knowledge_slug`, `knowledge_title`, `wiki_path`.
+
+4. Validate the binding's `knowledge_slug` matches `--knowledge-slug`. Mismatch → abort.
+
+### 2. Locate the page under the bound wiki
+
+Resolve `--page` to an actual file under `<wiki_path>/wiki/<type>/<slug>.md` (the cogni-wiki per-type page-dir convention — `concepts/`, `entities/`, `sources/`, `syntheses/`, `questions/`, `notes/`, …). Slugs are globally unique, so `Glob` `<wiki_path>/wiki/*/<slug>.md` resolves the type directory for you. If the slug does not resolve, attempt a title match against frontmatter `title:` fields across `<wiki_path>/wiki/**/*.md`. If still no match, stop and offer `knowledge-ingest-source`.
+
+### 3. Read the current page and the source
+
+- Read the full page text including frontmatter.
+- If `--reason new-source`, read the new source fully (URL or file).
+- If `--reason contradiction`, read the lint/contradiction finding that surfaced it AND the other page involved.
+
+### 4. Surface the proposed change BEFORE writing
+
+State in plain prose:
+
+1. **What is currently in the page** — quote the specific paragraph or claim being changed.
+2. **What the new claim is** — with the source that supports it.
+3. **What will be preserved** — the parts of the page that stay exactly as-is.
+4. **What will be deleted** — if anything is being removed, say so explicitly.
+5. **What the diff looks like** — show the before/after as a unified diff.
+
+Show this to the user. For autonomous runs, still emit the synthesis in the response but proceed without waiting for explicit confirmation.
+
+This is the **diff-before-write** discipline — the cogni-knowledge equivalent of `git diff` + manual inspection before commit.
+
+### 5. Apply the update via Edit
+
+Use the `Edit` tool (never `Write`) to preserve unchanged content byte-for-byte. For each planned change:
+
+- Replace the exact `old_string` with the new `new_string`.
+- Update the page's `updated:` frontmatter field to today's ISO date.
+- If the update adds a source, append it to the `sources:` list — never replace existing sources unless the old source is being explicitly retracted.
+- If the update changes the page `type`, say so in the diff and justify the retype.
+
+**Citation rule**: every new factual claim the update adds must link to a source — an inline source link or a `[[wikilink]]` to another page (which in turn cites a source). If the user cannot produce a source, the update stops. Unsourced claims erode the provenance chain that distinguishes this base from unverifiable notes.
+
+### 6. Sweep related pages (when `--related-sweep yes`)
+
+For every page that contains a `[[wikilink]]` to the page being updated, plus every page in the updated page's `related:` frontmatter, plus every page that shares ≥2 tags with it:
+
+1. Read the candidate page.
+2. Look for claims the update directly contradicts or renders stale.
+3. If found: either update the related page in the same session (through diff-before-write for each) or add a `## Stale (YYYY-MM-DD)` marker at the top of the candidate so the next `knowledge-lint` catches it.
+
+When the update adds, removes, or reshapes `[[wikilinks]]`, honour the forward → reverse link contract — every new forward `[[B]]` should be matched by a reverse `[[A]]` on B. The sweep is the primary path; `knowledge-lint`'s `reverse_link_missing` repair is the safety net. The locked reverse-link write can be applied via the vendored `backlink_audit.py --apply-plan` that `knowledge-ingest` already calls (the locking is internal to that script); keep this lightweight — never hand-edit `<wiki_path>/wiki/index.md` or another shared-state file directly.
+
+Never silently propagate contradictions. The sweep either resolves them or marks them.
+
+### 7. Handle special reasons
+
+- **`--reason retire`**: do not delete the page. Set `status: retired`, prepend a `## Retired (YYYY-MM-DD) — replaced by [[new-slug]]` note, and leave the body intact. Dangling `[[wikilinks]]` to retired pages still resolve, which is the point.
+- **`--reason retype`**: change `type:` and rewrite body structure to match the new type conventions. A `note` → `concept` promotion typically condenses loose observations into a structured definition. (Per the per-type page-dir convention, a retype that changes `type:` should also move the file to the matching `<wiki_path>/wiki/<new-type>/` directory.)
+
+### 8. Append to the log
+
+Append one line to `<wiki_path>/wiki/log.md` (append-only — never a read-modify-write):
+
+```
+## [{YYYY-MM-DD}] update | {slug} — {reason}
+```
+
+### 9. Do NOT bump entries_count
+
+An update is not a create. Leave `.cogni-knowledge`/`.cogni-wiki` counters untouched.
+
+### 10. Report to the user
+
+In ≤5 sentences: which page was updated and why, how many related pages were swept and how many were also modified, and the next recommended action (often `knowledge-lint` if this was a contradiction fix).
+
+## Golden rules
+
+1. **Diff before write, every time.** Show the change before applying it.
+2. **Citations required.** Every new claim links to a source.
+3. **No silent deletes.** Content removal is explicit and justified in the diff.
+4. **Retire, don't delete.** Obsolete pages get `status: retired`, not `rm`.
+5. **Sweep related pages.** A contradiction fixed in one place but not the other is a lie told twice.
+6. **Update, not Write.** Use `Edit` to preserve unchanged bytes — never rewrite a page in full unless the entire body is being replaced.
+
+## Out of scope
+
+- Does NOT dispatch `cogni-wiki:wiki-update` — the page is curated natively via the `Edit` tool.
+- Does NOT add a new source page — that is `knowledge-ingest-source`.
+- Does NOT run the lint/health passes — those are `knowledge-lint` / `knowledge-health`.
+- Does NOT bump `entries_count` or write the binding.
+
+## Output
+
+- One edited file under `<wiki_path>/wiki/<type>/` (the target page), possibly N more from the related sweep.
+- One appended line in `<wiki_path>/wiki/log.md`.
+
+## References
+
+- `${CLAUDE_PLUGIN_ROOT}/references/delegation-contract.md` — delegation boundary (the page is curated natively, not via `cogni-wiki:wiki-update`)
+- `${CLAUDE_PLUGIN_ROOT}/scripts/knowledge-binding.py --help` — binding read (wiki_path resolution)

--- a/cogni-knowledge/tests/test_prefill_contract.sh
+++ b/cogni-knowledge/tests/test_prefill_contract.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# test_prefill_contract.sh — grep-based contract assertions for the standalone
+# foundation-seeding surface: the knowledge-prefill skill.
+#
+# Per tests/README.md §"Contract tests": for pure LLM skills, regression
+# coverage is SKILL.md content invariants. These checks catch the most likely
+# failure mode — a path, flag, or step silently disappearing from the contract.
+# They do NOT assert LLM behaviour.
+#
+# Coverage:
+#   - knowledge-prefill: runs the vendored prefill_foundations.py (resolved
+#     vendored-first via resolve_wiki_scripts) against the bound wiki to seed
+#     foundation: true concept pages; exposes --filter / --list / --dry-run;
+#     reads the binding via knowledge-binding.py; documents the
+#     --skip-prefill-prompt opt-in rationale; does NOT dispatch
+#     cogni-wiki:wiki-prefill (vendored-native clean break).
+#
+# bash 3.2 + grep only.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+. "$(dirname "$0")/fixtures/test_helpers.sh"
+
+errors=0
+
+# --- knowledge-prefill SKILL.md ------------------------------------------
+SRC="$PLUGIN_ROOT/skills/knowledge-prefill/SKILL.md"
+if [ ! -f "$SRC" ]; then
+  red "FAIL: skills/knowledge-prefill/SKILL.md not found"
+  exit 1
+fi
+
+# Domain-prefixed generic name (the repo convention: 'prefill' must carry the
+# plugin's 'knowledge-' prefix) — the exact-name assert proves it.
+assert_grep 'name: knowledge-prefill' "$SRC" "knowledge-prefill: frontmatter name (domain-prefixed)"
+
+# Binding + wiki-root resolution.
+assert_grep 'knowledge-binding.py read' "$SRC" "knowledge-prefill: reads the binding via knowledge-binding.py"
+
+# Vendored-first engine resolution.
+assert_grep 'resolve_wiki_scripts' "$SRC" "knowledge-prefill: resolves the wiki-prefill script dir via the resolve_wiki_scripts probe"
+assert_grep 'scripts/vendor/cogni-wiki/skills/wiki-prefill/scripts' "$SRC" "knowledge-prefill: names the vendored-first wiki-prefill path"
+assert_grep '[Pp]robe.*cogni-wiki' "$SRC" "knowledge-prefill: keeps the cogni-wiki fallback probe"
+
+# Invokes the vendored prefill engine and exposes its CLI surface.
+assert_grep 'prefill_foundations.py' "$SRC" "knowledge-prefill: names the vendored prefill_foundations.py engine"
+assert_grep 'WIKI_PREFILL_SCRIPTS' "$SRC" "knowledge-prefill: wires resolve_wiki_scripts to the prefill_foundations.py invocation"
+assert_grep '\-\-filter' "$SRC" "knowledge-prefill: exposes the --filter set"
+assert_grep '\-\-list' "$SRC" "knowledge-prefill: exposes the --list mode"
+assert_grep '\-\-dry-run' "$SRC" "knowledge-prefill: exposes the --dry-run mode"
+
+# Documents the deliberate opt-in posture (knowledge-setup skips foundations).
+assert_grep 'skip.*prefill' "$SRC" "knowledge-prefill: documents the --skip-prefill-prompt opt-in rationale"
+
+# Clean break: the boundary is documented AND there is no concrete dispatch.
+assert_grep 'does not dispatch .cogni-wiki:wiki-prefill' "$SRC" "knowledge-prefill: documents the no-dispatch (vendored-native) boundary"
+assert_not_grep 'Skill("cogni-wiki:wiki-prefill' "$SRC" "knowledge-prefill: does NOT dispatch cogni-wiki:wiki-prefill (clean break)"
+assert_not_grep 'Skill: cogni-wiki:wiki-prefill' "$SRC" "knowledge-prefill: does NOT dispatch cogni-wiki:wiki-prefill (clean break, prose form)"
+
+if [ "$errors" -eq 0 ]; then
+  green "PASS: knowledge-prefill contract"
+else
+  red "FAIL: knowledge-prefill contract ($errors assertion(s))"
+fi
+exit "$errors"

--- a/cogni-knowledge/tests/test_update_contract.sh
+++ b/cogni-knowledge/tests/test_update_contract.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# test_update_contract.sh — grep-based contract assertions for the standalone
+# single-page curation surface: the knowledge-update skill.
+#
+# Per tests/README.md §"Contract tests": for pure LLM skills, regression
+# coverage is SKILL.md content invariants. These checks catch the most likely
+# failure mode — a path, flag, or step silently disappearing from the contract.
+# They do NOT assert LLM behaviour.
+#
+# Coverage:
+#   - knowledge-update: pure-LLM single-page curation (standalone analog of
+#     cogni-wiki:wiki-update), resolved against the bound wiki via the binding;
+#     Edit-driven (never Write) so unchanged bytes are preserved; enforces
+#     diff-before-write + per-claim citation discipline + the foundation guard;
+#     runs the related-sweep; handles the retire/retype reasons; reads the
+#     binding via knowledge-binding.py; does NOT dispatch cogni-wiki:wiki-update
+#     (clean break).
+#
+# bash 3.2 + grep only.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+. "$(dirname "$0")/fixtures/test_helpers.sh"
+
+errors=0
+
+# --- knowledge-update SKILL.md -------------------------------------------
+SRC="$PLUGIN_ROOT/skills/knowledge-update/SKILL.md"
+if [ ! -f "$SRC" ]; then
+  red "FAIL: skills/knowledge-update/SKILL.md not found"
+  exit 1
+fi
+
+# Domain-prefixed generic name (the repo convention: 'update' must carry the
+# plugin's 'knowledge-' prefix) — the exact-name assert proves it.
+assert_grep 'name: knowledge-update' "$SRC" "knowledge-update: frontmatter name (domain-prefixed)"
+
+# Edit + Write tools are required for the diff-before-write curation path.
+assert_grep 'allowed-tools:.*Edit' "$SRC" "knowledge-update: Edit in allowed-tools (diff-before-write, preserve bytes)"
+assert_grep 'allowed-tools:.*Write' "$SRC" "knowledge-update: Write in allowed-tools"
+
+# Binding + wiki-root resolution (vs cogni-wiki:wiki-update's cwd-walk).
+assert_grep 'knowledge-binding.py read' "$SRC" "knowledge-update: reads the binding via knowledge-binding.py"
+
+# Core curation discipline.
+assert_grep 'diff-before-write' "$SRC" "knowledge-update: documents the diff-before-write discipline"
+assert_grep 'Edit. tool' "$SRC" "knowledge-update: uses the Edit tool (not Write) to preserve unchanged bytes"
+assert_grep 'itation' "$SRC" "knowledge-update: states the citation discipline"
+assert_grep '\-\-reason' "$SRC" "knowledge-update: exposes the --reason parameter"
+assert_grep 'foundation: true' "$SRC" "knowledge-update: documents the foundation guard"
+assert_grep 'related.sweep' "$SRC" "knowledge-update: documents the related-sweep"
+
+# Clean break: the boundary is documented AND there is no concrete dispatch.
+assert_grep 'does not dispatch .cogni-wiki:wiki-update' "$SRC" "knowledge-update: documents the no-dispatch (native curation) boundary"
+assert_not_grep 'Skill("cogni-wiki:wiki-update' "$SRC" "knowledge-update: does NOT dispatch cogni-wiki:wiki-update (clean break)"
+assert_not_grep 'Skill: cogni-wiki:wiki-update' "$SRC" "knowledge-update: does NOT dispatch cogni-wiki:wiki-update (clean break, prose form)"
+
+if [ "$errors" -eq 0 ]; then
+  green "PASS: knowledge-update contract"
+else
+  red "FAIL: knowledge-update contract ($errors assertion(s))"
+fi
+exit "$errors"


### PR DESCRIPTION
Closes #534.

Adds the two remaining standalone Karpathy skills (increment 2 of the 4-item tracker; increment 1 — `knowledge-health` + `knowledge-lint` — already shipped via PR #545). Completing both closes the cogni-wiki archival parity item for manual curation + foundation seeding.

## Summary
- **`knowledge-update`** — manual single-page curation, the standalone analog of `cogni-wiki:wiki-update`. Pure-LLM, `Edit`-driven (never `Write`), no vendored engine. Reads the binding → `wiki_path`, resolves the page at `<wiki_path>/wiki/<type>/<slug>.md`, enforces diff-before-write + per-claim citation discipline + the `foundation: true` guard, runs the related-sweep, and handles the `retire`/`retype` special reasons. Does NOT dispatch `cogni-wiki:wiki-update`.
- **`knowledge-prefill`** — seeds canonical foundation pages by wrapping the vendored `prefill_foundations.py` (resolved vendored-first via `resolve_wiki_scripts`). Mirrors `knowledge-setup`'s `--skip-prefill-prompt` posture: setup deliberately suppresses generic foundations on a cogni-knowledge base, and this skill is the native opt-in so a standalone base can prefill later. Does NOT dispatch `cogni-wiki:wiki-prefill`.
- Two grep contract tests (`test_update_contract.sh`, `test_prefill_contract.sh`) guarding the frontmatter/flag/path invariants and the no-cogni-wiki-dispatch clean break.
- Plugin version bump `0.1.99 → 0.1.100`, mirrored in `marketplace.json`.

## Scope decisions
- **Full scope.** Both skills ship in one PR — independent, low-risk, well-templated ports (~2 SKILLs + 2 grep-only contract tests + 2 version-line edits). The vendored `prefill_foundations.py` + `foundations/` dir are present in-tree and resolve `FOUNDATIONS_DIR`/`CONFIG_BUMP_SCRIPT` correctly as-is (no `--foundations-dir` override needed). Slicing prefill into a third increment would leave #534 open on un-filed prose — the slice-and-close failure mode this avoids.
- **`knowledge-update` divergence from `wiki-update`:** reads the binding for `wiki_path` (vs `wiki-update`'s cwd-walk) and resolves the page under the per-type page-dir convention. No pre-flight engine probe (it owns no engine).
- **Deferred (non-gating):** the README components table drifts after adding two skills — a follow-up `cogni-docs:doc-generate` pass realigns the auto-section. Not part of #534's acceptance; kept out to hold this PR's blast radius tight.

## Test plan
- `bash cogni-knowledge/tests/test_update_contract.sh` — PASS (13 assertions).
- `bash cogni-knowledge/tests/test_prefill_contract.sh` — PASS (14 assertions).
- `bash cogni-knowledge/tests/test_skill_contracts.sh` — ALL PASS (no-dispatch boundary audit unchanged).
- `cogni-workspace/scripts/check-skill-names.sh` — OK (both domain-prefixed names accepted).
- `plugin.json` and the `marketplace.json` entry both read `0.1.100`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
