### PR TITLE
cogni-knowledge: first-class file:// citations + Python 3.9 manifest floor

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/_knowledge_lib.py
+++ b/cogni-knowledge/scripts/_knowledge_lib.py
@@ -297,25 +297,33 @@ def strip_inline_citation_markers(text: str) -> str:
     return _SUP_MARKER_RE.sub("", text)
 
 
-# The http(s) link target inside a numbered inline marker `<sup>[N](url)</sup>`.
-# Two shapes are emitted by the composer: a plain `(url)` and the angle-bracketed
-# `(<url>)` that `md_link_dest` produces when the URL itself contains `(`/`)`/
-# space. The alternation captures the bracketed form FIRST (so a URL legitimately
-# containing `)` — the exact reason `md_link_dest` brackets it — is not truncated
-# at that inner `)`); the unbracketed branch stops at the first `)`. A bare
+# The http(s)/file:// link target inside a numbered inline marker
+# `<sup>[N](url)</sup>`. Two shapes are emitted by the composer: a plain `(url)`
+# and the angle-bracketed `(<url>)` that `md_link_dest` produces when the URL
+# itself contains `(`/`)`/space. The alternation captures the bracketed form
+# FIRST (so a URL legitimately containing `)` — the exact reason `md_link_dest`
+# brackets it — is not truncated at that inner `)`); the unbracketed branch stops
+# at the first `)`. `file:` is a first-class scheme alongside `http(s)` so a local
+# source ingested via `knowledge-ingest-source --file` (provenance
+# `file://<abspath>`) is extracted, not silently dropped; both branches match on
+# `[^>]`/`[^)]`, so a `file://` path containing a literal space (e.g. a filename
+# with a space) is captured whole instead of truncating at the space. A bare
 # `<sup>[N]</sup>` marker (synthesis / distilled page, no external URL) has no
 # `(...)` and matches neither branch → it contributes no URL.
 _INLINE_CITATION_URL_RE = re.compile(
-    r"<sup>\[\d+\]\((?:<(https?://[^>]+)>|(https?://[^)]+?))\)</sup>"
+    r"<sup>\[\d+\]\((?:<((?:https?|file)://[^>]+)>|((?:https?|file)://[^)]+?))\)</sup>"
 )
 
 
 def extract_inline_citation_urls(text: str) -> list[str]:
-    """Every http(s) URL inside a `<sup>[N](url)</sup>` inline citation marker in
-    `text`, in appearance order (raw — the caller normalizes for comparison).
+    """Every http(s) or file:// URL inside a `<sup>[N](url)</sup>` inline citation
+    marker in `text`, in appearance order (raw — the caller normalizes for
+    comparison).
 
-    Handles both the plain `(url)` and the angle-bracketed `(<url>)` forms; a bare
-    `<sup>[N]</sup>` marker (no external URL) contributes nothing. Used by
+    Handles both the plain `(url)` and the angle-bracketed `(<url>)` forms, and
+    treats `file:` as first-class (a local-file source carries `file://<abspath>`
+    provenance, tolerated whole even when the path contains a literal space); a
+    bare `<sup>[N]</sup>` marker (no external URL) contributes nothing. Used by
     `citation-store.py build`'s `--ingest-manifest` gate (#383) to assert every
     inline URL is a known ingested-source URL, catching a slug-derived URL the
     composer reconstructed instead of copying the cited page's `sources:` value."""
@@ -325,12 +333,20 @@ def extract_inline_citation_urls(text: str) -> list[str]:
 
 
 def first_url(fm_value: str) -> str:
-    """First http(s) URL in a frontmatter `sources:` value, else "".
+    """First http(s) or file:// URL in a frontmatter `sources:` value, else "".
 
     A source page carries the inline-list shape `["<URL>"]`; a synthesis page
     carries a block-style `sources:` (its `wiki://…` entries live on indented
     lines that the top-level frontmatter parse never surfaces), so this returns
     "" for synthesis pages — correctly, they have no external URL.
+
+    `file:` is first-class: a local source ingested via
+    `knowledge-ingest-source --file` is stored honestly as `file://<abspath>`,
+    and the citation tooling that reads this (the source-ingester Phase-3
+    integrity check via `extract_page_id_and_url`, the `ingest-integrity.py`
+    sweep) must see the real URL, not "". A `file://` path may contain a literal
+    space, so the non-JSON fallback below does not stop at whitespace for the
+    `file:` scheme (it does for http(s), where a space never appears in a URL).
     """
     if not fm_value:
         return ""
@@ -338,17 +354,22 @@ def first_url(fm_value: str) -> str:
         parsed = json.loads(fm_value)
         if isinstance(parsed, list) and parsed and isinstance(parsed[0], str):
             parsed = parsed[0]
-        if isinstance(parsed, str) and parsed.startswith(("http://", "https://")):
-            return parsed
+        if isinstance(parsed, str) and parsed.startswith(
+            ("http://", "https://", "file://")
+        ):
+            return parsed.strip()
     except (ValueError, TypeError):
         pass
-    # Fallback only (non-JSON value). Strip trailing quotes and at most one
-    # leaked list-closer `]` — NOT a whole `]"'` charset, which would also eat a
-    # URL legitimately ending in `]`.
-    m = re.search(r"https?://\S+", fm_value)
+    # Fallback only (non-JSON value). http(s) URLs never contain a space, so
+    # `\S+` is right for them; a `file://` path can, so match the rest of the
+    # value (sans a leaked closing quote / list-closer) and rstrip trailing
+    # whitespace. Strip trailing quotes and at most one leaked list-closer `]` —
+    # NOT a whole `]"'` charset, which would also eat a URL legitimately ending
+    # in `]`.
+    m = re.search(r"https?://\S+|file://[^\"'\]]+", fm_value)
     if not m:
         return ""
-    url = m.group(0).rstrip("\"'")
+    url = m.group(0).rstrip().rstrip("\"'").rstrip()
     return url[:-1] if url.endswith("]") else url
 
 

--- a/cogni-knowledge/scripts/wiki-source-manifest.py
+++ b/cogni-knowledge/scripts/wiki-source-manifest.py
@@ -20,6 +20,13 @@ to this plan — the caller surfaces that as "narrow the plan or ingest more".
 Stdlib only; JSON envelope output per the insight-wave convention.
 """
 
+# Defer annotation evaluation so PEP 604 `X | None` annotations (e.g. `_emit`'s
+# `data: dict | None`) are stored as strings rather than evaluated at def-time —
+# keeps the module importable on the Python 3.9 toolchain floor the rest of
+# cogni-knowledge targets (3.9 lacks runtime `type | None`). `_knowledge_lib.py`
+# already carries this import for the same reason.
+from __future__ import annotations
+
 import argparse
 import importlib.util
 import json

--- a/cogni-knowledge/tests/test_knowledge_lib.sh
+++ b/cogni-knowledge/tests/test_knowledge_lib.sh
@@ -170,6 +170,47 @@ def assert_first_url():
     # Block-style / empty / non-URL → "".
     assert kl.first_url("") == ""
     assert kl.first_url("wiki://src-a") == ""
+    # file:// is first-class (a local source ingested via --file is stored as
+    # file://<abspath>); first_url must return it, not "".
+    assert kl.first_url('["file:///abs/path/report.pdf"]') == \
+        "file:///abs/path/report.pdf", kl.first_url('["file:///abs/path/report.pdf"]')
+    # A file:// path with a literal space is captured WHOLE — not truncated at
+    # the space the way a `\\S+` match would (defect 2 of the local-file path).
+    got = kl.first_url('["file:///abs/V8_MI_Data_ Sovereign_.pdf"]')
+    assert got == "file:///abs/V8_MI_Data_ Sovereign_.pdf", got
+    # Non-JSON fallback for a file:// value with a space: rest-of-value match,
+    # trailing whitespace/quote stripped, space inside the path preserved.
+    got_fb = kl.first_url('file:///abs/V8 Data.pdf')
+    assert got_fb == "file:///abs/V8 Data.pdf", got_fb
+
+
+def assert_extract_inline_citation_urls():
+    # http(s) markers extract in appearance order (the established behavior).
+    text = 'A<sup>[1](https://a.org/x)</sup>. B<sup>[2](https://b.org/y)</sup>.'
+    assert kl.extract_inline_citation_urls(text) == \
+        ["https://a.org/x", "https://b.org/y"]
+    # file:// is first-class: a local-source citation is extracted, not dropped.
+    f = 'C<sup>[3](file:///abs/p.pdf)</sup>.'
+    assert kl.extract_inline_citation_urls(f) == ["file:///abs/p.pdf"], \
+        kl.extract_inline_citation_urls(f)
+    # A file:// URL with a literal space is captured whole (unbracketed branch
+    # matches on [^)], so the space does not truncate it).
+    fs = 'D<sup>[4](file:///abs/V8 Data.pdf)</sup>.'
+    assert kl.extract_inline_citation_urls(fs) == ["file:///abs/V8 Data.pdf"], \
+        kl.extract_inline_citation_urls(fs)
+    # Angle-bracketed file:// form (md_link_dest brackets a dest with a space).
+    fb = 'E<sup>[5](<file:///abs/V8 Data.pdf>)</sup>.'
+    assert kl.extract_inline_citation_urls(fb) == ["file:///abs/V8 Data.pdf"], \
+        kl.extract_inline_citation_urls(fb)
+    # A sentence mixing a file:// and an http citation yields BOTH, in order
+    # (the regression that broke citation-store build with url_slug_mismatch).
+    mixed = 'F<sup>[6](file:///abs/p.pdf)</sup> and<sup>[7](https://w.org/z)</sup>.'
+    assert kl.extract_inline_citation_urls(mixed) == \
+        ["file:///abs/p.pdf", "https://w.org/z"], \
+        kl.extract_inline_citation_urls(mixed)
+    # A bare marker (no URL) and empty text contribute nothing.
+    assert kl.extract_inline_citation_urls('G<sup>[8]</sup>.') == []
+    assert kl.extract_inline_citation_urls("") == []
 
 
 def assert_md_link_dest():
@@ -974,6 +1015,7 @@ check("atomic_write_roundtrip", assert_atomic_write_roundtrip)
 check("slugify", assert_slugify)
 check("ref_heading", assert_ref_heading)
 check("first_url", assert_first_url)
+check("extract_inline_citation_urls", assert_extract_inline_citation_urls)
 check("md_link_dest", assert_md_link_dest)
 check("strip_reference_section", assert_strip_reference_section)
 check("body_word_count", assert_body_word_count)
@@ -1008,7 +1050,8 @@ grade canonicalization        "canonicalization — scheme/host lowercased, trai
 grade atomic_write_roundtrip  "atomic_write round-trips payload and leaves no .tmp debris"
 grade slugify                 "slugify — German umlaut transliteration (für→fuer), NFKD de-accent, empty/non-alnum→'' contract, max-len truncation"
 grade ref_heading             "ref_heading — localized reference heading (de→Referenzen), default/unknown→References"
-grade first_url               "first_url — JSON-list + non-JSON fallback URL extraction, no charset over-strip"
+grade first_url               "first_url — JSON-list + non-JSON fallback URL extraction, no charset over-strip, file:// first-class incl. space-in-path (#572)"
+grade extract_inline_citation_urls "extract_inline_citation_urls — http(s) + file:// markers (bracketed/unbracketed), space-in-file:// captured whole, mixed file+http in one sentence yields both, bare/empty→[] (#572)"
 grade md_link_dest            "md_link_dest — angle-brackets a destination containing parens/space (paren-URL citation links)"
 grade strip_reference_section "strip_reference_section — language-independent strip, #301 first-line match, synonym safety-net, preserves a non-reference bullet section"
 grade body_word_count         "body_word_count — body words excl. reference list (EN + DE), no-ref-section counts whole draft, None lang→English (#456 one canonical surface for compose Step 5.5 + wiki-reviewer)"


### PR DESCRIPTION
Refs #572.

Addresses three of the four defects in the local-file (`file://`) ingest + citation path reported in #572. The fourth (synthesis-impact same-day refresh detection) is a content-keying redesign that overlaps feature #571 and is deferred — see Scope decisions.

## Summary
- **Defect 1 — `file://` is first-class in citation tooling.** `_knowledge_lib.first_url` now returns a `file:` URL (not `""`), and `extract_inline_citation_urls` / `_INLINE_CITATION_URL_RE` now match a `file:` inline marker alongside `http(s)`. This unblocks `citation-store.py build` (no more `url_slug_mismatch` when a sentence mixes a `file://` citation with an `http` one) and fixes the third leg transitively: `extract_page_id_and_url` (the source-ingester Phase-3 integrity check + the `ingest-integrity.py` sweep) reads the page URL via `first_url`, so it stops returning empty for a `file://` source — no agent `.md` change needed.
- **Defect 2 — spaces in a local filename no longer truncate the citation URL.** Both inline-citation branches match on `[^>]`/`[^)]` (already space-tolerant), and `first_url`'s non-JSON fallback no longer stops at whitespace for the `file:` scheme, so a `file://…/V8_MI_Data_ Sovereign_…pdf` provenance URL is captured whole instead of truncating at the space.
- **Defect 3 — `wiki-source-manifest.py` runs on the Python 3.9 toolchain floor.** Added `from __future__ import annotations` so the `dict | None` annotation on `_emit` (line 131) is a deferred string, matching the effective 3.9 floor the rest of the toolchain already targets (`_knowledge_lib.py` already carries this import).
- Bumps `cogni-knowledge` to **0.1.103** in `plugin.json` + `marketplace.json` per repo convention.

## Scope decisions
- **In:** defects 1, 2, 3 — one coherent "file:// citation correctness + 3.9 floor hardening" change, confined to `_knowledge_lib.py` and `wiki-source-manifest.py` plus their unit tests.
- **Out (deferred, `Refs` not `Closes`):** defect 4 — `synthesis-impact.py` missing a same-day refresh (`synthesis-impact.py:199` gates on `new_created > updated`). The fix keys impact detection on provenance/sub-question coverage rather than a date comparison and overlaps feature #571's "first-class refresh synthesis from new source" path; landing it here would entangle two designs. It stays tracked on this (partial) issue, cross-linked to #571 — not silently dropped.

## Test plan
- [x] `bash cogni-knowledge/tests/test_knowledge_lib.sh` passes, including new `first_url` (file:// + space) and `extract_inline_citation_urls` cases (file:// bracketed/unbracketed, space captured whole, mixed file+http → both).
- [x] `bash cogni-knowledge/tests/test_citation_store.sh`, `test_wiki_source_manifest.sh`, `test_ingest_integrity.sh` pass (regressions).
- [x] `wiki-source-manifest.py` imports + `--help` runs (def-time `dict | None` no longer evaluated).
- [x] `plugin.json` and `marketplace.json` both read `0.1.103`.
