### PR TITLE
cogni-help: fix cogni-issues Step 8 local-logging (gen-id JSON envelope)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -152,7 +152,7 @@
     {
       "name": "cogni-help",
       "source": "./cogni-help",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "maturity": "incubating",
       "description": "Central help hub for the insight-wave ecosystem. Interactive courses (workflow-tour curriculum), plugin discovery, cross-plugin workflow guides, troubleshooting, quick-reference cheatsheets, and GitHub issue filing.",
       "keywords": [

--- a/cogni-help/.claude-plugin/plugin.json
+++ b/cogni-help/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-help",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Central help hub for the insight-wave ecosystem. Interactive courses (workflow-tour curriculum), plugin discovery, cross-plugin workflow guides, troubleshooting, quick-reference cheatsheets, and GitHub issue filing.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-help/skills/cogni-issues/SKILL.md
+++ b/cogni-help/skills/cogni-issues/SKILL.md
@@ -319,22 +319,41 @@ JSON error to the user and stop — never retry blindly. Common errors:
 
 ### 8. Log locally
 
+`gen-id` returns a JSON envelope — `{"id":"issue-<uuid>"}` — like every script in
+the ecosystem. **Extract the bare id** before building the record; inlining the raw
+envelope where the `id` *string* belongs produces invalid JSON and `add` aborts with
+a `JSONDecodeError`.
+
 ```bash
-ID_JSON=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/cogni-issues/scripts/issue-store.sh" gen-id)
+ID=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/cogni-issues/scripts/issue-store.sh" gen-id \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
 ```
 
-Then pipe the issue record as JSON via stdin:
+Then build the record as a single well-formed JSON object (substituting the captured
+`$ID` and the values from earlier steps) and pipe it via stdin:
 
 ```bash
-echo '<json_record>' | bash "${CLAUDE_PLUGIN_ROOT}/skills/cogni-issues/scripts/issue-store.sh" \
+cat <<JSON | bash "${CLAUDE_PLUGIN_ROOT}/skills/cogni-issues/scripts/issue-store.sh" \
   add "${working_dir}"
+{
+  "id": "${ID}",
+  "plugin": "${plugin}",
+  "marketplace": "${marketplace}",
+  "repository": "${repository}",
+  "github_number": ${github_number},
+  "github_url": "${github_url}",
+  "type": "${type}",
+  "title": "${title}",
+  "status": "open",
+  "created_at": "${now}",
+  "updated_at": "${now}"
+}
+JSON
 ```
-
-The record includes: `id`, `plugin`, `marketplace`, `repository`, `github_number`,
-`github_url`, `type`, `title`, `status` ("open"), `created_at`, `updated_at`.
 
 `github_number` and `github_url` come straight from the helper's create response — no
-URL parsing required.
+URL parsing required. `github_number` is the bare integer (unquoted); every other
+field is a JSON string.
 
 ### 9. Confirm
 


### PR DESCRIPTION
Closes #574.

## Summary
- Rewrite cogni-issues Step 8 ("Log locally") to extract the bare id from `gen-id`'s JSON envelope (`ID=$(... gen-id | python3 -c 'import json,sys;print(json.load(sys.stdin)["id"])')`) instead of capturing the raw `{"id":...}` object.
- Replace the vague `<json_record>` placeholder with a concrete, well-formed JSON record that interpolates `$ID`, so the JSON envelope can't be inlined into the `id` field and produce invalid JSON.
- Leave `issue-store.sh gen-id` unchanged — its JSON-envelope output is the contract per the repo-wide "all scripts return JSON" convention.
- Bump cogni-help `0.0.7 → 0.0.8` in plugin.json and mirror in marketplace.json (stays Incubating / 0.0.x per the cogni-help maturity override).

## Scope decisions
- **In:** SKILL.md Step 8 fix + version bumps. Fully resolves the acceptance criterion (logged record is well-formed and the issue lands in the local store).
- **Out / unchanged:** `issue-store.sh gen-id` — option (a) from the issue (bare-id stdout) was rejected because it would violate the cross-plugin JSON convention; option (b) (SKILL-side `.id` extraction) is the convention-respecting fix. gen-id's sole caller is this Step 8.
- **Deferred:** nothing.

## Test plan (verified)
- [x] `gen-id` still emits `{"id":"issue-<uuid>"}` (unchanged contract).
- [x] The revised Step 8 flow, run verbatim against an initialized store, exits 0 with no `JSONDecodeError` → `{"status":"added","total":1}`.
- [x] `read` shows the new record with a well-formed bare `id`.
- [x] plugin.json and marketplace.json both read `0.0.8` for cogni-help.

## Automated review
Plan record: https://github.com/cogni-work/insight-wave/issues/574#issuecomment-4652009573
