### PR TITLE
cogni-knowledge: standalone knowledge-distill leaves a clean base (bounded de-orphan gate)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.107",
+      "version": "0.1.108",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.107",
+  "version": "0.1.108",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/skills/knowledge-distill/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-distill/SKILL.md
@@ -502,7 +502,27 @@ After the loop, bump `entries_count` once by the count of newly-indexed pages (o
 python3 "$WIKI_INGEST_SCRIPTS/config_bump.py" --wiki-root "$WIKI_ROOT" --key entries_count --delta <n_new>
 ```
 
-Non-fatal on failure (reconcile via `wiki-lint --fix=entries_count_drift`). **Do NOT** run `lint_wiki.py --fix=all` / `health.py` here — `knowledge-finalize` Step 10.5 runs the whole-run conformance gate once, at the end, over the page set that now includes these distilled pages.
+Non-fatal on failure (reconcile via `wiki-lint --fix=entries_count_drift`). **Do NOT** run the *full* `lint_wiki.py --fix=all` / `health.py` conformance gate here — that stays in `knowledge-finalize` Step 10.5, which runs it once, at the end, over the page set that now includes these distilled pages. The **bounded** `--fix=reverse_link_missing` de-orphan gate in Step 7.2 below is the deliberate exception.
+
+### 7.2 Bounded de-orphan gate (reverse_link_missing)
+
+The distilled pages just written carry forward `[[<source-slug>]]` edges (concept→source) in their `## Sources` block, but the source pages do not yet hold the reverse `[[<concept-slug>]]` link — so a **standalone** distill (run later on an already-finalized base, with no `knowledge-compose` → `knowledge-finalize` to follow) would leave every page this phase wrote as an `orphan_page` with a `reverse_link_missing` gap until some future finalize that may never come. `knowledge-ingest` does not have this problem because it de-orphans its own pages inline (Steps 4.1 / 4.5.2); distill mirrors that posture here with a **bounded, idempotent** gate — not the whole-run conformance gate, only the one load-bearing reverse-link backfill.
+
+Resolve the cogni-wiki `wiki-lint` scripts dir with the SAME `resolve_wiki_scripts` helper used at the top of this skill — **fail-soft**: on a miss, warn and continue (the base self-heals on the next `knowledge-finalize` / `knowledge-lint`), exactly as the `wiki-ingest` resolution does:
+
+```
+WIKI_LINT_SCRIPTS=$(resolve_wiki_scripts wiki-lint lint_wiki.py) || { echo "⚠ cogni-wiki wiki-lint scripts not found — skipping the bounded de-orphan gate (run knowledge-finalize or knowledge-lint to reconcile)"; WIKI_LINT_SCRIPTS=""; }
+```
+
+When resolved, run the single bounded fix class. It mirrors every distilled page's `## Sources` `[[<source-slug>]]` edge back onto the source (and onto any cited `wiki/questions/<slug>.md` node), giving each page this phase wrote an inbound link. It is idempotent — a no-op on an already-clean base — and writes nothing else (`--fix=all`'s other four classes stay in finalize):
+
+```
+[ -n "$WIKI_LINT_SCRIPTS" ] && python3 "$WIKI_LINT_SCRIPTS/lint_wiki.py" \
+    --wiki-root "$WIKI_ROOT" \
+    --fix=reverse_link_missing
+```
+
+Capture the envelope; surface `data.fixed[]` / `data.failed[]` counts in the Step 9 summary. **Non-fatal per item** — a per-page fix failure lands in `data.failed[]` and never blocks the phase. (`orphan_page` is a lint warning, not a `--fix` class; 0 orphans comes from the inbound links this reverse-link backfill writes, never from `--fix` directly.)
 
 ### 8. Append wiki/log.md
 
@@ -535,6 +555,7 @@ Print ≤ 12 lines:
   - Subline: `If these are the same concept, the run forked a near-duplicate page; rename the proposal in the next run, or merge manually via the wiki.`
   - When `near_existing_total == 0` print nothing (no false-alarm noise on clean runs).
 - Wiki entries_count: `+<n_new>` (or `⚠ bump failed — run wiki-lint --fix=entries_count_drift`; or `unchanged` when `n_new == 0`)
+- Reverse-link backfill (Step 7.2): `<n_fixed>` link(s) added (`<n_failed>` failed) — or `0 (already clean)` / `skipped (wiki-lint scripts not found)` when the bounded de-orphan gate found nothing to do or could not resolve its scripts dir
 - Cost: `$X.XXX` (from the distiller return)
 - Next: `knowledge-compose` reads the distilled pages (concept/entity/summary/learning) as framing context (not citable evidence).
 
@@ -561,7 +582,7 @@ The title→slug tripwire is **pure observability** — it never blocks the pipe
 - Re-narrates the `## Summary` body of **updated** distilled pages (any of the four types) from the merged claims (Step 6.7, default-on, fail-soft; `--no-renarrate` opts out). `created` pages keep the distiller's fresh summary; pure re-runs touch nothing. It does NOT re-synthesize any other block, and it does NOT add a contradiction pass.
 - Merges **cross-lingual (DE↔EN) twin claims** on a mixed-language base (Step 6.6, default-on, fail-soft, auto-skip; `--no-crosslingual` opts out). An LLM only **confirms** pairs the script flagged (shared article-number anchor + low overlap); `concept-store.py crossmerge` re-validates the gate and UNIONs provenance onto the survivor — **never dropping a fact**. It does NOT touch single-language dedup (Step 6's job), and it explicitly does NOT use embedding/vector similarity (approach (c), rejected by the differentiation thesis).
 - Emits four page types — `concept` / `entity` plus, conservatively, the cross-source `summary` and run-level `learning`; the distiller defaults to `concept`/`entity` and reaches for the new types only when a cluster fits neither. It does NOT emit any other cogni-wiki page type (sources are Phase 4, syntheses are Phase 7).
-- Does NOT run the `lint_wiki.py --fix=all` / `health.py` conformance gate — `knowledge-finalize` Step 10.5 covers the whole run once.
+- Does NOT run the **full** `lint_wiki.py --fix=all` / `health.py` whole-run conformance gate — `knowledge-finalize` Step 10.5 covers the whole run once. It DOES run a **bounded** `--fix=reverse_link_missing` de-orphan gate inline (Step 7.2) so a standalone distill leaves the base structurally clean (0 orphans, 0 reverse-link gaps), mirroring `knowledge-ingest`'s inline posture.
 - Does NOT modify `binding.json` — Phase 7 (`knowledge-finalize`) appends the project entry.
 - Does NOT block the pipeline — every failure path warns and exits cleanly.
 

--- a/cogni-knowledge/skills/knowledge-distill/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-distill/SKILL.md
@@ -504,7 +504,7 @@ python3 "$WIKI_INGEST_SCRIPTS/config_bump.py" --wiki-root "$WIKI_ROOT" --key ent
 
 Non-fatal on failure (reconcile via `wiki-lint --fix=entries_count_drift`). **Do NOT** run the *full* `lint_wiki.py --fix=all` / `health.py` conformance gate here — that stays in `knowledge-finalize` Step 10.5, which runs it once, at the end, over the page set that now includes these distilled pages. The **bounded** `--fix=reverse_link_missing` de-orphan gate in Step 7.2 below is the deliberate exception.
 
-### 7.2 Bounded de-orphan gate (reverse_link_missing)
+### 7.2. Bounded de-orphan gate (reverse_link_missing)
 
 The distilled pages just written carry forward `[[<source-slug>]]` edges (concept→source) in their `## Sources` block, but the source pages do not yet hold the reverse `[[<concept-slug>]]` link — so a **standalone** distill (run later on an already-finalized base, with no `knowledge-compose` → `knowledge-finalize` to follow) would leave every page this phase wrote as an `orphan_page` with a `reverse_link_missing` gap until some future finalize that may never come. `knowledge-ingest` does not have this problem because it de-orphans its own pages inline (Steps 4.1 / 4.5.2); distill mirrors that posture here with a **bounded, idempotent** gate — not the whole-run conformance gate, only the one load-bearing reverse-link backfill.
 

--- a/cogni-knowledge/tests/test_distill_contract.sh
+++ b/cogni-knowledge/tests/test_distill_contract.sh
@@ -53,8 +53,10 @@ assert_grep 'near_existing_total' "$SKILL" "knowledge-distill: reads near_existi
 assert_grep 'near_existing_slugs' "$SKILL" "knowledge-distill: reads near_existing_slugs[] from merge output (#340)"
 assert_grep 'concepts created near an existing slug' "$SKILL" "knowledge-distill: Step 9 surfaces the title→slug tripwire warning"
 assert_grep 'observability' "$SKILL" "knowledge-distill: documents the tripwire as pure observability (no auto-merge)"
-# Must NOT run the conformance gate (finalize Step 10.5 owns it once).
-assert_not_grep 'health.py asserts' "$SKILL" "knowledge-distill: does NOT run the conformance gate itself"
+# Must NOT run the FULL conformance gate (finalize Step 10.5 owns --fix=all + health.py once).
+assert_not_grep 'health.py asserts' "$SKILL" "knowledge-distill: does NOT run the full conformance gate itself"
+# DOES run the bounded reverse_link_missing de-orphan gate inline so a standalone distill leaves a clean base.
+assert_grep 'fix=reverse_link_missing' "$SKILL" "knowledge-distill: runs the bounded reverse_link_missing de-orphan gate inline (Step 7.2)"
 assert_grep 'Task' "$SKILL" "knowledge-distill: Task in allowed-tools"
 # #341 Step 6.7 — re-narrate the ## Summary of updated pages from merged claims.
 assert_grep 'Task(concept-summary-narrator' "$SKILL" "knowledge-distill: dispatches concept-summary-narrator via Task (#341)"


### PR DESCRIPTION
Closes #599.

## Summary
- `knowledge-distill` Step 7 now runs a bounded, idempotent de-orphan gate (new Step 7.2) after `config_bump.py`: it fail-soft resolves the cogni-wiki `wiki-lint` scripts dir (`resolve_wiki_scripts wiki-lint lint_wiki.py`, warn-and-continue on miss, same posture as the existing `wiki-ingest` resolution) and runs `lint_wiki.py --wiki-root "$WIKI_ROOT" --fix=reverse_link_missing` (a valid idempotent FIX_CLASS, no-op when clean).
- This mirrors `knowledge-ingest`'s inline de-orphan posture (Steps 4.1 / 4.5.2) so a **standalone** `knowledge-distill` on an already-finalized base leaves the base structurally clean (0 orphans, 0 reverse-link gaps) instead of relying on a `knowledge-finalize` that never follows.
- The full `lint_wiki.py --fix=all` + `health.py` whole-run conformance gate stays in `knowledge-finalize` Step 10.5 — unchanged.
- Step 9 summary surfaces the new gate's fixed/failed counts.
- `test_distill_contract.sh` keeps asserting the full conformance gate is absent from distill, and adds an assertion that the bounded `--fix=reverse_link_missing` gate IS present.
- Version bumped 0.1.107 → 0.1.108 in `plugin.json` + mirrored in `marketplace.json`.

## Test plan
- [x] `bash cogni-knowledge/tests/test_distill_contract.sh` passes (new present-assertion + retained full-gate-absent assertion).
- [x] `test_skill_contracts.sh`, `test_finalize_contract.sh`, `test_ingest_contract.sh` pass (no regression).
- [x] `plugin.json` is 0.1.108 and `marketplace.json` mirrors it.
- [ ] Confirm `knowledge-finalize` Step 10.5 unchanged (still owns `--fix=all` + `health.py`).

## Scope decisions
- In scope: the bounded reverse_link_missing gate in distill, the narrowed Step 7 + Out-of-scope notes, the contract-test update, the version bump. Full scope — nothing deferred.
- Out of scope by design: the full `--fix=all` + `health.py` gate stays in finalize (the issue explicitly asks to keep it there).
- Per repo conventions, SKILL.md carries no issue/PR refs — the rationale is stated semantically.

## Review notes
- _Pre-existing (not introduced by this change):_ the `knowledge-distill` SKILL.md body is ~611 lines, over skill-creator's 500-line soft cap. The mechanism-detail prose for the existing Steps 6 / 6.6 / 6.7 / 6.9 could move to a `references/` file to bring the body under the cap. A soft cap on a heavily procedural multi-phase orchestrator whose inline scripts are load-bearing; flagged for a future cleanup, out of scope for this bug fix.
