### PR TITLE
cogni-knowledge: knowledge-distill sources the shared wiki-scripts helper

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.110",
+      "version": "0.1.111",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.110",
+  "version": "0.1.111",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/skills/knowledge-distill/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-distill/SKILL.md
@@ -59,6 +59,7 @@ If `WIKI_OK=no`, warn and exit cleanly (distill is optional — do not block the
 **Resolve the cogni-wiki script dir.** Use the SAME `resolve_wiki_scripts` helper `knowledge-ingest` / `knowledge-finalize` use (shared byte-for-byte) — it picks the newest numeric version dir. `concept-store.py merge` needs this dir for `_wiki_lock` / `is_foundation_page` / `parse_frontmatter`, and Step 6 needs `backlink_audit.py` / `wiki_index_update.py` / `config_bump.py`:
 
 ```
+. "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-wiki-scripts.sh"
 WIKI_INGEST_SCRIPTS=$(resolve_wiki_scripts wiki-ingest backlink_audit.py) || { echo "⚠ cogni-wiki wiki-ingest scripts not found — skipping distill (optional)"; exit 0; }
 ```
 
@@ -511,6 +512,7 @@ The distilled pages just written carry forward `[[<source-slug>]]` edges (concep
 Resolve the cogni-wiki `wiki-lint` scripts dir with the SAME `resolve_wiki_scripts` helper used at the top of this skill — **fail-soft**: on a miss, warn and continue (the base self-heals on the next `knowledge-finalize` / `knowledge-lint`), exactly as the `wiki-ingest` resolution does:
 
 ```
+. "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-wiki-scripts.sh"
 WIKI_LINT_SCRIPTS=$(resolve_wiki_scripts wiki-lint lint_wiki.py) || { echo "⚠ cogni-wiki wiki-lint scripts not found — skipping the bounded de-orphan gate (run knowledge-finalize or knowledge-lint to reconcile)"; WIKI_LINT_SCRIPTS=""; }
 ```
 


### PR DESCRIPTION
Closes #553.

## Summary
- Add `. "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-wiki-scripts.sh"` inside the line-62 Bash block (the optional-skip distill gate) so `resolve_wiki_scripts wiki-ingest backlink_audit.py` resolves instead of exiting 127.
- Add the same source line inside the line-514 Bash block (the bounded de-orphan gate) so `resolve_wiki_scripts wiki-lint lint_wiki.py` resolves — each fenced block is a separate shell, so a source in the first block does not persist to the second.
- Patch-bump `cogni-knowledge` 0.1.110 → 0.1.111 in `.claude-plugin/plugin.json` and mirror it in the root `marketplace.json` entry.

## Root cause
`knowledge-distill/SKILL.md` called `resolve_wiki_scripts` in two fenced Bash blocks but, unlike `knowledge-ingest` / `knowledge-finalize`, never sourced `resolve-wiki-scripts.sh` first. Each fenced block executes as its own shell, so the helper was undefined → the line-62 command substitution exited 127 → the `|| { … exit 0; }` fail-soft fired and standalone distill silently skipped its entire wiki-write path. The line-514 de-orphan gate was likewise dead.

## Scope decisions
- **In:** the two `knowledge-distill/SKILL.md` Bash blocks (62, 514) + the mandatory version bump. The pattern now matches `knowledge-ingest` / `knowledge-finalize` byte-for-byte.
- **Out:** nothing. The shared helper already exists at `cogni-knowledge/scripts/resolve-wiki-scripts.sh`, so no script change is needed. Full scope — nothing deferred.

## Test plan
- [x] `grep -c 'resolve-wiki-scripts.sh' cogni-knowledge/skills/knowledge-distill/SKILL.md` → 2 (one per fenced block).
- [x] `tests/test_distill_contract.sh` — all pass.
- [x] `tests/test_skill_contracts.sh` — ALL PASS.
- [x] `scripts/check-breadcrumbs.py` — clean (exit 0, no new breadcrumbs).
- [x] `plugin.json` + `marketplace.json` both read `0.1.111`.

## Review notes
- **Pre-existing whole-skill drift (not introduced by this change):** the `knowledge-distill/SKILL.md` body runs ~613 lines, over skill-creator's 500-line soft cap. The skill-quality-reviewer flagged this as `introduced_by_change: false` — the per-step merge-engine envelope contracts could move to `references/inverted-pipeline.md` (already cited) to slim the body. Out of scope for this surgical bug-fix; noted for a future refactor.
