### PR TITLE
cogni-claims: record knowledge-refresh --resweep as a conditional caller

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-claims",
       "source": "./cogni-claims",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "maturity": "preview",
       "description": "Claim verification and management system. Verifies sourced claims against cited URLs, detects deviations, guides users through resolution, and provides interactive cobrowsing recovery for unreachable sources.",
       "keywords": [

--- a/cogni-claims/.claude-plugin/plugin.json
+++ b/cogni-claims/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-claims",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Claim verification and management system. Verifies sourced claims against cited URLs, detects deviations, guides users through resolution, and provides interactive cobrowsing recovery for unreachable sources.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-claims/CLAUDE.md
+++ b/cogni-claims/CLAUDE.md
@@ -89,7 +89,7 @@ Initialized by `claims-store.sh init` (idempotent).
 
 Claims are submitted via `cogni-claims:claims` skill in submit mode. The `claim-entity` skill defines the shared data contract any submitting plugin must follow.
 
-> **Lost caller (cogni-knowledge, v0.1.0).** cogni-knowledge does **not** submit to cogni-claims. Its v0.1.0 inverted pipeline runs a local zero-network `knowledge-verify` (the `wiki-verifier` agent) against pre-extracted source claims instead, per its clean-break design. cogni-claims stays the verification path for the cogni-trends / cogni-portfolio / cogni-research / cogni-consulting submitters above.
+> **Conditional caller (cogni-knowledge).** cogni-knowledge's default per-run inverted pipeline does **not** submit to cogni-claims — it runs a local zero-network `knowledge-verify` (the `wiki-verifier` agent) against pre-extracted source claims instead, per its clean-break design (the per-run zero-network invariant). The exception is the **opt-in** `knowledge-refresh --resweep` path: it re-verifies the bound wiki's cited claims against their live source URLs by dispatching `cogni-claims:claims submit/verify`, making cogni-knowledge an upstream submitter on that path only. So cogni-claims remains the verification path for the cogni-trends / cogni-portfolio / cogni-research / cogni-consulting submitters above, plus cogni-knowledge whenever a maintainer runs the resweep.
 
 ## Pipeline Position
 


### PR DESCRIPTION
Closes #559.

## Summary
Rewrites the "Lost caller (cogni-knowledge)" callout in `cogni-claims/CLAUDE.md` (now "Conditional caller") so it records the dual reality: cogni-knowledge's default per-run inverted pipeline stays zero-network and does **not** submit, but the opt-in `knowledge-refresh --resweep` path dispatches `cogni-claims:claims submit/verify` to re-check cited claims against live sources — so cogni-knowledge is an upstream submitter on that path. Patch-bumps cogni-claims 0.10.2 → 0.10.3 (plugin.json + marketplace.json).

## Root cause
The callout flatly stated "cogni-knowledge does **not** submit to cogni-claims." Since the `knowledge-refresh --resweep` live-source re-check shipped (native re-home), that blanket statement is inaccurate.

## Scope
- **In:** the one-paragraph callout edit + the mandatory version bump. Full scope — nothing deferred.
- **Out:** no behavioral/code change; this is a cross-plugin relationship-doc accuracy fix.

## Test plan
- [x] `scripts/check-breadcrumbs.py` — clean (the edit also drops the stale `v0.1.0` version tag from the callout heading).
- [x] Diff confined to 3 files (CLAUDE.md + both manifests).
- [x] cogni-claims version reads 0.10.3 in plugin.json and marketplace.json.
