### PR TITLE
cogni-workspace: optional-Python-dep venv provisioning layer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,7 +78,7 @@
     {
       "name": "cogni-workspace",
       "source": "./cogni-workspace",
-      "version": "0.6.32",
+      "version": "0.6.33",
       "maturity": "preview",
       "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
       "keywords": [

--- a/cogni-workspace/.claude-plugin/plugin.json
+++ b/cogni-workspace/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-workspace",
-  "version": "0.6.32",
+  "version": "0.6.33",
   "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -98,9 +98,11 @@ Claude checks dependencies, discovers installed plugins, asks for your language 
 | `on-session-start.sh` | hook (SessionStart) | Sources workspace environment and validates plugin availability at session start |
 | `check-dependencies.sh` | script | Returns JSON with availability/version of required and optional dependencies |
 | `check-skill-names.sh` | script | Validates skill directory names against plugin.json manifest for consistency |
+| `check-workspace-python-deps.sh` | script | Fail-soft health check for optional Python packages in the workspace venv; reports per-package importability (`success` stays true) |
 | `discover-plugins.sh` | script | Scans marketplace cache for installed cogni-x plugins, returns JSON inventory |
 | `generate-settings.sh` | script | Generates settings files; supports `--update` to preserve custom env vars |
 | `install-mcp.sh` | script | Installs a git-based MCP server into `~/.claude/mcp-servers/` (clone, build, wrapper); outputs JSON with install and wrapper paths |
+| `install-workspace-deps.sh` | script | Provisions optional Python packages from `python-deps-registry.json` into an isolated venv at `~/.claude/workspace-python-venv/`; idempotent, `--force` reinstalls, JSON envelope |
 | `patch-desktop-config.py` | script | Merges git-installed MCP servers into Claude Desktop's config from `mcp-git-registry.json`, preserving existing entries |
 | `setup-obsidian.sh` | script | Copies vault templates, downloads Terminal plugin, substitutes path placeholders |
 | `update-obsidian.sh` | script | Merges profiles, fixes WSL paths, removes deprecated profiles, copies scripts |
@@ -135,10 +137,12 @@ cogni-workspace/
 ├── scripts/                      Utility scripts
 │   ├── check-dependencies.sh
 │   ├── check-skill-names.sh
+│   ├── check-workspace-python-deps.sh  Health check for optional Python packages
 │   ├── discover-plugins.sh
 │   ├── generate-settings.sh
 │   ├── get-market-config.py      Merge canonical market registry with plugin overlays
 │   ├── install-mcp.sh            Clone, build, and wrap git-based MCP servers
+│   ├── install-workspace-deps.sh Provision optional Python deps into an isolated venv
 │   ├── patch-desktop-config.py   Merge MCP entries into Claude Desktop config
 │   ├── setup-obsidian.sh
 │   └── update-obsidian.sh

--- a/cogni-workspace/references/python-deps-registry.json
+++ b/cogni-workspace/references/python-deps-registry.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0",
+  "description": "Optional Python-dependency registry — packages installed into an isolated workspace venv at ~/.claude/workspace-python-venv/ so plugins can opt into pip-backed fallbacks without violating the stdlib-only convention. Mirrors mcp-git-registry.json: a registry of things cogni-workspace provisions into ~/.claude/. All entries are OPTIONAL — consuming plugins must degrade gracefully when a package is absent.",
+  "packages": {
+    "pypdf": {
+      "name": "pypdf",
+      "version": ">=4.0,<6.0",
+      "required_by": ["cogni-knowledge"],
+      "notes": "Pure-Python PDF text-layer extraction. Powers cogni-knowledge's source-curator text-layer fallback on poppler-less hosts (scripts/pdf-extract.py re-execs under <venv>/bin/python via COGNI_WORKSPACE_PYTHON_VENV when pypdf is not importable on the host). Optional: without it the fallback degrades to pdf_render_unavailable."
+    }
+  }
+}

--- a/cogni-workspace/scripts/check-workspace-python-deps.sh
+++ b/cogni-workspace/scripts/check-workspace-python-deps.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# check-workspace-python-deps.sh - Report optional Python-dependency health
+# Usage: check-workspace-python-deps.sh [--registry <path>] [--venv <dir>]
+# Output: JSON {success, data, error, metadata}
+#
+# Mirrors check-dependencies.sh (non-blocking health check). Every package in
+# python-deps-registry.json is OPTIONAL, so success stays true even when packages
+# are missing — the data block reports what is and isn't importable from the
+# workspace venv (~/.claude/workspace-python-venv) so workspace-status can surface
+# WARNING (never CRITICAL) for absent optional packages.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+REGISTRY="$SCRIPT_DIR/../references/python-deps-registry.json"
+VENV_DIR="${COGNI_WORKSPACE_PYTHON_VENV:-$HOME/.claude/workspace-python-venv}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --registry) REGISTRY="$2"; shift 2 ;;
+    --venv)     VENV_DIR="$2"; shift 2 ;;
+    *)
+      echo "{\"success\":false,\"data\":{},\"error\":\"Unknown argument: $1\"}" >&2
+      exit 2
+      ;;
+  esac
+done
+
+VENV_PY="$VENV_DIR/bin/python"
+VENV_PRESENT=false
+[ -f "$VENV_DIR/pyvenv.cfg" ] && [ -x "$VENV_PY" ] && VENV_PRESENT=true
+
+if [ ! -f "$REGISTRY" ]; then
+  cat <<EOF
+{"success":true,"data":{"venv_present":$VENV_PRESENT,"venv_dir":"$VENV_DIR","packages":[],"missing_optional":0,"message":"registry not found — no optional packages declared"},"metadata":{"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","script":"$SCRIPT_NAME","version":"0.1.0"}}
+EOF
+  exit 0
+fi
+
+# Probe each registry package for importability under the venv interpreter.
+# An optional import_name overrides the package name (pip name != import name case).
+RESULTS=$(REGISTRY="$REGISTRY" VENV_PY="$VENV_PY" VENV_PRESENT="$VENV_PRESENT" python3 <<'PY'
+import json, os, subprocess
+
+registry = os.environ["REGISTRY"]
+venv_py = os.environ["VENV_PY"]
+venv_present = os.environ["VENV_PRESENT"] == "true"
+
+with open(registry) as f:
+    reg = json.load(f)
+
+out = []
+for key, p in (reg.get("packages") or {}).items():
+    name = p.get("name", key)
+    import_name = p.get("import_name", name)
+    available = False
+    version = None
+    if venv_present and os.access(venv_py, os.X_OK):
+        try:
+            r = subprocess.run(
+                [venv_py, "-c",
+                 "import importlib, importlib.metadata as m;"
+                 "importlib.import_module(%r);"
+                 "print(m.version(%r))" % (import_name, name)],
+                capture_output=True, text=True, timeout=30,
+            )
+            if r.returncode == 0:
+                available = True
+                version = (r.stdout.strip() or None)
+        except Exception:
+            available = False
+    out.append({
+        "name": name,
+        "import_name": import_name,
+        "available": available,
+        "version": version,
+        "required_by": p.get("required_by", []),
+    })
+
+print(json.dumps(out))
+PY
+) || RESULTS="[]"
+
+MISSING_OPTIONAL=$(echo "$RESULTS" | python3 -c "
+import json, sys
+pkgs = json.load(sys.stdin)
+print(len([p for p in pkgs if not p['available']]))
+" 2>/dev/null || echo "0")
+
+cat <<EOF
+{
+  "success": true,
+  "data": {
+    "venv_present": $VENV_PRESENT,
+    "venv_dir": "$VENV_DIR",
+    "packages": $RESULTS,
+    "missing_optional": $MISSING_OPTIONAL
+  },
+  "metadata": {
+    "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+    "script": "$SCRIPT_NAME",
+    "version": "0.1.0"
+  }
+}
+EOF

--- a/cogni-workspace/scripts/generate-settings.sh
+++ b/cogni-workspace/scripts/generate-settings.sh
@@ -60,6 +60,10 @@ with open("$PLUGINS_TMPFILE") as f:
 env = {}
 env["PROJECT_AGENTS_OPS_ROOT"] = target
 env["COGNI_WORKSPACE_ROOT"] = os.path.join(target, "cogni-workspace")
+# HOME-relative (NOT target-relative): the optional-Python-dep venv is shared
+# across all workspaces on this host, mirroring ~/.claude/mcp-servers/. This is
+# the exact path consumers re-exec under (e.g. cogni-knowledge pdf-extract.py).
+env["COGNI_WORKSPACE_PYTHON_VENV"] = os.path.expanduser(os.path.join("~", ".claude", "workspace-python-venv"))
 
 for p in plugins:
     name = p.get("name", "") if isinstance(p, dict) else p

--- a/cogni-workspace/scripts/install-workspace-deps.sh
+++ b/cogni-workspace/scripts/install-workspace-deps.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# install-workspace-deps.sh - Provision optional Python dependencies into an
+# isolated workspace venv at ~/.claude/workspace-python-venv/
+# Usage: install-workspace-deps.sh [--registry <path>] [--venv <dir>] [--force]
+# Output: JSON {success, data, error}
+#
+# Mirrors install-mcp.sh: cogni-workspace provisions a thing into ~/.claude/.
+# Here the thing is a clean (no --system-site-packages) virtualenv holding the
+# optional pip packages declared in references/python-deps-registry.json. The
+# venv is PEP 668-safe (a venv is not an externally-managed environment) and its
+# bin/python is what consuming plugins re-exec under via COGNI_WORKSPACE_PYTHON_VENV
+# (e.g. cogni-knowledge/scripts/pdf-extract.py). A clean venv is required so that
+# re-exec gets a predictable sys.path free of host compiled-dep contamination.
+#
+# All packages are OPTIONAL — this script is dispatched fail-soft by
+# manage-workspace; a missing python3 / venv module / network must surface a
+# clean error envelope, never abort the calling setup flow.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# Defaults
+REGISTRY="$SCRIPT_DIR/../references/python-deps-registry.json"
+VENV_DIR="${COGNI_WORKSPACE_PYTHON_VENV:-$HOME/.claude/workspace-python-venv}"
+FORCE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --registry) REGISTRY="$2"; shift 2 ;;
+    --venv)     VENV_DIR="$2"; shift 2 ;;
+    --force)    FORCE=true;    shift ;;
+    *)
+      echo "{\"success\":false,\"data\":{\"action\":\"error\"},\"error\":\"Unknown argument: $1\"}" >&2
+      exit 2
+      ;;
+  esac
+done
+
+emit_error() {
+  # $1 = action, $2 = error message
+  cat <<EOF
+{"success":false,"data":{"action":"$1","venv_dir":"$VENV_DIR"},"error":"$2"}
+EOF
+}
+
+# --- Prerequisites (fail-soft: clean envelope, exit 1, never abort the caller) ---
+if ! command -v python3 &>/dev/null; then
+  emit_error "unavailable" "python3 not found on PATH; optional Python deps cannot be provisioned"
+  exit 1
+fi
+
+if ! python3 -c "import venv" &>/dev/null; then
+  emit_error "unavailable" "python3 venv module not available; install python3-venv to provision optional deps"
+  exit 1
+fi
+
+if [ ! -f "$REGISTRY" ]; then
+  emit_error "error" "registry not found at $REGISTRY"
+  exit 1
+fi
+
+# --- Resolve the package specifier list from the registry (name + version pin) ---
+PKG_SPECS=$(python3 -c "
+import json, sys
+with open('$REGISTRY') as f:
+    reg = json.load(f)
+specs = []
+for key, p in (reg.get('packages') or {}).items():
+    name = p.get('name', key)
+    ver = (p.get('version') or '').strip()
+    specs.append(name + ver if ver else name)
+print('\n'.join(specs))
+" 2>/dev/null) || { emit_error "error" "failed to parse registry JSON at $REGISTRY"; exit 1; }
+
+if [ -z "$PKG_SPECS" ]; then
+  cat <<EOF
+{"success":true,"data":{"action":"skipped","venv_dir":"$VENV_DIR","packages":[],"message":"Registry declares no packages; nothing to provision."}}
+EOF
+  exit 0
+fi
+
+# --- Idempotency: a provisioned venv has pyvenv.cfg; skip unless --force ---
+if [ -f "$VENV_DIR/pyvenv.cfg" ] && [ "$FORCE" = false ]; then
+  cat <<EOF
+{"success":true,"data":{"action":"skipped","venv_dir":"$VENV_DIR","message":"venv already provisioned. Use --force to reinstall/upgrade."}}
+EOF
+  exit 0
+fi
+
+# --- Create (or reuse for --force) the clean isolated venv ---
+ACTION="installed"
+if [ -f "$VENV_DIR/pyvenv.cfg" ]; then
+  ACTION="updated"
+else
+  mkdir -p "$(dirname "$VENV_DIR")"
+  if ! python3 -m venv "$VENV_DIR" 2>/tmp/install-workspace-deps.log; then
+    LOG=$(tail -3 /tmp/install-workspace-deps.log 2>/dev/null | tr '\n' ' ' | tr '"' "'")
+    emit_error "error" "python3 -m venv failed: $LOG"
+    exit 1
+  fi
+fi
+
+VENV_PY="$VENV_DIR/bin/python"
+if [ ! -x "$VENV_PY" ]; then
+  emit_error "error" "venv interpreter missing at $VENV_PY after creation"
+  exit 1
+fi
+
+# --- pip install the registry packages into the venv ---
+# Build the install arg list (newline-delimited specs → array).
+INSTALL_ARGS=()
+while IFS= read -r spec; do
+  [ -n "$spec" ] && INSTALL_ARGS+=("$spec")
+done <<< "$PKG_SPECS"
+
+if ! "$VENV_PY" -m pip install --upgrade pip >/tmp/install-workspace-deps.log 2>&1; then
+  : # non-fatal: pip self-upgrade can fail offline; the package install below is the real gate
+fi
+
+if ! "$VENV_PY" -m pip install "${INSTALL_ARGS[@]}" >>/tmp/install-workspace-deps.log 2>&1; then
+  LOG=$(tail -5 /tmp/install-workspace-deps.log 2>/dev/null | tr '\n' ' ' | tr '"' "'")
+  emit_error "error" "pip install failed (network or build error): $LOG"
+  exit 1
+fi
+
+# --- Record install metadata (parallel to install-mcp's .mcp-install.json) ---
+PY_VERSION=$("$VENV_PY" --version 2>&1 | head -1)
+PKG_JSON=$(printf '%s\n' "${INSTALL_ARGS[@]}" | python3 -c "
+import json, sys
+print(json.dumps([line for line in sys.stdin.read().splitlines() if line]))
+")
+
+cat > "$VENV_DIR/.deps-install.json" <<EOF
+{
+  "packages": $PKG_JSON,
+  "installed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "python_version": "$PY_VERSION",
+  "registry": "$REGISTRY"
+}
+EOF
+
+cat <<EOF
+{"success":true,"data":{"action":"$ACTION","venv_dir":"$VENV_DIR","packages":$PKG_JSON,"python_version":"$PY_VERSION"}}
+EOF

--- a/cogni-workspace/skills/manage-workspace/SKILL.md
+++ b/cogni-workspace/skills/manage-workspace/SKILL.md
@@ -85,9 +85,30 @@ The script creates three files:
 - **`.workspace-env.sh`** — Same variables exported for non-Claude contexts (Obsidian Terminal, VS Code tasks, CI/CD).
 - **`.workspace-config.json`** — Workspace metadata (version, language, plugin list, timestamps).
 
-The script generates `_ROOT` and `_PLUGIN` environment variables for each plugin. It does not create plugin data directories — each plugin creates its own working directory when it first needs one (via its own setup/init skill).
+The script generates `_ROOT` and `_PLUGIN` environment variables for each plugin. It does not create plugin data directories — each plugin creates its own working directory when it first needs one (via its own setup/init skill). It also emits `COGNI_WORKSPACE_PYTHON_VENV` (pointing at `~/.claude/workspace-python-venv`), which the next step uses to provision optional Python dependencies.
 
 Pass the plugins argument as either a JSON string or a path to a JSON file containing the plugin array from the discovery step.
+
+### 3.5. Provision Optional Python Dependencies
+
+Some plugins ship pip-backed optional fallbacks (e.g. cogni-knowledge's
+text-layer PDF extraction via `pypdf`). cogni-workspace provisions these into an
+isolated venv at `~/.claude/workspace-python-venv/` — mirroring how MCP servers
+install into `~/.claude/` — so the stdlib-only convention for plugin scripts
+stays intact while the fallbacks "light up" automatically. Step 3 already emitted
+`COGNI_WORKSPACE_PYTHON_VENV` into the settings, so the venv path is in place
+before this step runs.
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/install-workspace-deps.sh
+```
+
+**Fail-soft — never block setup.** Every package is optional. If `python3`, the
+`venv` module, or the network is unavailable, the script returns a clean
+`{"success":false,...}` envelope; warn and continue (do not abort init). On
+success it returns `data.action` of `installed` / `updated` / `skipped` and the
+provisioned package list. Packages are declared in
+`references/python-deps-registry.json`.
 
 ### 4. Install Output Styles, CLAUDE.md Templates, and Theme Template
 
@@ -213,6 +234,19 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/generate-settings.sh \
 ```
 
 The `--update` flag preserves any custom env vars the user added manually.
+
+### 3.5. Refresh Optional Python Dependencies
+
+Re-provision the optional-dep venv so any newly declared packages (or version
+bumps) in `references/python-deps-registry.json` are picked up. `--force`
+reinstalls/upgrades into the existing `~/.claude/workspace-python-venv/`:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/install-workspace-deps.sh --force
+```
+
+Same fail-soft contract as Init Mode Step 3.5: warn and continue if `python3` /
+the `venv` module / the network is unavailable — never block the update.
 
 ### 4. Update Output Styles and Theme Template
 

--- a/cogni-workspace/skills/workspace-status/SKILL.md
+++ b/cogni-workspace/skills/workspace-status/SKILL.md
@@ -20,7 +20,7 @@ If no `.workspace-config.json` exists at the resolved path, stop and tell the us
 
 ## Running the Checks
 
-Run all six checks, then present a single consolidated report. The checks are ordered by dependency — foundation must exist before environment makes sense, environment must be correct before plugins can be verified.
+Run all seven checks, then present a single consolidated report. The checks are ordered by dependency — foundation must exist before environment makes sense, environment must be correct before plugins can be verified.
 
 ### 1. Foundation
 
@@ -135,6 +135,29 @@ The script returns JSON with each tool's availability and version. Report:
 
 If `check-dependencies.sh` returns `"success": false`, report which required tools are missing.
 
+### 5.5. Optional Python Packages
+
+Some plugins ship pip-backed optional fallbacks provisioned by `manage-workspace`
+into an isolated venv at `~/.claude/workspace-python-venv/` (e.g. cogni-knowledge's
+`pypdf` text-layer PDF fallback). These are always optional — their absence limits
+a specific feature, it never blocks core functionality.
+
+Run:
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-workspace-python-deps.sh
+```
+
+The script returns JSON with `data.venv_present`, a per-package `available` /
+`version` / `required_by` list, and `missing_optional`. Report:
+- **venv present + all packages importable** → OK.
+- **packages missing (or venv absent)** → WARNING, never CRITICAL. Tell the user
+  to run `/cogni-workspace:manage-workspace` (or `install-workspace-deps.sh`
+  directly) to provision them, and name which feature is limited (from
+  `required_by`).
+
+`check-workspace-python-deps.sh` always returns `"success": true` (every package
+is optional), so treat a non-empty `missing_optional` as an advisory, not a failure.
+
 ### 6. MCP Servers
 
 MCP servers power visual rendering (Excalidraw, Pencil), browser automation (claude-in-chrome),
@@ -182,6 +205,7 @@ Environment:  OK       | 12 vars set, 0 missing
 Plugins:      OK       | 5 registered, 5 installed
 Themes:       OK       | 3 themes available, 1 tiered, 0 drift advisories
 Dependencies: OK       | 2/2 required, 3/3 optional
+Python pkgs:  OK       | venv present, 1/1 optional importable
 MCP Servers:  OK       | 3/3 loaded (1 manual)
 
 Language: EN | Last updated: 2026-03-04


### PR DESCRIPTION
Closes #613.

Part B follow-up to merged #612 (#583). cogni-knowledge's `pdf-extract.py` already reads `COGNI_WORKSPACE_PYTHON_VENV` and re-execs under `<venv>/bin/python` when `pypdf` isn't importable on the host — but nothing emitted that var yet. This adds the cross-plugin provisioning layer in cogni-workspace (mirroring the MCP-install machinery) so optional Python deps land in an isolated venv during workspace setup and the fallback lights up automatically.

## Summary
- **`references/python-deps-registry.json`** (new) — mirrors the `mcp-git-registry.json` shape; seeds one entry: `pypdf` (version pin, `required_by:["cogni-knowledge"]`, notes). markitdown/cairosvg explicitly out of scope.
- **`scripts/install-workspace-deps.sh`** (new) — creates/reuses a clean isolated venv at `~/.claude/workspace-python-venv/` via `python3 -m venv` (PEP 668-safe, no `--system-site-packages` so #612's re-exec gets a clean `sys.path`), pip-installs registry packages, writes `.deps-install.json`. Idempotent (skip when `pyvenv.cfg` exists; `--force` reinstalls). `{success,data,error}` envelope; bash + python3 stdlib only.
- **`scripts/check-workspace-python-deps.sh`** (new) — fail-soft optional-deps health check (venv present? packages importable via `<venv>/bin/python`?), mirroring `check-dependencies.sh`; `success:true` even when optional packages are missing.
- **`scripts/generate-settings.sh`** — emits `COGNI_WORKSPACE_PYTHON_VENV = os.path.expanduser("~/.claude/workspace-python-venv")` right after `COGNI_WORKSPACE_ROOT`. HOME-relative (the one exception — the venv is shared per-host, mirroring `~/.claude/mcp-servers/`). Lands in `.claude/settings.local.json` and `.workspace-env.sh`.
- **`skills/manage-workspace/SKILL.md`** — Init-Mode Step 3.5 "Provision Optional Python Dependencies" and Update-Mode Step 3.5 "Refresh…", both fail-soft (warn+continue if python3/venv/network absent, never block setup).
- **`skills/workspace-status/SKILL.md`** — new Check 5.5 "Optional Python Packages" (WARNING never CRITICAL), six→seven check count, Status-Report table row.
- **`README.md`** — Components table + scripts/ tree enumerate the two new scripts.
- Version bump `0.6.32 → 0.6.33` (plugin.json + marketplace.json).

## Test plan (verified locally)
- [x] `install-workspace-deps.sh` → venv created, `pypdf` importable (5.9.0), `.deps-install.json` written.
- [x] Re-run → `action: skipped` (idempotent); `--force` → `action: updated`.
- [x] `check-workspace-python-deps.sh` → `success:true` with venv+package status (venv-absent case also `success:true`, `venv_present:false`).
- [x] `generate-settings.sh` → `COGNI_WORKSPACE_PYTHON_VENV = ~/.claude/workspace-python-venv` present in both `settings.local.json` and `.workspace-env.sh`.
- [x] registry JSON valid; plugin.json + marketplace.json both 0.6.33.

## Review notes
- A skill-quality review surfaced pre-existing maintainer breadcrumbs (`RFC #132`/`Phase 3`) in `workspace-status/SKILL.md`'s **Themes** section — unrelated to this change, already baseline-allowlisted (CI-safe). Left untouched to keep this PR scoped to #613; tracked separately for a semantic-rationale cleanup.
