### PR TITLE
test(cogni-knowledge): knowledge-setup Step 3.5 seed-layout contract test + heredoc hardening

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -326,7 +326,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.118",
+      "version": "0.1.119",
       "maturity": "preview",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.118",
+  "version": "0.1.119",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/skills/knowledge-setup/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-setup/SKILL.md
@@ -196,9 +196,14 @@ done
 
 **(b) Seed the curated root files — `wiki/index.md` (portal front door) and
 `wiki/overview.md` (narrative home).** Overwrite both `wiki-setup` seeds via Bash
-heredocs (mirroring (c), since this skill's `allowed-tools` carries no `Write`
-tool — the seed mechanism is `cat > … <<EOF`, not a `Write` call). Substitute
-`<knowledge-title>` and today's date `YYYY-MM-DD`:
+heredocs (since this skill's `allowed-tools` carries no `Write` tool — the seed
+mechanism is `cat > … <<'EOF'`, not a `Write` call). Both bodies use a **quoted**
+heredoc delimiter (`<<'EOF'`) — they need no shell expansion, and quoting keeps a
+`<knowledge-title>` that happens to contain a `$` or backtick from being expanded
+or executed. Substitute `<knowledge-title>` and today's date `YYYY-MM-DD`
+**textually** before running (the quoted delimiter means the shell will not expand
+a `$(date)` here — the log heredoc in (c) is the one place that stays unquoted
+precisely because it *does* rely on `$(date)`):
 
 - **`wiki/index.md`** becomes a curated **portal front door** — a machine-owned
   portal lead-in span (filled by `portal-narrator` / `knowledge-finalize` later)
@@ -217,7 +222,7 @@ tool — the seed mechanism is `cat > … <<EOF`, not a `Write` call). Substitut
   `overview_update.py` upserts the block) instead of recreating a bare default.
 
 ```
-cat > <knowledge_root>/wiki/index.md <<EOF
+cat > <knowledge_root>/wiki/index.md <<'EOF'
 # <knowledge-title>
 
 _Curated front door. The overview narrative lives in wiki/overview.md; each theme below links to its per-type sub-index as research lands._
@@ -229,7 +234,7 @@ _Theme map pending — each theme links to its per-type sub-index here as resear
 <!-- MACHINE-OWNED:PORTAL-LEADIN:END -->
 EOF
 
-cat > <knowledge_root>/wiki/overview.md <<EOF
+cat > <knowledge_root>/wiki/overview.md <<'EOF'
 # Overview
 
 <!-- MACHINE-OWNED:OVERVIEW-NARRATIVE:START -->
@@ -243,7 +248,8 @@ EOF
 the path helper resolves to the legacy flat `wiki/log.md` until the meta file
 exists, so the canonical target must be written directly.
 `_knowledge_lib.meta_dir(<knowledge_root>)` is definitionally
-`<knowledge_root>/wiki/meta`:
+`<knowledge_root>/wiki/meta`. This heredoc alone uses an **unquoted** delimiter
+(`<<EOF`) so the shell expands `$(date +%Y-%m-%d)` into the log line:
 
 ```
 mkdir -p <knowledge_root>/wiki/meta

--- a/cogni-knowledge/tests/test_setup_seed_contract.sh
+++ b/cogni-knowledge/tests/test_setup_seed_contract.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# test_setup_seed_contract.sh — knowledge-setup Step 3.5 (seed the curated
+# wiki-output layout for NEW wikis) contract assertions.
+#
+# Step 3.5 turns the schema_version 0.0.8 curated layout the SKILL's contract
+# section declares into the actual seeded shape for a fresh wiki. It is an
+# LLM-executed Bash recipe (the skill has no Write tool), so the only thing CI
+# can guard is that the recipe's load-bearing invariants stay present in the
+# SKILL prose. This file is the sibling of test_finalize_contract.sh /
+# test_ingest_contract.sh — content-invariant grep tests over the SKILL.
+#
+# The invariants intentionally pin the points that already drifted once between
+# the PR description and the merged code (overview.md kept, not removed) and the
+# robustness choices in the heredoc seeds (quoted vs unquoted delimiters).
+#
+# bash 3.2 + grep only.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+. "$(dirname "$0")/fixtures/test_helpers.sh"
+
+errors=0
+
+SETUP="$PLUGIN_ROOT/skills/knowledge-setup/SKILL.md"
+if [ ! -f "$SETUP" ]; then
+  red "FAIL: skills/knowledge-setup/SKILL.md not found"
+  exit 1
+fi
+
+# --- Step 3.5 exists + is gated to the fresh-wiki branch -----------------
+assert_grep '### 3.5 Seed the curated wiki-output layout' "$SETUP" "knowledge-setup: Step 3.5 heading present"
+assert_grep 'only on the fresh-wiki branch' "$SETUP" "knowledge-setup: Step 3.5 runs only on the fresh-wiki branch"
+assert_grep 'Skip it' "$SETUP" "knowledge-setup: Step 3.5 documents the skip path (existing wiki / --reframe)"
+
+# --- (a) per-type sub-index stubs via the canonical renderer -------------
+# Delegated to sub_index.py — NOT hand-authored markers (no-duplicate-upstream).
+assert_grep 'resolve_wiki_scripts wiki-ingest' "$SETUP" "knowledge-setup: resolves WIKI_INGEST_SCRIPTS (mirrors knowledge-finalize Step 0)"
+assert_grep 'sub_index.py' "$SETUP" "knowledge-setup: (a) seeds per-type stubs via sub_index.py render"
+assert_grep 'concepts entities summaries learnings sources questions syntheses' "$SETUP" "knowledge-setup: (a) loops all seven page types"
+assert_grep 'MACHINE-OWNED:<TYPE>-INDEX' "$SETUP" "knowledge-setup: (a) documents the per-type ownership marker the renderer writes"
+
+# --- (b) curated root files: index.md portal + overview.md narrative -----
+assert_grep 'wiki/index.md' "$SETUP" "knowledge-setup: (b) seeds wiki/index.md (portal front door)"
+assert_grep 'wiki/overview.md' "$SETUP" "knowledge-setup: (b) seeds wiki/overview.md (narrative home)"
+assert_grep 'MACHINE-OWNED:PORTAL-LEADIN' "$SETUP" "knowledge-setup: index.md carries the PORTAL-LEADIN sentinel"
+assert_grep 'MACHINE-OWNED:OVERVIEW-NARRATIVE' "$SETUP" "knowledge-setup: overview.md carries the OVERVIEW-NARRATIVE sentinel"
+assert_grep '## Categories' "$SETUP" "knowledge-setup: index.md has the ## Categories heading the root-index renderer upserts into"
+# The seed deliberately OMITS the placeholder line so strip_seed_placeholder
+# has nothing to strip (self-clean contract satisfied). The placeholder string
+# itself appears in the SKILL prose only as the thing to omit, so assert the
+# OMIT INSTRUCTION is present (positive) rather than whole-file absence.
+assert_grep 'strip_seed_placeholder' "$SETUP" "knowledge-setup: documents the strip_seed_placeholder self-clean contract"
+assert_grep '\*\*Omit\*\* the' "$SETUP" "knowledge-setup: instructs omitting the _No pages yet…_ seed placeholder line"
+
+# --- heredoc-delimiter hygiene -------------------------------------------
+# index.md + overview.md need NO shell expansion, so they use a QUOTED
+# delimiter (<<'EOF') — protects a substituted <knowledge-title> containing a
+# $ or backtick. The log heredoc (c) is the ONE place that stays unquoted
+# because it relies on $(date). Both must hold for the recipe to be safe.
+assert_grep "wiki/index.md <<'EOF'" "$SETUP" "knowledge-setup: index.md heredoc uses a quoted delimiter (no accidental expansion of the title)"
+assert_grep "wiki/overview.md <<'EOF'" "$SETUP" "knowledge-setup: overview.md heredoc uses a quoted delimiter"
+assert_grep 'wiki/meta/log.md <<EOF' "$SETUP" "knowledge-setup: log.md heredoc stays unquoted (relies on \$(date))"
+assert_grep 'date +%Y-%m-%d' "$SETUP" "knowledge-setup: (c) log line stamps the date via \$(date)"
+
+# --- (c) control log under wiki/meta/, seeded directly -------------------
+assert_grep 'wiki/meta/log.md' "$SETUP" "knowledge-setup: (c) seeds wiki/meta/log.md"
+assert_grep 'mkdir -p <knowledge_root>/wiki/meta' "$SETUP" "knowledge-setup: (c) creates the wiki/meta dir"
+# Must be seeded DIRECTLY, not via control-path.py (which resolves to the flat
+# legacy path until the meta file exists — the bootstrap caveat).
+assert_grep 'not via `control-path.py log`' "$SETUP" "knowledge-setup: (c) documents why log.md is seeded directly (control-path.py bootstrap caveat)"
+
+# --- (d) drop ONLY the flat log; KEEP overview.md ------------------------
+# This is the invariant that drifted between PR description (which said
+# "removes overview.md") and the merged code. Lock it down: the flat log is
+# removed, overview.md is explicitly KEPT.
+assert_grep 'rm -f <knowledge_root>/wiki/log.md' "$SETUP" "knowledge-setup: (d) removes the flat wiki/log.md"
+assert_grep 'Keep `wiki/overview.md`' "$SETUP" "knowledge-setup: (d) explicitly KEEPS wiki/overview.md (the narrative home)"
+# Defence-in-depth: no instruction to delete overview.md anywhere in the step.
+assert_not_grep 'rm -f <knowledge_root>/wiki/overview.md' "$SETUP" "knowledge-setup: NEVER removes wiki/overview.md"
+
+# --- (e) advertise schema_version 0.0.8 via the locked config_bump.py ----
+assert_grep 'config_bump.py' "$SETUP" "knowledge-setup: (e) bumps schema_version via the locked config_bump.py"
+assert_grep 'schema_version --set-string 0.0.8' "$SETUP" "knowledge-setup: (e) sets schema_version to 0.0.8"
+
+# --- the post-step invariant the future knowledge-health check will assert
+assert_grep 'never regrows a competing root file' "$SETUP" "knowledge-setup: invariant holds across the first knowledge-finalize (overview refreshed in place)"
+
+if [ $errors -eq 0 ]; then
+  green ""
+  green "knowledge-setup Step 3.5 seed-layout contract: ALL PASS"
+  exit 0
+else
+  red "$errors test(s) failed"
+  exit 1
+fi


### PR DESCRIPTION
Follow-up to #623 (curated-layout seeding in `knowledge-setup` Step 3.5), addressing two review findings.

## 1. Contract test (test coverage gap)
Every other knowledge-* step has a `test_*_contract.sh` guard; Step 3.5 shipped without one. Adds **`tests/test_setup_seed_contract.sh`** — content-invariant grep tests over the SKILL recipe (the step is LLM-executed Bash; the skill has no `Write` tool, so the recipe text is what CI can guard). It pins:

- the fresh-wiki gate + skip path
- `sub_index.py` delegation across all seven page types (no hand-authored markers)
- the `index.md` PORTAL-LEADIN / `overview.md` OVERVIEW-NARRATIVE sentinels + `## Categories` heading
- the `strip_seed_placeholder` omit instruction
- the `wiki/meta/log.md` direct-seed bootstrap caveat (not via `control-path.py`)
- the `config_bump.py … schema_version 0.0.8` bump
- **the exact invariant that drifted between #623's description and its merged code**: the step removes only the flat `wiki/log.md` and **keeps** `wiki/overview.md` (with a defence-in-depth `assert_not_grep` that it's never deleted)

## 2. Heredoc-delimiter hardening (robustness)
The `wiki/index.md` and `wiki/overview.md` seeds used an unquoted `<<EOF`, so the shell would expand `$`/backticks in the body — including a substituted `<knowledge-title>`. Neither body needs expansion, so both now use a **quoted** `<<'EOF'`. The `wiki/meta/log.md` heredoc stays unquoted by design (it relies on `$(date)`), and the prose now states that distinction explicitly.

## Verification
- `bash cogni-knowledge/tests/test_setup_seed_contract.sh` → ALL PASS
- `python3 scripts/check-breadcrumbs.py` → `success: true` (the new test lives outside the guard's `*/skills/`+`*/agents/` scope; the SKILL edit adds no breadcrumbs)
- both JSON manifests valid

Bumps `cogni-knowledge` 0.1.118 → 0.1.119.

> Note: the pre-existing `test_knowledge_setup_probe.sh` failure (stale knowledge-refresh assertions) is unrelated to this branch and is fixed by #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)