### PR TITLE
cogni-consult: consult-action-fields WBS deliverable manager

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -349,7 +349,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "maturity": "incubating",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -13,6 +13,7 @@ cogni-consult/
 ├── README.md                      User documentation (stub; full README is planned work)
 ├── references/
 │   ├── data-model.md              Engagement structure + entity schemas
+│   ├── deliverable-types.md       Deliverable-type catalog (field-type affinity)
 │   └── methods/
 │       └── scope-dimensions.md    SMART key question + 5 dimensions + WBS-close method
 ├── scripts/
@@ -23,11 +24,13 @@ cogni-consult/
 └── skills/
     ├── consult-setup/SKILL.md     Engagement entry point: scaffold + knowledge-base bind
     │                              + registry
-    └── consult-scope/SKILL.md     SMART key question + 5 scoping dimensions
-                                   + 3-6 action fields as the WBS
+    ├── consult-scope/SKILL.md     SMART key question + 5 scoping dimensions
+    │                              + 3-6 action fields as the WBS
+    └── consult-action-fields/SKILL.md  WBS dashboard + per-field deliverable
+                                   manifests + next-deliverable recommendation
 ```
 
-Later work: consult-action-fields, consult-design-thinking, consult-personas, consult-resume skills.
+Later work: consult-design-thinking, consult-personas, consult-resume skills.
 
 ## Design Principles
 

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -96,13 +96,17 @@ and their states.
       "slug": "market-sizing",
       "title": "Market sizing (TAM/SAM/SOM)",
       "state": "complete",
-      "dt_stage": "test"
+      "dt_stage": "test",
+      "producing_route": "consult-design-thinking",
+      "persona_review": "complete"
     },
     {
       "slug": "competitor-landscape",
       "title": "Competitor landscape",
       "state": "in-progress",
-      "dt_stage": "ideate"
+      "dt_stage": "ideate",
+      "producing_route": "consult-design-thinking",
+      "persona_review": "pending"
     }
   ]
 }
@@ -111,6 +115,14 @@ and their states.
 `dt_stage` records where the deliverable stands in its design-thinking loop:
 `empathize` → `define` → `ideate` → `prototype` → `test`. The loop may re-enter
 earlier stages; `state` stays `in-progress` until `test` passes.
+
+`producing_route` names the skill that produces the deliverable (default:
+`consult-design-thinking`); `consult-action-fields` records and recommends the
+route, it never dispatches it. `persona_review` tracks the acting-persona
+challenge pass per deliverable: `pending` → `in-progress` → `complete`. Both
+are written by `consult-action-fields` when the deliverable is planned;
+`engagement-status.sh` passes them through unchanged (its rollup reads only
+`state`).
 
 ### Deliverable artifacts ({deliverable-slug}.md)
 

--- a/cogni-consult/references/deliverable-types.md
+++ b/cogni-consult/references/deliverable-types.md
@@ -1,0 +1,66 @@
+---
+name: deliverable-types
+description: Catalog of deliverable types with field-type affinity — the reference for which deliverable types belong in which kind of action field.
+---
+
+# Deliverable Types
+
+Action fields are the WBS containers of an engagement; each field holds the
+deliverables that answer its framing. This catalog lists the deliverable types
+available when planning a field's deliverable set, with the **field-type
+affinity** that suggests where each type naturally belongs. It adapts
+cogni-consulting's deliverable catalog: where that plugin keys deliverables to
+Double Diamond phases, cogni-consult keys them to the *kind of action field*
+they serve — there are no phases here.
+
+## Field Types
+
+Action fields tend to cluster into four kinds. The affinity column below uses
+these labels; a field can match more than one kind, and the consultant always
+decides.
+
+| Field type | The field asks... | Example fields |
+|---|---|---|
+| `evidence` | What is true out there? | market-evidence, customer-insight, regulatory-landscape |
+| `analysis` | What does it mean for us? | portfolio-fit, capability-gap, risk-exposure |
+| `strategy` | What should we do? | strategic-options, business-model, positioning |
+| `execution` | How do we make it happen? | go-to-market, transformation-plan, operating-model |
+
+## Deliverable Catalog
+
+| Deliverable | Description | Formats | Field-type affinity |
+|---|---|---|---|
+| Market Assessment | Market size, dynamics, and entry barriers | DOCX, PPTX | evidence |
+| TIPS Landscape | Trend/implication/possibility map | MD, Excalidraw | evidence |
+| Claim Verification Log | Audit trail of verified/flagged assertions | MD, XLSX | evidence |
+| Portfolio Snapshot | Competitive positioning and value wedge | XLSX, PPTX | analysis |
+| Scenario Matrix | 2×2 scenario analysis with implications | PPTX, Excalidraw | analysis |
+| Canvas Stress-Test Report | Multi-persona evaluation with synthesis | MD | analysis |
+| Strategic Options Brief | Ranked alternatives with evaluation criteria | PPTX, DOCX | strategy |
+| Decision Board | Visual option map with recommendation | Excalidraw, SVG | strategy |
+| Lean Canvas | Research-backed business model hypothesis | MD | strategy |
+| Solution Brief | Designed solution with rationale and design decisions | MD, DOCX | strategy |
+| Business Case | Financials, assumptions, sensitivity analysis | XLSX + DOCX | strategy |
+| Executive Summary | One-pager for leadership alignment | PPTX, PDF | strategy, execution |
+| Action Roadmap | Phased implementation plan with milestones | PPTX, XLSX | execution |
+| Action Plan | Phased steps with owners, timeline, and success criteria | MD, XLSX | execution |
+| Cost Reduction Playbook | Prioritized savings opportunities with implementation | XLSX, DOCX | execution |
+| Transformation Roadmap | Current→target state with transition phases | PPTX, Excalidraw | execution |
+
+## Using the Catalog
+
+When planning a field's deliverable set with `consult-action-fields`:
+
+1. Read the field's `framing` line and judge which field type(s) it matches.
+2. Propose 1-3 deliverables whose affinity matches, naming each with a
+   kebab-case slug derived from the deliverable title.
+3. Let the consultant add, rename, or drop freely — affinity is a starting
+   recommendation, not a constraint. Engagement-specific deliverables outside
+   this catalog are normal; give them a clear title and slug like any other.
+4. Record the chosen format preference in the deliverable's markdown artifact
+   when it is produced, not in `field.json` — the manifest tracks state, not
+   formats.
+
+Every deliverable runs its own design-thinking loop regardless of type
+(`dt_stage` in `field.json`); the catalog only helps choose *what* to produce
+per field, never *how*.

--- a/cogni-consult/scripts/engagement-status.sh
+++ b/cogni-consult/scripts/engagement-status.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Read a cogni-consult engagement's consult-project.json and return its
-# workflow state. Stub: the consult-resume skill defines the full status contract.
+# Read a cogni-consult engagement's consult-project.json and derive the WBS
+# field/deliverable rollup. Primary consumer: the consult-action-fields skill.
 # Usage: bash engagement-status.sh <engagement-dir>
 # Output: JSON {"success": bool, "data": {...}, "error": "string"}
 

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -38,13 +38,17 @@ bash $CLAUDE_PLUGIN_ROOT/scripts/discover-projects.sh --json
 ```
 
 and confirm the intended engagement with the user when more than one is
-registered.
+registered. When discovery returns zero engagements, treat it the same as a
+missing `consult-project.json`.
 
-Read `<engagement-dir>/consult-project.json`. If it is missing, redirect to
-`consult-setup`; if `workflow_state.scope` is not `"complete"`, redirect:
-"Scoping isn't closed yet — the action fields come from `consult-scope`."
-Then dispatch `Skill("cogni-consult:consult-scope")` and stop — write
-nothing. The WBS exists only once scoping has named the fields.
+Read `<engagement-dir>/consult-project.json`. Branch explicitly:
+
+- If it is missing (or discovery returned zero engagements): dispatch
+  `Skill("cogni-consult:consult-setup")` and stop — write nothing.
+- If `workflow_state.scope` is not `"complete"`: redirect — "Scoping isn't
+  closed yet — the action fields come from `consult-scope`." — then dispatch
+  `Skill("cogni-consult:consult-scope")` and stop — write nothing. The WBS
+  exists only once scoping has named the fields.
 
 ### 2. Read the Current WBS State
 
@@ -55,10 +59,20 @@ read time and passes every `field.json` deliverable entry through verbatim:
 bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-status.sh <engagement-dir>
 ```
 
-On `"success": false`, stop and surface the error. For any field listed in
-`action_fields[]` whose `field.json` is missing (a scaffold gap), `Write` the
-stub per the data model before proceeding — never leave the root list and the
-directory tree inconsistent.
+On `"success": false`, stop and surface the error. On success, also read
+`data.warnings[]` — the script reports fields it could not parse there and
+marks them `state: "unreadable"`; surface those warnings with the dashboard.
+
+The rollup cannot distinguish a missing `field.json` from an existing stub
+with an empty `deliverables[]` (both report `pending` with no deliverables),
+so for each gap candidate — a field the rollup lists with no deliverables —
+attempt to `Read` `action-fields/<field-slug>/field.json` before considering
+a repair. Only when the file genuinely does not exist, `Write` the stub per
+the data model (sourcing `title` and `framing` from `scope/key-question.md`'s
+action-field list) — never leave the root list and the directory tree
+inconsistent, and never `Write` a stub for a field that is merely empty or
+`unreadable` (an unreadable file is the consultant's to inspect, not the
+skill's to replace).
 
 ### 3. Render the WBS Dashboard
 
@@ -71,6 +85,7 @@ priority), deliverables in manifest order:
 | market-evidence | market-sizing | complete | test | consult-design-thinking | complete |
 | market-evidence | competitor-landscape | in-progress | ideate | consult-design-thinking | pending |
 | portfolio-fit | — (no deliverables planned) | | | | |
+| go-to-market | ⚠ unreadable field.json (see warnings) | | | | |
 ```
 
 Close the dashboard with the **next-deliverable recommendation**: the first
@@ -123,11 +138,14 @@ Field-set changes touch two places, always both, in this order:
    - **Add**: `Write` the new field's `field.json` stub (`slug`, `title`,
      `framing`, `deliverables: []`).
    - **Split**: create stubs for the new fields, then move each surviving
-     deliverable entry into exactly one successor manifest (an `Edit` per
-     manifest) — entries move, they are never duplicated, so each
+     deliverable entry into exactly one successor manifest — an `Edit` per
+     receiving manifest plus an `Edit` removing the moved entries from the
+     source manifest. Entries move, they are never duplicated, so each
      deliverable keeps living in exactly one field.
    - **Merge**: append the absorbed field's `deliverables[]` entries to the
-     surviving field's manifest, then treat the absorbed field as dropped.
+     surviving field's manifest, `Edit` the absorbed field's retained
+     manifest to empty its `deliverables[]` (or annotate where each entry
+     moved), then treat the absorbed field as dropped.
    - **Drop** (and the leftover side of split/merge): honor the re-run
      guard from `consult-scope` — leave the field's directory and
      `field.json` in place and note the removal in the summary; deleting

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: consult-action-fields
+description: |
+  This skill should be used when the user wants to manage the WBS of a
+  cogni-consult engagement — listing each action field's deliverables and
+  their status, planning a field's deliverable set, picking the next
+  deliverable to work, or adding/splitting/merging action fields after
+  scoping. Trigger on: "show the WBS", "action fields dashboard", "what
+  deliverables are open", "plan the deliverables", "next deliverable",
+  "add an action field", "split this field", "merge two action fields",
+  or when consult-scope hands off a freshly scoped engagement. Route
+  Double Diamond phasing ("discover phase", "deliver phase status") to
+  cogni-consulting:consulting-resume instead.
+allowed-tools: Read, Write, Edit, Bash, Skill
+---
+
+# Action-Field WBS Management
+
+Manage the engagement's work-breakdown structure: each action field named
+during scoping is a container whose `field.json` manifests the deliverables
+that complete it. This skill renders the WBS dashboard (fields × deliverables
+× status), plans each field's deliverable set from
+`$CLAUDE_PLUGIN_ROOT/references/deliverable-types.md`, recommends the next
+unstarted deliverable, and keeps `consult-project.json` and the
+`action-fields/` tree consistent when fields are added, split, or merged.
+It manages the manifest layer only — producing a deliverable is the work of
+its producing route (a `consult-design-thinking` run by default).
+
+## Workflow
+
+### 1. Prerequisite Gate
+
+When arriving via an in-session `consult-scope` handoff, the engagement
+directory is already known — skip discovery. Otherwise locate the engagement:
+
+```bash
+bash $CLAUDE_PLUGIN_ROOT/scripts/discover-projects.sh --json
+```
+
+and confirm the intended engagement with the user when more than one is
+registered.
+
+Read `<engagement-dir>/consult-project.json`. If it is missing, redirect to
+`consult-setup`; if `workflow_state.scope` is not `"complete"`, redirect:
+"Scoping isn't closed yet — the action fields come from `consult-scope`."
+Then dispatch `Skill("cogni-consult:consult-scope")` and stop — write
+nothing. The WBS exists only once scoping has named the fields.
+
+### 2. Read the Current WBS State
+
+Run the status rollup first — it derives field and engagement completion at
+read time and passes every `field.json` deliverable entry through verbatim:
+
+```bash
+bash $CLAUDE_PLUGIN_ROOT/scripts/engagement-status.sh <engagement-dir>
+```
+
+On `"success": false`, stop and surface the error. For any field listed in
+`action_fields[]` whose `field.json` is missing (a scaffold gap), `Write` the
+stub per the data model before proceeding — never leave the root list and the
+directory tree inconsistent.
+
+### 3. Render the WBS Dashboard
+
+Present one table, fields in `action_fields[]` order (that order is the WBS
+priority), deliverables in manifest order:
+
+```
+| Action field | Deliverable | State | DT stage | Route | Persona review |
+|---|---|---|---|---|---|
+| market-evidence | market-sizing | complete | test | consult-design-thinking | complete |
+| market-evidence | competitor-landscape | in-progress | ideate | consult-design-thinking | pending |
+| portfolio-fit | — (no deliverables planned) | | | | |
+```
+
+Close the dashboard with the **next-deliverable recommendation**: the first
+deliverable with `state: "pending"`, walking fields in `action_fields[]`
+order and deliverables in manifest order. When a field has an empty
+`deliverables[]`, recommend planning that field's set (step 4) instead —
+an empty container outranks a half-done one. When every deliverable is
+`complete`, say so: the engagement is complete by derivation, there is
+nothing to store.
+
+### 4. Plan a Field's Deliverable Set
+
+For a field with no (or too few) deliverables, read
+`$CLAUDE_PLUGIN_ROOT/references/deliverable-types.md` (once per session — it
+covers every field), judge the field's type from its `framing`, and propose
+1-3 deliverables by affinity. Confirm with the consultant, then `Edit` the
+field's `field.json` once, appending all agreed entries, each shaped:
+
+```json
+{
+  "slug": "<deliverable-slug>",
+  "title": "<Deliverable Title>",
+  "state": "pending",
+  "dt_stage": "empathize",
+  "producing_route": "consult-design-thinking",
+  "persona_review": "pending"
+}
+```
+
+`producing_route` names the skill that will produce the deliverable —
+default `consult-design-thinking`; use another route only when the
+consultant names one (e.g. a direct `cogni-visual` export of an existing
+artifact). `persona_review` tracks the acting-persona challenge pass:
+`pending` → `in-progress` → `complete`. Both fields are manifest metadata —
+recommend the route, never dispatch it from here.
+
+Removing or renaming a deliverable is also an `Edit` of `field.json` — but
+never silently drop an entry whose `state` is not `pending`; started work is
+the consultant's to discard.
+
+### 5. Add, Split, or Merge Action Fields
+
+Field-set changes touch two places, always both, in this order:
+
+1. `Edit` `consult-project.json`: update `action_fields[]` to the new ordered
+   list of **slug strings only**, and set `updated` to today's ISO date (the
+   root `updated` covers action-field list changes; deliverable edits in
+   step 4 never touch it).
+2. Reconcile the directory tree under `action-fields/`:
+   - **Add**: `Write` the new field's `field.json` stub (`slug`, `title`,
+     `framing`, `deliverables: []`).
+   - **Split**: create stubs for the new fields, then move each surviving
+     deliverable entry into exactly one successor manifest (an `Edit` per
+     manifest) — entries move, they are never duplicated, so each
+     deliverable keeps living in exactly one field.
+   - **Merge**: append the absorbed field's `deliverables[]` entries to the
+     surviving field's manifest, then treat the absorbed field as dropped.
+   - **Drop** (and the leftover side of split/merge): honor the re-run
+     guard from `consult-scope` — leave the field's directory and
+     `field.json` in place and note the removal in the summary; deleting
+     deliverable history is the consultant's call, not the skill's.
+
+Never overwrite an existing `field.json` — it is the single source of truth
+for that field's deliverable states.
+
+### 6. Close the Session
+
+Summarize what changed (fields added/split/merged, deliverables planned) and
+re-state the next-deliverable recommendation with its producing route — e.g.
+"Next: `competitor-landscape` in `market-evidence`, via
+`consult-design-thinking` once it ships." Until that skill ships, point the
+consultant at the deliverable's markdown artifact under the field directory
+as the working surface.
+
+## Important Notes
+
+- **State ownership**: deliverable `state`, `dt_stage`, `producing_route`,
+  and `persona_review` live only in the field's `field.json`; field and
+  engagement completion are derived at read time. See
+  `$CLAUDE_PLUGIN_ROOT/references/data-model.md`.
+- **Edit, never rewrite**: all `consult-project.json` changes go through
+  `Edit` so setup-owned fields (`created`, `plugin_refs`, `language`)
+  survive; root `updated` changes only when `action_fields[]` itself does.
+- **Slug discipline**: `action_fields[]` holds kebab-case slug strings only —
+  `engagement-status.sh` rejects non-string entries as malformed.

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -92,9 +92,12 @@ Close the dashboard with the **next-deliverable recommendation**: the first
 deliverable with `state: "pending"`, walking fields in `action_fields[]`
 order and deliverables in manifest order. When a field has an empty
 `deliverables[]`, recommend planning that field's set (step 4) instead —
-an empty container outranks a half-done one. When every deliverable is
-`complete`, say so: the engagement is complete by derivation, there is
-nothing to store.
+an empty container outranks a half-done one. Skip unreadable fields in
+this walk — the rollup reports them with an empty `deliverables[]` too,
+but the right response is surfacing their warning, not a planning
+recommendation that would `Edit` a malformed `field.json`. When every
+deliverable is `complete`, say so: the engagement is complete by
+derivation, there is nothing to store.
 
 ### 4. Plan a Field's Deliverable Set
 
@@ -144,8 +147,8 @@ Field-set changes touch two places, always both, in this order:
      deliverable keeps living in exactly one field.
    - **Merge**: append the absorbed field's `deliverables[]` entries to the
      surviving field's manifest, `Edit` the absorbed field's retained
-     manifest to empty its `deliverables[]` (or annotate where each entry
-     moved), then treat the absorbed field as dropped.
+     manifest to empty its `deliverables[]` — the session summary records
+     where each entry moved — then treat the absorbed field as dropped.
    - **Drop** (and the leftover side of split/merge): honor the re-run
      guard from `consult-scope` — leave the field's directory and
      `field.json` in place and note the removal in the summary; deleting
@@ -160,8 +163,8 @@ Summarize what changed (fields added/split/merged, deliverables planned) and
 re-state the next-deliverable recommendation with its producing route — e.g.
 "Next: `competitor-landscape` in `market-evidence`, via
 `consult-design-thinking` once it ships." Until that skill ships, point the
-consultant at the deliverable's markdown artifact under the field directory
-as the working surface.
+consultant at the deliverable's markdown artifact location under the field
+directory as the working surface.
 
 ## Important Notes
 

--- a/cogni-consult/skills/consult-scope/SKILL.md
+++ b/cogni-consult/skills/consult-scope/SKILL.md
@@ -68,7 +68,7 @@ Close by naming 3-6 action fields per the method reference — each with a kebab
 
 ### 6. Close the Scope
 
-`Edit` `consult-project.json`: set `workflow_state.scope` to `"complete"` and `updated` to today's ISO date. Summarize what now exists — the key question, one line per dimension, and the action-field WBS — and recommend working the first action field's deliverables as the next step (via `consult-action-fields` once it ships; until then, point at the scaffolded `action-fields/` directories).
+`Edit` `consult-project.json`: set `workflow_state.scope` to `"complete"` and `updated` to today's ISO date. Summarize what now exists — the key question, one line per dimension, and the action-field WBS — and recommend working the first action field's deliverables as the next step — dispatch `Skill("cogni-consult:consult-action-fields")` to plan each field's deliverable set and pick the next deliverable.
 
 ## Important Notes
 

--- a/cogni-consult/skills/consult-scope/SKILL.md
+++ b/cogni-consult/skills/consult-scope/SKILL.md
@@ -68,7 +68,7 @@ Close by naming 3-6 action fields per the method reference — each with a kebab
 
 ### 6. Close the Scope
 
-`Edit` `consult-project.json`: set `workflow_state.scope` to `"complete"` and `updated` to today's ISO date. Summarize what now exists — the key question, one line per dimension, and the action-field WBS. Then recommend working the first action field's deliverables as the next step and dispatch `Skill("cogni-consult:consult-action-fields")` to plan each field's deliverable set and pick the next deliverable.
+`Edit` `consult-project.json`: set `workflow_state.scope` to `"complete"` and `updated` to today's ISO date. Summarize what now exists — the key question, one line per dimension, and the action-field WBS. Then recommend planning the first action field's deliverables as the next step and dispatch `Skill("cogni-consult:consult-action-fields")` to plan each field's deliverable set and pick the next deliverable.
 
 ## Important Notes
 

--- a/cogni-consult/skills/consult-scope/SKILL.md
+++ b/cogni-consult/skills/consult-scope/SKILL.md
@@ -68,7 +68,7 @@ Close by naming 3-6 action fields per the method reference — each with a kebab
 
 ### 6. Close the Scope
 
-`Edit` `consult-project.json`: set `workflow_state.scope` to `"complete"` and `updated` to today's ISO date. Summarize what now exists — the key question, one line per dimension, and the action-field WBS — and recommend working the first action field's deliverables as the next step — dispatch `Skill("cogni-consult:consult-action-fields")` to plan each field's deliverable set and pick the next deliverable.
+`Edit` `consult-project.json`: set `workflow_state.scope` to `"complete"` and `updated` to today's ISO date. Summarize what now exists — the key question, one line per dimension, and the action-field WBS. Then recommend working the first action field's deliverables as the next step and dispatch `Skill("cogni-consult:consult-action-fields")` to plan each field's deliverable set and pick the next deliverable.
 
 ## Important Notes
 


### PR DESCRIPTION
Closes #656.

## Summary
- New `skills/consult-action-fields/SKILL.md`: reads `action_fields[]` from `consult-project.json`, manages each field's deliverable manifest inside its existing `action-fields/<field-slug>/field.json` (no separate `deliverables.json` — `field.json` is already the single source of truth per the data model), renders the WBS dashboard (fields × deliverables × status) via `engagement-status.sh`, and recommends the next unstarted deliverable.
- Extends each `field.json` deliverable entry with `producing_route` (default `consult-design-thinking`) and `persona_review` (`pending`/`in-progress`/`complete`); reuses the existing `pending`/`in-progress`/`complete` state enum (maps the issue's planned/in-progress/done wording onto it — no second enum).
- Field add/split/merge keeps `consult-project.json` `action_fields[]` (slug strings only) and the `action-fields/` directory tree consistent, honoring the consult-scope re-run guard (never overwrite an existing `field.json`).
- New `references/deliverable-types.md`: adapts cogni-consulting's deliverable catalog (16 types) reframing Source Phase → field-type affinity. The cogni-consulting original is left untouched.
- Updates `consult-scope/SKILL.md` step 6 and `CLAUDE.md` to point at the now-shipped skill; extends `references/data-model.md` field.json schema with the two new fields.
- Bumps `plugin.json` and `marketplace.json` 0.0.3 → 0.0.4 (maturity stays `incubating`).

## Scope decisions
- **field.json, not deliverables.json**: the issue proposed a new `deliverables.json`, but `references/data-model.md` already defines `field.json` as the single source of truth for a field's deliverable states, and `engagement-status.sh` reads it. Adding a parallel file would create exactly the drift the data model designs out. The two new attributes are added to the existing per-deliverable entries instead.
- **No hard dispatch of unshipped skills**: `consult-design-thinking` and `consult-personas` are not yet shipped, so `producing_route`/`persona_review` are recorded and recommended (recommend-route semantics) rather than dispatched, mirroring how consult-scope referenced this very skill before it shipped.
- Full scope of the issue ships in one reviewable PR; nothing deferred.

## Plan record
https://github.com/cogni-work/insight-wave/issues/656#issuecomment-4679432373

## Test plan
- [ ] Run `consult-action-fields` against an engagement scoped by `consult-scope`; confirm it lists each action field with its deliverables, states, producing route, and persona-review status.
- [ ] Confirm the dashboard calls `engagement-status.sh <engagement-dir>` first and renders fields × deliverables × status.
- [ ] Confirm it recommends the first `pending` deliverable as the next step.
- [ ] Add a new action field via the skill; confirm `consult-project.json` `action_fields[]` gains the slug string AND a new `action-fields/<slug>/field.json` stub appears, with existing field.json files untouched.
- [ ] Confirm `references/deliverable-types.md` exists and `cogni-consulting/references/deliverable-map.md` is unchanged.
- [ ] Confirm `plugin.json` and `marketplace.json` both read 0.0.4 and `references/data-model.md` documents `producing_route` + `persona_review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)