### PR TITLE
cogni-consult: per-deliverable design-thinking loop skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -349,7 +349,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "maturity": "incubating",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work, and cogni-knowledge is the central research tool across all skills.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -14,7 +14,10 @@ cogni-consult/
 ├── references/
 │   ├── data-model.md              Engagement structure + entity schemas
 │   └── methods/
-│       └── scope-dimensions.md    SMART key question + 5 dimensions + WBS-close method
+│       ├── scope-dimensions.md    SMART key question + 5 dimensions + WBS-close method
+│       ├── empathy-mapping.md     Empathize-stage persona quadrant mapping
+│       ├── hmw-synthesis.md       Define-stage HMW problem-spec synthesis
+│       └── guided-ideation.md     Ideate-stage diverge→converge facilitation
 ├── scripts/
 │   ├── engagement-init.sh         Create engagement directory skeleton
 │   ├── engagement-status.sh       Read consult-project.json state → JSON
@@ -23,11 +26,13 @@ cogni-consult/
 └── skills/
     ├── consult-setup/SKILL.md     Engagement entry point: scaffold + knowledge-base bind
     │                              + registry
-    └── consult-scope/SKILL.md     SMART key question + 5 scoping dimensions
-                                   + 3-6 action fields as the WBS
+    ├── consult-scope/SKILL.md     SMART key question + 5 scoping dimensions
+    │                              + 3-6 action fields as the WBS
+    └── consult-design-thinking/SKILL.md  Per-deliverable DT loop (empathize→define
+                                   →ideate→prototype→test) + artifact + state writes
 ```
 
-Later work: consult-action-fields, consult-design-thinking, consult-personas, consult-resume skills.
+Later work: consult-action-fields, consult-personas, consult-resume skills.
 
 ## Design Principles
 

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -112,6 +112,13 @@ and their states.
 `empathize` → `define` → `ideate` → `prototype` → `test`. The loop may re-enter
 earlier stages; `state` stays `in-progress` until `test` passes.
 
+Deliverable entries may carry an optional `persona_review` field — the
+acting-persona challenge status for that deliverable: `pending` →
+`in-progress` (challenges start) → `complete` (every challenge dispositioned).
+Only the consult-personas skill sets and advances it; no skill creates the
+field on an entry that lacks it. When absent, persona `work_log` entries (and
+the artifact's challenge section) are the challenge record.
+
 ### Deliverable artifacts ({deliverable-slug}.md)
 
 Obsidian-browsable markdown with YAML frontmatter. State is intentionally

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -115,8 +115,9 @@ earlier stages; `state` stays `in-progress` until `test` passes.
 Deliverable entries may carry an optional `persona_review` field — the
 acting-persona challenge status for that deliverable: `pending` →
 `in-progress` (challenges start) → `complete` (every challenge dispositioned).
-Only the consult-personas skill sets and advances it; no skill creates the
-field on an entry that lacks it. When absent, persona `work_log` entries (and
+Only the consult-personas skill creates it; skills that run persona
+challenges (consult-personas, and consult-design-thinking's test stage)
+advance it; no skill creates the field on an entry that lacks it. When absent, persona `work_log` entries (and
 the artifact's challenge section) are the challenge record.
 
 ### Deliverable artifacts ({deliverable-slug}.md)

--- a/cogni-consult/references/methods/empathy-mapping.md
+++ b/cogni-consult/references/methods/empathy-mapping.md
@@ -1,0 +1,89 @@
+---
+name: Empathy Mapping
+stage: empathize
+type: divergent
+inputs: [personas, deliverable-framing, knowledge-base-synthesis]
+outputs: [enriched-personas]
+duration_estimate: "15-30 min per persona"
+---
+
+# Empathy Mapping
+
+Build a rich understanding of each persona by mapping what they think, feel, say, and do. This method bridges the gap between knowing *about* someone and understanding *what it's like to be them* — which is the difference between deliverables that look good on slides and deliverables stakeholders actually adopt. In cogni-consult it runs at the **empathize stage** of a deliverable's design-thinking loop, scoped to the personas that matter for *this* deliverable.
+
+## When to Use
+
+- At the empathize stage of any deliverable whose adoption depends on people — before sharpening the spec, understand who it must serve
+- When personas exist in `personas/` (even as hypotheses) and the engagement's knowledge base or prior deliverables have produced evidence to ground them
+- Skip when the deliverable is purely mechanical (e.g. a data extract) and no persona's reality changes the outcome — note the skip in the deliverable's define-stage spec
+
+## Guided Prompt Sequence
+
+### Step 1: Select a Persona
+
+Present the available personas from `personas/`. For each, show: name, role, context, core tension, current maturity level.
+
+Ask: "Which persona should we map first for this deliverable? I'd recommend the one whose reality most shapes whether it lands."
+
+### Step 2: Map Each Quadrant
+
+For each quadrant, draw from evidence first (knowledge-base synthesis, prior deliverables in this or other action fields), then supplement with consultant knowledge. The distinction matters — evidence-based entries carry more weight than assumptions, and gaps reveal where understanding is thin.
+
+**Thinks** — What occupies their mind? What worries them? What do they believe about the situation?
+- Prompt: "When this person thinks about [the deliverable's topic], what goes through their mind? What are they worried about? What assumptions do they carry?"
+
+**Feels** — What emotions drive their behavior? What frustrates, excites, or frightens them?
+- Prompt: "How does this person feel about the current situation? About the prospect of change? What past experiences color their feelings?"
+
+**Says** — What do they actually say out loud? What language do they use?
+- Prompt: "If you overheard this person talking to a colleague about [the deliverable's topic], what would they say? Use their actual words, not a polished version."
+
+**Does** — What behaviors can you observe? What workarounds have they created?
+- Prompt: "What does this person actually do day-to-day that relates to this deliverable? What workarounds have they invented? What do they avoid?"
+
+### Step 3: Surface Gaps and Contradictions
+
+After mapping all four quadrants, look for:
+
+- **Gaps**: Quadrants with thin or no evidence — these are where understanding is weakest and assumptions are most dangerous. Flag them explicitly; they are candidates for a knowledge-base research pass.
+- **Say-Do contradictions**: What people say often differs from what they do. These contradictions are rich design inputs — a person who says "I want data-driven decisions" but relies on gut feeling is telling you something important about trust and tools.
+- **Think-Feel tensions**: Internal conflicts (e.g., "thinks the change is necessary" but "feels anxious about losing control") predict adoption barriers that rational arguments won't resolve.
+
+### Step 4: Extract Needs
+
+From the empathy map, distill 2-5 need statements. Good needs:
+
+- Are framed from the persona's perspective, not the organization's
+- Describe the desired state, not the solution: "Needs to trust the data before making decisions" not "Needs a dashboard"
+- Connect to the core tension: each need should relate to what makes the current situation unsatisfying
+
+### Step 5: Update the Persona
+
+Write the enriched data back to `personas/{slug}.json` via `Edit`:
+- Populate `empathy_map` with the four quadrants
+- Add extracted needs to `needs`
+- Promote `maturity` to `"researched"` if substantive evidence was added (at least 2 quadrants have evidence-based entries)
+- Append to `work_log`: `{"action_field": "<field-slug>", "deliverable": "<deliverable-slug>", "action": "empathy-mapped", "date": "<ISO date>"}`
+
+### Step 6: Repeat for Additional Personas
+
+If 2-4 personas matter for this deliverable, map each one. Between personas, note where their empathy maps overlap or conflict — a tension between two personas' needs is often the most important design constraint, and feeds the define-stage spec directly.
+
+## Output
+
+The primary output is the enriched persona files in `personas/`. No separate artifact is needed — the empathy map lives inside the persona entity, and the key insights flow into the deliverable's define-stage spec.
+
+Optionally, present a summary to the consultant:
+
+> **Empathy mapping complete for [N] personas.**
+> - [Persona 1]: [one-line summary of key insight]
+> - [Persona 2]: [one-line summary]
+> - Key tension between personas: [if applicable]
+> - Gaps: [quadrants where evidence is thin]
+
+## Tips
+
+- Real quotes are gold — if the consultant has heard the persona say something, capture the exact words
+- Emotions are harder to surface than facts — give the consultant time to reflect rather than rushing to the next quadrant
+- Resist the urge to make the empathy map "nice" — contradictions, frustrations, and irrational behaviors are the most valuable inputs for design
+- If the consultant has no evidence for a quadrant, mark it as assumed rather than fabricating entries

--- a/cogni-consult/references/methods/guided-ideation.md
+++ b/cogni-consult/references/methods/guided-ideation.md
@@ -1,0 +1,90 @@
+---
+name: guided-ideation
+description: Facilitated creative session for generating and selecting solution ideas from a deliverable's define-stage problem spec.
+stage: ideate
+type: divergent-to-convergent
+inputs: [deliverable-problem-spec, personas, consultant-expertise]
+outputs: [solution-sketches]
+duration_estimate: "45-60 min"
+---
+
+# Guided Ideation
+
+A structured brainstorming method that moves from divergent idea generation to convergent solution selection. In cogni-consult it runs at the **ideate stage** of a deliverable's design-thinking loop: the input is the define-stage problem spec (the locked HMW questions), and the output feeds the prototype stage directly.
+
+## When to Use
+
+- At the ideate stage of any deliverable whose shape is not predetermined — when there is a real choice about what the deliverable should contain or recommend
+- Works well when solutions require human judgment and creativity rather than data analysis, and when the consultant and/or stakeholders have domain expertise to draw on
+- Keep it brief for deliverables with an obvious shape (e.g. a standard market-sizing table): one diverge-converge pass is enough
+
+## Facilitation Flow
+
+### 1. Restate the Challenge
+
+Start by reading back the deliverable's define-stage problem spec (the locked HMW questions). Confirm the consultant still sees this as the right framing. If understanding shifted since define, loop back — the design-thinking loop may re-enter earlier stages.
+
+### 2. Diverge — Generate Ideas
+
+The goal is quantity, not quality. Suspend judgment. Ask the consultant to think broadly:
+
+- "What are all the ways we could address this?"
+- "What would you do if there were no constraints?"
+- "What's the simplest possible version?"
+- "What would a competitor do? A startup? A completely different industry?"
+
+Capture every idea — even half-formed ones. Aim for 10-20 ideas. If the consultant stalls below 8, use creative constraints to unlock more:
+
+| Constraint | Prompt |
+|---|---|
+| Time | "What if you had to solve this by Friday?" |
+| Budget | "What if the budget were zero? What if it were unlimited?" |
+| Scale | "What if this had to serve 10x the audience?" |
+| Inversion | "What's the opposite of the current approach?" |
+| Analogy | "How does [another domain] solve a similar problem?" |
+
+### 3. Cluster Ideas
+
+Group the raw ideas into 3-6 themes. Name each cluster. Some ideas will span clusters — note the connections but assign each idea to its primary cluster.
+
+### 4. Converge — Select Top Ideas
+
+For each cluster, ask the consultant to identify the most promising idea. Selection criteria to guide the conversation:
+
+- **Impact**: How much does this move the needle on the HMW question?
+- **Feasibility**: Can we actually do this with available resources?
+- **Energy**: Does the consultant (or team) feel excited about this?
+
+Narrow to 2-3 top ideas.
+
+### 5. Solution Sketching
+
+For each top idea, flesh it out into a rough solution design:
+
+- **What**: Describe the solution in 2-3 sentences
+- **Who**: Who does what? (roles, responsibilities)
+- **How**: Key steps or activities involved
+- **When**: Rough timeline or sequence
+- **What could go wrong**: Top 1-2 risks and how to mitigate them
+
+These sketches are the direct input for the prototype stage — the strongest sketch (or a deliberate combination) becomes the deliverable artifact's spine.
+
+### 6. Quick Feasibility Check
+
+For each solution sketch, rate:
+- Can we start this within 2 weeks? (yes/no/depends)
+- Do we have the people? (yes/need to recruit/need external help)
+- What's the biggest unknown?
+
+This check prevents the deliverable from recommending a beautiful design that can't actually be executed.
+
+## Output
+
+The ideation results live inline in the deliverable's working conversation and flow into the artifact at the prototype stage — record the selected idea(s), the rejected clusters, and the selection rationale as an "Options considered" section of the deliverable artifact. Log the method selection in `.metadata/method-log.json` (proposed vs. selected, with rationale) per the data model.
+
+## Tips for the Facilitator
+
+- Silence is productive — give the consultant time to think rather than filling gaps
+- Capture the consultant's exact words — paraphrasing too early loses nuance
+- If one idea dominates, deliberately explore alternatives before accepting it
+- The best ideas often come from combining two weaker ones

--- a/cogni-consult/references/methods/guided-ideation.md
+++ b/cogni-consult/references/methods/guided-ideation.md
@@ -1,6 +1,5 @@
 ---
-name: guided-ideation
-description: Facilitated creative session for generating and selecting solution ideas from a deliverable's define-stage problem spec.
+name: Guided Ideation
 stage: ideate
 type: divergent-to-convergent
 inputs: [deliverable-problem-spec, personas, consultant-expertise]

--- a/cogni-consult/references/methods/hmw-synthesis.md
+++ b/cogni-consult/references/methods/hmw-synthesis.md
@@ -1,0 +1,67 @@
+---
+name: HMW Synthesis
+stage: define
+type: convergent
+inputs: [empathize-outputs, field-framing]
+outputs: [deliverable-problem-spec]
+duration_estimate: "20-30 min with consultant"
+---
+
+# How Might We (HMW) Synthesis
+
+Sharpen the problem a single deliverable must solve into actionable "How Might We" questions. In cogni-consult this runs at the **define stage** of a deliverable's design-thinking loop: the inputs are the empathize-stage outputs (enriched personas, surfaced tensions) plus the action field's `framing` line, and the output is the deliverable's problem spec — recorded inline in the deliverable conversation and artifact, not as a separate file.
+
+## When to Use
+
+- At the define stage of every deliverable — the bridge between understanding (empathize) and option generation (ideate)
+- Especially valuable when the empathize stage surfaced contradictions or tensions; the HMW question is where they become productive
+
+## Guided Prompt Sequence
+
+### Step 1: Review the Inputs
+Restate the action field's `framing` (from `field.json`) and the key insights from the empathize stage — persona needs, say-do contradictions, think-feel tensions. Confirm with the consultant that these are the right raw material for this deliverable.
+
+### Step 2: Draft HMW Questions
+Draft 2-3 HMW questions for the deliverable. When personas exist in `personas/`, use **persona-centered framing** — this shifts the question from organizational outcomes to human outcomes, keeping the people the deliverable serves at the center.
+
+**Persona-centered format** (recommended when personas exist):
+- "How might we help [persona] to [need/outcome]?"
+- Example: "How might we help shift leaders make data-driven decisions without adding to their cognitive load?"
+- When a HMW addresses multiple personas, name the primary one and note secondary stakeholders.
+
+**Outcome-centered format** (use when no personas exist or for system-level questions):
+- "How might we [outcome]?"
+- Example: "How might we make our monitoring platform the default choice for mid-market hybrid environments?"
+
+The persona-centered format is more powerful because it forces specificity — "reduce costs" becomes "help shift leaders spend less time on paperwork." When both formats seem equally valid, prefer the persona-centered one.
+
+Good HMW questions:
+
+**Are the right scope**:
+- Too broad: "How might we grow the business?" (useless)
+- Too narrow: "How might we add a dark mode toggle?" (premature)
+- Just right: "How might we help shift leaders make data-driven decisions without adding to their cognitive load?"
+
+**Contain a tension**:
+- "How might we help the field service team reduce response times while preserving the personal relationships customers depend on?"
+- "How might we enter the French market without cannibalizing our DACH partnerships?"
+
+**Are actionable**:
+- Each HMW should be something the ideate stage can brainstorm solutions for
+- If it's purely analytical ("How might we understand..."), reframe toward action
+
+### Step 3: Refine with Consultant
+Present the HMW questions and iterate:
+- Are these the right questions for *this deliverable* to be answering?
+- Do they capture the most important tensions?
+- Is the scope right — not too broad, not too narrow?
+- Missing any critical dimensions?
+
+### Step 4: Lock the Problem Spec
+Converge on 1-3 HMW questions that frame this deliverable's problem space — fewer than an engagement-level synthesis, because the scope is one deliverable, not a whole diamond. The locked spec is the brief for the ideate stage. Record it:
+
+- Inline in the deliverable conversation summary, and
+- As the deliverable artifact's opening "Problem" section once the prototype stage drafts the artifact, and
+- As a decision-log entry (the define-stage decision: which problem framing was locked, and why).
+
+No separate `hmw-questions.md` file — the deliverable artifact is the single home for this deliverable's content.

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -162,9 +162,8 @@ for that field's deliverable states.
 Summarize what changed (fields added/split/merged, deliverables planned) and
 re-state the next-deliverable recommendation with its producing route — e.g.
 "Next: `competitor-landscape` in `market-evidence`, via
-`consult-design-thinking` once it ships." Until that skill ships, point the
-consultant at the deliverable's markdown artifact location under the field
-directory as the working surface.
+`consult-design-thinking`." Offer to run that route now; the deliverable's
+markdown artifact lands under the field directory either way.
 
 ## Important Notes
 

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -6,8 +6,8 @@ description: |
   empathize→define→ideate→prototype→test on one deliverable inside an action
   field. Trigger on: "work the deliverable", "run design thinking on
   <deliverable>", "produce the <deliverable> deliverable", "start the DT loop",
-  "draft the deliverable", "continue the deliverable", or when
-  consult-action-fields recommends the next unstarted deliverable. Route global
+  "draft the deliverable", "continue the deliverable", or when a WBS
+  dashboard recommendation hands off the next unstarted deliverable. Route global
   phase phrasing ("discover phase", "develop phase", "diamond") to the
   cogni-consulting plugin instead — cogni-consult has no engagement-level
   phases; design thinking runs per deliverable.
@@ -51,9 +51,12 @@ Read `<engagement-dir>/consult-project.json`. Branch explicitly:
 Then identify the target deliverable: the consultant names it, or pick the
 recommendation handed in. Read the field's
 `action-fields/<field-slug>/field.json` and confirm the deliverable entry
-exists (slug, title, `state`, `dt_stage`). If the entry is missing, stop and
-point the consultant at the WBS manifest — this skill produces deliverables,
-it never invents manifest entries.
+exists (slug, title, `state`, `dt_stage`). If the entry is missing, stop —
+this skill produces deliverables, it never invents manifest entries. As the
+interim recovery, have the consultant add the deliverable entry (slug, title,
+`state: "pending"`, `dt_stage`) to `action-fields/<field-slug>/field.json`
+per `$CLAUDE_PLUGIN_ROOT/references/data-model.md`, then re-run this skill;
+once a WBS-authoring skill ships, this becomes a dispatch instead.
 
 When `language` is set in `consult-project.json`, hold the conversation in
 that language; technical terms, slugs, and file names stay English.

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -71,6 +71,13 @@ If the deliverable is already `in-progress`, resume at its current `dt_stage`
 — re-entering an earlier stage is normal (the loop may iterate); just keep
 `dt_stage` honest at each boundary.
 
+If the deliverable is `complete` and the consultant wants rework ("continue
+the deliverable", a revision request), confirm the re-entry first, then one
+`Edit` of `field.json` sets `state` back to `"in-progress"` with `dt_stage`
+at the stage the rework needs (often `define` or `ideate`), and one `Edit` of
+`.metadata/execution-log.json` appends the `complete` → `in-progress`
+transition to `transitions[]`.
+
 ### 3. Empathize
 
 Read `$CLAUDE_PLUGIN_ROOT/references/methods/empathy-mapping.md` and run it
@@ -80,10 +87,11 @@ knowledge — persona files can be added later without redoing the loop.
 
 When the engagement has a bound knowledge base
 (`plugin_refs.knowledge_base`), recommend pulling existing synthesis first —
-dispatch `Skill("cogni-knowledge:knowledge-query")` against that base for the
-deliverable's topic. Evidence comes from the knowledge base, never from raw
-web search; when the base has no coverage, note the gap as a research need
-rather than improvising sources.
+dispatch `Skill("cogni-knowledge:knowledge-query")` with
+`--knowledge-slug <plugin_refs.knowledge_base>` for the deliverable's topic.
+Evidence comes from the knowledge base, never from raw web search; when the
+base has no coverage, note the gap as a research need rather than
+improvising sources.
 
 Close the stage with one `Edit` of `field.json`: `dt_stage` → `"define"`.
 
@@ -130,9 +138,10 @@ evidence-backed claim carries a `sources[]` entry. Then `Edit` `field.json`:
 Challenge the draft as the stakeholder personas, in their voice: for each
 relevant `personas/*.json`, pose the objections that persona's `role`,
 `core_tension`, and `empathy_map` imply, and revise the artifact where a
-challenge lands. Append one `work_log` entry per persona challenged
+challenge lands. Append one `work_log` entry per persona challenged to that
+persona's `personas/<persona-slug>.json` `work_log` array via `Edit`
 (`{"action_field": ..., "deliverable": ..., "action": "challenged",
-"date": ...}`) via `Edit`. When the manifest entry carries a
+"date": ...}`). When the manifest entry carries a
 `persona_review` field, advance it (`pending` → `in-progress` → `complete`)
 alongside the challenges; when it doesn't, the work_log entries are the
 record. With no personas on disk, run the challenge against the consultant

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: consult-design-thinking
+description: |
+  This skill should be used when the user wants to produce a deliverable of a
+  cogni-consult engagement by running its design-thinking loop —
+  empathize→define→ideate→prototype→test on one deliverable inside an action
+  field. Trigger on: "work the deliverable", "run design thinking on
+  <deliverable>", "produce the <deliverable> deliverable", "start the DT loop",
+  "draft the deliverable", "continue the deliverable", or when
+  consult-action-fields recommends the next unstarted deliverable. Route global
+  phase phrasing ("discover phase", "develop phase", "diamond") to the
+  cogni-consulting plugin instead — cogni-consult has no engagement-level
+  phases; design thinking runs per deliverable.
+allowed-tools: Read, Write, Edit, Bash, Skill
+---
+
+# Per-Deliverable Design Thinking
+
+Produce one deliverable by walking it through its own design-thinking loop:
+empathize → define → ideate → prototype → test. The loop is scoped to a single
+deliverable inside one action field — there is no engagement-level phase
+machine. The stage methods live in `$CLAUDE_PLUGIN_ROOT/references/methods/`
+(`empathy-mapping.md`, `hmw-synthesis.md`, `guided-ideation.md`); this skill
+owns the conversation flow, the artifact, and the state writes. Schemas:
+`$CLAUDE_PLUGIN_ROOT/references/data-model.md`.
+
+## Workflow
+
+### 1. Prerequisite Gate
+
+When arriving via an in-session handoff (e.g. from a WBS dashboard
+recommendation), the engagement directory and target deliverable are already
+known — skip discovery. Otherwise locate the engagement:
+
+```bash
+bash $CLAUDE_PLUGIN_ROOT/scripts/discover-projects.sh --json
+```
+
+and confirm the intended engagement with the user when more than one is
+registered. When discovery returns zero engagements, treat it the same as a
+missing `consult-project.json`.
+
+Read `<engagement-dir>/consult-project.json`. Branch explicitly:
+
+- If it is missing (or discovery returned zero engagements): dispatch
+  `Skill("cogni-consult:consult-setup")` and stop — write nothing.
+- If `workflow_state.scope` is not `"complete"`: dispatch
+  `Skill("cogni-consult:consult-scope")` and stop — write nothing. The WBS
+  must exist before deliverable work starts.
+
+Then identify the target deliverable: the consultant names it, or pick the
+recommendation handed in. Read the field's
+`action-fields/<field-slug>/field.json` and confirm the deliverable entry
+exists (slug, title, `state`, `dt_stage`). If the entry is missing, stop and
+point the consultant at the WBS manifest — this skill produces deliverables,
+it never invents manifest entries.
+
+When `language` is set in `consult-project.json`, hold the conversation in
+that language; technical terms, slugs, and file names stay English.
+
+### 2. Open the Loop
+
+If the deliverable's `state` is `pending`: one `Edit` of `field.json` sets it
+to `"in-progress"` and `dt_stage` to `"empathize"`, and one `Edit` of
+`.metadata/execution-log.json` appends to its `transitions[]` array the entry
+`{"action_field": "<field-slug>", "deliverable": "<deliverable-slug>",
+"from": "pending", "to": "in-progress", "timestamp": "<ISO>",
+"triggered_by": "consult-design-thinking"}`.
+
+If the deliverable is already `in-progress`, resume at its current `dt_stage`
+— re-entering an earlier stage is normal (the loop may iterate); just keep
+`dt_stage` honest at each boundary.
+
+### 3. Empathize
+
+Read `$CLAUDE_PLUGIN_ROOT/references/methods/empathy-mapping.md` and run it
+for the personas that matter to this deliverable (`personas/*.json`). When the
+directory is empty, say so and continue with the consultant's own stakeholder
+knowledge — persona files can be added later without redoing the loop.
+
+When the engagement has a bound knowledge base
+(`plugin_refs.knowledge_base`), recommend pulling existing synthesis first —
+dispatch `Skill("cogni-knowledge:knowledge-query")` against that base for the
+deliverable's topic. Evidence comes from the knowledge base, never from raw
+web search; when the base has no coverage, note the gap as a research need
+rather than improvising sources.
+
+Close the stage with one `Edit` of `field.json`: `dt_stage` → `"define"`.
+
+### 4. Define
+
+Read `$CLAUDE_PLUGIN_ROOT/references/methods/hmw-synthesis.md` and sharpen
+the deliverable's problem spec from the empathize outputs plus the field's
+`framing`. Lock 1-3 HMW questions with the consultant.
+
+Append the locked spec to `.metadata/decision-log.json`'s `decisions[]` array as a decision
+(`{"id": "d-NNN", "action_field": ..., "deliverable": ..., "decision":
+"<locked problem framing>", "rationale": ..., "evidence_refs": [...],
+"timestamp": ...}`). Then `Edit` `field.json`: `dt_stage` → `"ideate"`.
+
+### 5. Ideate
+
+Read `$CLAUDE_PLUGIN_ROOT/references/methods/guided-ideation.md` and run the
+diverge→cluster→converge→sketch flow against the locked spec. Keep it
+proportionate — a deliverable with an obvious shape needs one quick pass, not
+a full workshop.
+
+Append the method selection to `.metadata/method-log.json`'s `methods[]` array
+(`{"action_field": ..., "deliverable": ..., "proposed": [...], "selected":
+[...], "rationale": ...}`). Then `Edit` `field.json`: `dt_stage` →
+`"prototype"`.
+
+### 6. Prototype
+
+Draft the deliverable artifact at
+`action-fields/<field-slug>/<deliverable-slug>.md` — Obsidian markdown with
+YAML frontmatter exactly per the data model: `slug`, `action_field`,
+`sources[]` (each entry the lineage triple `source_url`, `entity_ref`,
+`propagated_at`, plus `kb_ref` when the claim came from the knowledge base),
+and `updated`. State is intentionally absent from the frontmatter — it lives
+in `field.json` only.
+
+Structure the body from the loop's outputs: the problem (define), options
+considered (ideate), the chosen approach, and the content itself. Every
+evidence-backed claim carries a `sources[]` entry. Then `Edit` `field.json`:
+`dt_stage` → `"test"`.
+
+### 7. Test
+
+Challenge the draft as the stakeholder personas, in their voice: for each
+relevant `personas/*.json`, pose the objections that persona's `role`,
+`core_tension`, and `empathy_map` imply, and revise the artifact where a
+challenge lands. Append one `work_log` entry per persona challenged
+(`{"action_field": ..., "deliverable": ..., "action": "challenged",
+"date": ...}`) via `Edit`. When the manifest entry carries a
+`persona_review` field, advance it (`pending` → `in-progress` → `complete`)
+alongside the challenges; when it doesn't, the work_log entries are the
+record. With no personas on disk, run the challenge against the consultant
+directly ("what would your engagement partner push back on?") and say the
+acting-persona pass will deepen once personas exist.
+
+If the draft survives (consultant accepts): one `Edit` of `field.json` sets
+`state` → `"complete"` (keep `dt_stage` at `"test"`), and one `Edit` of
+`.metadata/execution-log.json` appends the `in-progress` → `complete`
+transition to `transitions[]`. If it does not survive, loop back — set `dt_stage` to the stage
+the revision needs (often `define` or `ideate`) and continue; `state` stays
+`in-progress`.
+
+### 8. Close the Session
+
+Summarize: the deliverable's final state, the artifact path, key decisions
+logged, and which personas challenged it. Recommend the next step — the next
+unstarted deliverable in the WBS (via the WBS dashboard skill when present in
+the plugin, or by reading the field manifests directly).
+
+## Important Notes
+
+- **State ownership**: deliverable `state` and `dt_stage` live only in the
+  field's `field.json`; the artifact frontmatter never carries state. Field
+  and engagement completion are derived at read time. See
+  `$CLAUDE_PLUGIN_ROOT/references/data-model.md`.
+- **Edit, never rewrite**: `field.json`, `consult-project.json`,
+  `personas/*.json`, and the `.metadata/` logs are all edited surgically;
+  the root `consult-project.json` is never touched by deliverable work (its
+  `updated` covers root-file changes only).
+- **Evidence discipline**: research goes through the engagement's bound
+  knowledge base (`cogni-knowledge:knowledge-query`), never raw web search;
+  every evidence-backed claim in the artifact carries the `sources[]`
+  lineage triple so corrections can cascade.
+- **Loop, not gate**: stages may re-enter earlier stages; `state` stays
+  `in-progress` until the test stage passes. Log state transitions (not
+  per-stage moves) in the execution log.

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -52,11 +52,11 @@ Then identify the target deliverable: the consultant names it, or pick the
 recommendation handed in. Read the field's
 `action-fields/<field-slug>/field.json` and confirm the deliverable entry
 exists (slug, title, `state`, `dt_stage`). If the entry is missing, stop —
-this skill produces deliverables, it never invents manifest entries. As the
-interim recovery, have the consultant add the deliverable entry (slug, title,
-`state: "pending"`, `dt_stage`) to `action-fields/<field-slug>/field.json`
-per `$CLAUDE_PLUGIN_ROOT/references/data-model.md`, then re-run this skill;
-once a WBS-authoring skill ships, this becomes a dispatch instead.
+this skill produces deliverables, it never invents manifest entries.
+Dispatch `Skill("cogni-consult:consult-action-fields")` to plan the field's
+deliverable set (it writes the full planned-entry shape, including
+`producing_route` and `persona_review`), then resume here with the planned
+entry.
 
 When `language` is set in `consult-project.json`, hold the conversation in
 that language; technical terms, slugs, and file names stay English.
@@ -144,10 +144,13 @@ relevant `personas/*.json`, pose the objections that persona's `role`,
 challenge lands. Append one `work_log` entry per persona challenged to that
 persona's `personas/<persona-slug>.json` `work_log` array via `Edit`
 (`{"action_field": ..., "deliverable": ..., "action": "challenged",
-"date": ...}`). When the manifest entry carries a
-`persona_review` field, advance it (`pending` → `in-progress` → `complete`)
-alongside the challenges; when it doesn't, the work_log entries are the
-record. With no personas on disk, run the challenge against the consultant
+"date": ...}`), and append (or update) a `## Persona Challenges` section in
+the deliverable artifact summarizing each persona's challenge and the
+consultant's disposition (accepted / revised / rejected with reason). When
+the manifest entry carries a `persona_review` field, advance it (`pending` →
+`in-progress` when challenges start, → `complete` only once every challenge
+is dispositioned); when it doesn't, the work_log entries and the artifact
+section are the record. With no personas on disk, run the challenge against the consultant
 directly ("what would your engagement partner push back on?") and say the
 acting-persona pass will deepen once personas exist.
 


### PR DESCRIPTION
Closes #657.

## Summary
- New `skills/consult-design-thinking/SKILL.md`: takes one deliverable slug within an `action-fields/<field-slug>/` container and runs empathize → define → ideate → prototype → test, writing the artifact `action-fields/<field-slug>/<deliverable-slug>.md` (Obsidian markdown + YAML frontmatter per the data model) and updating `field.json` `state`/`dt_stage` at each stage boundary (single source of truth; Edit-not-rewrite).
- Three method reference docs adapted from cogni-consulting into `references/methods/`: `empathy-mapping.md` (empathize), `hmw-synthesis.md` (define), `guided-ideation.md` (ideate). Phase frontmatter replaced with `stage:`, `phase_log` reframed to `work_log` WBS coordinates, file-output steps reframed to write inline into the single deliverable artifact. Originals untouched.
- Empathize recommends querying the engagement's bound knowledge base (`plugin_refs.knowledge_base`) via `cogni-knowledge:knowledge-query` as the evidence path — never raw WebSearch.
- Test-stage persona challenge runs inline against `personas/*.json` when present, with a graceful empty-personas fallback; appends a `work_log` entry per the persona data model.
- `.metadata` logging with the array keys named explicitly: execution-log `transitions[]` at state transitions (`triggered_by: consult-design-thinking`), method-log `methods[]` at ideate, decision-log `decisions[]` at define.
- CLAUDE.md architecture tree updated (new skill + three methods/ entries); `consult-design-thinking` removed from the "Later work" line.
- Version bump 0.0.3 → 0.0.4 in plugin.json and marketplace.json.

## Scope decisions
- In: the full per-deliverable DT loop, artifact + field.json state writes, the three adapted method docs, inline persona challenge with empty-personas fallback, knowledge-base evidence recommendation.
- Out (sibling issues, already filed — not re-filed): full persona pipeline and full cogni-knowledge pipeline wiring; this PR consumes both surfaces optionally so it is correct under either merge order.
- `field.json` deliverable entries may carry an optional `persona_review` extension when present, but the skill never requires it to pre-exist (that field lands with the sibling WBS-manager PR; `engagement-status.sh` passes unknown fields through).
- Known post-merge touch-up (not in this PR): the WBS-manager skill's forward pointer to this skill — that file lives only on the unmerged sibling PR #667; it belongs to the merge sequence after both PRs land.

## Expected merge conflicts with PR #667 (trivial, resolved by merge order)
- CLAUDE.md "Later work" line (each branch removes its own skill name) and the version bump (both bump 0.0.3→0.0.4 in plugin.json/marketplace.json). Resolve by taking both removals and re-bumping to the next patch on the second merge.

## Plan record
https://github.com/cogni-work/insight-wave/issues/657#issuecomment-4679630417

## Test plan
- [ ] SKILL.md frontmatter valid (name, third-person description with triggers + route-away, allowed-tools); passes `cogni-workspace/scripts/check-skill-names.sh`.
- [ ] No issue refs or version tags in SKILL.md / method docs (`scripts/check-breadcrumbs.py` — 0 new).
- [ ] Each stage writes `field.json` via Edit (state/dt_stage); artifact frontmatter matches data-model.md (slug, action_field, sources[] lineage triple + kb_ref, updated; no state).
- [ ] Prerequisite gate dispatches explicitly per branch (consult-setup for missing project, consult-scope for incomplete scope).
- [ ] Empathize references `cogni-knowledge:knowledge-query` against `plugin_refs.knowledge_base`, not WebSearch; test stage degrades gracefully when `personas/` is empty.
- [ ] Method docs carry `stage:` (not `phase:`) frontmatter and `work_log` WBS coordinates.
- [ ] plugin.json + marketplace.json both read 0.0.4; CLAUDE.md tree lists the new skill and three methods; "Later work" drops consult-design-thinking only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)