### PR TITLE
cogni-consult: log verbatim gap-check query for reproducible routing decisions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -350,7 +350,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -167,7 +167,7 @@ All three logs address work by the same structured coordinates —
 
 - **execution-log.json** — workflow-state transitions: `{"transitions": [{"action_field": "...", "deliverable": "...", "from": "pending", "to": "in-progress", "timestamp": "...", "triggered_by": "<skill>"}]}`
 - **method-log.json** — methods proposed/selected per deliverable: `{"methods": [{"action_field": "...", "deliverable": "...", "proposed": [...], "selected": [...], "rationale": "..."}]}`
-- **decision-log.json** — key decisions with rationale and evidence refs: `{"decisions": [{"id": "d-001", "action_field": "...", "deliverable": "...", "decision": "...", "rationale": "...", "evidence_refs": [...], "timestamp": "..."}]}`
+- **decision-log.json** — key decisions with rationale and evidence refs: `{"decisions": [{"id": "d-001", "action_field": "...", "deliverable": "...", "decision": "...", "rationale": "...", "evidence_refs": [...], "timestamp": "..."}]}`. Gap-check entries share the same array, discriminated by `"kind": "gap-check"`: `{"id": "d-002", "kind": "gap-check", "action_field": "...", "deliverable": "...", "question": "<verbatim --question>", "theme_label": null, "verdict": "covered", "top_hit": "<page-slug>", "top_score": 0.36, "timestamp": "..."}` (recording contract: `references/research-routing.md`, Gap-Check Recording)
 
 ### personas/{slug}.json (Acting Stakeholder Personas)
 

--- a/cogni-consult/references/research-routing.md
+++ b/cogni-consult/references/research-routing.md
@@ -44,6 +44,22 @@ Pick the rung that matches what the base already holds:
   shows a gap, escalate to one of the two rungs above rather than filling
   the gap from model memory or ad-hoc search.
 
+### Gap-Check Recording
+
+Record every gap-check by appending one entry to
+`.metadata/decision-log.json`'s `decisions[]` array tagged
+`"kind": "gap-check"`, carrying the **verbatim** question exactly as passed
+(`question`), the theme label or `null` (`theme_label`), the returned
+coverage verdict (`verdict`: `covered` / `partial` / `uncovered`), the
+top-ranked page slug or `null` (`top_hit`), its overlap score or `null`
+(`top_score`), plus the standard `id`, `action_field`, `deliverable`, and
+`timestamp` fields (entry shape: `references/data-model.md`). The verbatim
+query is the load-bearing field — a reconstructed query returns a different
+ranking score, so re-running the routing decision bit-for-bit requires the
+exact string, never a paraphrase. The `kind` discriminator keeps gap-check
+records distinguishable from the locked-spec decision entries sharing the
+same array.
+
 ## Depth Framing
 
 Frame the run's depth when dispatching `knowledge-plan`:

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -94,6 +94,9 @@ Research for this stage follows the Research Routing Rule in
 contract for every research run in the engagement. Start with the gap-check
 rung: dispatch `Skill("cogni-knowledge:knowledge-query")` with
 `--knowledge-slug <plugin_refs.knowledge_base>` for the deliverable's topic.
+Record each gap-check per the Gap-Check Recording contract in the Research
+Routing Rule — one `decisions[]` entry in `.metadata/decision-log.json`
+carrying the verbatim question.
 When the base has no coverage, escalate to the full inverted pipeline (or
 the `--source wiki` re-run on a populated base) per the rule, and copy the
 finalized synthesis to `action-fields/<field-slug>/research/<topic-slug>.md`


### PR DESCRIPTION
Closes #688.

## Summary
- Add a **Gap-Check Recording** contract to the Quick gap-check rung in `cogni-consult/references/research-routing.md`: every gap-check appends one `.metadata/decision-log.json` `decisions[]` entry tagged `kind: "gap-check"` carrying the verbatim `question`, `theme_label` (null if unused), `verdict`, `top_hit` slug, `top_score`, and the standard `id`/`action_field`/`deliverable`/`timestamp` — so the routing decision is re-runnable bit-for-bit (a reconstructed query returns a different ranking score, as the dogfood run showed: 0.31 vs the recorded 0.36).
- Add a 3-line pointer instruction to the **Empathize** stage of `consult-design-thinking/SKILL.md` referencing the canonical contract (no restated field list — anti-drift).
- Document the gap-check `decisions[]` entry shape (with the `kind` discriminator distinguishing it from locked-spec decision entries sharing the array) in `references/data-model.md`.
- Bump `cogni-consult` 0.1.0 → 0.1.1 in `plugin.json` and `marketplace.json` (rebased on the just-merged Preview promotion; the issue pre-dated it at 0.0.9).

## Scope decisions
- **In:** the canonical recording contract lives in `research-routing.md` (the file all three deliverable skills point at, auto-covering `consult-scope` / `consult-action-fields` if later wired), one recording instruction in the empathize stage that dispatches the gap-check today, and the schema doc.
- **Out / not needed:** no changes to `wiki-grounding.py` / `knowledge-query` — the inputs (`--question`, `--theme`) and outputs (verdict, top slug, score) are already in the caller's hands at dispatch time, and the decision-log is engagement-scoped state cogni-knowledge knows nothing about.
- **Deferred:** none — full scope.

## Test plan
- [x] `research-routing.md` Quick gap-check rung specifies the `decisions[]` entry with verbatim `question`, `theme_label`, `verdict`, `top_hit`, `top_score`, `kind` discriminator
- [x] `consult-design-thinking/SKILL.md` empathize stage instructs recording per the canonical contract without restating the field list
- [x] `data-model.md` documents the gap-check entry shape alongside the locked-spec decision shape
- [x] `scripts/check-breadcrumbs.py` passes (no new issue/PR refs in skills/references)
- [x] `check-skill-names.sh` passes; both manifests valid JSON at version `0.1.1`
- [x] skill-quality-reviewer verdict: pass

Plan record: https://github.com/cogni-work/insight-wave/issues/688#issuecomment-4691474489

🤖 Generated with [Claude Code](https://claude.com/claude-code)