### PR TITLE
docs(ecosystem-overview): add cogni-knowledge + cogni-wiki rows, reconcile plugin count to 16 (closes #673)

### DIFF
--- a/docs/ecosystem-overview.md
+++ b/docs/ecosystem-overview.md
@@ -8,7 +8,7 @@ For the canonical plugin descriptions, see the individual README files. For step
 
 ## Plugin Landscape
 
-The 14 plugins are grouped by the role they play in a typical engagement.
+The 16 plugins (15 active, 1 archived) are grouped by the role they play in a typical engagement — the same set the root [`marketplace.json`](../.claude-plugin/marketplace.json) enumerates.
 
 ### Foundation
 
@@ -24,6 +24,8 @@ Run `/manage-workspace` once per project directory before using any other plugin
 |--------|-------------|
 | [cogni-research](../cogni-research/README.md) | Runs a parallel multi-agent web research pipeline (STORM-inspired). Decomposes a topic into sub-questions, dispatches one agent per question, aggregates sources, writes a structured report with inline citations, and verifies claims. |
 | [cogni-trends](../cogni-trends/README.md) | Scouts industry trends using the Smarter Service Trendradar framework and bridges them to portfolio solutions via the TIPS content framework (Trends, Implications, Possibilities, Solutions). Produces CxO-ready trend reports with investment theme modeling. Bilingual EN/DE, DACH-focused. |
+| [cogni-knowledge](../cogni-knowledge/README.md) | Wiki-first research that compounds across runs. Binds each project to a cogni-wiki knowledge base so future runs read what prior runs filed before hitting the web. Inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification. See the [deep dive](plugin-guide/cogni-knowledge.md). |
+| [cogni-wiki](../cogni-wiki/README.md) | The knowledge substrate behind cogni-knowledge: a local Karpathy-style wiki of typed, cross-linked pages (sources, concepts, entities, questions, syntheses) with claim-level provenance. Incubating; its engine is being absorbed into cogni-knowledge (FMO), with archival pending the Epic C human sign-off. See the [deep dive](plugin-guide/cogni-wiki.md). |
 
 See [Research to Report workflow](workflows/research-to-report.md) for how research output moves downstream.
 


### PR DESCRIPTION
## Summary

Fixes the pre-existing drift in `docs/ecosystem-overview.md` deferred from #661: the doc enumerated **14** plugin rows and its prose said "14 plugins", while the root `marketplace.json` carries **16**.

## What changed

- **Added two missing rows** to the *Research and Analysis* section:
  - **cogni-knowledge** — the wiki-first research orchestrator (inverted pipeline, zero-network citation-consistent verification), linking its README + [deep dive](docs/plugin-guide/cogni-knowledge.md).
  - **cogni-wiki** — the knowledge substrate behind cogni-knowledge, linking its README + [deep dive](docs/plugin-guide/cogni-wiki.md).
- **Reconciled the count prose** from "The 14 plugins…" to "The 16 plugins (15 active, 1 archived)…", and pointed it at `marketplace.json` as the authoritative enumeration.

## Decisions (per the issue)

- **Count source:** the enumerated rows are reconciled to the **marketplace** (16). Verified the 16 enumerated rows now equal the 16 marketplace plugin names exactly — no missing, no extra.
- **cogni-wiki row:** written for **current reality** (a live *incubating* plugin) while acknowledging the pending FMO absorption + archival. It is **not** pre-emptively marked archived — the archival itself remains the Epic C (#506) human go/no-go gate, out of scope here.

## Verification

- Enumerated plugin rows (16) cross-checked programmatically against `marketplace.json` plugin names: exact match, zero missing / zero extra.
- All four new links resolve (`../cogni-knowledge/README.md`, `../cogni-wiki/README.md`, `plugin-guide/cogni-knowledge.md`, `plugin-guide/cogni-wiki.md` all exist).
- No other stale plugin-count reference remains in the doc.

Docs-only change — no plugin surface touched, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)