### PR TITLE
ci(repo): external-dispatch grep-guard — assert zero cogni-wiki:/cogni-research: dispatches (closes #507)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -93,7 +93,7 @@
     {
       "name": "cogni-trends",
       "source": "./cogni-trends",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "maturity": "preview",
       "description": "Strategic trend scouting and TIPS reporting pipeline. Combines the Smarter Service Trendradar (4 dimensions) with TIPS (Trends, Implications, Possibilities, Solutions): trend-scout → value-modeler → trend-research → trend-synthesis and/or trend-booklet → verify-trend-report. Evidence-backed CxO reports and reusable industry catalogs across DE/FR/IT/PL/NL/ES + US/UK.",
       "keywords": [

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           python3 scripts/check-breadcrumbs.py
 
   external-dispatch-guard:
-    name: External-dispatch guard (zero cogni-wiki:/cogni-research:)
+    name: External-dispatch guard (zero retired-engine dispatches)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,7 +32,7 @@ jobs:
         # Default shallow checkout is sufficient: the guard reads the working
         # tree via `git ls-files`, not git history.
 
-      - name: Assert zero cogni-wiki:/cogni-research: dispatches in live surfaces
+      - name: Assert zero cogni-wiki and cogni-research dispatches in live surfaces
         run: |
           set -euo pipefail
           python3 scripts/check-external-dispatch.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,3 +22,17 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/check-breadcrumbs.py
+
+  external-dispatch-guard:
+    name: External-dispatch guard (zero cogni-wiki:/cogni-research:)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        # Default shallow checkout is sufficient: the guard reads the working
+        # tree via `git ls-files`, not git history.
+
+      - name: Assert zero cogni-wiki:/cogni-research: dispatches in live surfaces
+        run: |
+          set -euo pipefail
+          python3 scripts/check-external-dispatch.py

--- a/cogni-trends/.claude-plugin/plugin.json
+++ b/cogni-trends/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-trends",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Strategic trend scouting and TIPS reporting pipeline. Combines the Smarter Service Trendradar (4 dimensions) with TIPS (Trends, Implications, Possibilities, Solutions): trend-scout → value-modeler → trend-research → trend-synthesis and/or trend-booklet → verify-trend-report. Evidence-backed CxO reports and reusable industry catalogs across DE/FR/IT/PL/NL/ES + US/UK.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-trends/skills/verify-trend-report/SKILL.md
+++ b/cogni-trends/skills/verify-trend-report/SKILL.md
@@ -9,8 +9,8 @@ description: |
   trend report", "enrich the trend report", "review the trend report", "extend
   the trend report", "trend report verification", or runs `/trends-resume` after
   trend-synthesis finished and picks the verify path. Also trigger when a
-  trend-synthesis Phase 3 summary recommends it. Mirror of cogni-research:verify-report,
-  scoped to the cogni-trends data model (`tips-trend-report.md` and
+  trend-synthesis Phase 3 summary recommends it. Modeled on the cogni-research
+  verify-report skill, scoped to the cogni-trends data model (`tips-trend-report.md` and
   `tips-trend-report-claims.json`).
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task, Skill, AskUserQuestion
 ---

--- a/scripts/check-external-dispatch.py
+++ b/scripts/check-external-dispatch.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""check-external-dispatch.py — deterministic external-dispatch guard.
+
+Asserts that **no live-dispatch surface** dispatches the retired engines
+`cogni-wiki:` or `cogni-research:` anywhere in the repo. This is the machine
+proof behind the FMO archival decision: once cogni-research and cogni-wiki are
+archived (source kept, not installable), a live caller dispatching them would
+break at runtime. The guard makes that absence objective and regression-proof.
+
+Scope — the surfaces a running session actually dispatches FROM:
+
+  - */skills/*/SKILL.md   (skill bodies + their YAML description)
+  - */agents/*.md         (agent prompts)
+  - */commands/*.md       (slash-command definitions)
+  - */hooks/**            (lifecycle hooks: *.sh / *.py / *.json)
+
+Excluded, by design (NOT live-dispatch surfaces):
+
+  - cogni-research/ , cogni-wiki/   the two plugins' own source trees
+  - cogni-knowledge/                its delegation-contract / references
+                                    legitimately NAME the retired plugins as
+                                    history; it dispatches neither (FMO vendored
+                                    the engine), and the runtime-path guard for
+                                    that lives in its own test_skill_contracts.
+  - */wiki/ , top-level wiki/       generated page dumps (a wiki mirror may
+                                    quote a retired dispatch as page content)
+  - docs/                           the doc mirror (prose, not a dispatch)
+
+`references/` directories are out of scope on purpose: a reference doc is
+loaded on demand as documentation, not the surface a session dispatches from, so
+a lineage mention there ("modeled on the cogni-research verify-report skill") is
+not a caller.
+
+Unlike the breadcrumb guard, this guard targets a HARD clean-zero — there is no
+legitimate live `cogni-wiki:`/`cogni-research:` dispatch after archival, so the
+ratchet/baseline model is the wrong tool. The single escape hatch is a per-line
+marker for a genuine NON-dispatch prose mention that must keep the literal token
+(rare); state the rationale on the same line:
+
+    ... see cogni-research:verify-report for the lineage  # external-dispatch-guard:allow
+
+The fix when the guard trips is to REMOVE the dispatch (cut the caller over to
+the vendored cogni-knowledge surface) or, for a true prose mention, reword it
+semantically to drop the `plugin:skill` token (drop the colon) — exactly the
+discipline the Maintainer-breadcrumb guard uses.
+
+stdlib only; runs under any python3. Exit 0 = clean (zero dispatches),
+1 = dispatch(es) found, 2 = script error.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+# git ls-files pathspec globs for the live-dispatch surfaces.
+DEFAULT_GLOBS = [
+    "*/skills/*/SKILL.md",
+    "*/agents/*.md",
+    "*/commands/*.md",
+    "*/hooks/*",
+    "*/hooks/*/*",
+]
+
+# Path-prefix excludes (own trees + the history-bearing FMO plugin).
+EXCLUDE_PREFIXES = ("cogni-research/", "cogni-wiki/", "cogni-knowledge/")
+
+# Path-segment excludes (generated wiki mirrors + the doc mirror). A surface
+# under any of these is content, not a caller.
+EXCLUDE_SEGMENTS = ("/wiki/", "/docs/")
+EXCLUDE_TOPLEVEL = ("wiki/", "docs/")
+
+# The dispatch-shaped token: `cogni-wiki:` / `cogni-research:` — the `plugin:`
+# half of a `plugin:skill` dispatch reference. A bare "cogni-research" (no
+# colon) is a plain noun and is NOT matched.
+DISPATCH_RE = re.compile(r"\bcogni-(wiki|research):")
+
+# Per-line escape hatch for a genuine non-dispatch prose mention.
+ALLOW_MARKER = "external-dispatch-guard:allow"
+
+
+def discover_files(root):
+    """Tracked live-dispatch surfaces, relative to root, via git ls-files."""
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", root, "ls-files", "-z"] + DEFAULT_GLOBS,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, OSError) as exc:
+        raise RuntimeError("git ls-files failed: {}".format(exc))
+    files = []
+    for rel in out.decode("utf-8").split("\x00"):
+        if not rel:
+            continue
+        if rel.startswith(EXCLUDE_PREFIXES):
+            continue
+        if rel.startswith(EXCLUDE_TOPLEVEL):
+            continue
+        if any(seg in ("/" + rel) for seg in EXCLUDE_SEGMENTS):
+            continue
+        files.append(rel)
+    return files
+
+
+def scan_file(abs_path, rel_path):
+    """Yield violation dicts for one file."""
+    try:
+        with open(abs_path, "r", encoding="utf-8") as fh:
+            lines = fh.readlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise RuntimeError("cannot read {}: {}".format(rel_path, exc))
+    for lineno, raw in enumerate(lines, start=1):
+        line = raw.rstrip("\n")
+        if ALLOW_MARKER in line:
+            continue
+        for m in DISPATCH_RE.finditer(line):
+            yield {
+                "file": rel_path,
+                "line": lineno,
+                "match": m.group(0),
+                "context": line.strip()[:140],
+            }
+
+
+def collect(root, explicit_files):
+    occ = []
+    if explicit_files:
+        pairs = []
+        for f in explicit_files:
+            abs_path = f if os.path.isabs(f) else os.path.join(root, f)
+            rel = os.path.relpath(abs_path, root)
+            if rel == os.pardir or rel.startswith(os.pardir + os.sep):
+                raise RuntimeError(
+                    "file {!r} is outside --root {!r}".format(f, root))
+            pairs.append((abs_path, rel))
+    else:
+        pairs = [(os.path.join(root, rel), rel) for rel in discover_files(root)]
+    for abs_path, rel in pairs:
+        occ.extend(scan_file(abs_path, rel))
+    return occ
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("files", nargs="*",
+                    help="explicit files to scan (default: git ls-files globs)")
+    ap.add_argument("--root", default=None,
+                    help="repo root for discovery + relative paths "
+                         "(default: parent of scripts/)")
+    args = ap.parse_args(argv)
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.abspath(args.root) if args.root else os.path.dirname(script_dir)
+
+    try:
+        violations = collect(root, args.files)
+    except RuntimeError as exc:
+        print(json.dumps({"success": False, "data": {}, "error": str(exc)}))
+        return 2
+
+    by_plugin = {}
+    for o in violations:
+        plugin = o["file"].split("/", 1)[0]
+        by_plugin[plugin] = by_plugin.get(plugin, 0) + 1
+
+    result = {
+        "success": not violations,
+        "data": {
+            "violations": violations,
+            "summary": {
+                "total": len(violations),
+                "by_plugin": by_plugin,
+                "files_affected": len(sorted({o["file"] for o in violations})),
+            },
+        },
+        "error": "",
+    }
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+    if violations:
+        print("\nFAIL: {} live cogni-wiki:/cogni-research: dispatch(es) found "
+              "in live-dispatch surfaces:".format(len(violations)), file=sys.stderr)
+        for o in violations:
+            print("  {}:{}: {}  ->  {}".format(
+                o["file"], o["line"], o["match"], o["context"]), file=sys.stderr)
+        print("\nFix: cut the caller over to the vendored cogni-knowledge "
+              "surface, OR — for a genuine non-dispatch prose mention — reword "
+              "it to drop the `plugin:skill` token (drop the colon), or mark the "
+              "line with `# external-dispatch-guard:allow` and a rationale.",
+              file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_check_external_dispatch.sh
+++ b/tests/test_check_external_dispatch.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# test_check_external_dispatch.sh — self-test for the external-dispatch guard.
+#
+# The guard asserts a HARD clean-zero: no live-dispatch surface
+# (*/skills/*/SKILL.md, */agents/*.md, */commands/*.md, */hooks/**) may carry a
+# `cogni-wiki:` / `cogni-research:` dispatch token. Cases:
+#   1. Negative controls (bare noun "cogni-research" with no colon) -> exit 0.
+#   2. Dispatch-laden fixture (cogni-wiki: + cogni-research:) -> exit 1, naming
+#      the file + line + match.
+#   3. Inline-allow escape hatch -> the flagged line is skipped.
+#   4. Path exclusions (cogni-knowledge/ history, */wiki/ mirror) skipped in
+#      discover mode -> exit 0 even though the token is present.
+#   5. Real tree -> exit 0 (clean-zero today).
+#
+# bash 3.2 + stdlib python3 only (+ git for the discover-mode exclusion case).
+
+set -eu
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+GUARD="$REPO_ROOT/scripts/check-external-dispatch.py"
+
+red()   { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+
+FAILED=0
+check() {  # check <label> <condition-exit-code>
+  if [ "$2" -eq 0 ]; then
+    green "PASS: $1"
+  else
+    red "FAIL: $1"
+    FAILED=1
+  fi
+}
+
+assert_json() {  # assert_json <label> <json> <python-asserts>
+  set +e
+  printf '%s' "$2" | python3 -c "$3"
+  local _code=$?
+  set -e
+  check "$1" "$_code"
+}
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# ---------------------------------------------------------------------------
+# Case 1 — negative control: a bare "cogni-research" noun (no colon) is fine.
+# ---------------------------------------------------------------------------
+mkdir -p "$WORK/clean/cogni-demo/skills/demo"
+cat > "$WORK/clean/cogni-demo/skills/demo/SKILL.md" <<'EOF'
+---
+name: demo
+---
+Modeled on the cogni-research verify-report skill, scoped to demo data.
+This plugin dispatches cogni-knowledge:knowledge-query, not the retired engines.
+EOF
+
+set +e
+OUT=$(python3 "$GUARD" --root "$WORK/clean" "cogni-demo/skills/demo/SKILL.md" 2>/dev/null)
+CODE=$?
+set -e
+check "bare-noun negative control exits 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "negative control reports zero violations" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is True, d
+assert d['data']['summary']['total']==0, d['data']['summary']
+"
+
+# ---------------------------------------------------------------------------
+# Case 2 — dispatch-laden fixture: must fail, naming file + line + match.
+# ---------------------------------------------------------------------------
+mkdir -p "$WORK/dirty/cogni-bad/agents"
+cat > "$WORK/dirty/cogni-bad/agents/bad.md" <<'EOF'
+First the agent dispatches Skill("cogni-wiki:wiki-query") to read the base.
+Then it falls back to cogni-research:section-researcher for fresh web work.
+EOF
+
+set +e
+OUT=$(python3 "$GUARD" --root "$WORK/dirty" "cogni-bad/agents/bad.md" 2>/dev/null)
+CODE=$?
+set -e
+check "dispatch fixture exits 1" "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
+assert_json "dispatch fixture names both tokens with correct file+line" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+v=d['data']['violations']
+got={(x['match'],x['line']) for x in v}
+want={('cogni-wiki:',1),('cogni-research:',2)}
+missing=want-got
+assert not missing, 'missing: %r (got %r)' % (missing, got)
+assert all(x['file']=='cogni-bad/agents/bad.md' for x in v), v
+assert d['success'] is False, d
+"
+
+# ---------------------------------------------------------------------------
+# Case 3 — inline-allow escape hatch skips an otherwise-flagged line.
+# ---------------------------------------------------------------------------
+mkdir -p "$WORK/allow/cogni-x/commands"
+cat > "$WORK/allow/cogni-x/commands/c.md" <<'EOF'
+Historical note: this menu mirrors cogni-research:verify-report's Next steps.  # external-dispatch-guard:allow
+EOF
+
+set +e
+OUT=$(python3 "$GUARD" --root "$WORK/allow" "cogni-x/commands/c.md" 2>/dev/null)
+CODE=$?
+set -e
+check "inline-allow line exits 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "inline-allow suppresses the dispatch token" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['data']['summary']['total']==0, d['data']['summary']
+"
+
+# ---------------------------------------------------------------------------
+# Case 4 — discover-mode path exclusions: a token under cogni-knowledge/ (FMO
+# history) or */wiki/ (generated mirror) must NOT trip the guard.
+# ---------------------------------------------------------------------------
+EXC="$WORK/exclude"
+mkdir -p "$EXC"
+git -C "$EXC" init -q
+git -C "$EXC" config user.email t@t.test
+git -C "$EXC" config user.name test
+mkdir -p "$EXC/cogni-knowledge/skills/k" "$EXC/cogni-foo/wiki/concepts" "$EXC/cogni-foo/skills/s"
+# cogni-knowledge legitimately NAMES the retired engines as history:
+printf -- '---\nname: k\n---\nDelegation history: this once dispatched cogni-wiki:wiki-ingest.\n' \
+  > "$EXC/cogni-knowledge/skills/k/SKILL.md"
+# a generated wiki mirror page may quote a retired dispatch as page content:
+printf -- '---\nname: x\n---\nThe source quoted cogni-research:section-researcher.\n' \
+  > "$EXC/cogni-foo/wiki/concepts/SKILL.md"
+# a genuinely-clean live surface in the same repo:
+printf -- '---\nname: s\n---\nDispatches cogni-knowledge:knowledge-compose only.\n' \
+  > "$EXC/cogni-foo/skills/s/SKILL.md"
+git -C "$EXC" add -A >/dev/null 2>&1
+git -C "$EXC" commit -qm init >/dev/null 2>&1
+
+set +e
+OUT=$(python3 "$GUARD" --root "$EXC" 2>/dev/null)
+CODE=$?
+set -e
+check "discover-mode exclusions pass (cogni-knowledge/ + */wiki/ skipped)" \
+  "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "exclusions report zero violations" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is True, d
+assert d['data']['summary']['total']==0, d['data']['summary']
+"
+
+# ---------------------------------------------------------------------------
+# Case 5 — real tree: the guard passes clean-zero today.
+# ---------------------------------------------------------------------------
+set +e
+python3 "$GUARD" >/dev/null 2>&1
+CODE=$?
+set -e
+check "real tree passes clean-zero" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+  green "All external-dispatch-guard tests passed."
+  exit 0
+else
+  red "Some external-dispatch-guard tests failed."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

The FMO archival **machine-proof** child (epic #512, phase 1). Adds a deterministic CI guard that asserts **no live-dispatch surface dispatches `cogni-wiki:` or `cogni-research:`** — the objective signal #506 (now signed off) required, and the precondition that lets the irreversible #508/#509 archive flips land without the risk of a broken runtime caller.

## What changed

- **`scripts/check-external-dispatch.py`** (new) — stdlib guard modeled on `check-breadcrumbs.py`. Scans the live-dispatch surfaces (`*/skills/*/SKILL.md`, `*/agents/*.md`, `*/commands/*.md`, `*/hooks/**`) for the `cogni-(wiki|research):` plugin-dispatch token. A bare `cogni-research` noun (no colon) is **not** matched. Excludes the two plugins' own trees, `cogni-knowledge/` (its delegation history legitimately *names* them), generated `*/wiki/` mirrors, and `docs/`. JSON envelope; exit `0`/`1`/`2`. Unlike the breadcrumb ratchet it targets a **hard clean-zero** — the one escape hatch is a per-line `external-dispatch-guard:allow` marker for a genuine non-dispatch prose mention.
- **`.github/workflows/lint.yml`** — new `external-dispatch-guard` job runs it on every PR (alongside the breadcrumb guard).
- **`tests/test_check_external_dispatch.sh`** (new) — 9 cases: dispatch detection (names file+line+match), the allow-marker, the bare-noun negative control, **discover-mode path exclusions** (`cogni-knowledge/` history + `*/wiki/` mirror skipped), and real-tree clean-zero.
- **`cogni-trends/skills/verify-trend-report/SKILL.md`** — reworded the sole in-scope lineage token (`"Mirror of cogni-research:verify-report"` → `"Modeled on the cogni-research verify-report skill"`) so the guard lands at clean-zero. `cogni-trends` 0.6.6 → 0.6.7, mirrored in marketplace.json.

## Why clean-zero is reachable now

Per the #506 sign-off verification: the three dispatch hotspots the gate originally named (`cogni-workspace/skills/ask`, `cogni-consulting/skills/*`, `cogni-trends/value-modeler`) were already cut over by the Migrate epic + cogni-consulting archival. A repo-wide scan found exactly **one** in-scope residual — the cogni-trends lineage prose above — now reworded. The `cogni-trends/CLAUDE.md` and `references/downstream-options.md` mentions are **documentation, not dispatch surfaces**, so they are out of the guard's scope by design (the guard's docstring states this).

## Verification

- `python3 scripts/check-external-dispatch.py` → **exit 0, zero violations** (clean-zero).
- `bash tests/test_check_external_dispatch.sh` → **all 9 cases pass** (incl. the detect path and the exclusion rule).
- `python3 scripts/check-breadcrumbs.py` + `bash tests/test_check_breadcrumbs.sh` → still green (unchanged).

## Scope

Closes #507. Unblocks the phase-2 archive flips **#508** (archive cogni-research) and **#509** (archive cogni-wiki), which depend on this guard being green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)