### PR TITLE
chore(cogni-research): archive — non-installable, source kept (closes #508)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -192,9 +192,10 @@
     {
       "name": "cogni-research",
       "source": "./cogni-research",
-      "version": "0.8.4",
-      "maturity": "preview",
-      "description": "Multi-agent research report generator with a STORM-inspired editorial workflow: parallel section research and claims-verified review loops across five report types (basic, detailed, deep, outline, resource). Web, local, wiki, or hybrid source modes. Localized intent-based bilingual search across 21 EU/UK/US/LATAM/APAC markets. Integrates cogni-claims and cogni-wiki.",
+      "version": "0.8.5",
+      "maturity": "archived",
+      "archived": true,
+      "description": "(Archived — superseded by cogni-knowledge.) Multi-agent research report generator with a STORM-inspired editorial workflow: parallel section research and claims-verified review loops across five report types (basic, detailed, deep, outline, resource). Web, local, wiki, or hybrid source modes. Localized intent-based bilingual search across 21 EU/UK/US/LATAM/APAC markets. Integrates cogni-claims and cogni-wiki.",
       "keywords": [
         "research",
         "report",

--- a/cogni-research/.claude-plugin/plugin.json
+++ b/cogni-research/.claude-plugin/plugin.json
@@ -1,7 +1,8 @@
 {
   "name": "cogni-research",
-  "version": "0.8.4",
-  "description": "Multi-agent research report generator with a STORM-inspired editorial workflow: parallel section research and claims-verified review loops across five report types (basic, detailed, deep, outline, resource). Web, local, wiki, or hybrid source modes. Localized intent-based bilingual search across 21 EU/UK/US/LATAM/APAC markets. Integrates cogni-claims and cogni-wiki.",
+  "version": "0.8.5",
+  "archived": true,
+  "description": "(Archived — superseded by cogni-knowledge.) Multi-agent research report generator with a STORM-inspired editorial workflow: parallel section research and claims-verified review loops across five report types (basic, detailed, deep, outline, resource). Web, local, wiki, or hybrid source modes. Localized intent-based bilingual search across 21 EU/UK/US/LATAM/APAC markets. Integrates cogni-claims and cogni-wiki.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"

--- a/cogni-research/README.md
+++ b/cogni-research/README.md
@@ -1,6 +1,6 @@
 # cogni-research
 
-> **Preview** (v0.x) — core skills defined but may change. Feedback welcome.
+> **Archived** — Security patches only. Superseded by [cogni-knowledge](../cogni-knowledge/README.md), which absorbs the web-research pipeline into its wiki-first inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent verification. Source is kept for the forked-agent lineage; the plugin is no longer installable.
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 


### PR DESCRIPTION
## Summary

FMO archival epic #512, phase 2 (deliverable 1 of #264 Phase 6). With the **#506** human go/no-go gate signed off and the **#507** CI grep-guard green at clean-zero (zero live `cogni-research:` dispatches repo-wide), cogni-research is redundant with cogni-knowledge and becomes **non-installable** while its source is kept for the forked-agent lineage.

## What changed (2 manifest edits + a README callout, per the issue)

- **`cogni-research/.claude-plugin/plugin.json`** — `"archived": true`, version 0.8.4 → 0.8.5, description prefixed `(Archived — superseded by cogni-knowledge.)`.
- **`.claude-plugin/marketplace.json`** — mirror: `archived: true`, `maturity: "archived"`, version 0.8.5, prefixed description (Claude Desktop update-detection keys off marketplace.json per `/CLAUDE.md` §"Version Management").
- **`cogni-research/README.md`** — replaced the Preview maturity callout with the Archived callout pointing at [cogni-knowledge](../cogni-knowledge/README.md), per the `/CLAUDE.md` maturity model ("each pre-1.0 and archived plugin has a maturity callout blockquote").

Mirrors the established cogni-consulting archival (v0.0.19) exactly.

## Scope / boundaries

- **Source kept, not installable** — the directory stays; only `archived: true` flips. Per the maturity model, archived = "security patches only".
- **Version-target staging (epic Q1)** — the v1.0/rename coordination is the maturity-flip child **#511**'s concern (phase 3), not this flip; this is a clean patch bump.
- Sibling **#509** (archive cogni-wiki) ships in parallel; both gate on the same #506+#507 and are independent of each other.

## Verification

- `plugin.json` + `marketplace.json` valid JSON; `archived: true` set in both; version mirrored 0.8.5.
- Breadcrumb guard + the new external-dispatch guard both still green (the latter correctly excludes cogni-research's own tree).

Closes #508. Unblocks (with #509) the phase-3 children #510 (CLAUDE.md data-flow + count) and #511 (FMO maturity flip + rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)