### PR TITLE
chore(cogni-wiki): archive — non-installable, source kept (closes #509)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -305,9 +305,10 @@
     {
       "name": "cogni-wiki",
       "source": "./cogni-wiki",
-      "version": "0.0.64",
-      "maturity": "incubating",
-      "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions surface at ingest, and knowledge compounds. Based on Karpathy's LLM Wiki pattern.",
+      "version": "0.0.65",
+      "maturity": "archived",
+      "archived": true,
+      "description": "(Archived — vendored into cogni-knowledge.) A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions surface at ingest, and knowledge compounds. Based on Karpathy's LLM Wiki pattern.",
       "keywords": [
         "wiki",
         "knowledge-base",

--- a/cogni-wiki/.claude-plugin/plugin.json
+++ b/cogni-wiki/.claude-plugin/plugin.json
@@ -1,7 +1,8 @@
 {
   "name": "cogni-wiki",
-  "version": "0.0.64",
-  "description": "A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions surface at ingest, and knowledge compounds. Based on Karpathy's LLM Wiki pattern.",
+  "version": "0.0.65",
+  "archived": true,
+  "description": "(Archived — vendored into cogni-knowledge.) A better RAG for personal and small-team knowledge work. Claude maintains a persistent, interlinked markdown wiki that compiles sources once at ingest — no embeddings, no vector store, no re-discovery per query. Answers come from the wiki (not memory), contradictions surface at ingest, and knowledge compounds. Based on Karpathy's LLM Wiki pattern.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"

--- a/cogni-wiki/README.md
+++ b/cogni-wiki/README.md
@@ -1,6 +1,6 @@
 # cogni-wiki
 
-> **Incubating** (v0.0.x) — skills, data formats, and workflows may change at any time.
+> **Archived** — Security patches only. The wiki engine is vendored into [cogni-knowledge](../cogni-knowledge/README.md) (the FMO absorbed the substrate), which carries the Karpathy-style wiki forward as its knowledge base. Source is kept for the engine lineage; the plugin is no longer installable. The wiki tree itself stays plain, Obsidian-browsable markdown — it stands alone with cogni-wiki uninstalled.
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 


### PR DESCRIPTION
## Summary

FMO archival epic #512, phase 2 (deliverable 1 of #388 Phase 9 — the substrate swallow). With the **#506** go/no-go gate signed off, the **#507** CI grep-guard green at clean-zero, and the cogni-wiki parity confirmed (the standalone surface re-homed natively into cogni-knowledge, SCHEMA.md/Obsidian portability preserved, the `_wiki_lock` invariant holding under the vendored engine), cogni-wiki becomes **non-installable** while its source is kept for the engine lineage.

## What changed (2 manifest edits + a README callout, per the issue)

- **`cogni-wiki/.claude-plugin/plugin.json`** — `"archived": true`, version 0.0.64 → 0.0.65, description prefixed `(Archived — vendored into cogni-knowledge.)`.
- **`.claude-plugin/marketplace.json`** — mirror: `archived: true`, `maturity: "archived"`, version 0.0.65, prefixed description.
- **`cogni-wiki/README.md`** — replaced the Incubating maturity callout with the Archived callout pointing at [cogni-knowledge](../cogni-knowledge/README.md) (which vendored the engine), and noting the wiki tree itself stays standalone Obsidian-browsable markdown.

Mirrors the established cogni-consulting archival (v0.0.19) exactly.

## Scope / boundaries

- **Source kept, not installable** — the directory stays; only `archived: true` flips. Archived = "security patches only".
- **Version-target staging (epic Q1)** — the v2.0/Established coordination is the maturity-flip child **#511**'s concern (phase 3), not this flip.
- Sibling **#508** (archive cogni-research) ships in parallel; both gate on the same #506+#507 and are independent of each other.

## Verification

- `plugin.json` + `marketplace.json` valid JSON; `archived: true` set in both; version mirrored 0.0.65.
- Breadcrumb guard + the external-dispatch guard both still green (the latter correctly excludes cogni-wiki's own tree).

Closes #509. Unblocks (with #508) the phase-3 children #510 (CLAUDE.md data-flow + count) and #511 (FMO maturity flip + rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)