### PR TITLE
docs(CLAUDE.md): drop archived plugins from the data-flow graph + reconcile plugin count (closes #510)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # insight-wave
 
-16-plugin monorepo for consulting, sales, and marketing on Claude Code. AGPL-3.0. All plugins follow the Claude Code plugin standard.
+16-plugin monorepo (13 installable + 3 archived: cogni-research, cogni-wiki, cogni-consulting) for consulting, sales, and marketing on Claude Code. AGPL-3.0. All plugins follow the Claude Code plugin standard.
 
 ## Repo Structure
 
 ```
 insight-wave/
-├── .claude-plugin/marketplace.json    Marketplace manifest (16 plugins)
+├── .claude-plugin/marketplace.json    Marketplace manifest (16 plugins: 13 installable, 3 archived)
 ├── cogni-{name}/                      Each plugin directory
 │   ├── .claude-plugin/plugin.json     Plugin manifest (name, version, description)
 │   ├── README.md                      Plugin documentation (IS/DOES/MEANS messaging)
@@ -81,7 +81,7 @@ Quality gates block downstream generation when upstream entities fail.
 ## Plugin Data Flow
 
 ```
-cogni-research ──→ cogni-narrative ──→ cogni-copywriting ──→ cogni-visual
+cogni-knowledge ─→ cogni-narrative ──→ cogni-copywriting ──→ cogni-visual
   (research)         (compose)           (polish)              (render)
        ↓                                                         ↑
 cogni-trends ←──→ cogni-portfolio ──→ cogni-sales            cogni-website


### PR DESCRIPTION
## Summary

FMO archival epic #512, phase 3 (deliverable 3 of #264 Phase 6 + #388 Phase 9). With cogni-research (#508) and cogni-wiki (#509) archived, the top-level maintainer-onboarding `/CLAUDE.md` no longer documents them as live runtime nodes.

## What changed (one file)

- **Plugin Data Flow diagram** — replaced the archived `cogni-research` node with `cogni-knowledge`, the single FMO node that absorbed the web-research pipeline (cogni-research) **and** the wiki substrate (cogni-wiki). cogni-wiki was never a top-level data-flow node (it's a cogni-knowledge-internal substrate), so no separate drop was needed. A repo-wide grep confirms **zero** remaining cogni-research/cogni-wiki references in the runtime graph or integration prose.
- **Plugin count reconciled** — the marketplace lists 16 entries, 3 now archived (cogni-research, cogni-wiki, cogni-consulting) → **13 installable**. The L3 headline and the L9 tree comment now both state "16 (13 installable, 3 archived)" consistently. (The plan-time L3/L9 "15-vs-13" inconsistency the issue cited was already reconciled to 16 upstream; this restates it with the archived breakdown.)

## Verification

- `grep -nE 'cogni-research|cogni-wiki' CLAUDE.md` → only the intentional L3 archived-list naming the 3 archived plugins; the data-flow graph and integration prose are clean.
- Plugin-count cross-checked against marketplace.json: 16 entries, `archived:true` on cogni-research / cogni-wiki / cogni-consulting → 13 installable.

Docs-only change to one file; no plugin surface touched, no version bump. Closes #510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)