### PR TITLE
release(cogni-knowledge): FMO maturity flip to 1.0.0 Released (closes #511)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -346,7 +346,7 @@
         "contradiction-tripwire",
         "knowledge-graph",
         "agents",
-        "preview"
+        "released"
       ]
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -329,8 +329,8 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "0.1.147",
-      "maturity": "preview",
+      "version": "1.0.0",
+      "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [
         "knowledge-base",

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "0.1.147",
+  "version": "1.0.0",
   "description": "Wiki-first research that compounds. Binds each run to a cogni-wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",
@@ -21,6 +21,6 @@
     "contradiction-tripwire",
     "knowledge-graph",
     "agents",
-    "preview"
+    "released"
   ]
 }

--- a/cogni-knowledge/README.md
+++ b/cogni-knowledge/README.md
@@ -1,7 +1,5 @@
 # cogni-knowledge
 
-> **Preview** (v0.x) — core skills defined but may change. Feedback welcome.
-
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
 > **Start here.** Run `/cogni-knowledge:knowledge-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.


### PR DESCRIPTION
## Summary

FMO archival epic #512, phase 3 (deliverable 4 of #264 Phase 6 + #388 Phase 9) — **the final child**. With both predecessors archived (#508 cogni-research, #509 cogni-wiki), cogni-knowledge is now the committed single-plugin Future Mode of Operation: both the standalone Karpathy wiki engine **and** the research orchestrator.

## Maintainer decisions (resolved in-session)

The issue escalated two maintainer-owned decisions; the autonomous drainer **parked** the issue rather than guess, and the maintainer answered them this session:

- **Q1 — version target: 1.0.0 / Released.** A maintainer-authorized crossing of the Preview → Released maturity-contract boundary.
- **Q2 — rename: keep `cogni-knowledge`.** No rename (so no plugin-name / dispatch-path / install-path churn).

## What changed

- **`cogni-knowledge/.claude-plugin/plugin.json`** — version `0.1.147` → `1.0.0`; trailing `preview` keyword → `released`.
- **`.claude-plugin/marketplace.json`** — mirror: version `1.0.0`, maturity `released`.
- **`cogni-knowledge/README.md`** — **removed** the `> **Preview** (v0.x) …` maturity callout. Per the repo convention (`/CLAUDE.md` §"README callout" + the maturity-model concept pages), the callout is carried **only** by pre-1.0 and archived plugins — a 1.x Released plugin carries none, so the flip is a **removal**, not a replacement. doc-audit Check 13 (version↔callout consistency) is satisfied (1.x → no callout). The separate "insight-wave readiness" callout is not a maturity callout and stays.

## Verification

- `plugin.json` + `marketplace.json` valid JSON; version mirrored 1.0.0; maturity `released`; `preview` keyword flipped to `released`.
- README first blockquote is now the readiness callout (the Preview maturity callout is gone) — consistent with the 1.x convention.
- Breadcrumb guard + external-dispatch guard both green.

## Epic close

This is the last open child of **epic #512 (Archive)** — every child (#506 gate, #507 guard, #508/#509 flips, #510 docs, #511 maturity) has now landed. The epic's close gate is satisfied; it will be closed on the next service-resume sweep (or here).

Closes #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)