### PR TITLE
docs: cascade European-first multi-market messaging into generated docs (closes #766)

### DIFF
--- a/docs/ecosystem-overview.md
+++ b/docs/ecosystem-overview.md
@@ -22,7 +22,7 @@ Run `/manage-workspace` once per project directory before using any other plugin
 
 | Plugin | What it does |
 |--------|-------------|
-| [cogni-trends](../cogni-trends/README.md) | Scouts industry trends using the Smarter Service Trendradar framework and bridges them to portfolio solutions via the TIPS content framework (Trends, Implications, Possibilities, Solutions). Produces CxO-ready trend reports with investment theme modeling. Bilingual EN/DE, DACH-focused. |
+| [cogni-trends](../cogni-trends/README.md) | Scouts industry trends using the Smarter Service Trendradar framework and bridges them to portfolio solutions via the TIPS content framework (Trends, Implications, Possibilities, Solutions). Produces CxO-ready trend reports with investment theme modeling. Bilingual (local + EN) research against per-market institutional authority sources across DACH/DE, FR, IT, ES, NL, PL plus UK/US. |
 | [cogni-knowledge](../cogni-knowledge/README.md) | Wiki-first research that compounds across runs. Binds each project to its own wiki knowledge base (the Karpathy-style engine is vendored in) so future runs read what prior runs filed before hitting the web. Inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification. See the [deep dive](plugin-guide/cogni-knowledge.md). |
 
 See [Research to Report workflow](workflows/research-to-report.md) for how research output moves downstream.
@@ -41,9 +41,9 @@ See the [Consulting Engagement workflow](workflows/consulting-engagement.md) for
 | Plugin | What it does |
 |--------|-------------|
 | [cogni-narrative](../cogni-narrative/README.md) | Transforms research reports and structured content into executive narratives using 8 story arc frameworks and 8 narrative techniques. Includes a TIPS-native arc for trend panoramas, a theme-thesis arc for investment narratives, and a JTBD portfolio arc for buyer-job-centric portfolio narratives. |
-| [cogni-copywriting](../cogni-copywriting/README.md) | Polishes documents using messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid). Runs parallel stakeholder persona reviews, readability optimization, JSON field polishing, and arc contract audit against cogni-narrative output. Bilingual EN/DE. |
-| [cogni-marketing](../cogni-marketing/README.md) | Bridges cogni-trends strategic themes and cogni-portfolio propositions into channel-ready content across 16 formats — thought leadership, demand generation, lead generation, sales enablement, and ABM. Bilingual DE/EN. |
-| [cogni-sales](../cogni-sales/README.md) | Generates B2B sales pitches using the Corporate Visions Why Change methodology. Supports named customer deals (deal-specific) and reusable segment pitches. Builds on cogni-portfolio data with optional TIPS strategic enrichment. Bilingual DE/EN. |
+| [cogni-copywriting](../cogni-copywriting/README.md) | Polishes documents using messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid). Runs parallel stakeholder persona reviews, readability optimization, JSON field polishing, and arc contract audit against cogni-narrative output. Translate-then-polish across DE/EN/FR/IT/PL/NL/ES. |
+| [cogni-marketing](../cogni-marketing/README.md) | Bridges cogni-trends strategic themes and cogni-portfolio propositions into channel-ready content across 16 formats — thought leadership, demand generation, lead generation, sales enablement, and ABM. Configurable brand voice; market-aware content across European and US/UK targets. |
+| [cogni-sales](../cogni-sales/README.md) | Generates B2B sales pitches using the Corporate Visions Why Change methodology. Supports named customer deals (deal-specific) and reusable segment pitches. Builds on cogni-portfolio data with optional TIPS strategic enrichment. Multilingual EN/DE/PT-BR. |
 
 ### Visual Delivery
 
@@ -154,6 +154,8 @@ All plugins depend on cogni-workspace for three shared concerns:
 **Theme management.** Visual plugins (cogni-visual, cogni-narrative, cogni-marketing, cogni-website) call the `pick-theme` skill from cogni-workspace to resolve a brand theme. Themes live in `{workspace}/cogni-workspace/themes/` and are shared across all plugins that produce HTML or visual output.
 
 **Session hooks.** cogni-workspace installs an `on-session-start.sh` hook that sources workspace environment variables and validates plugin availability each time a Claude Code session opens.
+
+**Market and language configuration.** insight-wave is European-first and multi-market: research, trend scouting, and content generation run bilingually (local language + English) against curated regional authority sources across a built-out set — DACH/DE, FR, IT, ES, NL, PL, UK, US — with 16+ output languages in native UTF-8. The canonical market registry lives in cogni-workspace; plugins read it at runtime via `get-market-config.py`. See [Supported markets & languages](../cogni-workspace/README.md#supported-markets--languages) for the full registry and the built-out-vs-registered distinction.
 
 ---
 

--- a/docs/plugin-guide/cogni-marketing.md
+++ b/docs/plugin-guide/cogni-marketing.md
@@ -19,7 +19,7 @@ All content traces back to source data: every piece carries frontmatter linking 
 - You have a portfolio and trend data and need to generate marketing content from them
 - You want to see where your content coverage has gaps across markets, themes, and funnel stages
 - You need to run a coordinated multi-channel campaign and track it
-- You need bilingual (DE/EN) content with consistent brand voice across formats and markets
+- You need multilingual content (bilingual local+EN, e.g. DE/EN) with consistent brand voice across formats and markets
 
 ### Prerequisites
 
@@ -92,7 +92,7 @@ Expected interaction:
 
 1. The skill scans for cogni-portfolio projects (`portfolio.json`) and cogni-trends projects (`tips-project.json`) in the workspace
 2. It lists what it found and asks you to confirm sources
-3. You configure brand voice: company name, language (DE/EN), tone descriptors, avoided terms
+3. You configure brand voice: company name, output language (inherited from the selected market), tone descriptors, avoided terms
 4. You select markets from the portfolio
 5. For each market, you map TIPS strategic themes to GTM paths
 6. The project directory is scaffolded

--- a/docs/plugin-guide/cogni-narrative.md
+++ b/docs/plugin-guide/cogni-narrative.md
@@ -179,7 +179,7 @@ See [../workflows/research-to-narrative.md](../workflows/research-to-narrative.m
 
 ### Trend report with German output
 
-TIPS trend reports often need German-language output for DACH market teams.
+TIPS trend reports often need German-language output for teams that work in German.
 
 1. Run `/narrative ./tips-output/ --arc trend-panorama --language de`
 2. The skill loads German section header templates and Amstad scoring rules

--- a/docs/plugin-guide/cogni-portfolio.md
+++ b/docs/plugin-guide/cogni-portfolio.md
@@ -307,6 +307,54 @@ Detect the current workflow phase, show entity counts and coverage gaps, and rec
 
 ---
 
+## Working across markets
+
+A portfolio carries distinct propositions per market. Each market (`markets/{slug}.json`) holds its own sizing, competitors, and buyer personas — switching markets doesn't reset your portfolio, it opens a different slot in the Feature x Market grid. A company with 5 features and 3 markets ends up with up to 15 proposition slots, each with its own DOES/MEANS statement, competitive context, and buyer language. The markets you add determine which slots exist; the propositions skill fills them.
+
+### Selecting a market
+
+Market selection happens during the `/markets` step, after products and features are defined. Run `/portfolio-setup` first to initialize the project, then use `/markets` to discover and size target markets:
+
+```
+/markets
+```
+
+Example prompts that trigger different market scopes:
+
+- "Size the mid-market ERP segment in Germany and Austria" — single-country scope (`de`), separate slot from `at`
+- "What is the TAM for cloud infrastructure monitoring across DACH?" — DACH composite (`dach`) covering DE, AT, CH under one market entity
+- "Add the EU composite market for regulatory-driven procurement research" — composite region (`eu`) for cross-border positioning
+- "Size the US enterprise segment for our security offering" — `us-na` for North American buyer context
+
+### What changes per market
+
+When you add a market entity, the research agents adapt their sizing queries, competitor scoping, and buyer persona language to that market's context. The table below shows the dimensions that drive per-market proposition content:
+
+| Market | Output language | Regulatory context | Buyer currency | Regional qualifier |
+|--------|-----------------|--------------------|----------------|--------------------|
+| DACH | German | BITKOM, BDI, Destatis | EUR | "in DACH" |
+| FR | French | ARCEP, Bpifrance, CNRS | EUR | "en France" |
+| IT | Italian | AGCM, AGCOM, ASI | EUR | "in Italia" |
+| EU | English (composite) | European Commission, BEREC, Digitaleurope | EUR | "in the EU" |
+| US/NA | English | FTC, NIST, industry analysts | USD | "in North America" |
+
+The full market-by-market configuration lives in the supported-markets registry (`../../cogni-workspace/references/supported-markets-registry.json`) — 25 regions for cogni-portfolio today, spanning single-country (DE, FR, IT, ES, NL, PL, AT, CZ, SK, HU, RO, HR, GR, MK), composite (DACH, EU, Nordics, US/NA, APAC, LATAM, MEA), extended (CN, JP), and global (UK, Global).
+
+### Switching markets mid-project
+
+cogni-portfolio does not have a single "active market" state. Each market is a separate entity file in `markets/`, and each proposition is a separate file keyed to a Feature x Market pair. Switching markets mid-project means adding a new market entity and running `/propositions` for the Feature x Market pairs in that new market — your existing propositions for other markets are unaffected.
+
+If you realize a market entity was created with the wrong slug or scope, use `scripts/cascade-rename.sh` to rename it and update all dependent proposition, solution, competitor, and customer files in one operation.
+
+### When to use which market
+
+- **Single-country** (`de`, `fr`, `it`, `es`, `nl`, `pl`): use when the buyer is a company headquartered in one country and procurement is local. Buyer language, regulatory context, and market size will be country-specific.
+- **DACH composite** (`dach`): use when the buyer operates across Germany, Austria, and Switzerland and a single proposition covers all three. Common for mid-market SaaS and industrial tech sales cycles.
+- **EU composite** (`eu`): use for regulatory or policy-driven positioning (e.g., GDPR compliance, AI Act readiness) where the directive applies EU-wide and the buyer's procurement is Brussels-facing.
+- **US/NA or APAC** (`na`, `apac`): use when you are entering a non-European market and want separate DOES/MEANS statements adapted to that buyer's language, competitive set, and purchasing norms.
+
+---
+
 ## Integration Points
 
 ### Upstream (what cogni-portfolio consumes)

--- a/docs/plugin-guide/cogni-trends.md
+++ b/docs/plugin-guide/cogni-trends.md
@@ -10,7 +10,7 @@ For the canonical IS/DOES/MEANS positioning of this plugin, see the [cogni-trend
 
 cogni-trends automates the research-heavy parts of strategic trend analysis while keeping framework judgment where it belongs — with the analyst. The pipeline runs in four stages: scout signals across 4 Trendradar dimensions, model them into investment themes and solution blueprints, generate CxO-level narrative reports, and accumulate curated knowledge in reusable industry catalogs.
 
-The plugin is purpose-built for the DACH market (Germany, Austria, Switzerland). Web research runs bilingually in English and German, targeting curated German institutional sources — VDMA, BITKOM, Fraunhofer, Zukunftsinstitut, EUR-Lex — alongside international databases. The underlying bilingual search architecture is generalizable; see `cogni-trends/references/architecture-pattern.md` for the reusable pattern.
+The plugin is European-first and multilingual. Web research runs bilingually — local language plus English — against curated per-market institutional authorities across the eight built-out markets: DACH/DE (German: VDMA, BITKOM, Fraunhofer), FR (French: INRIA, ARCEP, Les Echos), IT (Italian: CNR, AGCOM), ES (Spanish: CNMC, INTA, CSIC), NL (Dutch: TNO, ACM), PL (Polish: UKE, PAN, GUS), plus UK and US. DACH is the origin market and remains the most deeply curated, but all eight markets are fully wired into the bilingual research and authority-source overlays. The underlying bilingual search architecture is generalizable; see `cogni-trends/references/architecture-pattern.md` for the reusable pattern.
 
 Two complementary frameworks drive the analytical structure:
 
@@ -193,6 +193,45 @@ Re-enter a project mid-stream. Reads project state, shows phase progress and ent
 
 ---
 
+## Working across markets
+
+Every trend scouting run executes in two languages — DE and EN for DACH, FR and EN for France, IT and EN for Italy, and so on — so signals surface in both the local institutional corpus and the English-speaking industry press. The bilingual composition is not a translation step; it is a parallel query layer that issues local-language searches against curated per-market authority sources at the same time as the English-language tier. Selecting a different market routes the researcher persona's queries through a different authority set and appends the market's regional qualifier to every search string.
+
+### Selecting a market
+
+Market selection happens during `trend-scout` setup. When you describe what you want to scout, `trend-scout` picks up explicit market phrases, language signals, and — when ambiguous — asks you to confirm.
+
+Example prompts:
+
+- "Scout trends for the manufacturing sector in France" — explicit market phrase → `fr`; local queries run in French against INRIA, ARCEP, Les Echos
+- "Tendenze nel settore della logistica" — Italian-language signal → `it`; local queries run in Italian against CNR, AGCOM, Il Sole 24 Ore
+- "Scout logistics trends in DACH, output in German" — composite market phrase → `dach`; local queries run in German against VDMA, BITKOM, Fraunhofer
+
+### What changes per market
+
+| Market | Local language | Output language | Authority sources (trends tier) | Regional qualifier |
+|--------|---------------|-----------------|----------------------------------|-------------------|
+| DACH | German | German | VDMA, BITKOM, Fraunhofer | "in DACH" |
+| FR | French | French | INRIA, ARCEP, Les Echos | "en France" |
+| IT | Italian | Italian | CNR, AGCOM, Il Sole 24 Ore | "in Italia" |
+| PL | Polish | Polish | UKE, PAN, GUS | "w Polsce" |
+| ES | Spanish | Spanish | CNMC, INTA, CSIC | "en España" |
+
+The full market-by-market configuration lives in the supported-markets registry (`../../cogni-workspace/references/supported-markets-registry.json`) — 8 markets for cogni-trends today.
+
+### Switching markets mid-project
+
+Each cogni-trends project is initialized with a market code stored in `tips-project.json`. If you want to run the same scouting analysis for a different market, start a new project rather than changing the market on an existing one. The project slug includes the market (e.g., `industrial-automation-dach-abc12345` vs `industrial-automation-fr-def67890`), so two market variants can live side by side under the same project root without overwriting each other. Use `/trends-resume` to list and re-enter projects.
+
+### When to use which market
+
+- Pick `dach` when the engagement spans Germany, Austria, and Switzerland or when the buyer operates in the German-speaking market broadly. Use `de` when you specifically want Germany-only signals and German statutory/regulatory sources (Destatis, BMWK).
+- Pick `fr`, `it`, `es`, `nl`, or `pl` when the buyer is based in that country and local regulatory or institutional signals matter.
+- Pick `uk` or `us` when scouting trends for English-speaking markets where DACH or continental European sources would be noise.
+- The registered composites (EU, Nordics, LATAM, APAC) are in the registry but are not yet wired into the bilingual research overlays — if you select one, the scouting run falls back to English-only queries until per-composite authority overlays ship.
+
+---
+
 ## Integration Points
 
 ### Upstream (what cogni-trends consumes)
@@ -274,8 +313,8 @@ Use this when you have a completed trend report and need to transform it into vi
 cogni-trends accepts contributions in several areas:
 
 - **Industry catalogs** — seed catalogs for new sectors (Healthcare, Energy, Logistics, etc.)
-- **Research source integrations** — curated source lists for non-DACH markets (UK, US, APAC)
+- **Research source integrations** — extending curated authority overlays into the registered-but-not-yet-wired markets (composites such as EU and Nordics, single-country extensions such as AT, CZ, HU, and regional clusters such as APAC and LATAM)
 - **Scoring frameworks** — additional multi-framework scoring dimensions for the trend-generator
-- **Market adaptations** — bilingual search architectures for non-DACH markets following `references/architecture-pattern.md`
+- **Market adaptations** — bilingual search architectures for composite and extended markets following `references/architecture-pattern.md`
 
 See [CONTRIBUTING.md](../../cogni-trends/CONTRIBUTING.md) for guidelines.

--- a/docs/plugin-guide/cogni-workspace.md
+++ b/docs/plugin-guide/cogni-workspace.md
@@ -59,7 +59,7 @@ or:
 What the initialization does:
 
 1. Runs `check-dependencies.sh` and reports any missing required tools
-2. Asks for your language preference (English or German) and which tool integrations to enable
+2. Asks for your output language preference (English and German are common defaults; 16+ languages are supported — see [Supported markets & languages](../../cogni-workspace/README.md#supported-markets--languages)) and which tool integrations to enable
 3. Discovers installed cogni-x plugins via `discover-plugins.sh`
 4. Generates `.workspace-config.json` with plugin registry and metadata
 5. Generates `.workspace-env.sh` with environment variables for each plugin
@@ -191,6 +191,19 @@ Answers questions about the insight-wave ecosystem — plugins, skills, agents, 
 ```
 
 First lookup before grepping source files — faster and doesn't pull plugin internals into your context.
+
+---
+
+### `manage-markets` and `audit-region-sources` — Canonical market registry
+
+cogni-workspace owns the canonical market registry (`references/supported-markets-registry.json`) that every market-aware plugin reads through `scripts/get-market-config.py`. The full list of built-out markets, registered markets, and supported output languages lives in the [Supported markets & languages](../../cogni-workspace/README.md#supported-markets--languages) section of the cogni-workspace README — that is the single source of truth other plugin READMEs link to.
+
+`manage-markets` is the write path: use it to check registry status or add new markets. `audit-region-sources` is read-only: it audits per-plugin region-source overlays against the registry to catch orphan domains and drift.
+
+```
+/manage-markets
+/audit-region-sources
+```
 
 ---
 


### PR DESCRIPTION
## What

Regenerates the auto-generated `docs/` surfaces so Epic #762's **European-first, multi-market & multilingual** messaging cascades out of the READMEs into the generated docs. #762 only updated the READMEs; `cogni-docs:doc-hub`-generated docs still carried DACH-centric framing and would keep drifting until regenerated.

Closes #766.

## Changes (docs/ only)

- **`docs/ecosystem-overview.md`** — reframe the cogni-trends one-liner (was "Bilingual EN/DE, DACH-focused"), align the copywriting/marketing/sales one-liners with their current marketplace.json descriptions, and add a **Market and language configuration** note under Shared Infrastructure linking the canonical *Supported markets & languages* section.
- **`docs/plugin-guide/cogni-trends.md`** — overview reframed to European-first (8 built-out markets with per-market authorities); roadmap corrected (FR/IT/ES/NL/PL are built out, not "non-DACH future work"); new registry-sourced **Working across markets** subsection (bilingual-query mechanism).
- **`docs/plugin-guide/cogni-portfolio.md`** — new registry-sourced **Working across markets** subsection (region-segmentation mechanism, 25 regions).
- **`docs/plugin-guide/cogni-workspace.md`** — output language is configurable across 16+ languages (not "English or German"); added a `manage-markets` / `audit-region-sources` note pointing at the canonical registry it owns.
- **`docs/plugin-guide/cogni-marketing.md`**, **`docs/plugin-guide/cogni-narrative.md`** — dropped DE/EN-only scope claims.

The "Working across markets" subsections are present only for the two plugins in the registry's `plugins` map (cogni-trends, cogni-portfolio), per the doc-hub market-aware rule. They honestly distinguish built-out markets from the registered "expansion frontier" (composites/extended markets not yet wired into the research overlays). DACH usage **examples** were retained — only stale **scope claims** were corrected.

## Acceptance criteria

- [x] `docs/ecosystem-overview.md` and the relevant `docs/plugin-guide/*.md` reflect the European-first multi-market & multilingual framing (no stale DACH-only language). Verified: `grep -rnE "DACH-focused|purpose-built for the DACH|non-DACH market|Bilingual DE/EN|Bilingual EN/DE|English or German" docs/` → no matches.
- [x] `doc-audit` Check 15 (market-coverage consistency) passes — confirmed OK for cogni-trends and cogni-portfolio against `cogni-workspace/references/supported-markets-registry.json` (lede counts, primary markets, authority names, and tail clauses all match).

## Notes

- Pure `docs/` change — no `plugin.json` / `marketplace.json` version bumps (no skills/agents/structure touched).
- Out of scope (not expanded here): adding entries for knowledge/marketing/sales/website to the registry `plugins` map, and adding non-DACH usage *examples* to guides/workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)