### PR TITLE
feat(cogni-consult): add consult-dashboard skill + HTML engagement-status generator (closes #768)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -42,8 +42,13 @@ cogni-consult/
     │                              →ideate→prototype→test) + artifact + state writes
     ├── consult-personas/SKILL.md  Acting personas: define from scope, enrich,
     │                              act-as challenge against deliverables
-    └── consult-resume/SKILL.md    Engagement re-entry point: discovery + WBS
-                                   dashboard + workflow-state next-action routing
+    ├── consult-resume/SKILL.md    Engagement re-entry point: discovery + WBS
+    │                              dashboard + workflow-state next-action routing
+    └── consult-dashboard/         Themed HTML engagement dashboard (read-only)
+        ├── SKILL.md               pick-theme → design-variables → generate → open
+        ├── scripts/generate-dashboard.py  Render dashboard.html from project + field.json
+        ├── schemas/               design-variables.schema.json (theme contract)
+        └── examples/              design-variables example
 ```
 
 ## Design Principles

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -35,6 +35,7 @@ It is an orchestrator, not a producer: it manages engagement state and dispatche
 4. **Produce deliverables** — run the empathize→define→ideate→prototype→test loop on one deliverable at a time, with evidence from the bound knowledge base (`consult-design-thinking`)
 5. **Challenge with acting personas** — define stakeholder personas from the scope, enrich them with evidence, and have them push back on deliverables in their own voice (`consult-personas`)
 6. **Resume across sessions** — discover engagements, show WBS progress, and route to the most valuable next action (`consult-resume`)
+7. **See engagement status visually** — generate a themed, browsable HTML dashboard of the action-field WBS, deliverable states, design-thinking stages, and persona-review progress (`consult-dashboard`)
 
 ## What it means for you
 
@@ -42,6 +43,7 @@ It is an orchestrator, not a producer: it manages engagement state and dispatche
 - **Always know the next move** — deliverable-level state across the engagement's 3-6 action fields shows at a glance what is mid-loop, what awaits persona review, and what to pick up next, with no waiting on a global phase gate
 - **Catch objections while change is cheap** — acting personas (consulting partner, project manager) push back on each deliverable in their own voice at the prototype stage, surfacing the concerns that usually only land at the final readout
 - **Resume across sessions without re-briefing** — `consult-resume` rebuilds engagement status and routes to the most valuable next action, so a multi-week engagement never loses its thread between sessions
+- **See the whole engagement at a glance** — `consult-dashboard` renders a themed HTML view of the action-field WBS, deliverable states, design-thinking stages, and persona-review coverage, so progress and stuck deliverables are visible without reading JSON
 
 ## Install
 
@@ -62,6 +64,7 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 /cogni-consult:consult-action-fields # plan deliverable sets, pick the next deliverable
 /cogni-consult:consult-design-thinking # run the DT loop on one deliverable
 /cogni-consult:consult-personas     # define/enrich personas, challenge a deliverable
+/cogni-consult:consult-dashboard    # themed HTML engagement status dashboard
 ```
 
 Natural language works too: "start a consulting engagement for ACME's DACH cloud expansion", "scope the engagement", "work the competitor-map deliverable", "have the partner persona challenge the draft", "where was I with the engagement?".
@@ -107,9 +110,11 @@ Research never goes to raw web search: the engagement's bound knowledge base ser
 | `consult-action-fields` | Skill | WBS dashboard, per-field deliverable manifests, next-deliverable recommendation, add/split/merge |
 | `consult-design-thinking` | Skill | Per-deliverable design-thinking loop with artifact + state writes |
 | `consult-personas` | Skill | Acting personas: define from scope, enrich with evidence, act-as challenge against deliverables |
+| `consult-dashboard` | Skill | Themed HTML engagement dashboard: action-field WBS, deliverable state, design-thinking stage, persona-review progress |
 | `engagement-init.sh` | Script | Create the engagement directory skeleton + `consult-project.json` |
 | `engagement-status.sh` | Script | Derive field/deliverable rollups from `field.json` files → JSON |
 | `discover-projects.sh` | Script | Engagement discovery (delegates to the cogni-workspace helper) |
+| `consult-dashboard/scripts/generate-dashboard.py` | Script | Render the engagement HTML dashboard from `consult-project.json` + `field.json` files (read-only) |
 
 ## Architecture
 
@@ -128,7 +133,8 @@ cogni-consult/
 │   └── methods/                   Stage methods (scope dimensions, empathy mapping,
 │                                  HMW synthesis, guided ideation)
 ├── scripts/                       Engagement init/status/discovery (stdlib-only)
-└── skills/                        The six skills listed under Components
+└── skills/                        The seven skills listed under Components
+                                   (consult-dashboard bundles its generator + theme schema)
 ```
 
 ## Dependencies
@@ -136,7 +142,7 @@ cogni-consult/
 | Plugin | Required | Purpose |
 |--------|----------|---------|
 | cogni-knowledge | Yes | Bound once at setup (`plugin_refs.knowledge_base`) — the research spine every deliverable's evidence routes through |
-| cogni-workspace | No | Cross-session engagement discovery (`discover-projects.sh` delegates to its helper) |
+| cogni-workspace | No | Cross-session engagement discovery (`discover-projects.sh` delegates to its helper); `pick-theme` themes the `consult-dashboard` HTML (falls back to a built-in theme) |
 | cogni-visual / document-skills | No | Deliverable export (slides, documents) when a deliverable names an export route |
 
 cogni-consult is standalone as an orchestrator — it structures the engagement, the WBS, and the design-thinking loops on its own. cogni-knowledge is the one required integration: without it, deliverable research has no compounding base.

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -94,7 +94,7 @@ open "<engagement-dir>/output/dashboard.html"
 ```
 
 Tell the user the dashboard is open. To refresh after working on deliverables, just rerun the
-script (or let the `consult-dashboard-refresher` agent regenerate it at a milestone).
+script — re-running overwrites the previous `output/dashboard.html`.
 
 ## Dashboard Sections
 

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: consult-dashboard
+description: |
+  Generate an interactive HTML dashboard showing a cogni-consult engagement's
+  status — action fields, deliverables, design-thinking stage, and persona-review
+  progress. Use whenever the user mentions dashboard, engagement dashboard,
+  engagement status, "show me the engagement", "visualize the engagement", WBS
+  view, status overview, or wants to see the engagement in a browser — even if
+  they don't say "dashboard".
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Skill
+---
+
+# Consult Dashboard
+
+Generate a self-contained HTML dashboard that visualizes a consulting engagement's
+status — the action-field work breakdown, every deliverable's state and
+design-thinking stage, acting-persona review progress, knowledge-base linkage, and
+the recommended next action. The dashboard opens in the browser and is the visual
+sibling of the text WBS table that `consult-resume` and `consult-action-fields`
+render inline.
+
+## Core Concept
+
+Engagement status lives in `consult-project.json` plus one `field.json` per action
+field, where each deliverable carries its own `state`, `dt_stage`, and
+`persona_review`. The text WBS table is good for a quick check; this dashboard is for
+visual exploration — scanning field-by-field progress, spotting which deliverables are
+stuck mid-loop, and seeing persona-review coverage at a glance.
+
+Deliverable state is the **single source of truth** (it lives only in `field.json`);
+field and engagement completion are **derived at read time**, never stored. The
+generator is **read-only** — it never modifies any engagement file.
+
+## Workflow
+
+### 1. Find the Active Engagement
+
+Discover engagements with `scripts/discover-projects.sh` (the registry wrapper), or scan
+for `consult-project.json` files under `cogni-consult/` paths. If multiple engagements
+exist, ask the user which one to open. Store the resolved engagement directory path.
+
+### 2. Pick Theme
+
+First, check whether `<engagement-dir>/output/design-variables.json` already exists from
+a previous dashboard run. If it does, ask the user: "A dashboard theme is already
+configured. Reuse it, or pick a new one?" Default to reuse — most re-runs just want fresh
+data with the same look.
+
+- **If reusing**: skip directly to step 4 (Generate the Dashboard).
+- **If picking new** (or no design-variables exist): use the `cogni-workspace:pick-theme`
+  skill to let the user select a theme. The skill returns `theme_path`, `theme_name`, and
+  `theme_slug`.
+
+**Additional skip conditions** (auto-select without prompting): the caller already
+provided a `theme_path`, or only one theme exists in the workspace.
+
+### 3. Generate Design Variables
+
+Read the selected `theme.md` and produce a design-variables JSON file at
+`<engagement-dir>/output/design-variables.json`, following the schema at
+`$CLAUDE_PLUGIN_ROOT/skills/consult-dashboard/schemas/design-variables.schema.json`. See
+the example at
+`$CLAUDE_PLUGIN_ROOT/skills/consult-dashboard/examples/design-variables-cogni-work.json`.
+
+This is the same design-variables contract the rest of the ecosystem uses, so the consult
+dashboard inherits the same look as the portfolio dashboard. **What the LLM adds** beyond a
+raw token extraction: derive `surface2` (~4% darker than `surface`), `accent_muted` /
+`accent_dark` variants from `accent`, a Google Fonts `@import` URL, dark-theme shadow
+opacity, and WCAG-AA contrast between text and surfaces.
+
+**Required fields**: `theme_name`, `colors` (13 keys), `status` (4 keys), `fonts` (3 keys).
+**Optional with defaults**: `google_fonts_import` (empty), `radius` ("12px"), `shadows`.
+
+### 4. Generate the Dashboard
+
+```bash
+python3 $CLAUDE_PLUGIN_ROOT/skills/consult-dashboard/scripts/generate-dashboard.py "<engagement-dir>" --design-variables "<engagement-dir>/output/design-variables.json"
+```
+
+The script reads `consult-project.json` and every `action-fields/<slug>/field.json` (the
+same read model as `engagement-status.sh`), counts research syntheses under `scope/research/`
+and `action-fields/<slug>/research/`, loads the design-variables JSON, writes a self-contained
+HTML file at `<engagement-dir>/output/dashboard.html`, and prints
+`{"success": true, "data": {"path": ..., "theme": ..., "completion_pct": ...}, "error": ""}`.
+
+**Legacy fallback**: the script also accepts `--theme <path-to-theme.md>` (best-effort
+markdown parse) for CI/automated runs. Precedence: `--design-variables` > `--theme` >
+built-in default.
+
+### 5. Open in Browser
+
+```bash
+open "<engagement-dir>/output/dashboard.html"
+```
+
+Tell the user the dashboard is open. To refresh after working on deliverables, just rerun the
+script (or let the `consult-dashboard-refresher` agent regenerate it at a milestone).
+
+## Dashboard Sections
+
+The generated HTML is a single self-contained page with these sections:
+
+1. **Header** — engagement name, SMART key question, engagement-state badge, scope-state
+   badge, language, last updated.
+2. **Progress** — derived overall completion % (deliverables complete / total), with stat
+   cards for action fields, deliverables, persona reviews done, and research syntheses, plus a
+   progress bar and a complete/in-progress/pending breakdown.
+3. **Action fields — work breakdown** — one card per action field showing the field title,
+   framing, derived state, and a `done/total` count; each deliverable row shows its title, a
+   state badge, a five-step design-thinking indicator (empathize→define→ideate→prototype→test
+   with the current stage highlighted), and its persona-review status.
+4. **Knowledge base** — the bound knowledge-base slug and the count of research synthesis files
+   across scope and action fields.
+5. **Next action** — a single recommended next step derived from scope state and deliverable
+   states (finish scoping / continue an in-progress deliverable / start the next one / assemble
+   the output).
+
+A **Warnings** card appears only when a `field.json` is unreadable (surfaced, never conflated
+with "pending").
+
+## Important Notes
+
+- The dashboard is **read-only** — it visualizes engagement state, it does not modify any file.
+- The HTML file is fully self-contained (inline CSS, no external dependencies beyond an optional
+  Google Fonts import).
+- Re-running the script overwrites the previous dashboard at `output/dashboard.html`.
+- **Communication language**: read `consult-project.json` in the engagement root. If a `language`
+  field is present, communicate with the user in that language (status messages, instructions,
+  recommendations, questions). Technical terms, skill names, and CLI commands remain in English.
+  If no `language` field is present, default to English.

--- a/cogni-consult/skills/consult-dashboard/examples/design-variables-cogni-work.json
+++ b/cogni-consult/skills/consult-dashboard/examples/design-variables-cogni-work.json
@@ -1,0 +1,37 @@
+{
+  "theme_name": "cogni-work",
+  "colors": {
+    "primary": "#111111",
+    "secondary": "#333333",
+    "accent": "#C8E62E",
+    "accent_muted": "#A8C424",
+    "accent_dark": "#8BA31E",
+    "background": "#FAFAF8",
+    "surface": "#F2F2EE",
+    "surface2": "#e8e8e4",
+    "surface_dark": "#111111",
+    "border": "#E0E0DC",
+    "text": "#111111",
+    "text_light": "#FFFFFF",
+    "text_muted": "#6B7280"
+  },
+  "status": {
+    "success": "#2E7D32",
+    "warning": "#E5A100",
+    "danger": "#D32F2F",
+    "info": "#1565C0"
+  },
+  "fonts": {
+    "headers": "'Bricolage Grotesque', 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    "body": "'Outfit', 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    "mono": "'JetBrains Mono', 'Fira Code', Consolas, monospace"
+  },
+  "google_fonts_import": "@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@300;400;500;600;700&display=swap');",
+  "radius": "12px",
+  "shadows": {
+    "sm": "0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.06)",
+    "md": "0 4px 16px rgba(0,0,0,0.06), 0 1px 4px rgba(0,0,0,0.04)",
+    "lg": "0 12px 40px rgba(0,0,0,0.1), 0 4px 12px rgba(0,0,0,0.05)",
+    "xl": "0 24px 64px rgba(0,0,0,0.14), 0 8px 20px rgba(0,0,0,0.06)"
+  }
+}

--- a/cogni-consult/skills/consult-dashboard/examples/design-variables-cogni-work.json
+++ b/cogni-consult/skills/consult-dashboard/examples/design-variables-cogni-work.json
@@ -8,7 +8,7 @@
     "accent_dark": "#8BA31E",
     "background": "#FAFAF8",
     "surface": "#F2F2EE",
-    "surface2": "#e8e8e4",
+    "surface2": "#E8E8E4",
     "surface_dark": "#111111",
     "border": "#E0E0DC",
     "text": "#111111",

--- a/cogni-consult/skills/consult-dashboard/schemas/design-variables.schema.json
+++ b/cogni-consult/skills/consult-dashboard/schemas/design-variables.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Dashboard Design Variables",
+  "description": "LLM-to-Python contract for dashboard theming. The LLM reads a cogni-workspace theme.md and produces this JSON; the Python generator consumes it to set CSS custom properties.",
+  "type": "object",
+  "required": ["theme_name", "colors", "status", "fonts"],
+  "properties": {
+    "theme_name": {
+      "type": "string",
+      "description": "Human-readable theme name (e.g. 'cogni-work')"
+    },
+    "colors": {
+      "type": "object",
+      "required": [
+        "primary", "secondary", "accent", "accent_muted", "accent_dark",
+        "background", "surface", "surface2", "surface_dark",
+        "border", "text", "text_light", "text_muted"
+      ],
+      "properties": {
+        "primary":      { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "secondary":    { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "accent":       { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "accent_muted": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "accent_dark":  { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "background":   { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "surface":      { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "surface2":     { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "surface_dark": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "border":       { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "text":         { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "text_light":   { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "text_muted":   { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object",
+      "required": ["success", "warning", "danger", "info"],
+      "properties": {
+        "success": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "warning": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "danger":  { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "info":    { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" }
+      },
+      "additionalProperties": false
+    },
+    "fonts": {
+      "type": "object",
+      "required": ["headers", "body", "mono"],
+      "properties": {
+        "headers": { "type": "string", "description": "CSS font-family for headings" },
+        "body":    { "type": "string", "description": "CSS font-family for body text" },
+        "mono":    { "type": "string", "description": "CSS font-family for monospace" }
+      },
+      "additionalProperties": false
+    },
+    "google_fonts_import": {
+      "type": "string",
+      "description": "Full CSS @import statement for Google Fonts (e.g. \"@import url('https://fonts.googleapis.com/...');\")",
+      "default": ""
+    },
+    "radius": {
+      "type": "string",
+      "description": "Default border-radius CSS value",
+      "default": "12px"
+    },
+    "shadows": {
+      "type": "object",
+      "properties": {
+        "sm": { "type": "string" },
+        "md": { "type": "string" },
+        "lg": { "type": "string" },
+        "xl": { "type": "string" }
+      },
+      "additionalProperties": false,
+      "description": "CSS box-shadow values by size"
+    }
+  },
+  "additionalProperties": false
+}

--- a/cogni-consult/skills/consult-dashboard/scripts/generate-dashboard.py
+++ b/cogni-consult/skills/consult-dashboard/scripts/generate-dashboard.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Generate a self-contained HTML status dashboard for a cogni-consult engagement.
+
+Usage:
+  python3 generate-dashboard.py <engagement-dir> [--design-variables <path.json>] [--theme <theme.md>]
+Output: <engagement-dir>/output/dashboard.html
+Returns JSON on stdout: {"success": bool, "data": {...}, "error": "string"}
+
+The dashboard is the visual sibling of the text WBS table that consult-resume and
+consult-action-fields render. Data source: consult-project.json + each
+action-fields/<slug>/field.json (the same read model as engagement-status.sh, where
+deliverable state is the single source of truth and field/engagement rollups are
+DERIVED at read time, never stored). Read-only: never modifies any engagement file.
+"""
+
+import argparse
+import glob
+import html
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+DT_STAGES = ["empathize", "define", "ideate", "prototype", "test"]
+
+# ---------------------------------------------------------------------------
+# Theme — design-variables JSON is the contract; --theme parses a theme.md as a
+# legacy/CI fallback; DEFAULT_THEME is the last resort. Precedence:
+# --design-variables > --theme > DEFAULT_THEME.
+# ---------------------------------------------------------------------------
+
+DEFAULT_THEME = {
+    "theme_name": "cogni-work",
+    "colors": {
+        "primary": "#111111",
+        "secondary": "#333333",
+        "accent": "#C8E62E",
+        "accent_muted": "#A8C424",
+        "accent_dark": "#8BA31E",
+        "background": "#FAFAF8",
+        "surface": "#F2F2EE",
+        "surface2": "#E8E8E4",
+        "surface_dark": "#111111",
+        "border": "#E0E0DC",
+        "text": "#111111",
+        "text_light": "#FFFFFF",
+        "text_muted": "#6B7280",
+    },
+    "status": {
+        "success": "#2E7D32",
+        "warning": "#E5A100",
+        "danger": "#D32F2F",
+        "info": "#1565C0",
+    },
+    "fonts": {
+        "headers": "'Bricolage Grotesque', 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+        "body": "'Outfit', 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+        "mono": "'JetBrains Mono', 'Fira Code', Consolas, monospace",
+    },
+    "google_fonts_import": "@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@300;400;500;600;700&display=swap');",
+    "radius": "12px",
+    "shadows": {
+        "sm": "0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.06)",
+        "md": "0 4px 16px rgba(0,0,0,0.06), 0 1px 4px rgba(0,0,0,0.04)",
+        "lg": "0 12px 40px rgba(0,0,0,0.1), 0 4px 12px rgba(0,0,0,0.05)",
+        "xl": "0 24px 64px rgba(0,0,0,0.14), 0 8px 20px rgba(0,0,0,0.06)",
+    },
+}
+
+
+def _deep_merge(base, over):
+    """Overlay `over` onto a copy of `base`, recursing into nested dicts."""
+    out = dict(base)
+    for k, v in (over or {}).items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = _deep_merge(out[k], v)
+        elif v is not None:
+            out[k] = v
+    return out
+
+
+def load_design_variables(path):
+    """Read a design-variables.json file and overlay it on DEFAULT_THEME so a
+    partial file still yields a complete theme."""
+    with open(path) as f:
+        dv = json.load(f)
+    if not isinstance(dv, dict):
+        raise ValueError("design-variables must be a JSON object")
+    return _deep_merge(DEFAULT_THEME, dv)
+
+
+def parse_theme_md(path):
+    """Minimal theme.md fallback: pull the first few hex colors into accent/
+    primary/surface roles. Best-effort only — design-variables.json is the
+    real contract."""
+    with open(path) as f:
+        text = f.read()
+    hexes = re.findall(r"#[0-9A-Fa-f]{6}", text)
+    over = {"colors": {}}
+    roles = ["primary", "accent", "surface", "border", "secondary"]
+    for role, hexval in zip(roles, hexes):
+        over["colors"][role] = hexval
+    name = os.path.splitext(os.path.basename(path))[0]
+    over["theme_name"] = name
+    return _deep_merge(DEFAULT_THEME, over)
+
+
+def resolve_theme(design_variables, theme):
+    if design_variables:
+        return load_design_variables(design_variables), design_variables
+    if theme:
+        return parse_theme_md(theme), None
+    return dict(DEFAULT_THEME), None
+
+
+# ---------------------------------------------------------------------------
+# Engagement read model — mirrors engagement-status.sh, plus field title/framing
+# and research-synthesis counts the rollup script does not surface.
+# ---------------------------------------------------------------------------
+
+
+def _field_rollup(states):
+    if states and all(s == "complete" for s in states):
+        return "complete"
+    if any(s != "pending" for s in states):
+        return "in-progress"
+    return "pending"
+
+
+def load_engagement(engagement_dir):
+    """Return the engagement model, or raise ValueError with a user-facing message."""
+    proj_path = os.path.join(engagement_dir, "consult-project.json")
+    try:
+        with open(proj_path) as f:
+            project = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(f"unreadable engagement file {proj_path}: {exc}")
+
+    field_slugs = project.get("action_fields") or []
+    if not isinstance(field_slugs, list) or not all(isinstance(s, str) for s in field_slugs):
+        raise ValueError("malformed engagement file: action_fields must be a list of strings")
+
+    warnings = []
+    fields = []
+    for slug in field_slugs:
+        fdir = os.path.join(engagement_dir, "action-fields", slug)
+        fpath = os.path.join(fdir, "field.json")
+        title, framing = slug, ""
+        deliverables = []
+        state = "pending"
+        try:
+            with open(fpath) as f:
+                fjson = json.load(f)
+            title = fjson.get("title") or slug
+            framing = fjson.get("framing") or ""
+            deliverables = fjson.get("deliverables") or []
+            state = _field_rollup([d.get("state", "pending") for d in deliverables])
+        except FileNotFoundError:
+            pass
+        except (json.JSONDecodeError, OSError) as exc:
+            state = "unreadable"
+            warnings.append(f"unreadable field file {fpath}: {exc}")
+        research_count = len(glob.glob(os.path.join(fdir, "research", "*.md")))
+        fields.append({
+            "slug": slug,
+            "title": title,
+            "framing": framing,
+            "state": state,
+            "deliverables": deliverables,
+            "research_count": research_count,
+        })
+
+    scope_research = len(glob.glob(os.path.join(engagement_dir, "scope", "research", "*.md")))
+    return {
+        "slug": project.get("slug"),
+        "name": project.get("name") or project.get("slug") or "Engagement",
+        "language": project.get("language") or "en",
+        "key_question": project.get("key_question") or "",
+        "updated": project.get("updated") or "",
+        "scope_state": (project.get("workflow_state") or {}).get("scope", "pending"),
+        "knowledge_base": (project.get("plugin_refs") or {}).get("knowledge_base"),
+        "action_fields": fields,
+        "scope_research_count": scope_research,
+        "warnings": warnings,
+    }
+
+
+def compute_summary(eng):
+    fields = eng["action_fields"]
+    all_delivs = [d for f in fields for d in f["deliverables"]]
+    total = len(all_delivs)
+    by_state = {"complete": 0, "in-progress": 0, "pending": 0}
+    persona_complete = 0
+    for d in all_delivs:
+        st = d.get("state", "pending")
+        by_state[st] = by_state.get(st, 0) + 1
+        if d.get("persona_review") == "complete":
+            persona_complete += 1
+    field_states = {"complete": 0, "in-progress": 0, "pending": 0, "unreadable": 0}
+    for f in fields:
+        field_states[f["state"]] = field_states.get(f["state"], 0) + 1
+    pct = round(100 * by_state["complete"] / total) if total else 0
+    research_total = eng["scope_research_count"] + sum(f["research_count"] for f in fields)
+    if all(f["state"] == "complete" for f in fields) and fields:
+        engagement_state = "complete"
+    elif any(f["state"] != "pending" for f in fields):
+        engagement_state = "in-progress"
+    else:
+        engagement_state = "pending"
+    return {
+        "deliverables_total": total,
+        "deliverables_by_state": by_state,
+        "fields_total": len(fields),
+        "fields_by_state": field_states,
+        "persona_reviews_complete": persona_complete,
+        "research_total": research_total,
+        "completion_pct": pct,
+        "engagement_state": engagement_state,
+    }
+
+
+def next_action(eng, summary):
+    """A single recommendation line, mirroring engagement-status signals."""
+    if eng["scope_state"] != "complete":
+        return "Finish scoping the engagement (consult-scope) — define the SMART key question and action fields."
+    for f in eng["action_fields"]:
+        for d in f["deliverables"]:
+            if d.get("state") == "in-progress":
+                stage = d.get("dt_stage") or "empathize"
+                return f"Continue “{d.get('title', d.get('slug'))}” in {f['title']} (design thinking, {stage} stage)."
+    for f in eng["action_fields"]:
+        for d in f["deliverables"]:
+            if d.get("state") == "pending":
+                return f"Start “{d.get('title', d.get('slug'))}” in {f['title']} (consult-design-thinking)."
+        if not f["deliverables"]:
+            return f"Plan deliverables for {f['title']} (consult-action-fields)."
+    if summary["engagement_state"] == "complete":
+        return "All deliverables complete — review with acting personas and assemble the engagement output."
+    return "Review the engagement status."
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering
+# ---------------------------------------------------------------------------
+
+STATE_ROLE = {"complete": "success", "in-progress": "warning", "pending": "muted", "unreadable": "danger"}
+REVIEW_ROLE = {"complete": "success", "in-progress": "warning", "pending": "muted"}
+
+
+def esc(s):
+    return html.escape(str(s if s is not None else ""))
+
+
+def badge(text, role):
+    return f'<span class="badge badge-{role}">{esc(text)}</span>'
+
+
+def dt_indicator(stage):
+    """Five-step empathize→test indicator; prior + current stages are filled."""
+    try:
+        idx = DT_STAGES.index(stage) if stage in DT_STAGES else -1
+    except ValueError:
+        idx = -1
+    dots = []
+    for i, name in enumerate(DT_STAGES):
+        cls = "dt-dot"
+        if idx >= 0 and i < idx:
+            cls += " dt-done"
+        elif idx >= 0 and i == idx:
+            cls += " dt-current"
+        dots.append(f'<span class="{cls}" title="{esc(name)}"></span>')
+    label = esc(stage) if stage else "—"
+    return f'<span class="dt-track">{"".join(dots)}</span><span class="dt-label">{label}</span>'
+
+
+def render_field_card(field):
+    delivs = field["deliverables"]
+    rows = []
+    if not delivs:
+        rows.append('<div class="deliv-empty">No deliverables planned yet</div>')
+    for d in delivs:
+        st = d.get("state", "pending")
+        review = d.get("persona_review", "pending")
+        rows.append(
+            '<div class="deliv-row">'
+            f'<div class="deliv-title">{esc(d.get("title") or d.get("slug"))}</div>'
+            f'<div class="deliv-state">{badge(st, STATE_ROLE.get(st, "muted"))}</div>'
+            f'<div class="deliv-dt">{dt_indicator(d.get("dt_stage"))}</div>'
+            f'<div class="deliv-review">persona {badge(review, REVIEW_ROLE.get(review, "muted"))}</div>'
+            '</div>'
+        )
+    done = sum(1 for d in delivs if d.get("state") == "complete")
+    framing = f'<p class="field-framing">{esc(field["framing"])}</p>' if field["framing"] else ""
+    research = (
+        f'<span class="field-research">\U0001f4da {field["research_count"]} research</span>'
+        if field["research_count"] else ""
+    )
+    return (
+        '<div class="field-card">'
+        '<div class="field-head">'
+        f'<h3>{esc(field["title"])}</h3>'
+        f'<div class="field-meta">{badge(field["state"], STATE_ROLE.get(field["state"], "muted"))}'
+        f'<span class="field-count">{done}/{len(delivs)} done</span>{research}</div>'
+        '</div>'
+        f'{framing}'
+        f'<div class="deliv-list">{"".join(rows)}</div>'
+        '</div>'
+    )
+
+
+def render_html(eng, summary, theme):
+    colors = theme["colors"]
+    status = theme["status"]
+    fonts = theme["fonts"]
+    shadows = theme.get("shadows", DEFAULT_THEME["shadows"])
+    radius = theme.get("radius", "12px")
+    gfi = theme.get("google_fonts_import", "")
+
+    bystate = summary["deliverables_by_state"]
+    stat_cards = "".join([
+        f'<div class="stat"><div class="stat-num">{summary["completion_pct"]}%</div><div class="stat-lbl">deliverables complete</div></div>',
+        f'<div class="stat"><div class="stat-num">{summary["fields_total"]}</div><div class="stat-lbl">action fields</div></div>',
+        f'<div class="stat"><div class="stat-num">{summary["deliverables_total"]}</div><div class="stat-lbl">deliverables</div></div>',
+        f'<div class="stat"><div class="stat-num">{summary["persona_reviews_complete"]}</div><div class="stat-lbl">persona reviews done</div></div>',
+        f'<div class="stat"><div class="stat-num">{summary["research_total"]}</div><div class="stat-lbl">research syntheses</div></div>',
+    ])
+
+    field_cards = "".join(render_field_card(f) for f in eng["action_fields"])
+    if not eng["action_fields"]:
+        field_cards = '<div class="deliv-empty">No action fields defined yet — run consult-scope.</div>'
+
+    kb = eng["knowledge_base"]
+    kb_line = (
+        f'Bound knowledge base: <code>{esc(kb)}</code> · {summary["research_total"]} synthesis file(s) across scope + action fields'
+        if kb else "No knowledge base bound yet."
+    )
+
+    warn_block = ""
+    if eng["warnings"]:
+        items = "".join(f"<li>{esc(w)}</li>" for w in eng["warnings"])
+        warn_block = f'<section class="card warn"><h2>⚠ Warnings</h2><ul>{items}</ul></section>'
+
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    return f"""<!DOCTYPE html>
+<html lang="{esc(eng['language'])}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{esc(eng['name'])} — Engagement Dashboard</title>
+<style>
+{gfi}
+:root {{
+  --primary: {colors['primary']}; --secondary: {colors['secondary']};
+  --accent: {colors['accent']}; --accent-muted: {colors['accent_muted']}; --accent-dark: {colors['accent_dark']};
+  --bg: {colors['background']}; --surface: {colors['surface']}; --surface2: {colors['surface2']};
+  --surface-dark: {colors['surface_dark']}; --border: {colors['border']};
+  --text: {colors['text']}; --text-light: {colors['text_light']}; --text-muted: {colors['text_muted']};
+  --green: {status['success']}; --yellow: {status['warning']}; --red: {status['danger']}; --blue: {status['info']};
+  --font-headers: {fonts['headers']}; --font-body: {fonts['body']}; --font-mono: {fonts['mono']};
+  --radius: {radius};
+  --shadow-sm: {shadows['sm']}; --shadow-md: {shadows['md']}; --shadow-lg: {shadows['lg']};
+}}
+* {{ box-sizing: border-box; margin: 0; padding: 0; }}
+body {{ font-family: var(--font-body); background: var(--bg); color: var(--text); line-height: 1.5; padding: 2rem 1.5rem 4rem; }}
+.wrap {{ max-width: 1100px; margin: 0 auto; }}
+h1, h2, h3 {{ font-family: var(--font-headers); font-weight: 600; }}
+header.hero {{ background: var(--surface-dark); color: var(--text-light); border-radius: var(--radius); padding: 2rem; box-shadow: var(--shadow-lg); margin-bottom: 1.5rem; }}
+header.hero h1 {{ font-size: 1.9rem; margin-bottom: .5rem; }}
+header.hero .kq {{ font-size: 1.05rem; opacity: .9; max-width: 70ch; }}
+header.hero .hero-meta {{ margin-top: 1rem; display: flex; flex-wrap: wrap; gap: .5rem; align-items: center; }}
+.card {{ background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.5rem; box-shadow: var(--shadow-sm); margin-bottom: 1.5rem; }}
+.card > h2 {{ font-size: 1.2rem; margin-bottom: 1rem; }}
+.card.warn {{ border-color: var(--red); }}
+.stats {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; }}
+.stat {{ background: var(--surface2); border-radius: var(--radius); padding: 1.1rem; text-align: center; }}
+.stat-num {{ font-family: var(--font-headers); font-size: 1.8rem; font-weight: 700; color: var(--accent-dark); }}
+.stat-lbl {{ font-size: .8rem; color: var(--text-muted); margin-top: .25rem; }}
+.progress {{ height: 10px; background: var(--surface2); border-radius: 999px; overflow: hidden; margin: 1rem 0 .25rem; }}
+.progress > span {{ display: block; height: 100%; background: var(--accent); border-radius: 999px; }}
+.progress-lbl {{ font-size: .8rem; color: var(--text-muted); }}
+.fields {{ display: grid; grid-template-columns: 1fr; gap: 1rem; }}
+.field-card {{ background: var(--surface2); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; }}
+.field-head {{ display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: .5rem; }}
+.field-head h3 {{ font-size: 1.05rem; }}
+.field-meta {{ display: flex; align-items: center; gap: .6rem; }}
+.field-count {{ font-size: .8rem; color: var(--text-muted); }}
+.field-research {{ font-size: .78rem; color: var(--text-muted); }}
+.field-framing {{ font-size: .88rem; color: var(--text-muted); margin: .5rem 0 .75rem; }}
+.deliv-list {{ display: flex; flex-direction: column; gap: .4rem; margin-top: .5rem; }}
+.deliv-row {{ display: grid; grid-template-columns: minmax(0,2.2fr) auto minmax(0,1.6fr) auto; gap: .75rem; align-items: center; background: var(--surface); border-radius: 8px; padding: .55rem .75rem; }}
+.deliv-title {{ font-size: .92rem; font-weight: 500; }}
+.deliv-review {{ font-size: .76rem; color: var(--text-muted); text-align: right; }}
+.deliv-empty {{ font-size: .85rem; color: var(--text-muted); font-style: italic; padding: .5rem 0; }}
+.dt-track {{ display: inline-flex; gap: 3px; vertical-align: middle; }}
+.dt-dot {{ width: 9px; height: 9px; border-radius: 50%; background: var(--border); display: inline-block; }}
+.dt-dot.dt-done {{ background: var(--accent-muted); }}
+.dt-dot.dt-current {{ background: var(--accent-dark); box-shadow: 0 0 0 2px var(--surface2); }}
+.dt-label {{ font-size: .72rem; color: var(--text-muted); margin-left: .4rem; text-transform: capitalize; }}
+.badge {{ display: inline-block; font-size: .72rem; font-weight: 600; padding: .12rem .5rem; border-radius: 999px; text-transform: capitalize; }}
+.badge-success {{ background: color-mix(in srgb, var(--green) 16%, transparent); color: var(--green); }}
+.badge-warning {{ background: color-mix(in srgb, var(--yellow) 18%, transparent); color: var(--yellow); }}
+.badge-danger {{ background: color-mix(in srgb, var(--red) 16%, transparent); color: var(--red); }}
+.badge-muted {{ background: var(--surface2); color: var(--text-muted); }}
+.badge-info {{ background: color-mix(in srgb, var(--blue) 16%, transparent); color: var(--blue); }}
+.next {{ font-size: 1rem; }}
+.next strong {{ color: var(--accent-dark); }}
+code {{ font-family: var(--font-mono); font-size: .85em; background: var(--surface2); padding: .1rem .35rem; border-radius: 5px; }}
+footer {{ text-align: center; color: var(--text-muted); font-size: .78rem; margin-top: 2rem; }}
+@media (max-width: 640px) {{ .deliv-row {{ grid-template-columns: 1fr; gap: .35rem; }} .deliv-review {{ text-align: left; }} }}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="hero">
+    <h1>{esc(eng['name'])}</h1>
+    {f'<p class="kq">{esc(eng["key_question"])}</p>' if eng['key_question'] else ''}
+    <div class="hero-meta">
+      {badge('engagement ' + summary['engagement_state'], STATE_ROLE.get(summary['engagement_state'], 'muted'))}
+      {badge('scope ' + eng['scope_state'], STATE_ROLE.get(eng['scope_state'], 'muted'))}
+      {badge('lang ' + eng['language'], 'info')}
+      {f"<span style='opacity:.7;font-size:.8rem'>updated {esc(eng['updated'])}</span>" if eng['updated'] else ''}
+    </div>
+  </header>
+
+  <section class="card">
+    <h2>Progress</h2>
+    <div class="stats">{stat_cards}</div>
+    <div class="progress"><span style="width: {summary['completion_pct']}%"></span></div>
+    <div class="progress-lbl">{bystate['complete']} complete · {bystate['in-progress']} in progress · {bystate['pending']} pending</div>
+  </section>
+
+  <section class="card">
+    <h2>Action fields — work breakdown</h2>
+    <div class="fields">{field_cards}</div>
+  </section>
+
+  <section class="card">
+    <h2>Knowledge base</h2>
+    <p>{kb_line}</p>
+  </section>
+
+  <section class="card">
+    <h2>Next action</h2>
+    <p class="next">{esc(next_action(eng, summary))}</p>
+  </section>
+
+  {warn_block}
+
+  <footer>Generated {generated} · cogni-consult engagement dashboard · theme: {esc(theme.get('theme_name', 'default'))}</footer>
+</div>
+</body>
+</html>
+"""
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Generate a cogni-consult engagement HTML dashboard.")
+    ap.add_argument("engagement_dir")
+    ap.add_argument("--design-variables", dest="design_variables", default=None)
+    ap.add_argument("--theme", dest="theme", default=None)
+    args = ap.parse_args()
+
+    engagement_dir = os.path.abspath(args.engagement_dir)
+    try:
+        if not os.path.isdir(engagement_dir):
+            raise ValueError(f"engagement directory not found: {engagement_dir}")
+        eng = load_engagement(engagement_dir)
+        summary = compute_summary(eng)
+        theme, dv_path = resolve_theme(args.design_variables, args.theme)
+        out_dir = os.path.join(engagement_dir, "output")
+        os.makedirs(out_dir, exist_ok=True)
+        out_path = os.path.join(out_dir, "dashboard.html")
+        with open(out_path, "w") as f:
+            f.write(render_html(eng, summary, theme))
+    except (ValueError, OSError, json.JSONDecodeError) as exc:
+        print(json.dumps({"success": False, "data": {}, "error": str(exc)}))
+        return 1
+
+    print(json.dumps({
+        "success": True,
+        "data": {
+            "path": out_path,
+            "theme": theme.get("theme_name", "default"),
+            "design_variables": dv_path,
+            "engagement_state": summary["engagement_state"],
+            "completion_pct": summary["completion_pct"],
+        },
+        "error": "",
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a themed, browsable **HTML engagement-status dashboard** to cogni-consult — the visual sibling of the text WBS table that `consult-resume` / `consult-action-fields` render inline. Mirrors `portfolio-dashboard`; the data source (`engagement-status.sh` read model) already exists, so this is a presentation layer only.

Closes #768. Phase 1 of epic #770.

## What's added

- **`skills/consult-dashboard/SKILL.md`** — 5-step workflow: discover engagement → `cogni-workspace:pick-theme` (reuse-or-pick) → derive `design-variables.json` → run the generator → open `output/dashboard.html`. Honours the engagement `language` field.
- **`skills/consult-dashboard/scripts/generate-dashboard.py`** — stdlib-only generator. Reads `consult-project.json` + each `action-fields/<slug>/field.json` (deliverable `state` is the single source of truth; field/engagement rollups **derived at read time**), counts research syntheses, loads theme via `--design-variables` (precedence `--design-variables` > `--theme` > built-in default), writes a self-contained `output/dashboard.html`, returns `{"success","data","error"}` JSON. **Read-only** — never mutates an engagement file.
  - **Sections:** header (name, key question, engagement/scope-state badges, language, updated) · progress summary (derived %, field/deliverable/persona/research stat cards + bar) · action-field WBS grid (one card per field; per-deliverable state badge + 5-step design-thinking indicator + persona-review status) · knowledge-base linkage · next action.
- **`schemas/design-variables.schema.json`** + **`examples/design-variables-cogni-work.json`** — same token contract as portfolio, so the consult dashboard inherits the same look.
- **Docs**: README (What it does / MEANS / Quick start / Components / Architecture / Dependencies) + CLAUDE.md skills tree synced for the new skill.
- **Version 0.1.2 → 0.1.3** in `plugin.json` and `marketplace.json`.

## Verification

- Generated against a synthetic engagement (3 action fields, mixed deliverable states, one field with no `field.json`): exits 0, writes `output/dashboard.html`, `completion_pct` = 33% (1 of 3 deliverables complete) — matches `engagement-status.sh` on the same dir.
- HTML is self-contained (no external refs beyond an optional Google-Fonts `@import`); all section markers present; `color-mix` status badges render.
- Error paths return `{"success":false,...}` for a missing dir and a malformed `action_fields`.
- `cogni-workspace/scripts/check-skill-names.sh` → OK (domain-prefixed `consult-dashboard`); breadcrumb guard → no new violations; `py_compile` clean.

## Acceptance criteria

- [x] Generator writes `output/dashboard.html`, exits 0, renders header + progress + per-field deliverable rows consistent with `engagement-status.sh`.
- [x] Skill name passes `check-skill-names.sh` (domain-prefixed).
- [x] Generator is stdlib-only and returns `{"success","data","error"}` JSON.
- [x] `plugin.json` + `marketplace.json` both at `0.1.3`.
- [x] README/CLAUDE list the new skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
