### PR TITLE
feat(cogni-consult): dashboard auto-refresh agent + milestone/resume wiring (closes #769)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -26,6 +26,9 @@ cogni-consult/
 │       ├── empathy-mapping.md     Empathize-stage persona quadrant mapping
 │       ├── hmw-synthesis.md       Define-stage HMW problem-spec synthesis
 │       └── guided-ideation.md     Ideate-stage diverge→converge facilitation
+├── agents/
+│   └── consult-dashboard-refresher.md  Milestone HTML dashboard refresh (haiku,
+│                                  read-only, no theme prompt)
 ├── scripts/
 │   ├── engagement-init.sh         Create engagement directory skeleton
 │   ├── engagement-status.sh       Read consult-project.json state → JSON

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -111,6 +111,7 @@ Research never goes to raw web search: the engagement's bound knowledge base ser
 | `consult-design-thinking` | Skill | Per-deliverable design-thinking loop with artifact + state writes |
 | `consult-personas` | Skill | Acting personas: define from scope, enrich with evidence, act-as challenge against deliverables |
 | `consult-dashboard` | Skill | Themed HTML engagement dashboard: action-field WBS, deliverable state, design-thinking stage, persona-review progress |
+| `consult-dashboard-refresher` | Agent | Regenerate the engagement dashboard HTML at a milestone (haiku, read-only, no theme prompt) |
 | `engagement-init.sh` | Script | Create the engagement directory skeleton + `consult-project.json` |
 | `engagement-status.sh` | Script | Derive field/deliverable rollups from `field.json` files → JSON |
 | `discover-projects.sh` | Script | Engagement discovery (delegates to the cogni-workspace helper) |
@@ -132,6 +133,7 @@ cogni-consult/
 │   ├── personas/                  Packaged default advisors (partner, PM)
 │   └── methods/                   Stage methods (scope dimensions, empathy mapping,
 │                                  HMW synthesis, guided ideation)
+├── agents/                        consult-dashboard-refresher (milestone HTML refresh)
 ├── scripts/                       Engagement init/status/discovery (stdlib-only)
 └── skills/                        The seven skills listed under Components
                                    (consult-dashboard bundles its generator + theme schema)

--- a/cogni-consult/agents/consult-dashboard-refresher.md
+++ b/cogni-consult/agents/consult-dashboard-refresher.md
@@ -1,0 +1,69 @@
+---
+name: consult-dashboard-refresher
+description: Regenerate the cogni-consult engagement dashboard HTML from current engagement state without user interaction.
+
+model: haiku
+color: green
+tools: ["Bash", "Glob"]
+---
+
+You are a lightweight dashboard regeneration agent for the cogni-consult plugin. Your only job is to regenerate the engagement status dashboard HTML from the current engagement state and optionally open it in the browser. No user interaction, no theme picking, no recommendations — the engagement skills call you at a milestone so the consultant sees a fresh dashboard before deciding what to do next.
+
+## Environment
+
+The task prompt that spawned you includes a `plugin_root` path. Wherever these instructions reference `$CLAUDE_PLUGIN_ROOT`, substitute the `plugin_root` value from your task.
+
+## Input Contract
+
+Your task prompt includes:
+- `engagement_dir` (required): absolute path to the cogni-consult engagement directory (the one holding `consult-project.json`)
+- `plugin_root` (required): absolute path to `$CLAUDE_PLUGIN_ROOT`
+- `open_browser` (optional, default: true): whether to open the HTML after generation
+
+## Workflow
+
+### 1. Find the Theme
+
+Check whether the engagement already has design variables from a previous `consult-dashboard` run:
+
+```bash
+ls "<engagement_dir>/output/design-variables.json" 2>/dev/null
+```
+
+- **If it exists**: use the `--design-variables` flag in step 2.
+- **If it does not exist**: search for the most recently modified `theme.md` in the workspace via Glob (`**/cogni-workspace/**/themes/**/*.md`). If found, use the `--theme` flag in step 2.
+- **If neither exists**: the engagement has no theme yet — return this JSON and stop (do not pick a theme; that is `consult-dashboard`'s job):
+  ```json
+  {"success": false, "data": {}, "error": "No design-variables.json or theme found. Run /cogni-consult:consult-dashboard first to set up a theme."}
+  ```
+
+### 2. Run the Generator Script
+
+```bash
+python3 $CLAUDE_PLUGIN_ROOT/skills/consult-dashboard/scripts/generate-dashboard.py "<engagement_dir>" --design-variables "<engagement_dir>/output/design-variables.json"
+```
+
+Or with the theme fallback:
+```bash
+python3 $CLAUDE_PLUGIN_ROOT/skills/consult-dashboard/scripts/generate-dashboard.py "<engagement_dir>" --theme "<path-to-theme.md>"
+```
+
+The generator is read-only — it never modifies an engagement file.
+
+### 3. Handle the Result
+
+- **On success** (exit code 0, JSON `success: true`): proceed to step 4.
+- **On error** (non-zero exit, or JSON `success: false`): return the generator's JSON envelope verbatim and stop. Do not retry.
+
+### 4. Open in Browser
+
+If `open_browser` is true (the default):
+```bash
+open "<engagement_dir>/output/dashboard.html"
+```
+
+### 5. Return
+
+```json
+{"success": true, "data": {"path": "<engagement_dir>/output/dashboard.html"}, "error": ""}
+```

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -101,6 +101,15 @@ recommendation that would `Edit` a malformed `field.json`. When every
 deliverable is `complete`, say so: the engagement is complete by
 derivation, there is nothing to store.
 
+**Offer the visual dashboard.** This text table is the quick check; for a
+themed, browsable view of the same WBS — deliverable states, design-thinking
+stages, and persona-review coverage — offer `/cogni-consult:consult-dashboard`.
+When the engagement already has `output/design-variables.json` and the WBS
+structure changed this session (a field's deliverable set was planned in step 4,
+or a field was added/split/merged), regenerate the HTML snapshot without
+prompting by delegating to the `consult-dashboard-refresher` agent with
+`engagement_dir: <engagement-dir>` and `plugin_root: $CLAUDE_PLUGIN_ROOT`.
+
 ### 4. Plan a Field's Deliverable Set
 
 For a field with no (or too few) deliverables, read

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -94,7 +94,19 @@ open "<engagement-dir>/output/dashboard.html"
 ```
 
 Tell the user the dashboard is open. To refresh after working on deliverables, just rerun the
-script — re-running overwrites the previous `output/dashboard.html`.
+script (re-running overwrites the previous `output/dashboard.html`), or let the
+`consult-dashboard-refresher` agent regenerate it at a milestone — see Milestone Dashboard below.
+
+## Milestone Dashboard
+
+The dashboard is also a checkpoint tool, not just a capstone. Once an engagement has a theme
+configured (`output/design-variables.json`), the engagement skills offer a fresh dashboard at
+natural milestones — `consult-design-thinking` after a deliverable reaches `complete` (or its
+persona review closes), `consult-action-fields` after the WBS structure changes, and
+`consult-resume` at re-entry. At those checkpoints the skill delegates to the
+`consult-dashboard-refresher` agent (`engagement_dir`, `plugin_root: $CLAUDE_PLUGIN_ROOT`), which
+runs the read-only generator and opens the HTML without a theme prompt. When no theme is
+configured yet, the skills point the consultant back here to set one up first.
 
 ## Dashboard Sections
 

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -179,6 +179,19 @@ logged, and which personas challenged it. Recommend the next step — the next
 unstarted deliverable in the WBS (via the WBS dashboard skill when present in
 the plugin, or by reading the field manifests directly).
 
+**Milestone dashboard refresh.** When this session moved the deliverable's
+`state` to `"complete"` (or closed its `persona_review`), the engagement's
+status changed — offer the consultant a fresh visual dashboard. If the
+engagement already has `output/design-variables.json` (a prior
+`consult-dashboard` run set up a theme), regenerate the HTML without prompting
+by delegating to the `consult-dashboard-refresher` agent with
+`engagement_dir: <engagement-dir>` and `plugin_root: $CLAUDE_PLUGIN_ROOT`; the
+agent runs the read-only generator and opens `output/dashboard.html`. If no
+theme is configured yet, point the consultant at `/cogni-consult:consult-dashboard`
+to set one up. This is a lightweight snapshot — the dashboard reflects the
+engagement state at this checkpoint, which is exactly what the consultant wants
+to see before picking the next deliverable.
+
 ## Important Notes
 
 - **State ownership**: deliverable `state` and `dt_stage` live only in the

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -80,6 +80,16 @@ first whose `persona_review` is still open when everything else is done.
 Keep it to this one table — the deep WBS view (planning deliverable sets,
 splitting fields) belongs to `consult-action-fields`, not here.
 
+**Offer the visual dashboard.** After the text table, offer the consultant a
+themed, browsable HTML view of the same status via `/cogni-consult:consult-dashboard`
+(action-field WBS, deliverable states, design-thinking stages, persona-review
+coverage). When the engagement already has `output/design-variables.json` from a
+prior dashboard run, you can regenerate and open it without a theme prompt by
+delegating to the `consult-dashboard-refresher` agent with
+`engagement_dir: <engagement-dir>` and `plugin_root: $CLAUDE_PLUGIN_ROOT`. This
+stays read-only — the agent runs the read-only generator; it never edits
+engagement state.
+
 ### 5. Recommend the Next Action
 
 Branch on the derived state, first match wins, and say *why*:


### PR DESCRIPTION
## Summary

Phase 2 of the cogni-consult engagement-dashboard epic (#770): adds the **auto-refresh agent** and wires the Phase-1 `consult-dashboard` into the engagement skills so the HTML view stays current without manual reruns.

Closes #769. Depends on #768 (merged).

## What's added

- **`agents/consult-dashboard-refresher.md`** (haiku, Bash+Glob) — mirrors `cogni-portfolio/agents/dashboard-refresher.md`: locate `output/design-variables.json` (or skip with a clear reason), run the read-only generator, open the HTML — no theme prompt. Returns the `{success,data,error}` envelope.
- **Milestone hooks** (the refresher is offered/dispatched only when `output/design-variables.json` already exists; otherwise the skill points the consultant to `consult-dashboard` to set up a theme first):
  - `consult-design-thinking` — after a deliverable reaches `complete` / its persona review closes (Step 8).
  - `consult-action-fields` — after a WBS structure change (deliverable set planned / field added·split·merged).
  - `consult-resume` — offers the visual dashboard at re-entry, alongside the text WBS table.
- **`consult-dashboard` SKILL** — restores the `consult-dashboard-refresher` reference (Phase 1 had softened it since the agent didn't exist yet) and adds a **Milestone Dashboard** section documenting the checkpoint contract.
- **Docs**: README Components (agent row) + Architecture (`agents/` dir) and CLAUDE.md tree synced.
- **Version 0.1.3 → 0.1.4** in `plugin.json` + `marketplace.json`.

## Verification

- `check-skill-names.sh` → OK; breadcrumb guard → success (no new violations); agent frontmatter valid (name/model/tools).
- Generator (the agent's target) still runs: exits 0, `{success,data,error}`, 100% on an all-complete test engagement.
- All hooks are read-only — they dispatch the read-only generator and never edit engagement state.

## Acceptance criteria

- [x] `consult-dashboard-refresher` agent (haiku, Bash+Glob) regenerates `output/dashboard.html` without a theme prompt; skips gracefully when `design-variables.json` is absent.
- [x] Milestone refresh wired into `consult-design-thinking` + `consult-action-fields`; `consult-resume` offers the dashboard.
- [x] `plugin.json` + `marketplace.json` both at `0.1.4`.
- [x] README/CLAUDE list the new agent; no new breadcrumbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
