### PR TITLE
docs: roll narrative style guide across all 13 plugin READMEs (Check 18 conformance)

### DIFF
--- a/cogni-claims/README.md
+++ b/cogni-claims/README.md
@@ -4,24 +4,24 @@
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-cogni-claims is the citation-integrity layer for the insight-wave ecosystem — a systematic verification workflow that detects when sourced claims misrepresent, overstate, or contradict what their cited sources actually say.
+A systematic claim-verification workflow for the insight-wave ecosystem — other plugins generate sourced content; this one checks whether the cited sources actually say what is claimed.
 
 ## Why this exists
 
-LLMs cite sources confidently — but the citations are often wrong. Numbers get rounded into different claims, conclusions overshoot what the source actually says, and URLs sometimes point to pages that don't exist. The gap between "cited" and "correct" is large enough to cause real harm, and it's well-documented:
+LLMs cite sources confidently, but the citations are often wrong — and the gap between "cited" and "correct" is large enough to cause real harm.
 
-| Problem | Finding | Source |
-|---------|---------|--------|
-| Fabricated citations | 14–95% of LLM citations are hallucinated depending on domain (2.2M citations analyzed) | [GhostCite, 2025](https://arxiv.org/html/2602.06718) |
-| Inaccurate citations | AI search engines fail to produce accurate citations in >60% of tests (8 engines tested) | [CJR Tow Center, 2025](https://www.cjr.org/tow_center/we-compared-eight-ai-search-engines-theyre-all-bad-at-citing-news.php) |
-| Bibliographic errors | 45.4% of GPT-4o citations contain bibliographic errors (most commonly invalid DOIs); 19.9% entirely fabricated | [JMIR Mental Health, 2025](https://mental.jmir.org/2025/1/e80371) |
-| Real-world harm | Lawyers sanctioned after submitting AI-fabricated case citations to court | [Mata v. Avianca, 2023](https://law.justia.com/cases/federal/district-courts/new-york/nysdce/1:2022cv01461/575354/54/) |
+| Problem | What happens | Impact |
+|---------|--------------|--------|
+| Citations are hallucinated | A claim points to a source that never made it ([14–95% of LLM citations, depending on domain](https://arxiv.org/html/2602.06718)) | Readers trust a number that no source supports |
+| Conclusions overshoot the source | The claim asserts more than the cited page says ([>60% of AI-search answers cite inaccurately](https://www.cjr.org/tow_center/we-compared-eight-ai-search-engines-theyre-all-bad-at-citing-news.php)) | Reports overstate evidence and lose credibility on review |
+| Bibliographic details are wrong | Invalid DOIs, broken URLs, fabricated references ([45.4% of GPT-4o citations contain errors](https://mental.jmir.org/2025/1/e80371)) | A fact-checker can't trace the claim back to anything real |
+| Errors reach high-stakes work | Unverified citations ship into published, sometimes legal, documents ([lawyers sanctioned over AI-fabricated case citations](https://law.justia.com/cases/federal/district-courts/new-york/nysdce/1:2022cv01461/575354/54/)) | Professional and legal consequences land after publish, when it's too late |
 
-Every claim above has been verified against its source using this plugin. This plugin exists because "cited" doesn't mean "correct."
+Every claim above was itself verified against its source using this plugin. "Cited" does not mean "correct."
 
 ## What it is
 
-A systematic claim-verification workflow for Claude Code / Claude Cowork. Other plugins generate sourced content — this one checks whether the sources actually say what's claimed. It detects five deviation types — misquotation, unsupported conclusions, selective omission, data staleness, and source contradiction — and routes each finding through explicit human resolution before publish. It's designed for cross-plugin use: submit claims from anywhere, verify and resolve them here.
+The citation-integrity layer for insight-wave: a verification engine that treats a cited claim and its source as two things that must agree, and the disagreement as the entity worth tracking. It is cross-plugin by design — claims submitted from anywhere in the ecosystem flow through the shared `claim-entity` data contract — and human-in-the-loop by principle, since LLM-detected discrepancies are assessments a person must adjudicate, never auto-applied corrections.
 
 ## What it does
 
@@ -36,9 +36,9 @@ A systematic claim-verification workflow for Claude Code / Claude Cowork. Other 
 
 If you ship research, reports, or any content that leans on sourced claims, this is your safety net before publish.
 
-- **Catch errors before they reach your audience.** Each claim is fetched against its cited source and checked for 5 deviation types — misquotation, unsupported conclusions, selective omission, data staleness, and source contradiction.
-- **Stay in control.** Deviation detection is LLM-based, but every finding routes through one of three explicit decisions — correct, dispute, or accept. 100% of claims pass through human review before publish; the tool flags, you decide.
-- **Reconstruct the evidence chain in seconds, not hours.** Every claim, verification result, and resolution decision persists as structured JSON in three linked records (ClaimRecord + DeviationRecord + ResolutionRecord) with timestamps and source excerpts — so an audit question a quarter later resolves in one `/claims inspect` call instead of half a day digging through drafts.
+- **Catch errors before your audience does.** Each claim is fetched against its cited source and checked for 5 deviation types, so misquotes and overshooting conclusions surface while you can still fix them.
+- **Stay in control of every fix.** Detection is LLM-based, but 100% of findings route through an explicit human decision — correct, dispute, or accept. The tool flags; you decide.
+- **Reconstruct the evidence chain in seconds.** Every claim, finding, and decision persists as structured JSON with timestamps and source excerpts — so an audit question a quarter later resolves in one `/claims inspect` call instead of half a day digging through old drafts.
 
 ## Known Limitations
 
@@ -77,13 +77,29 @@ Or just describe what you want in natural language — the plugin figures out th
 
 ## Try it
 
-After installing, type one prompt:
+After installing, point it at a draft that carries cited claims and verify them in one pass:
 
-> Search the web for LLM citation hallucination errors and verify the claims
+> Run `/claims submit --batch report.md` then `/claims verify`
 
-Claude researches the topic, produces sourced findings, then automatically verifies each claim against its cited source. You'll see which claims check out and which don't — then you can resolve any deviations.
+`submit` imports each `[Source: ...](URL)` citation as a claim; `verify` dispatches one fetcher per unique URL and checks every claim against what its source actually says. Then review the result:
 
-Results land in your project's `cogni-claims/` directory:
+> Run `/claims dashboard`
+
+You'll see each claim grouped by status, with the deviation called out inline, e.g.:
+
+```
+cogni-claims — 7 verified, 2 deviated, 1 source_unavailable
+  clm-3  deviated (high) — unsupported_conclusion
+         claim: "adoption doubled in 2024"
+         source appears to say: "adoption rose ~15% in 2024"
+  clm-8  source_unavailable — WebFetch 403 (try /claims cobrowse)
+```
+
+Then resolve the flagged ones — correct the claim, dispute the finding, or accept it:
+
+> Run `/claims resolve clm-3`
+
+Each finding shows the source excerpt inline, so you can judge for yourself whether the deviation is real before acting on it. Everything lands in your project's `cogni-claims/` directory, where the registry, cached sources, and per-claim history give you a durable audit trail you can re-run or hand to a reviewer:
 
 ```
 cogni-claims/
@@ -108,7 +124,13 @@ See [skills/claim-entity/references/schema.md](skills/claim-entity/references/sc
 
 ## How it works
 
-Claims are stored in your project's `cogni-claims/` directory as JSON. When you verify, the plugin dispatches a **claim-verifier** agent per unique source URL — each agent fetches the page once and checks all claims referencing it. For deviated claims, the **source-inspector** agent can open the source in Chrome and highlight the relevant passage so you can see the discrepancy in context.
+The lifecycle runs `submit → verify → review → inspect → resolve`, with `cobrowse` as a recovery branch. The ordering is deliberate: verification can only assess a claim once the claim and its source URL are both on record, and a human can only resolve a finding once verification has produced one with its evidence attached.
+
+Claims persist in your project's `cogni-claims/` directory as JSON — one `ClaimRecord` per assertion, with any `DeviationRecord` and `ResolutionRecord` linked to it. Keeping the records on disk rather than in chat history is what lets the evidence chain survive across sessions.
+
+On verify, the plugin groups claims by source URL and dispatches one **claim-verifier** agent per unique URL. Grouping matters: a page is fetched once no matter how many claims cite it, so a report leaning heavily on a single source doesn't trigger redundant fetches. Each agent reads the page and scores its claims against five deviation types, returning findings as JSON. Detection is intentionally conservative — when a comparison is genuinely ambiguous, the agent does not flag, because false positives erode the trust the tool depends on.
+
+Fetching uses WebFetch as the sole automated method. If WebFetch is blocked (403, paywall, anti-bot), the claim is marked `source_unavailable` rather than silently assumed correct — unverifiable is not verified. Those sources are recovered through `/claims cobrowse`, where you dismiss cookie banners and log in while Claude reads via the browser. For any deviated claim, the **source-inspector** agent opens the page in Chrome and highlights the passage so you can judge the discrepancy in context before deciding.
 
 ## Components
 
@@ -156,7 +178,7 @@ Contributions welcome — bug fixes, new deviation types, verification improveme
 
 ## Custom development
 
-Need a custom verification workflow, integration with your internal systems, or a new plugin for your domain? Contact [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
+Need a custom verification workflow, a new deviation type for your domain, or integration with your internal review systems? [cogni-work.ai](https://cogni-work.ai) builds and maintains bespoke Claude Code automation for teams — or reach out directly at [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
 
 ## License
 

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -6,7 +6,7 @@
 
 > **Start here.** Run `/cogni-consult:consult-resume` for engagement status and the next recommended action, or `/cogni-consult:consult-setup` to start a new engagement.
 
-Consulting engagement orchestrator for [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai) where **action fields are the work-breakdown-structure containers** for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.
+A [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai) consulting orchestrator where action fields are the work-breakdown-structure and each deliverable runs its own design-thinking loop on one shared cogni-knowledge base.
 
 ## Why this exists
 
@@ -17,15 +17,11 @@ Consulting engagement orchestrator for [Claude Code](https://claude.com/claude-c
 | Stakeholder perspectives live in a slide nobody reads | Deliverables ship without being challenged in the buyer's or PM's voice | Blind spots surface late — in front of the client, not before |
 | Research is a throwaway per-question web search | Each question starts from zero and earlier findings evaporate | Effort is repeated and later deliverables can't build on earlier syntheses |
 
+A consulting engagement managed as one rigid phase pipeline runs at the pace of its slowest gate, flattens deliverables into a single rhythm, and re-researches what it already knew — the engagement costs more hours and ships its blind spots to the client instead of catching them first.
+
 ## What it is
 
-A consulting engagement orchestrator built on three structural bets:
-
-- **Action fields as WBS** — scoping derives 3-6 action fields from one SMART key question; every deliverable lives inside exactly one field, and progress is tracked per deliverable, not per global phase.
-- **Design thinking per deliverable** — each deliverable iterates its own loop; fields complete when their deliverables do, and the engagement is complete by derivation.
-- **Knowledge base as the research spine** — one cogni-knowledge base is bound once at setup (`plugin_refs.knowledge_base`); all research routes through it per the canonical Research Routing Rule and compounds across the engagement.
-
-It is an orchestrator, not a producer: it manages engagement state and dispatches content work to the plugins that own it. It was selected after a side-by-side dogfood evaluation of two consulting-orchestration approaches; the comparison record lives in [docs/contributing/cogni-consult-evaluation.md](../docs/contributing/cogni-consult-evaluation.md).
+A consulting engagement orchestrator that treats action fields as the work-breakdown-structure, design thinking as a per-deliverable loop, and one cogni-knowledge base as the shared research spine. It is an orchestrator, not a producer — it manages engagement state and dispatches content work to the plugins that own it. It was selected over an alternative approach in a side-by-side dogfood evaluation (record: [docs/contributing/cogni-consult-evaluation.md](../docs/contributing/cogni-consult-evaluation.md)).
 
 ## What it does
 
@@ -39,11 +35,10 @@ It is an orchestrator, not a producer: it manages engagement state and dispatche
 
 ## What it means for you
 
-- **Research compounds instead of evaporating** — every deliverable's evidence lands in one refinable cogni-knowledge base, so the tenth deliverable starts smarter than the first instead of re-running the same searches
-- **Always know the next move** — deliverable-level state across the engagement's 3-6 action fields shows at a glance what is mid-loop, what awaits persona review, and what to pick up next, with no waiting on a global phase gate
-- **Catch objections while change is cheap** — acting personas (consulting partner, project manager) push back on each deliverable in their own voice at the prototype stage, surfacing the concerns that usually only land at the final readout
-- **Resume across sessions without re-briefing** — `consult-resume` rebuilds engagement status and routes to the most valuable next action, so a multi-week engagement never loses its thread between sessions
-- **See the whole engagement at a glance** — `consult-dashboard` renders a themed HTML view of the action-field WBS, deliverable states, design-thinking stages, and persona-review coverage, so progress and stuck deliverables are visible without reading JSON
+- **Compound your research instead of repeating it.** Every deliverable's evidence lands in one refinable cogni-knowledge base, so the tenth deliverable starts from what the first nine already found instead of re-running the same searches.
+- **Move ready work without waiting on a phase gate.** Deliverable-level state across the engagement's 3-6 action fields shows what is mid-loop, what awaits persona review, and what to pick up next — no deliverable stalls behind an unrelated one.
+- **Catch objections while change is cheap.** Two acting personas push back on each deliverable in their own voice at the prototype stage, surfacing concerns that otherwise land at the final readout.
+- **Resume across sessions without re-briefing.** `consult-resume` rebuilds engagement status and routes to the next action, so a multi-week engagement never loses its thread between sessions.
 
 ## Install
 
@@ -69,6 +64,26 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 
 Natural language works too: "start a consulting engagement for ACME's DACH cloud expansion", "scope the engagement", "work the competitor-map deliverable", "have the partner persona challenge the draft", "where was I with the engagement?".
 
+## Try it
+
+Scaffold an engagement and bind its knowledge base:
+
+> Run `/cogni-consult:consult-setup`
+
+This writes `cogni-consult/{slug}/consult-project.json` and the engagement skeleton. Then frame the key question and derive the work-breakdown-structure:
+
+> Run `/cogni-consult:consult-scope`
+
+You get 3-6 action fields, each with its own `action-fields/{field-slug}/field.json`. Pick a deliverable and run its design-thinking loop:
+
+> Run `/cogni-consult:consult-design-thinking`
+
+The deliverable artifact lands at `action-fields/{field-slug}/{deliverable-slug}.md` with `sources[]` lineage and its state advanced in `field.json`. Coming back later? Re-enter from the top:
+
+> Run `/cogni-consult:consult-resume`
+
+You'll see the WBS dashboard — every field, every deliverable's state and design-thinking stage — and the single next action to take.
+
 ## Data model
 
 | Entity | Lives in | Owns |
@@ -84,6 +99,8 @@ Field and engagement completion are derived at read time — never stored. Full 
 
 ## How it works
 
+Setup comes first because everything downstream is path-addressed against the engagement skeleton it writes, and the knowledge base it binds is the spine every later research run reaches. Scoping then converts one SMART key question into 3-6 action fields — the work-breakdown-structure — so the rest of the engagement is organized by *what the work is about*, not by which process phase it sits in.
+
 ```
 consult-setup ──→ consult-scope ──→ consult-action-fields ──→ consult-design-thinking
  (scaffold +        (key question +     (plan deliverable        (empathize→define→ideate
@@ -98,7 +115,9 @@ consult-setup ──→ consult-scope ──→ consult-action-fields ──→ 
 cogni-knowledge (bound once at setup) ←── every research run, per references/research-routing.md
 ```
 
-Research never goes to raw web search: the engagement's bound knowledge base serves quick gap-checks (`knowledge-query`), full inverted-pipeline runs for new topics, and `--source wiki` re-runs on covered topics — with finalized syntheses copied to the owning action field's `research/` directory.
+Each deliverable then runs its own empathize→define→ideate→prototype→test loop on its own clock — a field completes when its deliverables do, and the engagement completes by derivation rather than by a global gate. That is why ready work never blocks: deliverable state lives in each `field.json`, and completion is computed at read time, never stored. Acting personas enter at the prototype stage so objections surface while the draft is still cheap to change.
+
+Research never goes to raw web search: the engagement's bound knowledge base serves quick gap-checks (`knowledge-query`), full inverted-pipeline runs for new topics, and `--source wiki` re-runs on covered topics — with finalized syntheses copied to the owning action field's `research/` directory. Routing every run through one base is what lets later deliverables build on earlier findings instead of paying to rediscover them.
 
 ## Components
 
@@ -148,6 +167,10 @@ cogni-consult/
 | cogni-visual / document-skills | No | Deliverable export (slides, documents) when a deliverable names an export route |
 
 cogni-consult is standalone as an orchestrator — it structures the engagement, the WBS, and the design-thinking loops on its own. cogni-knowledge is the one required integration: without it, deliverable research has no compounding base.
+
+## Custom development
+
+Need a tailored deliverable type, a custom acting persona, or this orchestrator wired into your own engagement stack? [cogni-work.ai](https://cogni-work.ai) builds and maintains bespoke Claude Code automation for consulting teams.
 
 ## License
 

--- a/cogni-copywriting/README.md
+++ b/cogni-copywriting/README.md
@@ -4,24 +4,25 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-The polish layer between research and delivery in the insight-wave pipeline — cogni-copywriting refines AI-generated drafts into executive-ready documents on the McKinsey Pyramid Principle plus seven messaging frameworks. Five parallel stakeholder personas catch blind spots, multilingual readability validation scores the result (Flesch-family for DE/EN/FR/IT/PL/NL/ES, plus German Wolf Schneider), translate-then-polish carries it across those same seven languages via an EN/DE pivot, and Power Positions adds sales enhancement — all while preserving the upstream story arc structure from cogni-narrative. Runs in [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai/cowork). A `copy-json` adapter polishes text fields inside JSON files, and `audit-copywriter` verifies arc contracts stay in sync with cogni-narrative upstream.
+The polish layer of the insight-wave pipeline — a Claude Code toolkit that refines AI-generated drafts into executive-ready documents on the McKinsey Pyramid Principle and messaging frameworks.
 
 ## Why this exists
 
-AI-generated content reads like AI-generated content — competent but generic, wordy, and structurally flat. Executive readers have no patience for it:
+AI-generated content reads like AI-generated content — competent but generic, wordy, and structurally flat. Executive readers have no patience for it, and the cost lands after the document has already gone out:
 
 | Problem | What happens | Impact |
 |---------|-------------|--------|
 | Buried conclusions | Reports lead with background instead of the bottom line | Executives stop reading after the first paragraph |
 | Stakeholder blind spots | Writers optimize for one audience, miss others | Legal flags risks post-publish; technical reviewers find errors too late |
-| Inconsistent tone | Different documents from the same team sound like different companies | Brand dilution and reduced credibility |
+| Inconsistent tone | Different documents from the same team sound like different companies | Brand dilutes and credibility erodes |
 | Passive, academic voice | AI output defaults to hedged, passive construction | Weak recommendations that don't drive decisions |
+| Manual localization | German and English versions are edited in separate review cycles | One to two days added per document before it can ship |
 
-This plugin applies structured messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB) and runs parallel stakeholder personas to catch blind spots — so documents are clear, actionable, and audience-tested before they ship.
+A polished first draft is the difference between a document a decision-maker acts on and one that stalls in review — and the cost compounds across every report, brief, and proposal a team puts out.
 
 ## What it is
 
-A professional editing toolkit for the insight-wave ecosystem. Seven messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid) handle structure and tone, with Power Positions (IS/DOES/MEANS) available as a sales-mode enhancement. Five stakeholder personas (executive, technical, legal, marketing, end-user) simulate reader reactions in parallel. When paired with cogni-narrative, it detects story arc frontmatter and applies element-specific techniques — polishing without breaking narrative structure.
+A document-polishing engine built on the McKinsey Pyramid Principle and a library of structured messaging frameworks, with multilingual readability scoring at its core. It sits at the polish stage of the insight-wave pipeline: cogni-knowledge researches and cogni-narrative composes, then this layer turns the draft into a clear, audience-tested, executive-ready document — preserving any story-arc structure inherited from upstream rather than flattening it.
 
 ## What it does
 
@@ -35,10 +36,10 @@ A professional editing toolkit for the insight-wave ecosystem. Seven messaging f
 
 ## What it means for you
 
-- **Ship executive-ready documents in one pass** instead of 3-4 editing rounds — BLUF framing, Pyramid structure, active voice, and visual hierarchy applied together, not piecemeal.
-- **Stress-test with 5 parallel personas** to catch what a single reviewer misses — legal risks, technical gaps, marketing opportunities surfaced before the document leaves your desk.
-- **Protect your narrative investment.** Arc-aware polishing detects story arc structure and applies element-specific techniques — so a document that took cogni-narrative 30 minutes to compose doesn't lose its persuasive spine during editing.
-- **Publish in both markets without a second editing cycle.** English uses Flesch scoring (target 50-60); German uses Wolf Schneider rules with Amstad scoring (target 30-50) — eliminating the separate localization review that typically adds 1-2 days per document.
+- **Ship executive-ready in one pass.** Bottom-line framing, Pyramid structure, active voice, and visual hierarchy applied together replace the usual 3-4 editing rounds.
+- **Catch what one reviewer misses.** Five parallel stakeholder personas surface legal risks, technical gaps, and marketing opportunities before the document leaves your desk — not after.
+- **Protect your narrative investment.** Arc-aware polishing preserves story-arc structure, so a document cogni-narrative spent time composing keeps its persuasive spine through editing.
+- **Publish in both markets without a second cycle.** English scores on Flesch (target 50-60) and German on Amstad with Wolf Schneider rules (target 30-50), eliminating the separate localization review that adds 1-2 days per document.
 
 ## Install
 
@@ -69,11 +70,25 @@ Or describe what you want:
 
 ## Try it
 
-After installing, type one prompt:
+Point the copywriter at a draft and run it:
 
-> Polish this document for executive readability
+> Run `/copywrite quarterly-report.md`
 
-Claude reads the document, detects its type, applies the appropriate messaging framework, transforms passive voice to active, adds visual hierarchy, and validates with readability scoring. Then run `/review-doc` to get multi-stakeholder feedback.
+The copywriter detects the document type, applies the matching messaging framework, transforms passive voice to active, adds visual hierarchy, and scores the result. The original is backed up to `.quarterly-report.md`, and the polished version overwrites the input. You'll see a summary like:
+
+```
+quarterly-report.md — polished
+  Framework: Pyramid (answer-first)
+  Active voice: 84% (was 41%)
+  Readability: Flesch 56 (target 50-60)
+  Backup: .quarterly-report.md
+```
+
+Then stress-test it with the stakeholder review:
+
+> Run `/review-doc quarterly-report.md`
+
+Five personas — executive, technical, legal, marketing, end-user — read the document in parallel, raise their questions, and the synthesized CRITICAL and HIGH findings are auto-applied. Want feedback without edits? Add `--no-improve`. Polishing only one dimension? Scope it: `/copywrite quarterly-report.md --scope=tone` leaves structure and formatting untouched.
 
 ## Example workflows
 
@@ -121,6 +136,12 @@ Detects German language automatically, loads Wolf Schneider style rules — brea
 | Spanish | Szigriszt-Pazos | Usted, accents + ñ, inverted ¿¡ | 50-60 (aspirational) | via EN/DE pivot — `--translate=es` |
 
 Translation runs as a two-pass translate-then-polish flow: Pass A transfers meaning (preserving citations, URLs, frontmatter technical IDs, and protected content byte-identical); Pass B applies the target-language style discipline above. Every direction pivots on EN or DE — direct non-EN/DE pairs (e.g. fr→it) are rejected. For the five additional languages the absolute Flesch-family band is aspirational; the translation validator enforces a relative-to-source rule on the same target-language scale. Non-arc FR/IT/PL/NL/ES translation ships now (#255 Slice 1), and arc-mode translation ships across **all seven languages** for the `corporate-visions` and `jtbd-portfolio` arcs (#255 Slices 2–3) — arc-element and bridge headings are substituted from cogni-narrative's canonical heading set rather than freely translated. Broader arc coverage (the other 9 arcs) remains future work; direct non-EN/DE pairs are rejected.
+
+## How it works
+
+Polishing runs as a five-step sequential pipeline, and the order is the point. Step 1 parses parameters and reads `references/00-index.md`, a decision tree that detects the mode — standard, arc, or sales — and loads exactly the references that mode needs rather than every framework at once. Step 2 applies the structural framework (Pyramid, BLUF, SCQA, and the rest), because a document's skeleton has to be right before its prose is worth refining. Step 3 does the line-level work: voice transformation to active, sentence and paragraph splitting, bold anchoring, visual rhythm, and audience-tuned acronym expansion. Step 4 runs the optional stakeholder review but never blocks delivery. Step 5 validates and writes — German characters preserved, citation count intact, readability scored — after backing up the original.
+
+Structure precedes prose for a reason: reordering an argument after it has been word-smithed wastes the polish, so the framework is applied first and the sentence-level discipline second. Arc mode inverts only the structural step — when cogni-narrative frontmatter carries an `arc_id`, the arc *is* the structure, so Step 2 is skipped and element-specific techniques replace the generic framework, keeping the inherited story arc intact. Translation runs as a translate-then-polish two-pass flow that pivots on English or German, transferring meaning first and applying target-language style discipline second, so localization and polish never fight each other. The `audit-copywriter` skill keeps the arc-preservation contract in sync with cogni-narrative upstream so that arc-aware polishing never drifts from the definitions it depends on.
 
 ## Components
 
@@ -172,7 +193,7 @@ Contributions welcome — new messaging frameworks, persona definitions, languag
 
 ## Custom development
 
-Need custom messaging frameworks, house style integration, or a new plugin for your domain? Contact [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
+Need a custom messaging framework, your house style baked into the polish rules, an extra target language, or a new plugin built for your domain? [cogni-work.ai](https://cogni-work.ai) builds and maintains custom Claude Code automation for teams.
 
 ## License
 

--- a/cogni-help/README.md
+++ b/cogni-help/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-cogni-help unifies the [insight-wave](https://github.com/cogni-work/insight-wave) ecosystem into a single entry point — teaching users through a workflow-tour curriculum, routing tasks to the right plugin, chaining multi-plugin workflows, diagnosing problems, generating one-screen cheatsheets, and filing GitHub issues straight from the session — so 12 plugins with 70+ skills behave like one coherent system.
+The onboarding and navigation layer for the [insight-wave](https://github.com/cogni-work/insight-wave) ecosystem — the single entry point that makes 12 plugins with 70+ skills behave like one coherent system.
 
 ## Why this exists
 
@@ -15,9 +15,11 @@ cogni-help unifies the [insight-wave](https://github.com/cogni-work/insight-wave
 | Silent failures | A missing dependency or stale workspace breaks skills at runtime | Cryptic errors with no diagnostic path — users blame the plugin, not the config |
 | No structured learning | Users learn by stumbling into slash commands | Shallow usage — power features go undiscovered |
 
+A capable ecosystem nobody can navigate is a capability nobody uses — the cost of insight-wave's breadth is paid in every onboarding hour and every undiscovered pipeline.
+
 ## What it is
 
-A meta-plugin for the insight-wave ecosystem. While other plugins produce content — research, narratives, portfolios, visuals — cogni-help teaches you how to use them together. A 7-tour curriculum walks the canonical end-to-end pipelines, from first-run install through a full consulting engagement. Seven cross-plugin workflow templates chain plugins into end-to-end pipelines. Diagnostics catch configuration issues before they surface as skill failures.
+A meta-plugin for the insight-wave ecosystem, built on a workflow-tour curriculum keyed 1:1 to the canonical cross-plugin pipelines. While the other plugins produce content — research, narratives, portfolios, visuals — cogni-help is the layer that teaches you how to use them together and routes you to the right one. It owns no domain data; it indexes the ecosystem so the other twelve plugins read as a single system.
 
 ## What it does
 
@@ -64,6 +66,27 @@ Or describe what you want:
 - "Teach me how to use insight-wave"
 - "How do I go from research to a slide deck?"
 - "Something is broken with cogni-portfolio"
+
+## Try it
+
+Don't know which plugin handles your task? Describe it in plain language:
+
+> Run `/guide "I need to turn research into a slide deck"`
+
+The guide skill matches your description against all 12 plugins and 70+ skills and routes you to the pipeline, e.g.:
+
+```
+research-to-report pipeline:
+  cogni-knowledge  → research a topic into a wiki
+  cogni-narrative  → compose the findings into a story
+  cogni-visual     → render slides from the narrative
+```
+
+Then walk the matching tour hands-on:
+
+> Run `/teach tour-research-to-report`
+
+The tour runs ~45–60 minutes across five modules — Theory, Demo, Exercise, Quiz, Recap — and tracks your progress to the lesson, so you can stop and resume `/courses` later without losing your place. The exercise module has you run real commands against your own workspace, so you finish with a working artifact rather than just notes. If something breaks along the way, `/troubleshoot` checks plugin integrity and dependencies and points you at the fix.
 
 ## Components
 
@@ -122,6 +145,14 @@ Tour progress is stored in `.claude/cogni-help.local.md` (YAML frontmatter).
 Issue state is stored in `cogni-issues/issues.json` in the working directory.
 Exercise artifacts are written to `_teacher-exercises/`.
 
+## How it works
+
+cogni-help is a thin index over the ecosystem rather than a content producer, so each skill resolves a different navigation question against the same shared map. `guide` reads a plugin-capability catalog and matches a natural-language task description to the plugin and skill that owns it — discovery comes first, because a user who picks the wrong plugin never reaches the pipeline that would have worked.
+
+Once the right entry point is known, `workflow` and `teach` take over. `workflow` returns one of the cross-plugin templates — ordered plugin chains like research-to-report or portfolio-to-pitch — so the multi-plugin handoffs are explicit instead of rediscovered each time. `teach` walks the same chains interactively: each of the seven tours maps 1:1 to a workflow template and steps through Theory → Demo → Exercise → Quiz → Recap, persisting progress to `.claude/cogni-help.local.md` so a tour can be paused and resumed at the module it left off.
+
+The remaining skills support that core loop. `troubleshoot` runs ahead of failure — it checks plugin integrity, dependencies, and workspace health (delegating infrastructure checks to cogni-workspace) so a missing dependency surfaces as a diagnostic rather than a cryptic runtime error. `cheatsheet` reads any plugin's metadata to render a one-screen reference, and `cogni-issues` files bugs and requests against the right ecosystem repo without leaving the session. Every dependency is soft: cogni-help runs without any specific plugin installed, and only the tours and workflows that walk a given plugin require it to be present.
+
 ## Architecture
 
 ```
@@ -172,7 +203,7 @@ Contributions welcome — tour content, workflow templates, diagnostic checks, a
 
 ## Custom development
 
-Need custom training tours or a new plugin? Contact [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
+Need a bespoke training curriculum for your team, a new workflow tour, or a plugin built for your stack? [cogni-work.ai](https://cogni-work.ai) builds and maintains custom Claude Code automation and onboarding for organizations adopting the insight-wave ecosystem.
 
 ## License
 

--- a/cogni-knowledge/README.md
+++ b/cogni-knowledge/README.md
@@ -4,9 +4,7 @@
 
 > **Start here.** Run `/cogni-knowledge:knowledge-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
 
-**Wiki-first research that compounds — and stays honest.** Every shipped deep-research tool today produces a document and loses the underlying knowledge to chat history. cogni-knowledge inverts that posture: a research run *binds* to a named knowledge base, deposits its findings into a persistent wiki, and the next run reads from the same wiki before going to the web. Knowledge gets denser with every project — instead of starting from zero each time — and every citation is verified against the cited source's pre-extracted claims (zero network), so the base you build is one you can trust.
-
-cogni-knowledge is **self-contained**: it bundles a vendored wiki engine (`scripts/vendor/cogni-wiki/`, resolved vendored-first) and dispatches zero external wiki-plugin skills. The pipeline runs its own local agents, and the only new state cogni-knowledge owns is a `binding.json` that records "this wiki is the knowledge base for topic area X, and these research projects have contributed to it."
+A wiki-first research engine on an inverted pipeline: each run deposits verified findings into a persistent wiki the next run reads first — the compounding-knowledge core of insight-wave.
 
 > **Multi-market & multilingual.** Bind a market to your knowledge base and research runs bilingually (local language + English) against curated regional authority sources — European-first across DACH/DE/FR/IT/ES/NL/PL plus UK/US, with 16+ output languages. See [Supported markets & languages](../cogni-workspace/README.md#supported-markets--languages).
 
@@ -21,13 +19,11 @@ cogni-knowledge is **self-contained**: it bundles a vendored wiki engine (`scrip
 | Trust in a cited number | Hope the model quoted the source right | Every citation checked against the source's pre-extracted claims (zero network); unsupported ones auto-revise |
 | Refresh stale claims | Manual re-research | `knowledge-refresh` (push-mode re-researches stale topics via the inverted pipeline) |
 
+Every report you ship discards the research underneath it — so the next related question starts from zero, and the same web crawl is paid for again and again.
+
 ## What it is
 
-**IS:** A self-contained, wiki-first research engine built on two pillars — **compounding** (research accumulates in a persistent wiki instead of dying in chat history) and **citation-consistent verification** (every claim is checked against its cited source, with zero network calls). A knowledge base is a vendored wiki plus a `binding.json` manifest; the wiki engine ships inside the plugin, so there is nothing external to install.
-
-**DOES:** Researches a topic from the web and files the findings into a persistent wiki — then checks every citation against its source and reuses that wiki on the next run. A single run decomposes the topic into sub-questions, curates and fetches sources, extracts their claims into wiki pages, composes a cited draft, verifies each citation against the source's own claims (auto-revising unsupported ones), and deposits a verified synthesis the next run can read. Contradiction tripwires flag sources that disagree, without blocking the run.
-
-**MEANS for you:** the work compounds. Run research on EU AI Act Article 6 today; tomorrow's run on foundation-model obligations reads what you already filed before going back to the web. Query and refresh the accumulated base in plain language — no vector store, no embeddings, just markdown that gets denser and more trusted with every project.
+A self-contained, wiki-first research engine built on two pillars: compounding — research accumulates in a persistent wiki instead of dying in chat history — and citation-consistent verification, where every claim is checked against its cited source with zero network calls. A knowledge base is a vendored wiki plus a `binding.json` manifest; the wiki engine ships inside the plugin, so there is nothing external to install.
 
 ## What it does
 
@@ -51,11 +47,10 @@ See `references/absorption-roadmap.md` for the inverted-pipeline design. The plu
 
 ## What it means for you
 
-- **Stop producing throwaway reports — start building knowledge that compounds.** Each run deposits its verified findings into a persistent, interlinked wiki you refine and re-query, and the next project reads what you already filed before going to the web. The deliverable isn't a document that ages out in a folder — it's a knowledge base that gets denser, more trusted, and more useful with every project.
-- **Ship a report whose every citation is backed, not hopeful — fact-checking is a first-class pillar, not an afterthought.** Every claim is held to a **citation-consistent** standard: scored against the cited source's ingest-time pre-extracted claims with zero network calls, with the revisor auto-revising unsupported statements (capped at 2 passes) and three contradiction tripwires flagging sources that disagree. This is consistency against what was ingested — deliberately distinct from `cogni-claims`, which re-fetches live source URLs — so every numbered `[N]` marker traces to evidence already on the page, in seconds, not to a model's recollection.
-- **Defend any fact in one lookup.** A `derived_from_research:` lineage stamp on every page points a stale or disputed claim straight back to the run that filed it — no archaeology through old chat logs when a number gets challenged weeks later.
-- **Own your knowledge base as plain markdown.** No vector store, no embeddings, no lock-in — the whole base is Obsidian-browsable markdown you can read, grep, edit, and version in git. Inspect it with `knowledge-dashboard`, ask it in natural language with `knowledge-query`, and keep it current with `knowledge-refresh`.
-- **Read the answer in seconds, not skim a wall of text.** New projects are concise by default — `executive` density front-loads the bottom line (BLUF + Minto Pyramid, a document-level Key Takeaways block, a ~2000-word ceiling) so a busy reader absorbs the findings at a glance; opt into the long-form, exhaustively-cited document with `--prose-density standard --target-words 4000`. (Conciseness is a supporting benefit — the compounding knowledge base above is still the point.)
+- **Build knowledge that compounds, not throwaway reports.** Each run deposits verified findings into a persistent wiki the next project reads before going to the web — so the base gets denser and more useful with every project instead of starting from zero.
+- **Trust every citation, not hope it's right.** Each `[N]` marker is scored against its source's pre-extracted claims with zero network calls; the revisor auto-revises unsupported statements in up to 2 passes.
+- **Defend any fact in one lookup.** A `derived_from_research:` lineage stamp points a disputed claim straight back to the run that filed it — no archaeology through old chat logs.
+- **Own your base as plain markdown.** No vector store, no embeddings, no lock-in — the whole base is Obsidian-browsable markdown you read, grep, edit, and version in git.
 
 ## Install
 
@@ -93,6 +88,28 @@ Or just describe what you want in natural language:
 - "Refresh the stale pages in my wiki"
 
 The second project reads the wiki the first one deposited — that is the compounding loop. The `dashboard` and `query` skills let you inspect and ask the accumulated base. Use `knowledge-refresh --mode push` later to keep stale pages fresh.
+
+## Try it
+
+Set up a base, then run one research project end to end:
+
+> Run `/cogni-knowledge:knowledge-setup --knowledge-slug eu-ai-act --knowledge-title "EU AI Act knowledge base"`
+
+This scaffolds the wiki and writes `eu-ai-act/.cogni-knowledge/binding.json`. Now research a topic:
+
+> Run `/cogni-knowledge:knowledge-plan --knowledge-slug eu-ai-act --topic "EU AI Act Article 6 high-risk systems"`
+
+then chain `knowledge-curate` → `knowledge-fetch` → `knowledge-ingest` → `knowledge-compose` → `knowledge-verify` → `knowledge-finalize`. The verified synthesis lands at:
+
+```
+eu-ai-act/wiki/syntheses/<slug>.md
+```
+
+with a `derived_from_research:` lineage stamp and every citation scored against its source. Ask the accumulated base in plain language:
+
+> Run `/cogni-knowledge:knowledge-query --knowledge-slug eu-ai-act --question "what does the wiki say about foundation models?"`
+
+The answer cites `[[slug]]` pages already on the wiki — and the next research run reads them before touching the web. Open the wiki folder in Obsidian and you can browse every synthesis, source, and concept page as linked markdown, following citations back to where each claim came from. Each run you do compounds the base rather than starting over, so coverage deepens and repeat questions get faster, better-grounded answers.
 
 ## Data model
 
@@ -138,7 +155,9 @@ knowledge-refresh --knowledge-slug X --mode push
          → knowledge-distill (optional) → knowledge-compose → knowledge-verify → knowledge-finalize
 ```
 
-The deposited synthesis pages are now part of the wiki and visible to the next `knowledge-compose` run, which reads `wiki/syntheses/*.md` as prior cross-source framing — the compounding loop.
+The order is the design. `knowledge-curate` resolves wiki coverage *before* searching the web (read-before-web), so a sub-question the base already answers narrows its search instead of re-crawling. Sources are ingested into the wiki *before* any draft runs — claims are pre-extracted at ingest time, which is what later lets verification score every citation with zero network calls. Composition reads only the populated wiki, so the draft can never cite a source the base hasn't filed. Verification runs after composition because a citation can only be checked once it exists, and the revisor loop repoints or rephrases unsupported sentences before finalize deposits anything.
+
+Two design choices make the base compound rather than merely accumulate. The optional Phase 4.5 distillation merges recurring facts into concept and entity pages that successive runs enrich instead of duplicate. And finalize stamps each synthesis with `derived_from_research:` lineage and deposits it into `wiki/syntheses/` — where the next `knowledge-compose` run reads it as prior cross-source framing. The deposited synthesis pages are now part of the wiki and visible to that next run, closing the loop.
 
 ## Components
 
@@ -216,7 +235,7 @@ These are pure enhancements — the plugin runs without them and degrades to an 
 
 ## Custom development
 
-Adding a skill: every skill delegates. If you find yourself writing a new agent or duplicating the vendored wiki-engine logic, the right answer is almost always to push the change upstream and re-delegate. See `references/delegation-contract.md` for the contract.
+Need a knowledge base tuned to your domain, custom ingest sources, or a pipeline built on this engine? [cogni-work.ai](https://cogni-work.ai) builds and maintains bespoke Claude Code research automation for teams. To extend the plugin yourself, every skill delegates — see `references/delegation-contract.md` for the contract.
 
 ## License
 

--- a/cogni-marketing/README.md
+++ b/cogni-marketing/README.md
@@ -6,13 +6,13 @@
 
 > **Start here.** Run `/cogni-marketing:marketing-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
 
-B2B marketing content engine for the insight-wave ecosystem. Bridges cogni-trends strategic themes and cogni-portfolio propositions into channel-ready content. Supports thought leadership, demand generation, lead generation, sales enablement, and ABM across markets with configurable brand voice. Bilingual DE/EN.
+A B2B marketing content engine that turns cogni-trends strategic themes and cogni-portfolio propositions into channel-ready content — the bridge from structured strategy to publishable work.
 
 > **Multi-market & multilingual.** cogni-marketing inherits the target market from cogni-portfolio — European-first across DACH/DE/FR/IT/ES/NL/PL plus UK/US — and produces bilingual DE/EN content with per-market brand voice. See [Supported markets & languages](../cogni-workspace/README.md#supported-markets--languages).
 
 ## Why this exists
 
-Portfolio data and trend insights sit in structured JSON — but marketing teams need blog posts, whitepapers, battle cards, and campaigns. The gap between structured strategy and publishable content is where most B2B marketing stalls:
+Portfolio data and trend insights sit in structured JSON — but marketing teams need blog posts, whitepapers, battle cards, and campaigns. The gap between structured strategy and publishable content is where most B2B marketing stalls. The strategy already exists; the work of turning it into channel-ready pieces, market by market, is what never quite gets done:
 
 | Problem | What happens | Impact |
 |---------|-------------|--------|
@@ -21,11 +21,11 @@ Portfolio data and trend insights sit in structured JSON — but marketing teams
 | Inconsistent brand voice | Different writers produce different tones across markets and formats | Brand dilution across touchpoints |
 | No content coverage visibility | Teams can't see which market × theme × funnel stage combinations have content gaps | Wasted effort on saturated topics, blind spots on others |
 
-This plugin automates the bridge: it reads your portfolio propositions and TIPS trend themes, generates content across 16 formats and 5 content types, orchestrates campaigns, and tracks coverage via a dashboard.
+Every piece below is a symptom of the same root cause: strategy and content live in two different places, and bridging them by hand does not scale.
 
 ## What it is
 
-A content generation bridge between strategy and execution in the insight-wave ecosystem. cogni-trends produces strategic themes (GTM paths); cogni-portfolio produces propositions and competitive intelligence. cogni-marketing consumes both and generates channel-ready content across five funnel stages — from thought leadership that builds awareness to battle cards that close deals. A 3D content matrix (market x GTM path x content type) ensures coverage visibility across the entire portfolio.
+A content-generation bridge between strategy and execution in the insight-wave ecosystem. cogni-trends produces strategic themes (GTM paths) and cogni-portfolio produces propositions and competitive intelligence; cogni-marketing is the consumer that sits downstream of both. Its organizing model is a 3D content matrix — market × GTM path × content type — so every piece traces back to a theme and a proposition, and coverage stays visible across the whole portfolio.
 
 ## What it does
 
@@ -38,11 +38,11 @@ A content generation bridge between strategy and execution in the insight-wave e
 
 ## What it means for you
 
-- **Connect every piece to strategy.** 100% of generated content traces back to a TIPS theme and portfolio proposition — zero generic filler, no orphan posts.
-- **Generate 16 formats from one brief.** Blog posts, LinkedIn articles, whitepapers, battle cards, email nurtures, video scripts, carousels, and more — each adapted to channel conventions in a single content run.
-- **Run content batches in parallel.** Content-writer agents run concurrently, producing a full content batch in minutes instead of the days a sequential workflow takes.
-- **See coverage gaps at a glance.** The 3D dashboard (market × GTM path × content type) shows exactly which combinations have content and which don't — across all markets, themes, and funnel stages on one screen.
-- **Publish bilingual without re-authoring.** Full DE/EN support with language-specific brand voice configuration — one strategy, two languages, no manual translation pass.
+- **Connect every piece to strategy.** Each generated piece traces back to a TIPS theme and a portfolio proposition — no generic filler, no orphan posts.
+- **Generate 16 formats from one brief.** Blogs, LinkedIn articles, whitepapers, battle cards, email nurtures, video scripts, carousels, and more — each adapted to channel conventions in a single run.
+- **Run content batches in parallel.** Content-writer agents run concurrently, producing a full batch in minutes instead of the days a sequential workflow takes.
+- **See coverage gaps at a glance.** The dashboard maps which market × GTM path × content type combinations have content and which don't, on one screen.
+- **Publish bilingual without re-authoring.** DE/EN support with language-specific brand voice — one strategy, two languages, no manual translation pass.
 
 ## Install
 
@@ -79,13 +79,20 @@ Or describe what you want in natural language:
 
 ## Try it
 
-After installing, type one prompt:
+Set up a project, then run the resume skill to see where you stand:
 
-> Set up a marketing project and generate a content strategy
+> Run `/cogni-marketing:marketing-setup`, then `/cogni-marketing:marketing-resume`
 
-Claude discovers your portfolio and TIPS data, configures brand voice defaults, builds a content matrix showing where content is needed, and recommends a generation sequence. Then generate content for any cell in the matrix.
+Setup discovers your cogni-portfolio and cogni-trends data, configures brand voice defaults, and writes `marketing-project.json`. The resume skill then reports project status, content gaps, and the recommended next step:
 
-Results land in your project directory:
+```
+cogni-marketing — DACH/EN, 2 GTM paths
+  Strategy: content-matrix.json present — 18 cells, 3 with content
+  Gap: lead-generation (consideration stage) — 0 of 6 cells filled
+  Next: /cogni-marketing:content-strategy, then /cogni-marketing:lead-gen
+```
+
+Generate content for any cell — e.g. `/cogni-marketing:thought-leadership` for awareness pieces — and content-writer agents produce the batch in parallel, each piece following its format spec and your configured brand voice. Because the matrix knows which cells are filled, you can keep generating until coverage is complete and watch the gap report shrink run by run. When you are ready to publish, the campaign-builder and content-calendar skills sequence the pieces into multi-channel timelines. Results land in your project directory:
 
 ```
 cogni-marketing/{project-slug}/
@@ -108,6 +115,14 @@ cogni-marketing/{project-slug}/
 Content pieces are markdown files with YAML frontmatter tracking type, format, market, GTM path, funnel stage, language, brand voice, and source traceability back to TIPS claims and portfolio propositions. See [references/data-model.md](references/data-model.md) for the full schema.
 
 16 content formats: blog, linkedin-article, linkedin-post, whitepaper, email-nurture, landing-page, battle-card, one-pager, webinar-outline, carousel, video-script, keynote-abstract, podcast-outline, demo-script, objection-handler, executive-briefing.
+
+## How it works
+
+The pipeline runs in dependency order: `marketing-setup → content-strategy → content generators → campaign-builder → content-calendar → marketing-dashboard`. Setup comes first because everything downstream needs a single source of truth — `marketing-setup` reads cogni-portfolio propositions and cogni-trends themes, resolves brand voice and markets, and writes `marketing-project.json`.
+
+`content-strategy` then builds the 3D matrix (market × GTM path × content type) and detects gaps, so the generators always know which cells are empty and in what priority order to fill them. The five content generators — thought-leadership, demand-generation, lead-generation, sales-enablement, and abm — map to the five funnel stages; each dispatches content-writer agents in parallel against a format spec, the resolved brand voice, and the cited source data. Generation is sharded per cell so a batch can run concurrently rather than one piece at a time.
+
+Downstream, `campaign-builder` sequences finished pieces into multi-channel campaigns with phased funnel progression (attract → engage → convert), `content-calendar` assigns publication dates and channels, and `marketing-dashboard` renders coverage across the whole matrix. The ordering matters: campaigns can only sequence content that exists, and the dashboard can only report coverage once the matrix and the generated pieces are both in place. Source traceability is carried in each file's YAML frontmatter, so a TIPS claim or proposition can be traced from any published piece back to its origin.
 
 ## Components
 
@@ -181,7 +196,7 @@ Contributions welcome — content formats, channel adapters, brand voice presets
 
 ## Custom development
 
-Need custom content formats, CRM integration, or a new plugin for your domain? Contact [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
+Need custom content formats, a CRM integration, or a marketing engine tailored to your channels and markets? [cogni-work.ai](https://cogni-work.ai) builds and maintains bespoke Claude Code automation for B2B marketing teams.
 
 ## License
 

--- a/cogni-narrative/README.md
+++ b/cogni-narrative/README.md
@@ -4,11 +4,11 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-The story arc engine for the insight-wave ecosystem — transforms structured research and portfolio output into executive-grade narratives using 11 arc frameworks (Corporate Visions, JTBD Portfolio, Strategic Foresight, Trend Panorama, and seven more) and 8 narrative techniques, with review scoring (0–100, A–F) and derivative formats (executive brief, talking points, one-pager), sitting between cogni-knowledge and cogni-copywriting in the pipeline and feeding cogni-visual, cogni-sales, and cogni-marketing downstream. Bilingual EN/DE.
+The story arc engine for the insight-wave ecosystem — it imposes named arc-framework discipline on structured research, turning data into executive-grade narratives between cogni-knowledge and cogni-copywriting.
 
 ## Why this exists
 
-Research output is structured but not persuasive. Executives don't read data dumps — they need a story that connects evidence to decisions:
+Research output is structured but not persuasive. Executives don't read data dumps — they need a story that connects evidence to decisions, and a synthesis that reads well in one document reads flat in the next when every author invents the structure from scratch:
 
 | Problem | What happens | Impact |
 |---------|-------------|--------|
@@ -17,7 +17,7 @@ Research output is structured but not persuasive. Executives don't read data dum
 | Format lock-in | One narrative output, one format — can't easily derive briefs, talking points, or one-pagers | Manual rewriting for each audience and format |
 | Quality unmeasured | No scoring or review gates for narrative quality | Weak narratives ship without feedback |
 
-This plugin applies structured story arc frameworks — each with defined sections, evidence requirements, and transition patterns — so narratives are consistently compelling and reviewable.
+A strong synthesis dies when it lands in front of the wrong reader in the wrong shape — and there is no way to tell a compelling draft from a flat one until someone has already skimmed past it.
 
 > **Important**: This plugin generates executive narratives from structured input. All outputs should be reviewed for accuracy and tone before use in executive presentations, board materials, or external communications.
 
@@ -33,11 +33,11 @@ A story arc engine for the insight-wave ecosystem. Eleven named arc frameworks �
 
 ## What it means for you
 
-- **Arc-disciplined, not improvised.** Every narrative follows one of 10 proven story arc structures — cutting first-draft time from hours to under 15 minutes while maintaining consistent quality across documents and authors.
-- **Match the arc to the audience before you write.** Eleven frameworks cover every consulting output type — from sales enablement to board-ready investment themes to company pages — so structure decisions are made by context, not guesswork.
-- **Quality-gated.** Automated scoring (0-100, A-F grades) on structural compliance, critical accuracy, evidence density, and language — with improvement suggestions per dimension.
-- **One narrative, three derivative formats.** Executive briefs, talking points, and one-pagers — adapted from the source narrative without rewriting.
-- **Ship in the reader's language.** Full EN/DE support with localized arc headers and proper Unicode — no post-processing needed for German-language clients or DACH reports.
+- **Arc-disciplined, not improvised.** Every narrative follows a proven story arc — cutting first-draft time from hours to under 15 minutes, with quality consistent across documents and authors.
+- **Match the arc to the audience first.** Eleven frameworks cover every consulting output type — sales enablement, investment themes, company pages — so structure follows context, not guesswork.
+- **Catch a weak draft before it ships.** Automated scoring (0-100, A-F) on structure, accuracy, evidence density, and language flags soft sections with per-dimension fixes — before a reader skims past.
+- **Repurpose without rewriting.** Derive an executive brief, talking points, and a one-pager from one narrative — three formats, no per-channel rework.
+- **Ship in the reader's language.** Full EN/DE support with localized arc headers and proper Unicode — no post-processing for German clients or DACH reports.
 
 ## Install
 
@@ -68,11 +68,23 @@ Or describe what you want:
 
 ## Try it
 
-After installing, type one prompt:
+Point the plugin at a research-output directory and run the transform:
 
-> Transform this research into an executive narrative
+> Run `/cogni-narrative:narrative ./research-output/`
 
-Claude reads your research output, auto-detects the best story arc, asks you to confirm or override, then generates a 1,500-word executive narrative with inline citations back to source files.
+Claude reads the structured content, proposes the best-fit story arc, and asks you to confirm or override before writing. Approve it, and you get an executive narrative at `./research-output/insight-summary.md` — arc-structured sections with inline citations back to the source files, plus `arc_id` and element metadata in the YAML frontmatter.
+
+Then score what you wrote:
+
+> Run `/cogni-narrative:narrative-review ./research-output/insight-summary.md`
+
+You get a scorecard with a 0-100 composite, an A-F grade, per-gate results (structural, critical, evidence, language), and the top improvement suggestions.
+
+Need a shorter cut for a different audience? Derive one without rewriting:
+
+> Run `/cogni-narrative:narrative-adapt ./research-output/insight-summary.md --format executive-brief`
+
+The adapter writes `executive-brief.md` alongside the source, condensing proportionally while preserving the arc.
 
 ## Story arc frameworks
 
@@ -112,6 +124,12 @@ Claude reads your research output, auto-detects the best story arc, asks you to 
 ### German-Language Output
 
 Run `/narrative ./research-output/ --lang de` to generate a narrative in German with proper Unicode umlauts and localized section headers.
+
+## How it works
+
+The pipeline runs arc-first, because structure must be chosen before evidence can be placed into it. When you invoke `narrative`, `bridge-citations.py` first converts upstream `[Source: Publisher](URL)` inline citations into per-source markdown files, so the writer can cite and link them cleanly. The skill then analyzes the input's shape and proposes a story arc — one of eleven named frameworks, each defining its own element flow, evidence requirements, and transition patterns. Corporate Visions runs Why Change → Why Now → Why You → Why Pay; trend-panorama runs Forces → Impact → Horizons → Foundations; and so on. You confirm or override, then a per-arc phase-4b synthesis workflow maps the structured content into that arc's elements and writes `insight-summary.md` with `arc_id` frontmatter.
+
+`narrative-review` exists as a separate step because quality is a property of the finished narrative, not a side effect of writing it — it scores the draft across four gates (structural compliance, critical accuracy, evidence density, language correctness) into a composite 0-100 score and A-F grade, with per-dimension suggestions. `narrative-adapt` runs last and downstream: it reads the scored narrative and condenses it proportionally into derivative formats rather than re-deriving structure, so the arc survives into the brief, the talking points, and the one-pager. The `arc_id` frontmatter then carries forward — cogni-copywriting reads it for arc-aware polishing, and cogni-visual reads the narrative for slides and web output.
 
 ## Components
 
@@ -166,7 +184,7 @@ Contributions welcome — new arc frameworks, narrative techniques, language tem
 
 ## Custom development
 
-Need custom story arc frameworks, house narrative style, or a new plugin for your domain? Contact [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
+Need a custom story arc framework, your house narrative style encoded as a gate, or a new plugin built for your domain? [cogni-work.ai](https://cogni-work.ai) builds and maintains bespoke Claude Code narrative automation for consulting and sales teams.
 
 ## License
 

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -8,11 +8,11 @@
 
 > **Start here.** Run `/cogni-portfolio:portfolio-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
 
-A [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai/cowork) plugin for portfolio messaging and proposition planning. Helps SMEs build structured, market-specific value propositions using the IS/DOES/MEANS (FAB) framework — from product definition through competitive analysis and customer profiling to export-ready deliverables, across eight pluggable industry taxonomies (B2B SaaS, FinTech, HealthTech, MarTech, Industrial Tech, ICT, Professional Services, Commercial Open Source) and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).
+A [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai/cowork) plugin that builds market-specific value propositions on the IS/DOES/MEANS (FAB) framework, the proposition-planning anchor of the insight-wave ecosystem.
 
 ## Why this exists
 
-B2B companies know what they sell — but struggle to articulate why each market segment should care. The gap between product knowledge and market-specific messaging is where most positioning stalls:
+B2B companies know what they sell — but struggle to articulate why each market segment should care. The gap between product knowledge and market-specific messaging is where most positioning stalls: the same pitch goes to every segment, the analysis lives in scattered decks, and the work has to be redone by hand the moment a market or competitor shifts.
 
 | Problem | What happens | Impact |
 |---------|-------------|--------|
@@ -23,7 +23,7 @@ B2B companies know what they sell — but struggle to articulate why each market
 
 ## What it is
 
-A structured portfolio messaging workflow for Claude Code / Claude Cowork. Eight pluggable taxonomy templates (B2B ICT, SaaS, FinTech, HealthTech, etc.) provide industry-standard classification. The IS/DOES/MEANS framework ensures every proposition answers: what IS the capability, what DOES it do for the buyer, and what does it MEAN for their business.
+A structured portfolio-messaging engine built on the IS/DOES/MEANS (FAB) framework and a Feature × Market data model. It treats positioning as a verifiable artifact: each proposition answers what the capability IS, what it DOES for the buyer, and what it MEANS for their business, scoped to one market segment at a time. Where other insight-wave plugins generate content, this one is the source of truth for what a company offers and to whom.
 
 ## What it does
 
@@ -44,12 +44,10 @@ A structured portfolio messaging workflow for Claude Code / Claude Cowork. Eight
 
 ## What it means for you
 
-- **Portfolio positioning in days, not weeks.** What used to take 2 weeks of analyst time per product line — market sizing, competitive mapping, proposition writing — runs in structured parallel with research agents.
-- **Market-specific by design.** Every proposition is scoped to a Feature × Market pair, so one feature generates a distinct DOES/MEANS pitch per segment — no more single generic message stretched across 3–5 target markets.
-- **Eight industry taxonomies built in.** B2B ICT (57 categories), SaaS, FinTech, HealthTech, MarTech, Industrial Tech, Professional Services, Commercial Open Source — auto-selected by company context.
-- **Export-ready across four formats.** Proposals, market briefs, portfolio workbooks (markdown + XLSX), and an interactive HTML dashboard — one `portfolio-communicate` run produces all four from the same entity data.
-- **Canvas to portfolio in one step.** Bootstrap a full portfolio directly from a Lean Canvas — extract products, features, and markets from a founding-stage hypothesis without a single field of manual re-entry.
-- **Deep-dive without leaving the plugin.** Two dedicated research agents (`feature-deep-diver`, `proposition-deep-diver`) validate buyer language against live web evidence and propose refinements grounded in verifiable sources.
+- **Position your portfolio in days, not weeks.** Market sizing, competitive mapping, and proposition writing that took two weeks of analyst time per product line now run in structured parallel with research agents.
+- **Pitch each segment in its own language.** Every proposition is scoped to one Feature × Market pair, so a single feature yields a distinct DOES/MEANS message per segment instead of one generic pitch stretched across every market.
+- **Export once, reuse everywhere.** One `portfolio-communicate` run produces proposals, market briefs, workbooks (markdown + XLSX), and an interactive dashboard from the same entity data — sales always reads the latest messaging.
+- **Trust the claims.** Web-sourced assertions are verified against their cited sources, so the positioning you ship rests on evidence, not assumption.
 
 ## Install
 
@@ -93,11 +91,26 @@ Or just describe what you want in natural language:
 
 ## Try it
 
-After installing, type one prompt:
+Start a project and let it capture your company context:
 
-> Set up a portfolio project for a cloud infrastructure company targeting mid-market SaaS
+> Run `/cogni-portfolio:portfolio-setup`
 
-Claude captures your company context, auto-selects the B2B ICT taxonomy, initializes the project, and walks you through defining products, features, and target markets. From there, generate propositions, competitive analysis, and export-ready deliverables.
+Describe the company — say, a cloud infrastructure provider targeting mid-market SaaS. Claude auto-selects the B2B ICT taxonomy, scaffolds the project, and writes the manifest:
+
+```
+cogni-portfolio/acme-cloud/
+├── portfolio.json          # company context, taxonomy, config
+├── products/               # top-level offerings
+├── features/               # market-independent capabilities (IS layer)
+├── markets/                # target segments with TAM/SAM/SOM
+└── propositions/           # IS/DOES/MEANS per Feature × Market
+```
+
+From there, define products and features, size your markets, then generate propositions:
+
+> Run `/cogni-portfolio:propositions`
+
+Each Feature × Market pair gets a distinct IS/DOES/MEANS message written to `propositions/{feature}--{market}.json`. Quality gates score each one and flag thin messaging before it flows downstream, so weak propositions never reach a pitch or a website unchecked. From there you can size markets, analyze competitors, and export pitches and proposals — every deliverable traces back to the same Feature × Market join. Returning later? Run `/cogni-portfolio:portfolio-resume` for status and the recommended next step.
 
 ## Data model
 
@@ -120,7 +133,11 @@ See [references/data-model.md](references/data-model.md) for the full schema wit
 
 ## How it works
 
-Each portfolio project lives in `cogni-portfolio/{slug}/` with typed JSON files organized by entity. The workflow follows a logical progression: setup → products → features → markets → propositions → customers → solutions → compete → verify → communicate. Research-intensive steps (market sizing, competitive analysis, customer profiling) dispatch parallel web-research agents. Propositions are scored by quality assessors against DOES/MEANS criteria, with a quality gate for downstream consumption.
+Each portfolio project lives in `cogni-portfolio/{slug}/` as typed JSON files organized by entity. The workflow runs in dependency order — `setup → products → features → markets → propositions → solutions → compete → customers → verify → communicate` — because each step consumes what the previous one produced. Features (the IS layer) must exist before a proposition can say what a capability DOES; markets must be sized before a proposition can be scoped to a segment. The ordering is not cosmetic: it is what makes Feature × Market the core join that propositions, solutions, and competitor analysis all key off.
+
+Research-intensive steps — market sizing, competitive analysis, customer profiling — dispatch parallel web-research agents that auto-log every web-sourced claim with its source URL and entity provenance, so assertions stay traceable back to evidence.
+
+Most entity types then pass through a three-layer quality gate: scripts validate JSON schema compliance, LLM assessor agents score content dimensions (mechanism clarity, differentiation, market-specificity), and stakeholder-perspective agents simulate three reader viewpoints to return accept / warn / fail verdicts. The gate is load-bearing — it blocks downstream generation when upstream entities fail, so a weak feature can never quietly seed a weak proposition. `portfolio-verify` closes the loop: once cited claims are resolved, corrections propagate back into entity files and cascade staleness through every dependent entity.
 
 ## Components
 
@@ -215,7 +232,7 @@ Contributions welcome — taxonomy templates, quality assessment dimensions, exp
 
 ## Custom development
 
-Need a custom taxonomy template, industry-specific frameworks, or a new plugin for your domain? Contact [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
+Need a custom taxonomy template, an industry-specific proposition framework, or a new plugin built for your domain? [cogni-work.ai](https://cogni-work.ai) builds and maintains bespoke Claude Code automation for teams — or reach out directly at [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
 
 ## License
 

--- a/cogni-sales/README.md
+++ b/cogni-sales/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-B2B sales pitch generation using Corporate Visions Why Change methodology. Creates sales presentations and proposals for named customers (deal-specific) or market segments (reusable). Builds on cogni-portfolio data with optional TIPS strategic enrichment. Multilingual EN / DE / PT-BR.
+A B2B pitch-generation pipeline built on the Corporate Visions Why Change methodology, turning cogni-portfolio data into deal-specific or reusable segment sales narratives.
 
 > **Multi-market & multilingual.** Pitch setup matches the deal to one of the platform's supported markets — European-first across DACH/DE/FR/IT/ES/NL/PL plus UK/US — with multilingual output (EN / DE / PT-BR). See [Supported markets & languages](../cogni-workspace/README.md#supported-markets--languages).
 
@@ -19,11 +19,11 @@ Generic pitch decks don't win deals. Buyers expect sellers to understand their s
 | Methodology drift | Why Change structure gets diluted without discipline — phases blur, evidence thins | Weaker narrative arc, lower win rates |
 | No claim traceability | Market stats and competitor assertions cited without source verification | Credibility risk when buyers check the numbers |
 
-This plugin automates the research-heavy parts of the Corporate Visions Why Change framework — web research, evidence gathering, narrative framing — while keeping strategic judgment with you.
+A pitch that lands a week late, leans on stale numbers, or drifts off the Why Change arc is a deal the seller is already losing — and the cost compounds across every opportunity in the pipeline.
 
 ## What it is
 
-A pitch generation pipeline built on the Corporate Visions Why Change methodology. Four research phases — Why Change, Why Now, Why You, Why Pay — each backed by dedicated web research agents that gather company-specific or industry-level evidence. cogni-portfolio provides the product data (propositions, solutions, competitors); cogni-trends optionally enriches with strategic themes. The output is a sales-presentation.md and sales-proposal.md with sequential citations — ready for cogni-visual to render into slides.
+A pitch-generation pipeline organized around the Corporate Visions Why Change methodology — the four-question arc of Why Change, Why Now, Why You, and Why Pay. It treats your portfolio as the source of truth: cogni-portfolio supplies the product data, cogni-narrative supplies the story-arc patterns, and cogni-trends optionally layers in strategic themes. Other plugins generate content; this one shapes that content into a buyer-ready sales narrative.
 
 ## What it does
 
@@ -37,11 +37,10 @@ A pitch generation pipeline built on the Corporate Visions Why Change methodolog
 
 ## What it means for you
 
-- **Deal-specific in hours, not days.** The researcher agent handles web research, company analysis, and evidence gathering — you review and steer.
-- **Methodology-disciplined across 100% of pitches.** Every deck follows all four Why Change phases (Why Change → Why Now → Why You → Why Pay) with proper evidence structure — no phase skipped, no message diluted.
-- **Cover both 1:1 and 1:many sales motions without rebuilding the pipeline.** Customer mode researches the named account; segment mode produces a reusable template for any organization in the vertical — one engine, zero duplication effort per new pitch.
-- **Claims-verified before you present.** Every factual claim in the deck is registered with a source URL; optional cogni-claims integration verifies all of them in one pass — zero unsourced statistics in front of the customer.
-- **Keep multi-day deals moving without rework.** Interrupted pitches resume from the last completed phase — no research lost, no phase reruns, no pipeline stall when a conversation ends mid-workflow.
+- **Pitch in hours, not days.** The researcher agent runs the web research, company analysis, and evidence gathering across all four phases — you review and steer instead of starting from a blank deck.
+- **Stay on-method every time.** Every pitch follows all four Why Change phases with structured evidence — no phase skipped, no message diluted, even under deadline pressure.
+- **Serve 1:1 and 1:many from one engine.** Customer mode researches the named account; segment mode produces a reusable template for the whole vertical — zero pipeline rebuild between deal-specific and market pitches.
+- **Present numbers you can defend.** Every factual claim is registered with a source URL, and optional cogni-claims verification checks them in one pass — no unsourced statistics in front of the buyer.
 
 ## Install
 
@@ -69,13 +68,13 @@ Or describe what you want in natural language:
 
 ## Try it
 
-After installing, type one prompt:
+Start a pitch with the command:
 
-> Create a Why Change pitch for a cloud services customer
+> Run `/cogni-sales:why-change`
 
-Claude discovers your portfolio, asks for customer details, then works through all four phases — researching the web, building evidence, and writing narrative prose for each. At the end, you get two deliverables ready for review.
+Claude discovers your cogni-portfolio projects, asks whether this is a named-customer or a segment pitch, matches the market, and then works through all four phases in sequence — researching the web, gathering evidence, and writing narrative prose for each. A quality gate after every phase lets you approve or revise before the next one runs, so you steer the strategy while the agent does the legwork.
 
-Results land in your project directory:
+Every claim the research surfaces is registered with its source URL, so you can verify the evidence before the pitch ever reaches a prospect. When the run finishes, the two deliverables land under your project directory:
 
 ```
 cogni-sales/{pitch-slug}/
@@ -102,6 +101,14 @@ cogni-sales/{pitch-slug}/
 ## Data model
 
 Each pitch project tracks state in `pitch-log.json` with pitch mode (customer/segment), workflow phase, buying center roles (economic buyer, technical evaluator, end users, champion), portfolio references, and language config. Per-phase bridge files split structured research (`research.json`) from prose output (`narrative.md`). See [skills/why-change/references/pitch-data-model.md](skills/why-change/references/pitch-data-model.md) for the full schema.
+
+## How it works
+
+The pipeline runs the four Why Change questions in a fixed order — `setup → why-change → why-now → why-you → why-pay → synthesize → review` — because each phase builds on the case the previous one established. Setup grounds everything: it discovers a cogni-portfolio project, fixes the pitch mode (customer vs. segment), matches the market, and records the buying-center roles, so every later phase researches against the right account and audience.
+
+The four research phases each dispatch the `why-change-researcher` agent. The researcher reasons backwards from portfolio capabilities to strategic themes first, then runs guided web research — Why Change establishes the unsafe status quo, Why Now adds time-bound urgency, Why You differentiates, and Why Pay quantifies the business impact. Each phase writes a structured `research.json` (evidence, buyer-role tags, claims) separately from its `narrative.md` prose, so findings and writing stay independently revisable.
+
+`synthesize` then assembles all four phases into `sales-presentation.md` and `sales-proposal.md` with sequentially renumbered citations. Synthesis comes last because renumbering and cross-phase arc continuity only make sense once every phase is final. A closed `review` loop follows: the `pitch-review-assessor` evaluates the result from buyer, sales-director, and marketing-director perspectives, and the `pitch-revisor` applies surgical fixes if needed (capped at two passes). Because state lives in `pitch-log.json`, an interrupted pitch resumes from the last completed phase rather than re-running research.
 
 ## Components
 
@@ -159,7 +166,7 @@ Contributions welcome — sales methodologies, pitch templates, evidence strateg
 
 ## Custom development
 
-Need a custom sales methodology, CRM integration, or a new plugin for your domain? Contact [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
+Need a custom sales methodology beyond Why Change, a CRM integration, or a new plugin tailored to your domain? [cogni-work.ai](https://cogni-work.ai) builds and maintains bespoke Claude Code automation for sales and consulting teams.
 
 ## License
 

--- a/cogni-trends/README.md
+++ b/cogni-trends/README.md
@@ -8,7 +8,7 @@
 
 > **Start here.** Run `/cogni-trends:trends-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
 
-A [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai/cowork) plugin for scouting, selecting, and reporting on strategic industry trends — **European-first — covering DACH/DE/FR/IT/PL/NL/ES and US/UK, with German-Mittelstand roots**. Combines the [Smarter Service Trendradar](https://www.smarter-service.com/2023/01/31/trendradar-fuer-die-multikrise-und-neue-geooekonomie/) (4-dimension structure by Bernhard Steimel) with the TIPS content framework (Trends, Implications, Possibilities, Solutions — a B2B consulting methodology widely used since the early 2000s; see [WO2018046399A1](https://patents.google.com/patent/WO2018046399A1/en) for a detailed treatment, filed by Siemens 2017, ceased 2019).
+A [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai/cowork) plugin that scouts, scores, and reports industry trends via the Smarter Service Trendradar and TIPS value chain across European/Anglo markets.
 
 ## Frameworks
 
@@ -36,7 +36,7 @@ The dimensions define *where* trends live. TIPS defines *how* each trend is anal
 
 ## Why this exists
 
-Strategic trend analysis requires scanning hundreds of sources across languages, scoring candidates against multiple frameworks, and synthesizing everything into a report with verifiable evidence. Most trend reports are either shallow (top-10 lists without evidence) or expensive (months of consultant time).
+Strategic trend analysis means scanning hundreds of sources across languages, scoring candidates against multiple frameworks, and synthesizing everything into a report a CxO will act on. Most trend reports collapse under that load — either shallow top-10 lists or months of consultant time.
 
 | Problem | What happens | Impact |
 |---------|-------------|--------|
@@ -45,11 +45,11 @@ Strategic trend analysis requires scanning hundreds of sources across languages,
 | Evidence-free narratives | Trend reports cite no quantitative data | Low credibility with decision-makers |
 | Manual effort | Weeks of desk research per trend cycle | Outdated by the time it ships |
 
-This plugin automates the research-heavy parts while keeping strategic judgment where it belongs — with you.
+The research-heavy scanning, scoring, and enrichment are exactly the parts that drain weeks and still leave gaps — while the strategic judgment they feed stays with you.
 
 ## What it is
 
-A four-stage trend intelligence pipeline for the insight-wave ecosystem that scouts, models, researches, reports, and catalogs industry signals. The Smarter Service Trendradar provides the 4-dimension scoring structure; the TIPS framework (Trends → Implications → Possibilities → Solutions) drives the value chain from scouted signals to portfolio-grounded solution blueprints. Upstream of cogni-portfolio (which consumes solution templates via trends-bridge) and cogni-narrative (which transforms trend output into arc-driven reports). Reusable industry catalogs accumulate knowledge across engagements.
+A trend intelligence engine built on two strategic-foresight frameworks: the Smarter Service Trendradar, which structures where trends live across four dimensions, and the TIPS value chain (Trends → Implications → Possibilities → Solutions), which carries each signal through to a portfolio-grounded solution blueprint. It sits upstream of cogni-portfolio and cogni-narrative in the insight-wave ecosystem, and its industry catalogs persist so knowledge compounds across engagements rather than dying with each report.
 
 ## What it does
 
@@ -65,17 +65,10 @@ Connects industry trends to portfolio solutions for European markets. The pipeli
 
 ## What it means for you
 
-If you need to stay ahead of industry trends for strategy, advisory, or portfolio decisions, this is your research accelerator.
-
-- **Cover more ground, faster.** Persona-shaped bilingual web searches with preliminary grounding, adaptive budgets, and source quality tiering — executed in minutes.
-- **Score every candidate, not gut-feel.** Every candidate scored on impact, probability, strategic fit, source quality (CRAAP), and signal strength using Ansoff and Rogers frameworks.
-- **From trends to solutions.** T→I→P→S value paths bridge scouted trends into 3-7 investment themes per run, each with portfolio-grounded solution blueprints — not just trend narratives.
-- **Evidence-backed output.** Optional deep research (STORM-inspired) for high-value trends, structural review with cross-theme quality gates, and every quantitative claim has an inline citation you can verify.
-- **Curated argument plus full catalog.** Pick `/trend-synthesis` for the curated investment-themes report, `/trend-booklet` for the comprehensive catalog of all 60 candidates, or both — they share the same enriched evidence.
-- **Polished visual output in one step.** Reports finish as themed, interactive HTML with 5+ Chart.js visualizations and concept diagrams — share-ready, not a raw markdown file you have to format yourself.
-- **Cross-pursuit learning.** Industry catalogs accumulate curated solutions, SPIs, and metrics across engagements — each pursuit gets +20-40% richer context from prior work.
-- **Multi-session workflow.** Resume any project mid-stream with full state recovery via `/trends-resume` — zero context loss between sessions.
-- **Research your market natively.** Per-market bilingual queries against curated regional institutional sources — DACH (VDMA, BITKOM, Fraunhofer), FR (INRIA, Les Echos), IT (CNR, AGCOM), PL (UKE, POLSA), NL (TNO, ACM), ES (CNMC, INTA), plus US/UK. Zero reliance on generic US-centric datasets; output in your chosen language.
+- **Research your market natively.** Per-market bilingual queries run against the institutions your buyers trust — VDMA and BITKOM for DACH, INRIA for FR, CNR and AGCOM for IT — not generic US-centric datasets, with output in your chosen language.
+- **Trust the shortlist.** Every candidate is scored on impact, probability, strategic fit, source quality, and signal strength using Ansoff and Rogers — so the trends that surface are framework-ranked, not gut-picked.
+- **Reach solutions, not just narratives.** T→I→P→S value paths turn scouted signals into 3–7 portfolio-grounded investment themes per run, each carrying concrete solution blueprints.
+- **Hand over a share-ready report.** The output finishes as themed, interactive HTML with Chart.js visualizations and concept diagrams — and industry catalogs compound, giving each new pursuit +20-40% richer context from prior work.
 
 ## Install
 
@@ -115,21 +108,41 @@ Or invoke skills directly:
 /trends-resume       → resume a project mid-stream with status and next actions
 ```
 
+## Try it
+
+Start a project by scouting trends for an industry:
+
+> Run `/cogni-trends:trend-scout`
+
+You'll pick an industry interactively, then watch persona-shaped bilingual research run across the four Trendradar dimensions and produce 60 scored candidates:
+
+```
+project/trend-candidates.md   — 60 candidates, scored on impact / probability /
+                                 strategic fit / source quality / signal strength
+project/.metadata/            — scout output, grounding searches, run logs
+```
+
+Lost track of where a project stands? Run the entry point any time:
+
+> Run `/cogni-trends:trends-resume`
+
+It reports the current phase, the artifacts already produced, and the single next step — model investment themes, enrich the evidence, or compose the report — so you re-enter exactly where you left off with no context loss between sessions. Every candidate carries its scores and source citations, so you can trace why a trend ranked where it did before committing to it downstream.
+
 ## How it works
 
-**trend-scout** initializes a research project with interactive configuration disclosure, then runs 3 preliminary grounding searches (RAG-Fusion pattern) to calibrate query formulation. Dispatches a persona-shaped **trend-web-researcher** agent — each Smarter Service dimension gets queries shaped by a domain expert persona (Regulatory Analyst, CSO, CX Strategist, CTO) following the 4strat STEEP multi-agent approach. In thorough mode, the query budget adapts based on signal yield per dimension (FLARE-inspired). An optional **trend-signal-curator** agent ranks the ~85 raw signals into quality tiers (primary/secondary/supporting) using a 5-dimension composite score. Finally, a **trend-generator** agent produces 60 scored candidates using extended thinking with persona reasoning.
+The pipeline runs in dependency order — scout → model → research → synthesize/catalog → verify — because each stage consumes the prior stage's artifact, and a report can only be evidence-backed once the evidence has been enriched.
 
-**value-modeler** reads scouted candidates and builds T→I→P→S relationship networks, consolidates them into 3-7 MECE investment themes (Handlungsfelder), and generates solution templates with portfolio blueprints. When cogni-portfolio is available, solutions are anchored to real products and features. Includes interactive Business Relevance scoring and multi-framework solution ranking.
+**trend-scout** runs 3 preliminary grounding searches (RAG-Fusion) to calibrate queries, then dispatches a persona-shaped **trend-web-researcher** — each Smarter Service dimension gets queries from a domain-expert persona (Regulatory Analyst, CSO, CX Strategist, CTO) following the 4strat STEEP approach. In thorough mode the query budget adapts to signal yield per dimension (FLARE). An optional **trend-signal-curator** tiers the ~85 raw signals on a 5-dimension score before a **trend-generator** produces 60 scored candidates.
 
-**trend-research** reads modeled investment themes and the agreed candidate set, optionally dispatches 3–5 parallel **trend-deep-researcher** agents for recursive TIPS-aligned deep research on high-value ACT-horizon trends (STORM-inspired tree exploration), then dispatches 4 parallel **trend-report-writer** agents (one per Trendradar dimension) for evidence enrichment. Validates the resulting `enriched-trends-{dimension}.json` files via a JSON-validity gate, then writes `.metadata/trend-research-output.json` — the single manifest that downstream skills consume.
+**value-modeler** builds T→I→P→S relationship networks from those candidates, consolidates them into 3-7 MECE investment themes, and generates solution templates with portfolio blueprints — anchored to real products when cogni-portfolio is present.
 
-**trend-synthesis** reads the research manifest, anchors each investment theme to its dominant Smarter Service dimension, writes a shared dimension primer, and dispatches N parallel **trend-report-investment-theme-writer** agents (slim 3-beat investment-case mode: Stake / Move / Cost-of-Inaction). Then dispatches 4 sequential **trend-report-composer** agents to compose the dimension narratives (T → I → P → S order, voice consistency). Closes on a Foundations-anchored "Capability Imperative" synthesis. Writes `tips-trend-report.md` plus `tips-trend-report-claims.json`.
+**trend-research** optionally dispatches 3–5 **trend-deep-researcher** agents for STORM-inspired recursive research on high-value ACT-horizon trends, then 4 parallel **trend-report-writer** agents (one per dimension) for evidence enrichment. A JSON-validity gate guards the per-dimension files before it writes `.metadata/trend-research-output.json` — the single manifest both synthesis skills gate on.
 
-**trend-booklet** reads the same research manifest, walks the value model to compute candidate → theme back-references, and dispatches 4 parallel **trend-booklet-formatter** agents (no web research) to render every candidate as a per-entry block (summary, citations, themes, keywords) organized by subcategory → horizon. Orphan candidates (no theme back-reference) land in per-dimension appendices. Writes `tips-trend-booklet.md` plus a structured sidecar `tips-trend-booklet-index.json` for downstream visualizers.
+**trend-synthesis** anchors each theme to its dominant dimension and dispatches **trend-report-investment-theme-writer** agents (slim Stake / Move / Cost-of-Inaction cases), then 4 sequential **trend-report-composer** agents for the dimension narratives, closing on a "Capability Imperative" synthesis → `tips-trend-report.md` plus its claims registry.
 
-**verify-trend-report** runs the extended quality pipeline on `tips-trend-report.md`: claim verification via cogni-claims, cross-theme structural review by **trend-report-reviewer**, optional revision via **trend-report-revisor**, and a final menu offering executive polish (cogni-copywriting) or themed HTML enrichment (cogni-visual).
+**trend-booklet** walks the value model for candidate → theme back-references and dispatches 4 **trend-booklet-formatter** agents to render every candidate by subcategory → horizon; orphans land in per-dimension appendices.
 
-**trends-catalog** curates solutions, SPIs, metrics, and collaterals from completed projects into persistent industry catalogs. Each engagement improves the base catalog for future pursuits in the same industry.
+**verify-trend-report** runs claim verification via cogni-claims, cross-theme structural review, optional revision, and a final menu offering executive polish or themed HTML. **trends-catalog** then curates solutions, SPIs, and metrics into persistent industry catalogs, so each engagement improves the base for the next.
 
 ## Components
 
@@ -253,7 +266,7 @@ Contributions welcome — trend frameworks, industry taxonomies, research source
 
 ## Custom development
 
-Need a custom trend framework, additional market coverage, or a new plugin for your domain? Contact [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
+Need a custom trend framework, additional market coverage with new regional authority sources, or a plugin built for your domain? [cogni-work.ai](https://cogni-work.ai) builds and maintains custom Claude Code automation for consulting and strategy teams.
 
 ## License
 

--- a/cogni-visual/README.md
+++ b/cogni-visual/README.md
@@ -4,21 +4,24 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-A [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai/cowork) plugin for brief-based visual production — skills distill polished narratives and structured data into YAML+Markdown briefs (slides, infographics, storyboards, web narratives, enriched reports), then rendering agents hand those briefs to PPTX, Excalidraw, Pencil MCP, and HTML backends. Every output inherits brand identity from your cogni-workspace theme instead of generic templates.
+A [Claude Code](https://claude.com/claude-code) / [Claude Cowork](https://claude.ai/cowork) plugin that turns a polished narrative into branded visual deliverables — the last-mile production step of the insight-wave consulting pipeline.
 
 ## Why this exists
 
-The last mile of consulting delivery is visual production. Insights and narratives are ready — but turning them into presentations, diagrams, and branded collateral is where projects stall:
+The thinking is done and the narrative is written — but the deliverable a client actually sees still has to be built by hand. That last mile is where consulting projects lose days and where polished insight starts to look generic.
 
 | Problem | What happens | Impact |
 |---------|-------------|--------|
-| Manual visual production | Creating a branded slide deck from narrative content takes 1-2 days of formatting work | Delivery bottleneck — insights ready on Tuesday, client sees them on Thursday |
-| Format fragmentation | Same core message needs slides for the boardroom, a journey map for the workshop, a web page for the follow-up | Each format is a separate production effort |
-| Template fatigue | Generic templates produce generic-looking output; custom design is expensive | Deliverables look like every other consultancy's output |
+| Manual visual production | Building a branded slide deck from finished narrative content runs to 1-2 days of layout and formatting | Delivery bottleneck — insight is ready Tuesday, the client sees it Thursday |
+| Format fragmentation | The same core message needs slides for the boardroom, a poster for the workshop, and a web page for the follow-up | Every format becomes a separate production effort, re-typed from the same source |
+| Template fatigue | Generic templates produce generic-looking output, and custom design is slow and expensive to commission | Deliverables look interchangeable with every other consultancy's output |
+| No check before render | Weak headlines and missing calls to action only surface once the file is fully rendered | Rework is expensive — fixing a slide means re-running the whole rendering pipeline |
+
+Each of these costs compounds across every deliverable on every engagement, so the production tax never goes away.
 
 ## What it is
 
-A brief-based visual production pipeline. Skills generate structured briefs (YAML + Markdown) from narratives or data. Renderers and downstream tools (document-skills:pptx, Excalidraw MCP, Pencil MCP) turn those briefs into final output files. All visuals inherit brand identity from cogni-workspace themes.
+A brief-based visual production engine built on a two-stage model: a structured brief (YAML frontmatter plus Markdown body) is the design specification, and rendering agents are the production line that turns it into a finished file. The brief is the source of truth, so every output is theme-driven rather than template-driven — visuals inherit brand identity from a cogni-workspace theme. Other plugins compose and polish the narrative; this one makes it look like a deliverable.
 
 ## What it does
 
@@ -32,10 +35,10 @@ A brief-based visual production pipeline. Skills generate structured briefs (YAM
 
 ## What it means for you
 
-- **Narrative to slides in under 10 minutes.** Assertion headlines, number plays, speaker notes, and 11 slide layout types — generated from your polished narrative, not typed from scratch. What used to take 1-2 days of formatting now takes one prompt.
-- **Multiple visual formats from one narrative.** Slides for the boardroom, web pages for digital follow-up, poster storyboards for print, infographics in three traditions (Mike Rohde sketchnote, Dan Roam whiteboard, Economist editorial), and markdown reports enriched into themed HTML with interactive Chart.js charts and inline SVG concept diagrams — all from the same source document, no re-authoring.
-- **Brand-driven, not template-driven.** Visuals inherit colors, fonts, and identity from your cogni-workspace theme — changing one theme file reskins all output, not editing each object.
-- **Review before you render.** Three-stakeholder brief review catches weak headlines, missing CTAs, and layout mismatches before committing to a rendering pipeline — cheaper to fix a line of text than re-render.
+- **Skip the formatting day.** Turn a polished narrative into a presentation brief in one prompt — assertion headlines, number plays, speaker notes, and 11 slide layout types generated for you instead of the 1-2 days of manual formatting it replaces.
+- **Reuse one narrative across every format.** Produce slides, scrollable web pages, print poster storyboards, and single-page infographics from the same source document — no re-authoring per channel.
+- **Reskin everything from one file.** Visuals inherit colors and fonts from your cogni-workspace theme, so changing one theme file restyles every output instead of editing each object by hand.
+- **Catch weak headlines before you render.** A three-perspective brief review flags soft headlines, missing CTAs, and layout mismatches up front — fixing a line of text is far cheaper than re-running a render.
 
 ## Known Limitations
 
@@ -76,15 +79,27 @@ Or just describe what you want in natural language:
 
 ## Try it
 
-After installing, type one prompt:
+Start from a polished narrative and turn it into an infographic. First, generate the brief:
 
-> Create a presentation brief from my narrative and render it as slides
+```
+story-to-infographic my-narrative.md
+```
 
-Claude reads your narrative, detects the story arc from frontmatter, models the audience, maps content to slide layouts with assertion headlines and number plays, and outputs a presentation brief ready for PPTX rendering.
+Claude reads the narrative, detects its story arc from frontmatter, distills the content into 3-8 scannable blocks with hero numbers and assertion headlines, and writes an `infographic-brief.md` next to your source.
+
+Then render it. The `/render-infographic` command reads the brief's `style_preset` and routes to the right rendering agent automatically:
+
+> Run `/render-infographic infographic-brief.md`
+
+A sketchnote or whiteboard preset routes to Excalidraw for a hand-drawn scene; an economist, editorial, data-viz, or corporate preset routes to Pencil MCP for a clean editorial `.pen` page. Either way the output inherits your cogni-workspace theme, and you get a finished infographic file beside the brief — colors and fonts already on-brand, no manual styling step.
 
 ## How it works
 
-The pipeline follows a compose-polish-visualize flow: narratives from cogni-narrative are polished by cogni-copywriting, then visualized here. Each visual skill produces a structured brief (YAML frontmatter + Markdown body). Renderers consume the brief and produce the final file.
+The plugin sits at the end of a compose-polish-visualize flow: cogni-narrative composes the story, cogni-copywriting polishes the prose, and cogni-visual visualizes the result. It keeps that final stage in two deliberately separate phases — brief generation and rendering — because authoring a design and producing pixels are different jobs with different failure modes.
+
+In the first phase, a `story-to-X` skill reads the narrative and writes a structured brief: YAML frontmatter for metadata (type, theme, arc) and a Markdown body for the content specification. The brief deliberately carries no colors or fonts — those are resolved later from the theme — so the same brief can be reskinned without re-authoring. Splitting design from rendering is also what makes review cheap: the `review-brief` skill assesses the brief from three stakeholder perspectives (design, audience, usability) before any rendering cost is incurred, so a weak headline is caught as text rather than as a finished file.
+
+In the second phase, a rendering agent consumes the brief and produces the output file, reading the cogni-workspace theme directly for brand identity. Different deliverables route to different backends: slide briefs go to PPTX or a self-contained HTML deck, web and storyboard briefs to Pencil MCP, and infographic briefs through the `/render-infographic` dispatcher, which reads the brief's `style_preset` and routes to a hand-drawn (Excalidraw) or editorial (Pencil) agent. Because the brief is the single source of truth, every backend renders the same specification consistently.
 
 ## Components
 
@@ -184,7 +199,7 @@ Contributions welcome — visual templates, layout types, rendering improvements
 
 ## Custom development
 
-Need custom visual templates, branded rendering pipelines, or a new plugin for your domain? Contact [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
+Need bespoke visual templates, a branded rendering pipeline tuned to your house style, or a new plugin built for your domain? [cogni-work.ai](https://cogni-work.ai) designs and maintains custom Claude Code automation for consulting and marketing teams.
 
 ## License
 

--- a/cogni-website/README.md
+++ b/cogni-website/README.md
@@ -6,7 +6,7 @@
 
 > **Start here.** Run `/cogni-website:website-resume` for project status and next-step guidance — whether you're starting fresh or returning to an in-progress project.
 
-Assembles multi-page customer websites from portfolio, marketing, trend, and research content produced by other insight-wave plugins — outputting a deployable static site with shared navigation, theming, and responsive HTML.
+A static-site generator that assembles multi-page customer websites from the portfolio, marketing, trend, and research content other insight-wave plugins produce.
 
 > **DACH & EU-ready by default.** Generates jurisdiction-specific legal pages (Impressum, Datenschutzerklärung, Cookie-Hinweis) for DE, AT, CH, and EU with the required statutory disclosures, German-primary. See [Supported markets & languages](../cogni-workspace/README.md#supported-markets--languages) for the platform's full market reach.
 
@@ -77,7 +77,25 @@ Or describe what you want in natural language:
 
 ## Try it
 
-Run `/website-setup` in any Claude Code session where cogni-portfolio is installed. The skill discovers available content sources and walks you through theme selection, company details, and legal jurisdiction in a single interactive session.
+In a Claude Code session where cogni-portfolio is installed, start the project:
+
+> Run `/cogni-website:website-setup`
+
+The skill discovers every available content source, walks you through theme selection, company details, and legal jurisdiction, and writes `website-project.json`. Next, plan and build the site:
+
+> Run `/cogni-website:website-plan`, then `/cogni-website:website-build`
+
+Plan proposes a page list for you to confirm; build runs the page-generator agents in parallel. The deployable site lands in `output/website/`:
+
+```
+output/website/
+├── index.html        Homepage
+├── css/style.css     Shared theme-driven stylesheet
+├── pages/            Product, blog, contact, and legal pages
+└── sitemap.xml
+```
+
+Open `index.html` over a local HTTP server with `/cogni-website:website-preview` to navigate it with working links. The pages inherit colors and fonts from your chosen cogni-workspace theme, so the look matches the rest of your material out of the box. Legal pages — Impressum, privacy policy, cookie notice — come from reviewable jurisdiction templates rather than LLM-authored text, filled only with the facts you supplied. The result is a self-contained folder you can serve as-is or hand to a host.
 
 ## Data model
 
@@ -203,7 +221,7 @@ cogni-website/
 
 ## Custom development
 
-Need a custom page type, CMS integration, or a domain-specific website template? Contact [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
+Need a custom page type, a CMS integration, or a domain-specific website template built on this pipeline? [cogni-work.ai](https://cogni-work.ai) builds and maintains bespoke Claude Code automation for teams — reach the maintainers at [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
 
 ## License
 

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -4,26 +4,24 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-The foundation-layer plugin for the [insight-wave](https://claude.ai/cowork) ecosystem — the only plugin that other cogni-x plugins depend on, and the one that must be initialized first. cogni-workspace owns environment configuration, MCP server installation, theme storage, plugin discovery, workspace health diagnostics, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the `ask` skill — so every cogni-x plugin starts running, not configuring.
+The foundation layer of the [insight-wave](https://claude.ai/cowork) ecosystem — the one plugin every other cogni-x plugin depends on, and the one you initialize first.
 
 ## Why this exists
 
-Each insight-wave plugin needs environment variables, themes, and discovery of sibling plugins. Without a shared orchestrator, every plugin reinvents configuration:
+Every insight-wave plugin needs the same workspace state — environment variables, themes, MCP tools, knowledge of its sibling plugins. With no shared owner for that state, each plugin reinvents it, and the seams show up at the worst time:
 
 | Problem | What happens | Impact |
 |---------|-------------|--------|
-| No shared config | Each plugin manages its own env vars and paths | Inconsistent setup, manual duplication |
-| Theme fragmentation | Visual plugins each scan for themes independently | Broken renders when theme paths don't match |
-| Plugin drift | No way to detect version mismatches or missing dependencies | Skills fail at runtime with cryptic errors |
-| Manual setup | Every new workspace requires manual scaffolding | 20+ minutes of boilerplate per project |
+| No shared config | Each plugin manages its own env vars and paths | The same path is defined three ways; one drifts and a skill reads the stale value |
+| Theme fragmentation | Visual plugins each scan for themes independently | A slide deck and a dashboard render in different colors from the same project |
+| Plugin drift | Nothing detects version mismatches or missing dependencies | A skill fails mid-run with a cryptic error instead of a clear "dependency missing" |
+| Manual setup | Every new workspace is scaffolded by hand | 20+ minutes of boilerplate before the first real plugin runs |
 
-This plugin provides the infrastructure layer — workspace initialization, theme management, plugin discovery, and health diagnostics — so domain plugins can focus on their actual work.
+The cost compounds with every plugin added and every workspace created: configuration work that should happen once is paid again and again, and the failures it causes surface as runtime errors no user can diagnose.
 
 ## What it is
 
-cogni-workspace implements the **infrastructure-as-plugin pattern**: a dedicated plugin whose sole job is to own the shared state that all other plugins consume — environment variables, plugin registry, theme storage, and tool configuration. It is the only plugin in the ecosystem with no upward dependencies; every other cogni-x plugin depends on it, and none of them duplicate what it provides.
-
-In the Claude Code / Claude Cowork plugin model, workspace-level state (paths, env vars, installed MCPs) cannot be assumed — it must be actively initialized and maintained. cogni-workspace does this in one command and keeps it consistent across plugin updates. Health diagnostics run a five-tier check (foundation, env vars, plugin registry, themes, dependencies) so drift is caught before downstream skills break, not after.
+cogni-workspace is the ecosystem's infrastructure-as-plugin layer: a dedicated plugin whose sole job is to own the shared state every other plugin consumes — environment variables, the plugin registry, theme storage, and tool configuration. It is the only plugin with no upward dependencies; every other cogni-x plugin depends on it, and none of them duplicate what it owns. It is also the home of the canonical supported-markets registry that every market-aware plugin reads.
 
 ## What it does
 
@@ -38,11 +36,10 @@ In the Claude Code / Claude Cowork plugin model, workspace-level state (paths, e
 
 ## What it means for you
 
-- **One command to set up or update.** `manage-workspace` auto-detects mode, discovers installed plugins, generates env vars, settings, themes, and output styles — replacing 20+ minutes of manual scaffolding per project.
-- **Zero hand-edited MCP config.** `install-mcp` clones and builds git-based MCP servers (Excalidraw, Pencil), detects native app MCPs (browsermcp, claude-in-chrome), and patches Claude Desktop config with automatic backup — rendering plugins like cogni-visual and cogni-portfolio find their tools without a single JSON edit.
-- **Consistent theming across all visual output.** Slides, journey maps, web narratives, and dashboards across 5+ visual plugins inherit colors and fonts from one theme file — reskinning the entire ecosystem is a single-file edit, not 5+ separate ones.
-- **Catch workspace drift before skills break.** Five-tier health diagnostics (foundation, env vars, plugin registry, themes, dependencies) surface mismatches and missing deps before they cause cryptic runtime failures.
-- **Safe updates with rollback in seconds.** `manage-workspace` backs up before modifying — if an update breaks something, restore the previous state in one command, no manual file recovery.
+- **Set up a whole workspace in one command.** One `manage-workspace` run auto-detects mode, discovers plugins, and generates env vars, settings, themes, and output styles — replacing 20+ minutes of hand-scaffolding, and backing up first so a bad update rolls back in seconds.
+- **Skip hand-editing MCP config entirely.** `install-mcp` clones, builds, and wires up git-based and native MCP servers and patches Claude Desktop config — plugins find their tools without a single JSON edit.
+- **Reskin everything from one file.** Slides, journey maps, web narratives, and dashboards across 5+ visual plugins inherit colors and fonts from one theme, so a rebrand is a single-file edit.
+- **Catch drift before a skill breaks.** Five-tier health diagnostics surface missing deps and version mismatches as a clear report, not a cryptic mid-run failure.
 
 ## Supported markets & languages
 
@@ -98,11 +95,33 @@ Or describe what you want:
 
 ## Try it
 
-After installing, type one prompt:
+Initialize a workspace in the directory where your cogni-x plugins live:
 
-> Initialize a insight-wave workspace
+> Run `/cogni-workspace:manage-workspace`
 
-Claude checks dependencies, discovers installed plugins, asks for your language preference and tool integrations, then generates `.claude/settings.local.json`, `.workspace-env.sh`, `.workspace-config.json`, output style templates, and the default theme. Your workspace is ready for all cogni-x plugins.
+Claude checks dependencies, discovers your installed plugins, and asks for your output language and tool integrations. It then writes the workspace into the current directory:
+
+```
+.claude/settings.local.json   # env vars + plugin registry
+.workspace-env.sh             # sourced by the session-start hook
+.workspace-config.json        # discovered plugins, preferences
+.claude/output-styles/        # language-specific behavioral anchors
+themes/                       # default cogni-work theme
+```
+
+Then confirm everything is wired up:
+
+> Run `/cogni-workspace:workspace-status`
+
+You'll get a five-tier report — foundation, env vars, plugin registry, themes, dependencies — each marked OK or flagged, with a clear pointer to the fix when something is off. From here every cogni-x plugin reads its configuration from the workspace instead of asking you to set it up again. Re-run `manage-workspace` any time you install a new plugin and it updates the registry in place, so the rest of the ecosystem stays wired up without touching a single config file by hand.
+
+## How it works
+
+cogni-workspace runs as the first link in every ecosystem session. The session-start hook (`on-session-start.sh`) sources `.workspace-env.sh` and validates plugin availability before any other skill runs, so downstream plugins always open against a known-good environment rather than discovering a missing variable mid-task.
+
+Setup itself is a single ordered pass. `manage-workspace` runs `check-dependencies.sh` first (you can't configure tools that aren't installed), then `discover-plugins.sh` scans the marketplace cache to learn which cogni-x plugins are present and what env var names they expect. With the inventory known, `generate-settings.sh` writes the settings files, `install-mcp` clones and wires any MCP servers the discovered plugins need, and the Obsidian and theme steps follow. Each step backs up before it writes, so an interrupted or bad run is recoverable.
+
+State lives in two layers that other plugins consume. Configuration (env vars, the plugin registry, themes) is read at runtime — `pick-theme` is the single entry point visual plugins call for theme paths, and `get-market-config.py` merges the canonical supported-markets registry with each plugin's overlay so market data is never duplicated. Health is verified on demand: `workspace-status` re-runs the five-tier check (foundation, env vars, plugin registry, themes, dependencies) so drift is located before a skill trips over it, not after. The ordering throughout is deliberate — discover before configure, configure before wire, back up before write.
 
 ## Components
 
@@ -211,7 +230,7 @@ Contributions welcome — theme templates, platform support, diagnostic checks, 
 
 ## Custom development
 
-Need enterprise workspace configurations, custom theme infrastructure, or a new plugin for your domain? Contact [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
+Need bespoke workspace configurations, custom theme infrastructure, or a new plugin built for your domain? [cogni-work.ai](https://cogni-work.ai) builds and maintains custom Claude Code automation for teams — or reach out directly at [stephan@cogni-work.ai](mailto:stephan@cogni-work.ai).
 
 ## License
 


### PR DESCRIPTION
## Summary

Rolls the narrative style guide across **all 13** insight-wave plugin READMEs, bringing every one into **doc-audit Check 18 (Narrative Conformance)** and strengthening weak IS/DOES/MEANS messaging in one bundled pass. Baseline: all 13 READMEs were `DRIFT` on Check 18; after this PR all 13 pass the deterministic Check 18 signals (per-section word bands, scaffold-leak scan, required-section presence).

This is the conformance-rollout child of the cogni-docs narrative-guide epic — see `cogni-work/managed-service#233` (epic #234). The narrative-guide, the doc-power fix surface (#231), and the doc-audit Check 18 enforcement (#232) all shipped upstream; this PR applies them to the marketplace READMEs.

**README-prose only.** Every auto-generated section — maturity / readiness / markets / entry-point callouts, `## What it does`, Components, Architecture, Dependencies, Install, Quick start, License, footer — is preserved untouched. No `plugin.json` / `marketplace.json` changes, no version bumps.

## Plugins fixed (13/13)

| Plugin | Check 18 before → after | Key conformance fixes |
|---|---|---|
| cogni-knowledge | DRIFT → OK | **False `## What it is`**: stripped `IS:/DOES:/MEANS:` scaffold labels → IS-only identity; title 151w→28w; MEANS rebuilt (compounding-first, preserved); added `## Try it`; expanded `## How it works` |
| cogni-consult | DRIFT → OK | title 53w→27w; `## What it is` de-bled; MEANS bullets re-led as imperatives; added `## Try it` + `## Custom development` |
| cogni-claims | DRIFT → OK | `## What it is` DOES-bleed removed; problem table → Problem/What happens/Impact; added `## How it works`; cogni-work.ai link |
| cogni-narrative | DRIFT → OK | title 67w→26w; added `## How it works`; MEANS bullets imperative; cogni-work.ai link |
| cogni-copywriting | DRIFT → OK | title 104w→27w; added `## How it works`; expanded `## Try it`; cogni-work.ai link |
| cogni-workspace | DRIFT → OK | title 63w→23w; problem section ends on cost; MEANS 5→4 bullets; added `## How it works` |
| cogni-trends | DRIFT → OK | title de-attributed 68w→26w; `## What it is` de-bled; MEANS 9→4 bullets; `## How it works` trimmed to band; added `## Try it` |
| cogni-portfolio | DRIFT → OK | title 68w→24w (taxonomy/geo moved out); MEANS 6→4 bullets; expanded `## Try it` + `## How it works` |
| cogni-visual | DRIFT → OK | title 56w→26w; expanded `## Why this exists` / `## Try it` / `## How it works`; cogni-work.ai link |
| cogni-help | DRIFT → OK | title 51w→26w (DOES moved out); `## What it is` trimmed; added `## Try it` + `## How it works` |
| cogni-marketing | DRIFT → OK | title 37w→28w; `## What it is` de-bled; added `## How it works`; runnable `## Try it` |
| cogni-sales | DRIFT → OK | title 38w→24w; problem ends on cost; MEANS 5→4 bullets; added `## How it works`; real `/why-change` walkthrough |
| cogni-website | DRIFT → OK | expanded `## Try it` (namespaced command + output); cogni-work.ai link; title tightened |

## Test plan

- [x] `scan-plugin.sh` narrative scan: all 13 plugins clean on deterministic Check 18 (word bands ±15%, zero scaffold leaks, required sections present)
- [x] Diff is README-only; no preserved/auto-generated section heading or callout added/removed (verified)
- [x] cogni-knowledge `## What it is` is IS-only; `## What it means for you` still leads with the compounding/refinable-knowledge benefit (protected messaging invariant)
- [ ] Re-run `/cogni-docs:doc-audit all` on this branch and confirm Check 18 = OK across all plugins
- [ ] Spot-check rendered READMEs on github.com

## Out of scope (not addressed here)

A few plugins carry **non-narrative** drift surfaced by the baseline audit that this pass intentionally does not touch (it edits only the 8 hand-written sections): cogni-knowledge architecture/descriptions/dependencies/docs, cogni-consult architecture/plugin.json keyword, cogni-claims descriptions, and cogni-portfolio/cogni-visual/cogni-website architecture-tree counts/version annotations. These belong to a separate `doc-generate` / `doc-sync` sweep.

Rolls the narrative guide across insight-wave READMEs for `cogni-work/managed-service#233` (epic #234).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
