### PR TITLE
cogni-consult: consult-resume rework branch + inline framework assignment

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -134,6 +134,26 @@ Branch on the derived state, first match wins, and say *why*:
   derivation — and offer `consult-action-fields` to extend the WBS if the
   consultant wants to add fields or deliverables.
 
+Two further offers surface only when the consultant's request or a deliverable's
+state calls for them — not as standing menu items:
+
+- **The consultant names an already-`complete` deliverable to revisit or
+  modify** (a rework request) → offer to reopen it and route to
+  `consult-design-thinking`, naming the field, the deliverable, and the stage
+  the rework should re-enter (often `define` or `ideate`). The reopen itself —
+  the `complete` → `in-progress` Edit and the up-front cascade-stale of its
+  downstream dependents — is owned by `consult-design-thinking`'s Open-the-Loop
+  step, so resume stays read-only; it routes, it does not write.
+- **A deliverable's stored `chosen_framework` is `null`** (a legacy deliverable
+  created before a framework was chosen) and the consultant wants to assign one
+  → offer to set it inline rather than sending them on a separate
+  `consult-action-fields` round-trip. "Inline" means the offer surfaces here in
+  the recommendation flow; the actual `field.json` write is delegated to
+  `consult-action-fields` (which owns the deliverable manifest), so resume's
+  read-only contract holds. Surface this only when the framework gap is
+  relevant to the next action — never as blanket nagging across every legacy
+  deliverable.
+
 Recommend one action, not a menu. On the consultant's confirmation, dispatch
 the named skill via `Skill(...)` with the engagement path as the in-session
 handoff (the target skills skip rediscovery on handoff).


### PR DESCRIPTION
Closes #811.

## Summary
- Add a **rework branch** to consult-resume Step 5: when the consultant names an already-`complete` deliverable to revisit/modify, resume offers to reopen it and routes into `consult-design-thinking` (which owns the `complete`→`in-progress` re-entry and up-front cascade-stale), naming the field, deliverable, and re-entry stage.
- Add an **inline `chosen_framework` assignment offer**: when a deliverable's stored framework is `null`/legacy and the consultant wants to assign one, resume offers it inline instead of a separate `consult-action-fields` round-trip.
- Both stay **read-only in resume** — the reopen Edit is owned by `consult-design-thinking`; the `chosen_framework` `field.json` write is delegated to `consult-action-fields`. "Inline" means the consultant doesn't separately discover/launch a skill, not that resume writes state.
- Both offers are **gated** on the consultant's request or deliverable state ("never as blanket nagging", "not as standing menu items"), preserving "one recommendation, not a menu".
- Patch version bump 0.1.16 → 0.1.17 (plugin.json + marketplace.json).

## Base
Builds on `origin/main` (cogni-consult 0.1.16, after #810 / PR #817 merged).

## Test plan
- [x] Step 5 gains the rework branch (routes to consult-design-thinking, names field/deliverable/re-entry stage) and the inline-framework branch (delegates the write to consult-action-fields).
- [x] Important Notes read-only invariant unchanged; new branches delegate all writes — no contradiction.
- [x] Both branches gated, not unconditional menu items.
- [x] check-skill-names.sh OK; breadcrumb guard clean; both plugin tests pass.
- [x] plugin.json + marketplace.json both 0.1.17.