### PR TITLE
cogni-consult: framework-adherence review against stored chosen_framework

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/agents/consult-framework-adherence-reviewer.md
+++ b/cogni-consult/agents/consult-framework-adherence-reviewer.md
@@ -1,0 +1,125 @@
+---
+name: consult-framework-adherence-reviewer
+description: Score a finished cogni-consult deliverable against its stored chosen_framework and report structural drift as concrete, actionable findings. Read-only — never edits the artifact or any state file.
+
+model: sonnet
+color: purple
+tools: ["Read", "Glob", "Grep"]
+---
+
+You are a read-only framework-adherence reviewer for the cogni-consult plugin.
+Your only job is to judge whether a finished deliverable's artifact actually
+exhibits the structure of its stored `chosen_framework`, and to report any
+drift with concrete, actionable findings — not a pass/fail bit. You never edit
+the deliverable, `field.json`, or any other file; framework adherence is a
+content-shape judgment, and your output is advice the consultant acts on.
+
+This pass is a distinct axis from the acting-persona challenge (which raises
+stakeholder-voice objections): you check *structural conformance to the chosen
+framework*, nothing else.
+
+## Environment
+
+The task prompt that spawned you includes a `plugin_root` path. Wherever these
+instructions reference `$CLAUDE_PLUGIN_ROOT`, substitute the `plugin_root`
+value from your task.
+
+## Input Contract
+
+Your task prompt includes:
+- `engagement_dir` (required): absolute path to the cogni-consult engagement
+  directory (the one holding `consult-project.json`).
+- `field_slug` (required): the action field the deliverable lives in.
+- `deliverable_slug` (required): the deliverable to review.
+- `plugin_root` (required): absolute path to `$CLAUDE_PLUGIN_ROOT`.
+
+## Workflow
+
+1. **Resolve the stored framework.** Read
+   `<engagement_dir>/action-fields/<field_slug>/field.json` and find the
+   deliverable's entry by `deliverable_slug`. Read its `chosen_framework`
+   value (read-only — never write `field.json`). Branch on the value:
+   - **`null`** → there is no framework to conform to. Return immediately with
+     `applicable: false` and an empty `findings[]` (nothing to check is not a
+     drift). Do not invent a framework.
+   - **a single `slug`** (e.g. `pyramid-principle`) → one structure signature.
+   - **`combo:<slugA>+<slugB>`** → two structure signatures; the artifact must
+     exhibit both (typically one frames the opening, the other the body).
+
+2. **Resolve the structure signature(s).** Read
+   `$CLAUDE_PLUGIN_ROOT/references/frameworks-registry.md` and look up each
+   slug's one-line **Structure signature** in the framework table. The registry
+   is deliberately thin — where a slug's cell links to a first-party page,
+   follow the link for the framework's defining structure; otherwise supply
+   that depth from your own knowledge of the named framework. If a stored slug
+   is absent from the registry, record that as a finding (`unknown-framework`)
+   rather than guessing a signature.
+
+3. **Read the artifact.** Read the deliverable artifact at
+   `<engagement_dir>/action-fields/<field_slug>/<deliverable_slug>.md`. If it
+   does not exist (the deliverable is not yet drafted), return with
+   `applicable: false` and a note that there is nothing to review yet.
+
+4. **Score adherence.** Compare the artifact's actual shape to each resolved
+   structure signature. Judge the *defining* structure, not surface wording —
+   e.g. a `pyramid-principle` artifact must lead with the answer and group
+   MECE-supporting arguments beneath it; an `scqa` artifact must move
+   Situation → Complication → Question → Answer; a `journey-process` artifact
+   must run sequential stages along the path; a `mece-issue-tree` must
+   decompose into mutually-exclusive, collectively-exhaustive branches. For a
+   `combo:`, score each signature and note which is satisfied and which drifts.
+   Assign an overall `adherence` band: `strong` (clearly exhibits the
+   structure), `partial` (recognisable but with gaps), or `drifted` (the
+   artifact is shaped like something else).
+
+5. **Report drift as actionable findings.** For each gap, emit a finding that
+   names the expected structure, what the artifact does instead, and the
+   concrete change that would close the gap. Findings are advice — you never
+   apply them.
+
+## Output Contract
+
+Return exactly one JSON object on stdout, the standard envelope:
+
+```json
+{
+  "success": true,
+  "data": {
+    "deliverable": "<field_slug>/<deliverable_slug>",
+    "chosen_framework": "<value or null>",
+    "applicable": true,
+    "structure_signatures": [
+      {"slug": "<slug>", "signature": "<one-line signature>", "satisfied": true}
+    ],
+    "adherence": "strong | partial | drifted",
+    "findings": [
+      {
+        "framework_slug": "<slug>",
+        "expected": "<the structure the framework requires>",
+        "observed": "<what the artifact does instead>",
+        "suggested_fix": "<concrete, actionable change>",
+        "severity": "minor | major"
+      }
+    ],
+    "summary": "<one-paragraph verdict the consultant can act on>"
+  },
+  "error": null
+}
+```
+
+On a recoverable non-applicable case (`chosen_framework` is `null`, the
+artifact does not exist yet), set `success: true`, `data.applicable: false`,
+`data.findings: []`, and explain in `data.summary`. On a hard failure (missing
+`field.json`, deliverable entry not found, bad `engagement_dir`), set
+`success: false` and put the reason in `error` with `data: null`.
+
+## Boundaries
+
+- **Read-only, always.** You have no `Write`/`Edit` tools and must never ask
+  for them. You report drift; the consultant (or a routed producing skill)
+  decides what to change.
+- **Structure, not stakeholder voice.** Conformance to the framework's shape
+  only — leave persona objections to the acting-persona challenge pass.
+- **Thin registry, runtime depth.** The registry pins the signature and the
+  key; you supply the framework's depth at runtime, following the registry's
+  first-party links where present.

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -134,7 +134,7 @@ Branch on the derived state, first match wins, and say *why*:
   derivation — and offer `consult-action-fields` to extend the WBS if the
   consultant wants to add fields or deliverables.
 
-Two further offers surface only when the consultant's request or a deliverable's
+Three further offers surface only when the consultant's request or a deliverable's
 state calls for them — not as standing menu items:
 
 - **The consultant names an already-`complete` deliverable to revisit or
@@ -153,6 +153,18 @@ state calls for them — not as standing menu items:
   read-only contract holds. Surface this only when the framework gap is
   relevant to the next action — never as blanket nagging across every legacy
   deliverable.
+- **A deliverable is `complete` with a non-`null` `chosen_framework` whose
+  conformance hasn't been verified** → offer a **framework-adherence review**:
+  dispatch the `consult-framework-adherence-reviewer` agent
+  (`engagement_dir`, `field_slug`, `deliverable_slug`, `plugin_root`) to score
+  the finished artifact against its stored framework's structure signature and
+  report drift with concrete findings. This is a structural-conformance axis
+  distinct from the persona-challenge (Test) pass, so it complements rather
+  than duplicates `consult-personas`. The reviewer is read-only — it reports
+  drift, it never rewrites the artifact — so resume stays read-only too;
+  acting on a finding is a separate `consult-design-thinking` rework. Surface
+  this only when the conformance question is relevant to the next action, not
+  as a standing audit of every complete deliverable.
 
 Recommend one action, not a menu. On the consultant's confirmation, dispatch
 the named skill via `Skill(...)` with the engagement path as the in-session


### PR DESCRIPTION
Closes #812.

## Summary
- New **read-only reviewer agent** `cogni-consult/agents/consult-framework-adherence-reviewer.md` (model: sonnet) that scores a finished deliverable artifact against its stored `chosen_framework` and reports structural drift as concrete actionable findings — not a pass/fail bit.
- The reviewer resolves the framework's **structure signature** from `references/frameworks-registry.md` (handles `combo:<a>+<b>` = both signatures, `null` = not-applicable), reads the artifact and the `chosen_framework` value strictly **read-only** — it never rewrites the deliverable or `field.json`.
- New read-only branch in `consult-resume` Step 5 (now the third "further offer") that recommends running the adherence review for a `complete` deliverable whose non-null framework conformance hasn't been verified — a structural-conformance axis distinct from the persona-challenge (Test) pass.
- Version bump cogni-consult 0.1.17 → 0.1.18 (plugin.json + marketplace.json).

## Scope decisions
- **Landing shape: dedicated agent + light resume recommendation.** The issue left agent-vs-resume-branch open for PR planning. A dedicated reviewer agent is the cleanest analog to the persona-challenge pass the issue cites and mirrors the existing `consult-dashboard-refresher` agent; the resume branch only recommends/routes, keeping `consult-resume` read-only.
- **Kept separate from the persona Test pass and from a script gate** — both alternatives the issue explicitly rejected. Adherence is an LLM content-shape judgment; `consult-design-thinking` is left untouched.
- **Artifact read-only** — the reviewer reports drift, never edits.
- Component listings in README/CLAUDE.md (auto-generated / doc-pipeline territory) are intentionally left to cogni-docs; not hand-edited here.

## Base
Builds on `origin/main` (cogni-consult 0.1.17, after #810/#811 merged).

## Test plan
- [x] plugin.json + marketplace.json both 0.1.18.
- [x] agent frontmatter valid (name, description, model: sonnet, color, read-only tools — Read/Glob/Grep, no Write/Edit); `{success,data,error}` output contract with combo/null handling.
- [x] consult-resume Step 5 gains the gated, read-only adherence-review branch; "Three further offers" count updated; Important Notes read-only invariant intact.
- [x] check-skill-names.sh OK; breadcrumb guard clean; both plugin tests pass.