### PR TITLE
cogni-consult: separate interaction language from deliverable language

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -101,5 +101,5 @@ All scripts are stdlib-only (bash + python3, no pip dependencies).
 - Workflow state per deliverable: `pending` → `in-progress` → `complete` (→ `in-progress` on iteration re-entry); stored only in `field.json`, field and engagement completion derived at read time
 - `dt_stage` tracks the design-thinking stage per deliverable (`empathize`/`define`/`ideate`/`prototype`/`test`)
 - Entity outputs are Obsidian-browsable markdown with YAML frontmatter; state files are plain JSON
-- `language` field in consult-project.json controls communication language (technical terms stay English)
+- `language` field in consult-project.json is the deliverable/output language for artifacts (technical terms stay English); the user-facing interaction language is a separate, runtime-derived axis (workspace default + message-detection override, never stored) — see `references/interaction-language.md`
 - **Research routing**: every research run goes through the engagement's bound knowledge base per `references/research-routing.md` — the canonical rule all deliverable-producing skills point at (binding via `plugin_refs.knowledge_base`, pipeline rungs, depth framing, syntheses copied to `action-fields/<field-slug>/research/<topic-slug>.md`); raw WebSearch only for a single trivial fact-check

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -90,7 +90,7 @@ list, and cross-plugin project references — not per-deliverable state.
 |-------|----------|-------------|
 | `slug` | Yes | Kebab-case identifier derived from engagement name |
 | `name` | Yes | Human-readable engagement name |
-| `language` | No | ISO 639-1 code (default: `en`). Controls communication language; technical terms stay English |
+| `language` | No | ISO 639-1 code (default: `en`). The **deliverable/output** language for the engagement's artifacts; technical terms stay English. Not the conversation language — that interaction axis is runtime-derived, never stored (see `references/interaction-language.md`) |
 | `key_question` | Yes | The SMART key question framed during scoping |
 | `action_fields` | Yes | Ordered list of action-field slugs (3-6); the WBS top level. Field/deliverable state lives in each field's `field.json`, not here |
 | `workflow_state` | Yes | `scope` state only: `pending` → `in-progress` → `complete` |

--- a/cogni-consult/references/interaction-language.md
+++ b/cogni-consult/references/interaction-language.md
@@ -1,0 +1,38 @@
+# Interaction language vs. deliverable language
+
+cogni-consult separates two independent language axes. Conflating them forces a
+single choice where two are needed — e.g. an engagement whose deliverables are
+deliberately English while the consultant and user converse in German.
+
+## The two axes
+
+| Axis | What it controls | Where it lives |
+|------|------------------|----------------|
+| **deliverable language** | The language of generated artifacts — knowledge-base output, dashboard document language, written deliverables. | The `language` field in `consult-project.json` (ISO 639-1, default `en`). Persisted; set at setup; seeds `--output-language` for the knowledge base. |
+| **interaction language** | The language of the user-facing conversation — questions, acknowledgments, status messages, recommendations. | Runtime-derived, **never persisted**. Resolved fresh each session (see below). |
+
+The `language` field is the deliverable axis **only**. Never read it to decide
+which language to *converse* in.
+
+## Resolving the interaction language
+
+Resolve it the same way `cogni-help:cogni-issues` does, in this order:
+
+1. **Workspace default** — read `.workspace-config.json` in the workspace root;
+   its `language` field (e.g. `"en"` or `"de"`) is the default interaction
+   language. The workspace `CLAUDE.md` may also state a preferred language.
+2. **Message-detection override** — if the user's message is written in a
+   different language, prefer the user's language. Someone writing in German
+   wants a German reply even when the workspace is set to English.
+3. **Fallback** — if `.workspace-config.json` is missing and the message
+   language is unclear, default to English.
+
+Conduct the entire conversation in the resolved interaction language; technical
+terms, slugs, skill names, CLI commands, and file names stay English regardless.
+
+## Why they are separate
+
+A consultant can legitimately produce English deliverables for a client while
+working through them with a German-speaking stakeholder. One axis cannot express
+that. Keeping the deliverable language in `consult-project.json` and deriving the
+interaction language at runtime lets each follow its own source of truth.

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -146,7 +146,9 @@ with "pending").
 - The HTML file is fully self-contained (inline CSS, no external dependencies beyond an optional
   Google Fonts import).
 - Re-running the script overwrites the previous dashboard at `output/dashboard.html`.
-- **Communication language**: read `consult-project.json` in the engagement root. If a `language`
-  field is present, communicate with the user in that language (status messages, instructions,
-  recommendations, questions). Technical terms, skill names, and CLI commands remain in English.
-  If no `language` field is present, default to English.
+- **Interaction language**: communicate with the user (status messages, instructions,
+  recommendations, questions) in the resolved interaction language — the workspace default,
+  overridden by the user's message language — not the engagement's `language` field, which is
+  the deliverable axis (it controls the dashboard document's `<html lang>` and the language
+  badge, not how you address the user). Technical terms, skill names, and CLI commands remain in
+  English. See `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`.

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -133,8 +133,10 @@ deliverable set (it writes the full planned-entry shape, including
 `producing_route` and `persona_review`), then resume here with the planned
 entry.
 
-When `language` is set in `consult-project.json`, hold the conversation in
-that language; technical terms, slugs, and file names stay English.
+Conduct the conversation in the resolved **interaction language** (workspace
+default, overridden by the user's message language) — independent of the
+engagement's `language` field, which is the deliverable axis. See
+`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`.
 
 ### 2. Open the Loop
 

--- a/cogni-consult/skills/consult-personas/SKILL.md
+++ b/cogni-consult/skills/consult-personas/SKILL.md
@@ -44,8 +44,10 @@ registered. Read `<engagement-dir>/consult-project.json`. If it is missing
 NOT a prerequisite — the two default advisors are useful from day one; only
 scope-seeding (step 3) needs a completed scope.
 
-When `language` is set, hold the conversation in that language; technical
-terms, slugs, and file names stay English.
+Conduct the conversation in the resolved **interaction language** (workspace
+default, overridden by the user's message language) — independent of the
+engagement's `language` field, which is the deliverable axis. See
+`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`.
 
 ### 2. Ensure the Default Advisors Exist
 

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -44,8 +44,10 @@ setup owns scaffolding and the knowledge-base binding.
   which to resume — unless the user already named one; then fuzzy-match on
   name or slug and confirm only when the match is ambiguous.
 
-When `language` is set on the selected engagement, hold the conversation in
-that language; technical terms, slugs, and file names stay English.
+Conduct the conversation in the resolved **interaction language** (workspace
+default, overridden by the user's message language) — independent of the
+engagement's `language` field, which is the deliverable axis. See
+`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`.
 
 ### 3. Read the Engagement Status
 

--- a/cogni-consult/skills/consult-scope/SKILL.md
+++ b/cogni-consult/skills/consult-scope/SKILL.md
@@ -36,7 +36,7 @@ When `workflow_state.scope` is already `complete`, this is a re-scope (pivot): c
 
 Read `$CLAUDE_PLUGIN_ROOT/references/methods/scope-dimensions.md`, then set `workflow_state.scope` to `"in-progress"` and `updated` to today's ISO date in one `Edit` — never rewrite `consult-project.json` (the `created` timestamp and `plugin_refs` set by setup must survive; `updated` covers scope edits per the data model, so an interrupted session still shows fresh modification).
 
-When `language` is set, hold the conversation in that language; technical terms, slugs, and file names stay English.
+Conduct the conversation in the resolved **interaction language** (workspace default, overridden by the user's message language) — independent of the engagement's `language` field, which is the deliverable axis. See `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`.
 
 ### 3. Key Question, Then the Five Dimensions
 

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -30,7 +30,7 @@ Collect these fields, extracting whatever the user already provided and asking o
 - **Client**: Company or organization name
 - **Desired outcome**: One sentence describing what success looks like
 - **Market**: One of `dach`, `de`, `fr`, `it`, `pl`, `nl`, `es`, `us`, `uk`, `eu` — collected explicitly, never derived from language (the mapping is ambiguous, e.g. `de` could mean `dach` or `de`)
-- **Language**: ISO 639-1 communication language (default `en`; check a `.workspace-config.json` `language` field in the workspace root first)
+- **Language**: ISO 639-1 **deliverable/output** language for the engagement's artifacts (default `en`). This is the deliverable axis only — the user-facing conversation follows the separately-resolved interaction language (see `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`), so do not set this field to match how the user happens to be writing.
 
 Derive the engagement slug from the name in kebab-case — short and recognizable.
 
@@ -100,5 +100,5 @@ Close by confirming what exists (engagement directory, bound knowledge base, reg
 
 - **State ownership**: `consult-project.json` holds only the `scope` workflow state. Deliverable state lives exclusively in each field's `field.json` — setup never touches it (no fields exist yet). See `$CLAUDE_PLUGIN_ROOT/references/data-model.md`.
 - **One base per engagement**: never bind a second knowledge base; re-runs reuse `plugin_refs.knowledge_base`.
-- **Communication language**: when `language` is set, communicate in that language; technical terms, skill names, and CLI commands stay English.
+- **Interaction language**: conduct the conversation in the resolved interaction language (workspace default, overridden by the user's message language), independent of the engagement's deliverable-axis `language` field; technical terms, skill names, and CLI commands stay English. See `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`.
 - **Legacy boundary**: legacy Double Diamond engagement directories are never shared with or migrated into cogni-consult structures; they remain where they are.


### PR DESCRIPTION
Closes #816.

## Summary
- Add `references/interaction-language.md` codifying a two-axis rule: `interaction_language` (conversation) follows the workspace `.workspace-config.json` `language` default and is overridden by the detected user-message language, and is never persisted; `language` in `consult-project.json` is the deliverable/output axis only and is never consulted for conversation direction.
- Replace the copy-pasted conversation-language coupling sentence in all six consult-* skills (consult-setup, consult-resume, consult-scope, consult-design-thinking, consult-personas, consult-dashboard) with a one-line pointer to the new shared reference. consult-action-fields carries no coupling sentence (it references `language` only as a setup-owned field), so it is intentionally untouched.
- Reword `references/data-model.md` and `CLAUDE.md` to clarify the `language` field is the deliverable/output language, not the interaction language. The consult-setup `Language` field bullet (previously "ISO 639-1 communication language") is reworded in the same pass so the field definition no longer conflates the two axes.
- Bump cogni-consult `0.1.20` -> `0.1.21` in plugin.json and marketplace.json.

## Scope decisions
- In scope: the full convention change across all six coupling sites plus the two clarifying doc rows — these must change together or the skills contradict each other, so the unit of closure equals completion.
- Out of scope (intentionally untouched, confirmed deliverable-axis): consult-setup `language` value-setting and `--output-language` seeding, `generate-dashboard.py` `<html lang>` / lang badge, and the `consult-project.json` schema — no script, JSON-schema, or migration change is needed since `language` keeps its meaning.
- No escalations: the cogni-issues two-axis pattern is an unambiguous precedent for the default-and-override rule.

## Test plan
- [x] `grep -rn 'hold the conversation in' cogni-consult/skills/` returns no matches.
- [x] `grep -rln 'interaction-language.md' cogni-consult/skills/` lists all six consult-* SKILL.md files.
- [x] `cogni-consult/references/interaction-language.md` exists and states both axes, the workspace default, the message-detection override, and that the interaction language is never persisted.
- [x] plugin.json and marketplace.json both show version `0.1.21`.
- [x] `check-skill-names.sh` and `check-breadcrumbs.py` pass (no `#NNN` / version tags introduced in SKILL.md / references / CLAUDE.md).