### PR TITLE
cogni-consult: publish-routing reference (deliverable types → formats → routes)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/publish-routing.md
+++ b/cogni-consult/references/publish-routing.md
@@ -1,0 +1,122 @@
+---
+name: publish-routing
+description: Canonical contract mapping a completed deliverable to a presentation format and the dispatch route that builds its brief — the single source of truth the publish path executes instead of hard-coding routing.
+---
+
+# Publish Routing
+
+When a deliverable is complete and the consultant elects to publish it, this
+file is the canonical contract for **which presentation format it becomes** and
+**exactly how the corresponding brief is built**. The publish path points here
+rather than restating the routing, so the contract stays auditable and cannot
+drift across skills.
+
+A publish run takes a finished deliverable artifact at
+`action-fields/<field-slug>/<deliverable-slug>.md` and terminates in a clean
+**brief** — the handoff the consultant takes to Claude Design (claude.ai/design)
+to render in their own design system. Rendering and brand are out of plugin
+scope: cogni-consult produces the brief, Claude Design produces the rendered
+artifact.
+
+## Presentation Formats
+
+The consultant chooses one of four target formats at publish time. The choice is
+not fixed per deliverable type — `deliverable-types.md` records a deliverable's
+format preference in its own artifact when it is produced, never in `field.json`
+— so the routing below keys on the **format the consultant elects**, not on a
+catalog default.
+
+| Format | What it produces | Built by |
+|---|---|---|
+| `slides` | An ordered section outline for a presentation deck | consult-native outline brief |
+| `web-poster` | A single-scroll web page / poster outline | consult-native outline brief |
+| `report` | A themed, visually enriched HTML/PDF/DOCX report | `cogni-visual:enrich-report` |
+| `infographic` | A single-page data infographic | `cogni-visual:story-to-infographic` |
+
+## Routing by Format
+
+### slides / web-poster → consult-native outline brief
+
+Consult deliverables are **framework-shaped** (Pyramid / SCQA / MECE), not
+**arc-shaped**. The arc-optimized cogni-visual skills (`story-to-slides`,
+`story-to-web`) auto-detect a narrative arc and build best when the source is a
+story; a WBS-addressed analytical deliverable is not a story, so dispatching them
+directly yields a weak brief. For the same reason this path does **not**
+re-narrate the deliverable through `cogni-narrative` — arc-ifying a
+framework-shaped deliverable softens the executive/Pyramid register it is written
+in.
+
+Instead, derive a **consult-native outline brief** directly from the
+deliverable's own structure: an ordered list of `{section_title, section_body}`
+entries, citations preserved. The mapping from the deliverable's framework to the
+outline:
+
+- **Pyramid answer / governing thought** → the opening (title slide or hero
+  section).
+- **MECE groups / SCQA movements** → one section entry each, in the
+  deliverable's own order.
+- **Supporting evidence and citations** → carried into the corresponding
+  section body; never dropped.
+
+The brief is a plain title-and-description outline — exactly what Claude Design's
+presentation generator consumes. Write it alongside the deliverable, e.g.
+`action-fields/<field-slug>/publish/<deliverable-slug>-outline.md`.
+
+### report → cogni-visual:enrich-report
+
+A finished markdown deliverable needs no arc — `enrich-report` post-processes
+existing content into a themed visual report.
+
+```
+Skill: cogni-visual:enrich-report
+  source_path: action-fields/<field-slug>/<deliverable-slug>.md
+```
+
+`source_path` is the only required input; everything else defaults (theme falls
+through to `cogni-workspace:pick-theme`, language is read from frontmatter,
+`formats` defaults to HTML — add `pdf` / `docx` when the consultant needs them).
+The enriched output lands by default at
+`action-fields/<field-slug>/output/<deliverable-slug>-enriched.html`.
+
+### infographic → cogni-visual:story-to-infographic
+
+`story-to-infographic` distils a single-page infographic from prose; `arc_id` is
+optional (auto-detected), so it works on any markdown deliverable.
+
+```
+Skill: cogni-visual:story-to-infographic
+  source_path: action-fields/<field-slug>/<deliverable-slug>.md
+```
+
+It emits an `infographic-brief.md` and auto-renders it. Pick a `style_preset`
+(`editorial`, `data-viz`, `economist`, `corporate`, …) when the consultant has a
+house look in mind.
+
+## Optional Voice Polish
+
+Before building any brief, the deliverable or outline text may be polished with
+`cogni-copywriting:copywriter`. This step is optional and graceful-degrading —
+skip it and the route still produces a valid brief.
+
+```
+Skill: cogni-copywriting:copywriter
+  FILE_PATH=<absolute path to the deliverable or outline .md>
+  --scope=tone   AUDIENCE=mixed
+```
+
+Scope guidance: `--scope=tone` for a light pass that preserves structure;
+`--scope=compress` to tighten for an executive audience; `--scope=full` for a
+Pyramid / BLUF restructuring before a client-facing presentation. `TARGET_LANG`
+translates when the brief's language differs from the deliverable's.
+
+## Handoff Contract
+
+Every route terminates in a **brief file**, and the brief's path *is* the
+handoff. Briefs are stored as **path references** — never copied into consult
+state — mirroring the research storage contract: the deliverable and its
+downstream brief are linked by path, so a correction upstream is visible
+downstream without duplicating content.
+
+The consultant takes the brief to Claude Design (claude.ai/design) and renders it
+in their own design system. cogni-consult never renders and never owns brand —
+its output stops at the brief.


### PR DESCRIPTION
Closes #823.

Epic #827 phase 1: the authoritative, auditable routing contract the upcoming publish skill (#824) consumes instead of hard-coding routing logic. Reference document only — no skill or script behaviour changes.

## Summary
- Add `cogni-consult/references/publish-routing.md`: a routing table keyed on the presentation format the consultant chooses at publish time (deliverable-types records format preference in the deliverable artifact, not `field.json`), mapping each format to a dispatch route.
- Routes: slides / web-poster → a consult-native outline brief schema (ordered `{section_title, section_body}` derived from the deliverable's own Pyramid/MECE structure, citations preserved); report → `cogni-visual:enrich-report`; infographic → `cogni-visual:story-to-infographic`.
- Slides/web rationale stated accurately: consult deliverables are framework-shaped (Pyramid/SCQA/MECE), not arc-shaped, so the path does NOT dispatch the arc-optimized cogni-visual story-to-slides/story-to-web skills and does NOT re-narrate through cogni-narrative.
- Optional, graceful-degrading `cogni-copywriting:copywriter` voice-polish step (FILE_PATH / --scope / AUDIENCE / TARGET_LANG).
- Handoff convention: every route terminates in a clean brief stored as a PATH REFERENCE (never copied into consult state, mirroring research-routing's storage contract); the consultant hands the brief to Claude Design to render — rendering and brand are out of plugin scope.
- Bump cogni-consult 0.1.21 → 0.1.22 in plugin.json and marketplace.json.

## Scope decisions
- Full scope for this issue: the reference document is a single coherent deliverable. The publish skill that consumes it is a separate epic #827 child (#824), intentionally not part of this PR.
- House style follows `deliverable-types.md` (YAML frontmatter + H1 + H2 + pipe tables) since this is a catalog-like contract.
- No maintainer breadcrumbs in the reference body per the breadcrumb guard.

## Test plan
- [x] `references/publish-routing.md` exists with frontmatter, a routing table over all four formats, and the four route definitions.
- [x] Slides/web section states the framework-shaped (not arc-shaped) rationale and does NOT dispatch story-to-slides/story-to-web or cogni-narrative.
- [x] report → enrich-report; infographic → story-to-infographic; optional polish → copywriter with KEY=value args.
- [x] Handoff/storage section: briefs are PATH REFERENCES (never copied); rendering/brand out of scope (Claude Design).
- [x] plugin.json and marketplace.json both read 0.1.22.
- [x] check-breadcrumbs.py passes.