### PR TITLE
feat(cogni-knowledge): persistent per-phase run-metrics ledger (B1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/references/run-metrics-wiring.md
+++ b/cogni-knowledge/references/run-metrics-wiring.md
@@ -1,0 +1,57 @@
+# Run-metrics ledger — phase-exit wiring contract
+
+Each pipeline phase (`knowledge-plan` … `knowledge-finalize`) persists one row to
+`<project_path>/.metadata/run-metrics.json` at phase exit via
+`scripts/run-metrics.py record`, so a research run leaves a **durable per-phase
+timing + cost ledger** the read-side skills (`knowledge-resume`,
+`knowledge-dashboard`) and any perf study can read without hand-instrumenting the
+pipeline. The phases already compute cost + agent counts in their final summary;
+this just persists them — the only new work is capturing the phase's start time.
+
+`knowledge-setup` is **excluded**: it is a one-time base bootstrap that runs
+*before* any project directory exists, so it has no `<project_path>/.metadata/`
+to write into. The ledger spans `plan → finalize`, which is the actual research
+run.
+
+## The contract (each phase skill)
+
+1. **At the top of the workflow** (pre-flight / Step 0), capture the phase start:
+
+   ```
+   PHASE_START=$(date -u +%FT%TZ)
+   ```
+
+2. **At phase exit** (immediately after the Final summary step), record the row.
+   The phase name is fixed per skill; `--agent-count` is the number of subagents
+   this phase dispatched (0 for the script-only phases — `fetch`); `--cost-usd`
+   is the sum of `cost_estimate.estimated_usd` across this phase's agent returns
+   (the same numbers the Final summary already prints):
+
+   ```
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/run-metrics.py" record \
+       --project-path "<project_path>" \
+       --phase <plan|curate|fetch|ingest|compose|verify|finalize> \
+       --started-at "$PHASE_START" --ended-at "$(date -u +%FT%TZ)" \
+       --agent-count <N> \
+       --cost-usd <summed estimated_usd, default 0>
+   ```
+
+   The script computes `elapsed_s` from the two timestamps and appends the row.
+
+**Fail-soft, always.** A `run-metrics.py record` failure (missing `.metadata/`,
+unreadable ledger, etc.) **never blocks the phase** — the ledger is observability
+only, and `record` already degrades gracefully (a corrupt ledger is reset, not
+fatal). Surface a one-line warning at most.
+
+**Append-only.** A re-run of a phase appends a new row rather than overwriting;
+`run-metrics.py report` sums all rows, so retries stay visible.
+
+## Reading it back
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/run-metrics.py" report --project-path "<project_path>"
+```
+
+returns the per-phase rows, `totals {elapsed_s, elapsed_min, cost_estimate_usd,
+agent_count}`, and a rendered table — the read surface for a `knowledge-resume`
+timeline view or a perf study.

--- a/cogni-knowledge/scripts/run-metrics.py
+++ b/cogni-knowledge/scripts/run-metrics.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+run-metrics.py — persistent per-phase timing + cost ledger for the inverted
+pipeline (the B1 observability primitive).
+
+Every phase skill (knowledge-setup … knowledge-finalize) records one row at
+phase exit, so a run leaves a durable `<project>/.metadata/run-metrics.json`
+the read-side skills (knowledge-resume / knowledge-dashboard) and any perf
+study can read without hand-instrumenting the pipeline. Phases already compute
+their own cost + agent counts in their final summary; this just persists them.
+
+  record   Append one phase row to run-metrics.json. Append-only — a re-run of
+           a phase appends a new row (a real event), and `report` sums them, so
+           retries are visible rather than silently overwritten.
+
+  report   Read run-metrics.json and emit the phase rows plus totals
+           (elapsed_s, cost_estimate_usd, agent_count) and a rendered table.
+           This is the read surface knowledge-resume / a perf study consume.
+
+Both degrade gracefully: `report` on a project with no ledger yet returns an
+empty-but-valid envelope rather than crashing (same posture as
+pipeline-summary.py cmd_project on a legacy project).
+
+All output uses the insight-wave script envelope:
+  {"success": bool, "data": {...}, "error": "..."}
+
+Stdlib only. No pip dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _knowledge_lib import atomic_write  # noqa: E402
+
+SCHEMA_VERSION = "0.1.0"
+METADATA_DIRNAME = ".metadata"
+LEDGER_FILENAME = "run-metrics.json"
+
+# Canonical phase order for the rendered report. An unknown phase still records
+# and reports — it simply sorts after the known phases (stable by insertion).
+_PHASE_ORDER = [
+    "setup", "plan", "curate", "fetch", "ingest",
+    "distill", "compose", "verify", "finalize",
+]
+
+
+def _emit(success: bool, data: dict | None = None, error: str = "") -> int:
+    payload = {"success": success, "data": data or {}, "error": error}
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0 if success else 1
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _ledger_path(project_path: str) -> Path:
+    return Path(project_path) / METADATA_DIRNAME / LEDGER_FILENAME
+
+
+def _load(path: Path) -> dict:
+    if not path.exists():
+        return {"schema_version": SCHEMA_VERSION, "phases": []}
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        # Corrupt / unreadable ledger: start fresh rather than abort a phase
+        # exit on an observability artifact. The lost rows are non-critical.
+        return {"schema_version": SCHEMA_VERSION, "phases": []}
+    if not isinstance(doc, dict) or not isinstance(doc.get("phases"), list):
+        return {"schema_version": SCHEMA_VERSION, "phases": []}
+    doc.setdefault("schema_version", SCHEMA_VERSION)
+    return doc
+
+
+def cmd_record(args: argparse.Namespace) -> int:
+    meta_dir = Path(args.project_path) / METADATA_DIRNAME
+    if not meta_dir.is_dir():
+        return _emit(False, error=f"no .metadata/ under project path: {args.project_path}")
+
+    elapsed = args.elapsed_s
+    if elapsed is None and args.started_at and args.ended_at:
+        try:
+            t0 = _dt.datetime.strptime(args.started_at, "%Y-%m-%dT%H:%M:%SZ")
+            t1 = _dt.datetime.strptime(args.ended_at, "%Y-%m-%dT%H:%M:%SZ")
+            elapsed = round((t1 - t0).total_seconds(), 1)
+        except ValueError:
+            elapsed = None
+
+    row = {
+        "phase": args.phase,
+        "started_at": args.started_at or "",
+        "ended_at": args.ended_at or "",
+        "elapsed_s": elapsed,
+        "agent_count": args.agent_count,
+        "cost_estimate_usd": round(args.cost_usd, 4),
+        "recorded_at": _now_iso(),
+    }
+
+    path = _ledger_path(args.project_path)
+    doc = _load(path)
+    doc["phases"].append(row)
+    atomic_write(path, doc)
+    return _emit(True, data={"recorded": row, "phases_total": len(doc["phases"]), "path": str(path)})
+
+
+def _phase_sort_key(phase: str):
+    try:
+        return (0, _PHASE_ORDER.index(phase))
+    except ValueError:
+        return (1, 0)  # unknown phases after known, stable insertion otherwise
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    path = _ledger_path(args.project_path)
+    doc = _load(path)
+    phases = doc.get("phases", [])
+
+    total_elapsed = round(sum((p.get("elapsed_s") or 0.0) for p in phases), 1)
+    total_cost = round(sum((p.get("cost_estimate_usd") or 0.0) for p in phases), 4)
+    total_agents = sum(int(p.get("agent_count") or 0) for p in phases)
+
+    ordered = sorted(phases, key=lambda p: _phase_sort_key(p.get("phase", "")))
+
+    lines = ["phase        elapsed_s     %   agents    cost_usd"]
+    for p in ordered:
+        el = p.get("elapsed_s") or 0.0
+        pct = (100.0 * el / total_elapsed) if total_elapsed else 0.0
+        lines.append(
+            f"{str(p.get('phase','?'))[:12]:12s} {el:9.1f} {pct:5.1f}% "
+            f"{int(p.get('agent_count') or 0):6d}   ${p.get('cost_estimate_usd') or 0.0:.4f}"
+        )
+    lines.append(
+        f"{'TOTAL':12s} {total_elapsed:9.1f} {100.0 if total_elapsed else 0.0:5.1f}% "
+        f"{total_agents:6d}   ${total_cost:.4f}"
+    )
+
+    return _emit(True, data={
+        "phases": ordered,
+        "totals": {
+            "elapsed_s": total_elapsed,
+            "elapsed_min": round(total_elapsed / 60.0, 1),
+            "cost_estimate_usd": total_cost,
+            "agent_count": total_agents,
+        },
+        "rendered": "\n".join(lines),
+        "ledger_present": path.exists(),
+    })
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Persistent per-phase timing + cost ledger for the inverted pipeline.",
+        allow_abbrev=False,
+    )
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    p_rec = sub.add_parser("record", help="Append one phase row at phase exit.")
+    p_rec.add_argument("--project-path", required=True)
+    p_rec.add_argument("--phase", required=True,
+                       help="Phase name, e.g. setup|plan|curate|fetch|ingest|distill|compose|verify|finalize.")
+    p_rec.add_argument("--elapsed-s", type=float, default=None,
+                       help="Wall-clock seconds for the phase. If omitted but --started-at/--ended-at are given, computed.")
+    p_rec.add_argument("--started-at", default="", help="ISO 8601 UTC (YYYY-MM-DDThh:mm:ssZ).")
+    p_rec.add_argument("--ended-at", default="", help="ISO 8601 UTC (YYYY-MM-DDThh:mm:ssZ).")
+    p_rec.add_argument("--agent-count", type=int, default=0, help="Subagents dispatched in this phase.")
+    p_rec.add_argument("--cost-usd", type=float, default=0.0,
+                       help="Summed cost_estimate.estimated_usd across this phase's agents.")
+    p_rec.set_defaults(func=cmd_record)
+
+    p_rep = sub.add_parser("report", help="Read the ledger; emit phase rows + totals + a rendered table.")
+    p_rep.add_argument("--project-path", required=True)
+    p_rep.set_defaults(func=cmd_report)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/cogni-knowledge/skills/knowledge-compose/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-compose/SKILL.md
@@ -405,6 +405,20 @@ Surface a density-aware summary line — but do not auto-retry. The two densitie
 
 The advisory `wiki-reviewer` (finalize Step 10.7) independently re-scores the draft — under `standard` it only flags a likely-*truncated* draft (`< 0.50` of budget), never a short-but-complete one; under `executive` it caps on excess. The compose-time line is a fast heads-up, not a gate.
 
+### 8. Record run metrics (phase-exit ledger)
+
+Persist this phase's timing + cost to `<project_path>/.metadata/run-metrics.json` so the run leaves a durable per-phase ledger (read by `knowledge-resume` / `knowledge-dashboard` / a perf study). Capture `PHASE_START=$(date -u +%FT%TZ)` at the top of this skill's run (Step 0); then at exit:
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/run-metrics.py" record \
+    --project-path "<project_path>" --phase compose \
+    --started-at "$PHASE_START" --ended-at "$(date -u +%FT%TZ)" \
+    --agent-count <1 composer, +1 if Step 5.5 expansion ran> \
+    --cost-usd <composer cost_estimate.estimated_usd (+ expansion when it ran)>
+```
+
+Fail-soft — a record failure never blocks the phase. Full contract: `${CLAUDE_PLUGIN_ROOT}/references/run-metrics-wiring.md`.
+
 ## Edge cases
 
 - **Outline recovery in action.** The outline file exists from a prior crashed run. The composer skips Phase 1 (saves model time and avoids re-deriving the section plan), runs Phase 2 fresh, and writes the draft + citation manifest. The outline's `drafted_words` placeholders get filled by the resume pass. Surface "RESUME_FROM_OUTLINE=true (outline recovery)" in the summary so the operator sees what happened.

--- a/cogni-knowledge/skills/knowledge-curate/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-curate/SKILL.md
@@ -194,6 +194,19 @@ Parse the result for the final summary. Print ≤ 8 lines:
 - Failed sub-questions (if any): `sq-NN, sq-MM` — re-run with `--sub-question-ids sq-NN,sq-MM`
 - Next: run `knowledge-fetch --knowledge-slug <slug> --project-path <project_path>` to build the fetch manifest (a near no-op — bodies are already cached; add `--cobrowse` only if you want to recover WebFetch misses via your browser)
 
+### 5. Record run metrics (phase-exit ledger)
+
+Persist this phase's timing + cost to `<project_path>/.metadata/run-metrics.json` so the run leaves a durable per-phase ledger (read by `knowledge-resume` / `knowledge-dashboard` / a perf study). Capture `PHASE_START=$(date -u +%FT%TZ)` at the top of this skill's run (Step 0); then at exit:
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/run-metrics.py" record \
+    --project-path "<project_path>" --phase curate \
+    --started-at "$PHASE_START" --ended-at "$(date -u +%FT%TZ)" \
+    --agent-count <curators dispatched> --cost-usd <summed curator cost_estimate.estimated_usd>
+```
+
+Note the curate cost is the dominant per-run spend, so capturing it here is what makes the cost ledger meaningful. Fail-soft — a record failure never blocks the phase. Full contract: `${CLAUDE_PLUGIN_ROOT}/references/run-metrics-wiring.md`.
+
 ## Edge cases
 
 - **Re-curate of an existing project.** `candidates.json` already exists. `candidate-store.py init` is idempotent (no overwrite). Curators dispatched again will re-emit batches; the merge step dedupes by URL, unions sub-question refs, keeps the higher score, and prefers the side whose `fetch.status == "ok"` so a good body survives the dedup. Re-fetches short-circuit on the fetch-cache (Phase-4 Step 1), so a re-curate is cheap.

--- a/cogni-knowledge/skills/knowledge-fetch/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-fetch/SKILL.md
@@ -127,6 +127,19 @@ Print ≤ 10 lines:
 
 If `unavailable_count / total_candidates > 0.3`, emit a non-blocking warning: "high unavailable rate (X%) — consider `--cobrowse` to recover misses, or evicting stale negative-cache entries via fetch-cache.py evict".
 
+### 5. Record run metrics (phase-exit ledger)
+
+Persist this phase's timing + cost to `<project_path>/.metadata/run-metrics.json` so the run leaves a durable per-phase ledger (read by `knowledge-resume` / `knowledge-dashboard` / a perf study). Capture `PHASE_START=$(date -u +%FT%TZ)` at the top of this skill's run (Step 0); then at exit:
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/run-metrics.py" record \
+    --project-path "<project_path>" --phase fetch \
+    --started-at "$PHASE_START" --ended-at "$(date -u +%FT%TZ)" \
+    --agent-count <cobrowse source-fetchers, else 0> --cost-usd <summed cobrowse cost, else 0>
+```
+
+The default (no-cobrowse) path dispatches no agents and costs nothing — record `--agent-count 0 --cost-usd 0`. Fail-soft — a record failure never blocks the phase. Full contract: `${CLAUDE_PLUGIN_ROOT}/references/run-metrics-wiring.md`.
+
 ## Edge cases
 
 - **Empty candidates list.** Nothing to manifest. Skip to summary with a note. Often means `knowledge-curate` failed silently — direct the user to re-run curate.

--- a/cogni-knowledge/skills/knowledge-finalize/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-finalize/SKILL.md
@@ -1040,6 +1040,20 @@ Print ≤ 13 lines (the verbatim/paraphrase ratio, the contradiction-tripwire bl
 
 If Step 2 surfaced `unsupported > 0`, repeat the `⚠ Finalized with <N> unsupported citations` warning so the audit trail is on-screen.
 
+### 12. Record run metrics (phase-exit ledger)
+
+Persist this phase's timing + cost to `<project_path>/.metadata/run-metrics.json` so the run leaves a durable per-phase ledger (read by `knowledge-resume` / `knowledge-dashboard` / a perf study). Capture `PHASE_START=$(date -u +%FT%TZ)` at the top of this skill's run (Step 0); then at exit:
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/run-metrics.py" record \
+    --project-path "<project_path>" --phase finalize \
+    --started-at "$PHASE_START" --ended-at "$(date -u +%FT%TZ)" \
+    --agent-count <optional agents dispatched: contradictor + reviewer + portal/concepts narrators> \
+    --cost-usd <summed cost_estimate.estimated_usd across those agents, default 0>
+```
+
+This row closes the per-project ledger; `run-metrics.py report --project-path <project_path>` then renders the full plan→finalize timeline. Fail-soft — a record failure never blocks the deposit. Full contract: `${CLAUDE_PLUGIN_ROOT}/references/run-metrics-wiring.md`.
+
 ## Edge cases
 
 - **Re-run on an already-finalized project.** `<WIKI_ROOT>/wiki/syntheses/<slug>.md` exists — abort with the `--overwrite` nudge. If `--overwrite`, the synthesis page is rewritten but `config_bump.py --delta 1` would over-count; pass `--overwrite` only when the previous synthesis page is being replaced after a hand-edit, and reconcile entries_count via `wiki-lint --fix=entries_count_drift` afterward.

--- a/cogni-knowledge/skills/knowledge-ingest/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-ingest/SKILL.md
@@ -434,6 +434,20 @@ Print ≤ 10 lines:
 
 If `len(ingested) == 0` and `len(skipped) > 0`, emit a warning: "no new pages written this run — every fetched source was already in ingest-manifest.json or skipped; check the skipped breakdown".
 
+### 7. Record run metrics (phase-exit ledger)
+
+Persist this phase's timing + cost to `<project_path>/.metadata/run-metrics.json` so the run leaves a durable per-phase ledger (read by `knowledge-resume` / `knowledge-dashboard` / a perf study). Capture `PHASE_START=$(date -u +%FT%TZ)` at the top of this skill's run (Step 0); then at exit:
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/run-metrics.py" record \
+    --project-path "<project_path>" --phase ingest \
+    --started-at "$PHASE_START" --ended-at "$(date -u +%FT%TZ)" \
+    --agent-count <source-ingesters dispatched (+ any source-contradictors)> \
+    --cost-usd <summed cost_estimate.estimated_usd across ingester + claim-extractor>
+```
+
+Fail-soft — a record failure never blocks the phase. Full contract: `${CLAUDE_PLUGIN_ROOT}/references/run-metrics-wiring.md`.
+
 ## Edge cases
 
 - **Re-ingest of an existing project.** `ingest-manifest.json` already exists; the orchestrator skips entries already in `ingested[]` (URL-keyed). Manual cleanup (delete page + remove from manifest) is the path to force a re-ingest of a specific URL.

--- a/cogni-knowledge/skills/knowledge-plan/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-plan/SKILL.md
@@ -210,6 +210,19 @@ Print ≤ 6 lines:
 - Framing (only when Step 0.4 engaged): `<project_path>/.metadata/framing.md`
 - Next: run `knowledge-curate --knowledge-slug <slug> --project-path <project_path>` to discover candidate sources
 
+### 6. Record run metrics (phase-exit ledger)
+
+Persist this phase's timing + cost to `<project_path>/.metadata/run-metrics.json` so the run leaves a durable per-phase ledger (read by `knowledge-resume` / `knowledge-dashboard` / a perf study). Capture `PHASE_START=$(date -u +%FT%TZ)` at the top of this skill's run (Step 0); then at exit, once `project_path` exists (Step 1):
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/run-metrics.py" record \
+    --project-path "<project_path>" --phase plan \
+    --started-at "$PHASE_START" --ended-at "$(date -u +%FT%TZ)" \
+    --agent-count 0 --cost-usd <plan.json cost_estimate_usd, default 0>
+```
+
+Fail-soft — a record failure never blocks the phase. Full contract: `${CLAUDE_PLUGIN_ROOT}/references/run-metrics-wiring.md`.
+
 ## Edge cases
 
 - **Topic resolves to the same slug as an existing project on the same day.** Step 1 aborts. The user can rephrase the topic or wait until tomorrow — multi-run-per-day on the same topic is not a supported use case.

--- a/cogni-knowledge/skills/knowledge-verify/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-verify/SKILL.md
@@ -439,6 +439,20 @@ If the loop terminated EXHAUSTED (`UNSUPPORTED_COUNT > 0` AND `REVISION_ROUND ==
 
 If the verifier surfaced `missing_pages[]`, surface `⚠ Missing pages: <slug1>, <slug2>, …` so the operator knows the wiki was modified between compose and verify.
 
+### 7. Record run metrics (phase-exit ledger)
+
+Persist this phase's timing + cost to `<project_path>/.metadata/run-metrics.json` so the run leaves a durable per-phase ledger (read by `knowledge-resume` / `knowledge-dashboard` / a perf study). Capture `PHASE_START=$(date -u +%FT%TZ)` at the top of this skill's run (Step 0); then at exit:
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/run-metrics.py" record \
+    --project-path "<project_path>" --phase verify \
+    --started-at "$PHASE_START" --ended-at "$(date -u +%FT%TZ)" \
+    --agent-count <verifier shards dispatched + revisor rounds> \
+    --cost-usd <summed cost_estimate.estimated_usd across all verifier + revisor dispatches>
+```
+
+Fail-soft — a record failure never blocks the phase. Full contract: `${CLAUDE_PLUGIN_ROOT}/references/run-metrics-wiring.md`.
+
 ## Edge cases
 
 - **Zero deviations on first verifier pass.** Loop terminates immediately after `REVISION_ROUND=0`. `CURRENT_DRAFT_VERSION` stays at N; the draft on disk is unchanged. `verify-vN.json` records the clean verdict for `knowledge-finalize` to consume.

--- a/cogni-knowledge/tests/test_run_metrics.sh
+++ b/cogni-knowledge/tests/test_run_metrics.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# test_run_metrics.sh — smoke test for run-metrics.py (B1: per-phase
+# timing + cost ledger).
+#
+# Asserts:
+#   1. record appends a row to <project>/.metadata/run-metrics.json and
+#      computes elapsed_s from --started-at / --ended-at.
+#   2. record honours an explicit --elapsed-s (no timestamps needed).
+#   3. record is append-only: two records for the same project keep both rows.
+#   4. report sums elapsed_s / cost_estimate_usd / agent_count across rows and
+#      orders phases by the canonical pipeline order (plan before finalize even
+#      when recorded out of order).
+#   5. report on a project with no ledger returns success + ledger_present=false
+#      (graceful degradation — never crashes a read).
+#   6. record on a project with no .metadata/ returns success:false (no silent
+#      write to a non-project path).
+#
+# bash 3.2 + stdlib python3 only.
+
+set -eu
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$PLUGIN_ROOT/scripts/run-metrics.py"
+
+. "$(dirname "$0")/fixtures/test_helpers.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  red "FAIL: run-metrics.py not found at $SCRIPT"
+  exit 1
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+errors=0
+
+PROJ="$WORK/proj"
+mkdir -p "$PROJ/.metadata"
+
+# --- 1. record computes elapsed from timestamps --------------------------
+OUT=$(python3 "$SCRIPT" record --project-path "$PROJ" --phase curate \
+  --started-at 2026-06-16T16:29:07Z --ended-at 2026-06-16T16:43:14Z \
+  --agent-count 3 --cost-usd 0.132)
+if echo "$OUT" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d['success'] is True, d
+r = d['data']['recorded']
+assert r['phase'] == 'curate', r
+assert r['elapsed_s'] == 847.0, r          # 16:43:14 - 16:29:07 = 847s
+assert r['agent_count'] == 3, r
+assert r['cost_estimate_usd'] == 0.132, r
+print('OK')
+" | grep -q OK; then
+  green "PASS: record computes elapsed_s from timestamps + stores fields"
+else
+  red "FAIL: record timestamp/elapsed"; red "  got: $OUT"; errors=$((errors + 1))
+fi
+
+# --- 2. record honours explicit --elapsed-s ------------------------------
+python3 "$SCRIPT" record --project-path "$PROJ" --phase plan --elapsed-s 44.9 >/dev/null
+
+# --- 3. append-only: both rows present -----------------------------------
+LEDGER="$PROJ/.metadata/run-metrics.json"
+if python3 -c "
+import json
+d = json.load(open('$LEDGER'))
+assert len(d['phases']) == 2, d
+phases = [p['phase'] for p in d['phases']]
+assert phases == ['curate', 'plan'], phases   # append order preserved on disk
+print('OK')
+" | grep -q OK; then
+  green "PASS: record is append-only (both rows kept, on-disk insertion order)"
+else
+  red "FAIL: append-only"; errors=$((errors + 1))
+fi
+
+# --- 4. report sums + orders by canonical pipeline order -----------------
+REP=$(python3 "$SCRIPT" report --project-path "$PROJ")
+if echo "$REP" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)['data']
+t = d['totals']
+assert t['elapsed_s'] == 891.9, t          # 847.0 + 44.9
+assert t['cost_estimate_usd'] == 0.132, t
+assert t['agent_count'] == 3, t
+ordered = [p['phase'] for p in d['phases']]
+assert ordered == ['plan', 'curate'], ordered   # canonical order, not insertion
+assert 'TOTAL' in d['rendered'], d['rendered']
+print('OK')
+" | grep -q OK; then
+  green "PASS: report sums totals + orders phases canonically (plan before curate)"
+else
+  red "FAIL: report totals/order"; red "  got: $REP"; errors=$((errors + 1))
+fi
+
+# --- 5. report on a project with no ledger (graceful) --------------------
+EMPTY="$WORK/empty"
+mkdir -p "$EMPTY/.metadata"
+OUT=$(python3 "$SCRIPT" report --project-path "$EMPTY")
+if echo "$OUT" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d['success'] is True, d
+assert d['data']['ledger_present'] is False, d
+assert d['data']['totals']['elapsed_s'] == 0, d
+print('OK')
+" | grep -q OK; then
+  green "PASS: report on no-ledger project degrades gracefully (success, ledger_present=false)"
+else
+  red "FAIL: no-ledger report"; red "  got: $OUT"; errors=$((errors + 1))
+fi
+
+# --- 6. record on a non-project path (no .metadata/) fails cleanly -------
+OUT=$(python3 "$SCRIPT" record --project-path "$WORK/nope" --phase plan --elapsed-s 1 || true)
+if echo "$OUT" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d['success'] is False, d
+print('OK')
+" | grep -q OK; then
+  green "PASS: record on a path with no .metadata/ returns success:false"
+else
+  red "FAIL: non-project record should fail"; red "  got: $OUT"; errors=$((errors + 1))
+fi
+
+if [ $errors -eq 0 ]; then
+  green ""
+  green "ALL PASS"
+  exit 0
+else
+  red "$errors test(s) failed"
+  exit 1
+fi


### PR DESCRIPTION
## What

Adds a durable per-project timing + cost ledger to the cogni-knowledge inverted pipeline, so a research run's performance can be measured run-over-run without hand-instrumenting the pipeline. (Implements **B1** from a performance + observability study of the plugin.)

- **`scripts/run-metrics.py`** — `record` appends one phase row to `<project>/.metadata/run-metrics.json` at phase exit; `report` renders the phase timeline + totals (`elapsed_s`, `cost_estimate_usd`, `agent_count`). Stdlib, `{success,data,error}` envelope, atomic append, **append-only**, **fail-soft** (a corrupt/absent ledger degrades, never aborts a phase).
- **7 pipeline skills wired** (`plan` → `finalize`) with a uniform phase-exit "Record run metrics" step. `setup` is excluded by design (it precedes the project dir). Contract documented in **`references/run-metrics-wiring.md`**.
- **`tests/test_run_metrics.sh`** — covers record / elapsed-from-timestamps / append-only / report ordering + totals / graceful-no-ledger / non-project-path. Passes.
- Version bump **1.0.8 → 1.0.9** (`plugin.json` + `marketplace.json`).

## Why

Before this, the pipeline emitted cost only in ephemeral per-agent summaries and recorded **no** per-phase wall-clock — "you can't optimize what you can't measure." A perf study had to hand-build a scratch timing bracketer and manually transcribe cost. This makes the timeline a first-class artifact.

## Validation

Proven on a live cold-cache run (`perf-cra-2`): `run-metrics.json` was produced **natively across all 7 phases** and `run-metrics.py report` rendered the end-to-end timeline + per-phase cost. The ledger also surfaced a real anomaly (a phase whose wall-clock spanned an API-outage pause showed up as wildly out-of-profile and was correctable) — exactly the observability gap it closes.

Guards/tests green: breadcrumb guard, skill-name check, and the `compose`/`finalize` contract tests all pass alongside the new test.

## Notes

- No behavior change to the pipeline itself — pure instrumentation (one sub-second atomic append per phase exit).
- Follow-ups filed separately: ingesters self-reporting cost + `max_agent_duration` in the ledger (#843), and `pipeline-summary.py` finalize-awareness (#842).

🤖 Generated with [Claude Code](https://claude.com/claude-code)