### PR TITLE
feat(cogni-knowledge): deterministic excerpt-presence leg in ingest-integrity sweep (closes #873)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.26",
+      "version": "1.0.27",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/ingest-integrity.py
+++ b/cogni-knowledge/scripts/ingest-integrity.py
@@ -23,8 +23,16 @@ Subcommand:
           page's frontmatter `content_hash:` equals the fetch-cache entry's
           `content_hash` for the dispatched URL — catching the body-only variant
           where an agent kept its own id/sources but emitted a sibling's body
-          (and the sibling's `content_hash:` line) under wave cross-talk. Emit
-          the violations the orchestrator quarantines.
+          (and the sibling's `content_hash:` line) under wave cross-talk; and a
+          fourth, excerpt-presence leg asserts each `pre_extracted_claims:`
+          `excerpt_quote` is a substring of that entry's cached body — catching
+          the claim-level variant where id/sources/content_hash all conform but a
+          claim's quote was extracted from another source's body (the grounding
+          floor: a cited claim must actually appear in the page it grounds). A
+          page whose excerpt-presence rate falls below `--excerpt-threshold`
+          (default 0.95) is reported `excerpt_presence_below_threshold`, and the
+          per-run rate is emitted in `data.excerpt_presence_rate`. Emit the
+          violations the orchestrator quarantines.
 
 Pure detector — read-only, never mutates the wiki. The orchestrator owns all
 side effects (quarantine move, manifest edits), the established detect-in-script
@@ -46,6 +54,7 @@ from _knowledge_lib import (  # noqa: E402
     extract_page_content_hash,
     extract_page_id_and_url,
     normalize_url,
+    parse_pre_extracted_claims,
 )
 
 
@@ -58,14 +67,17 @@ def _emit(success: bool, data: dict | None = None, error: str = "") -> int:
 def _violation(wiki_root: Path, slug: str, expected_url: str, reason: str,
                observed_id: str = "", observed_url: str = "",
                observed_content_hash: str = "", expected_content_hash: str = "",
-               content_hash_ok: bool = True) -> dict:
+               content_hash_ok: bool = True,
+               excerpt_presence_ok: bool = True,
+               excerpt_presence_rate: float | None = None) -> dict:
     """Assemble one violation record. `id_ok` / `url_ok` are derived from the
     observed-vs-expected comparison, so a `page_missing` entry (observed "")
-    falls out as both-false without a separate code path. `content_hash_ok` is
-    passed in (not derived) because its "leg not checked / cache miss / either
-    side empty" cases must read True regardless of the bare string comparison;
-    its three keys default to the no-`--knowledge-root` shape so that path emits
-    the same record plus harmless extra keys."""
+    falls out as both-false without a separate code path. `content_hash_ok` and
+    `excerpt_presence_ok` are passed in (not derived) because their "leg not
+    checked / cache miss / either side empty" cases must read True regardless of
+    the bare comparison; the content_hash / excerpt-presence keys default to the
+    no-`--knowledge-root` shape so that path emits the same record plus harmless
+    extra keys (`excerpt_presence_rate` stays None when the leg did not score)."""
     return {
         "slug": slug,
         "expected_url": expected_url,
@@ -77,18 +89,23 @@ def _violation(wiki_root: Path, slug: str, expected_url: str, reason: str,
         "id_ok": observed_id == slug,
         "url_ok": normalize_url(observed_url) == normalize_url(expected_url),
         "content_hash_ok": content_hash_ok,
+        "excerpt_presence_ok": excerpt_presence_ok,
+        "excerpt_presence_rate": excerpt_presence_rate,
         "reason": reason,
     }
 
 
-def _cache_content_hash(knowledge_root: str, url: str) -> str:
-    """The authoritative `content_hash` (`sha256:<hex>`) for `url` from the
-    knowledge base's fetch-cache, by shelling to `fetch-cache.py fetch` (which
-    owns the cache layout — we never re-inline that, per the delegation
-    contract). Returns "" on any cache miss / non-zero exit / unparseable
-    envelope / missing field, so the content_hash leg simply skips rather than
-    false-flagging. No `--max-age-days` — a stale-but-present entry is still the
-    authoritative body hash; staleness must not suppress the integrity check."""
+def _cache_entry(knowledge_root: str, url: str) -> dict:
+    """The authoritative fetch-cache entry for `url` from the knowledge base's
+    fetch-cache, by shelling to `fetch-cache.py fetch` (which owns the cache layout
+    — we never re-inline that, per the delegation contract). Returns {} on any
+    cache miss / non-zero exit / unparseable envelope, so both the content_hash and
+    excerpt-presence legs simply skip rather than false-flagging. No
+    `--max-age-days` — a stale-but-present entry is still the authoritative body +
+    hash; staleness must not suppress the integrity check.
+
+    Both legs read from the one entry this returns, so the sweep fires a single
+    subprocess per page rather than one per leg."""
     fetch_cache = Path(__file__).resolve().parent / "fetch-cache.py"
     try:
         proc = subprocess.run(
@@ -97,11 +114,11 @@ def _cache_content_hash(knowledge_root: str, url: str) -> str:
             capture_output=True, text=True,
         )
         if proc.returncode != 0:
-            return ""
+            return {}
         entry = json.loads(proc.stdout).get("data", {}).get("entry", {})
     except (OSError, json.JSONDecodeError):
-        return ""
-    return str(entry.get("content_hash", "") or "")
+        return {}
+    return entry if isinstance(entry, dict) else {}
 
 
 def _read_dispatch(path_arg: str) -> list[dict]:
@@ -114,11 +131,14 @@ def _read_dispatch(path_arg: str) -> list[dict]:
 
 def cmd_sweep(args: argparse.Namespace) -> int:
     wiki_root = Path(args.wiki_root)
-    knowledge_root = args.knowledge_root  # optional; None → content_hash leg off
+    knowledge_root = args.knowledge_root  # optional; None → content_hash + excerpt legs off
+    threshold = args.excerpt_threshold
     table = _read_dispatch(args.dispatch)
 
     ok: list[str] = []
     violations: list[dict] = []
+    excerpt_ok_total = 0      # claims whose excerpt_quote was present in its body
+    excerpt_claims_total = 0  # claims carrying an excerpt_quote that the leg scored
     for entry in table:
         slug = str(entry.get("slug", ""))
         expected_url = str(entry.get("url", ""))
@@ -133,40 +153,78 @@ def cmd_sweep(args: argparse.Namespace) -> int:
         id_ok = observed_id == slug
         url_ok = normalize_url(observed_url) == normalize_url(expected_url)
 
-        # content_hash leg — additive, only when --knowledge-root is given. Skip
-        # (== ok) on a cache miss / empty hash on either side, so it never
-        # produces a false positive; compares the cache entry's authoritative
-        # body hash against the page's frontmatter content_hash, NOT a recomputed
-        # on-disk hash (which diverges by design once trailers are appended).
+        # content_hash + excerpt-presence legs — additive, only when
+        # --knowledge-root is given. Both read the one shared fetch-cache entry
+        # (one subprocess per page). Each leg skips (== ok) on a cache miss /
+        # empty side so it never produces a false positive.
         observed_ch = ""
         expected_ch = ""
         content_hash_ok = True
+        excerpt_presence_ok = True
+        excerpt_presence_rate: float | None = None
         if knowledge_root:
+            cache_entry = _cache_entry(knowledge_root, expected_url)
+            cached_body = str(cache_entry.get("body", "") or "")
+
+            # content_hash leg — compares the cache entry's authoritative body
+            # hash against the page's frontmatter content_hash, NOT a recomputed
+            # on-disk hash (which diverges by design once trailers are appended).
             observed_ch = extract_page_content_hash(page_text)
-            expected_ch = _cache_content_hash(knowledge_root, expected_url)
+            expected_ch = str(cache_entry.get("content_hash", "") or "")
             content_hash_ok = (
                 not observed_ch or not expected_ch or observed_ch == expected_ch
             )
 
-        if id_ok and url_ok and content_hash_ok:
+            # excerpt-presence leg — for every claim carrying a non-empty
+            # excerpt_quote, assert the quote is a substring of the cached source
+            # body. This catches the variant where id/sources/content_hash all
+            # conform but a claim's excerpt_quote was extracted from a sibling's
+            # body (cross-wave attention cross-talk). Fail-safe: a cache miss
+            # (empty body) or a page whose claims carry no excerpt_quote skips the
+            # leg as ok, leaving the rate None (the leg did not score).
+            if cached_body:
+                quotes = [
+                    q for claim in parse_pre_extracted_claims(page_text)
+                    if (q := str(claim.get("excerpt_quote", "") or "").strip())
+                ]
+                if quotes:
+                    present = sum(1 for q in quotes if q in cached_body)
+                    excerpt_presence_rate = present / len(quotes)
+                    excerpt_presence_ok = excerpt_presence_rate >= threshold
+                    excerpt_ok_total += present
+                    excerpt_claims_total += len(quotes)
+
+        if id_ok and url_ok and content_hash_ok and excerpt_presence_ok:
             ok.append(slug)
             continue
 
         # Reason precedence: id/url are the loud wholesale signals; content_hash
-        # is the narrow body-only one a page that passes id+url can still fail.
+        # is the narrow body-only one a page that passes id+url can still fail;
+        # excerpt_presence is the narrowest claim-level one (id/url/content_hash
+        # all conform, but a claim's excerpt_quote is absent from the body).
         # When both id+url are wrong (the cross-contamination signature) prefer
         # id_mismatch — it is the conformance-gate name and the loudest signal.
         if not id_ok:
             reason = "id_mismatch"
         elif not url_ok:
             reason = "url_mismatch"
-        else:
+        elif not content_hash_ok:
             reason = "content_hash_mismatch"
+        else:
+            reason = "excerpt_presence_below_threshold"
         violations.append(_violation(wiki_root, slug, expected_url, reason,
                                      observed_id, observed_url,
-                                     observed_ch, expected_ch, content_hash_ok))
+                                     observed_ch, expected_ch, content_hash_ok,
+                                     excerpt_presence_ok, excerpt_presence_rate))
 
-    return _emit(True, data={"checked": len(table), "ok": ok, "violations": violations})
+    # Per-run excerpt-presence rate across every scored claim (None when the leg
+    # was off — no --knowledge-root — or every page was a cache miss / claimless).
+    excerpt_presence_rate_overall = (
+        excerpt_ok_total / excerpt_claims_total if excerpt_claims_total else None
+    )
+    return _emit(True, data={"checked": len(table), "ok": ok,
+                             "violations": violations,
+                             "excerpt_presence_rate": excerpt_presence_rate_overall})
 
 
 def main(argv=None) -> int:
@@ -186,9 +244,20 @@ def main(argv=None) -> int:
     p_sweep.add_argument(
         "--knowledge-root", default=None,
         help="Knowledge-base root (the dir holding .cogni-knowledge/). When set, "
-             "enables the content_hash leg: each page's frontmatter content_hash "
-             "is asserted against the fetch-cache entry for the dispatched URL. "
+             "enables the content_hash and excerpt-presence legs: each page's "
+             "frontmatter content_hash is asserted against the fetch-cache entry "
+             "for the dispatched URL, and each pre_extracted_claims[] excerpt_quote "
+             "is asserted to be a substring of that entry's cached body. "
              "Omit for the id/sources-only sweep (unchanged behavior).",
+    )
+    p_sweep.add_argument(
+        "--excerpt-threshold", type=float, default=0.95,
+        help="Excerpt-presence rate (0.0-1.0) a page must clear when "
+             "--knowledge-root is given: the fraction of its pre_extracted_claims[] "
+             "excerpt_quote strings that are substrings of the cached source body. "
+             "A page below this rate is a excerpt_presence_below_threshold violation "
+             "the orchestrator quarantines (default 0.95). No effect without "
+             "--knowledge-root.",
     )
     p_sweep.set_defaults(func=cmd_sweep)
 

--- a/cogni-knowledge/tests/test_ingest_integrity.sh
+++ b/cogni-knowledge/tests/test_ingest_integrity.sh
@@ -237,6 +237,124 @@ assert set(d["ok"])=={"ch-good","ch-bad","ch-nocache"}, d["ok"]
 ' && green "PASS: no --knowledge-root -> content_hash leg off (today behavior)" \
   || { red "FAIL: backwards-compat broke"; echo "$OUT_NOKR"; errors=$((errors+1)); }
 
+# --- excerpt-presence leg (--knowledge-root, grounding L1) --------------------
+# The claim-level variant: id + sources URL + content_hash all conform, but a
+# claim's excerpt_quote is absent from the page's cached source body (cross-wave
+# attention cross-talk wrote one source's quote onto another's page). These
+# pages carry pre_extracted_claims: and NO content_hash: line, so the id/url and
+# (no-op) content_hash legs all pass and only the excerpt-presence leg fires.
+write_page_ep() {  # $1=slug $2=url $3=claims-block (YAML under pre_extracted_claims:)
+  cat > "$KR_WIKI/wiki/sources/$1.md" <<EOF
+---
+id: $1
+title: "Page for $1"
+type: source
+created: 2026-01-01
+updated: 2026-01-01
+sources: ["$2"]
+pre_extracted_claims:
+$3
+---
+
+# Page for $1
+
+The grounding surface is the cached source body, not this rendered body.
+EOF
+}
+
+EP_BODY="Recital text. Article 6 designates certain AI systems as high-risk under Annex III of the Regulation."
+GOOD_QUOTE="certain AI systems as high-risk"
+BAD_QUOTE="this excerpt appears in no cached body"
+
+GOOD_CLAIMS="  - id: clm-001
+    text: \"AI Act high-risk classification\"
+    excerpt_quote: \"$GOOD_QUOTE\""
+BAD_CLAIMS="  - id: clm-001
+    text: \"Claim grounded in the wrong body\"
+    excerpt_quote: \"$BAD_QUOTE\""
+PARTIAL_CLAIMS="  - id: clm-001
+    text: \"Present claim\"
+    excerpt_quote: \"$GOOD_QUOTE\"
+  - id: clm-002
+    text: \"Absent claim\"
+    excerpt_quote: \"$BAD_QUOTE\""
+
+# ep-good: single claim, excerpt present in cached body -> rate 1.0, ok
+store_cache_entry "https://europa.eu/ep-good" "$EP_BODY" >/dev/null
+write_page_ep ep-good "https://europa.eu/ep-good" "$GOOD_CLAIMS"
+# ep-bad: single claim, excerpt absent -> rate 0.0, below-threshold violation
+store_cache_entry "https://europa.eu/ep-bad" "$EP_BODY" >/dev/null
+write_page_ep ep-bad "https://europa.eu/ep-bad" "$BAD_CLAIMS"
+# ep-partial: 2 claims (1 present, 1 absent) -> rate 0.5, below default 0.95
+store_cache_entry "https://europa.eu/ep-partial" "$EP_BODY" >/dev/null
+write_page_ep ep-partial "https://europa.eu/ep-partial" "$PARTIAL_CLAIMS"
+# ep-nocache: claim present-looking, but NO cache entry for its URL (miss) -> skip
+write_page_ep ep-nocache "https://europa.eu/ep-nocache" "$GOOD_CLAIMS"
+
+EP_DISPATCH="$WORK/ep-dispatch.json"
+cat > "$EP_DISPATCH" <<'EOF'
+[
+  {"slug": "ep-good", "url": "https://europa.eu/ep-good"},
+  {"slug": "ep-bad", "url": "https://europa.eu/ep-bad"},
+  {"slug": "ep-partial", "url": "https://europa.eu/ep-partial"},
+  {"slug": "ep-nocache", "url": "https://europa.eu/ep-nocache"}
+]
+EOF
+
+# 9) excerpt-presence leg: ep-bad/ep-partial below threshold, ep-good/ep-nocache ok,
+#    per-run aggregate rate emitted.
+OUT_EP="$(python3 "$SCRIPT" sweep --wiki-root "$KR_WIKI" --knowledge-root "$KR" --dispatch "$EP_DISPATCH")"
+echo "$OUT_EP" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)["data"]
+v={x["slug"]:x for x in d["violations"]}
+# positive: every excerpt present -> ok
+assert "ep-good" in d["ok"], d
+assert "ep-good" not in v, v
+# absent excerpt: id/url/content_hash ok but excerpt-presence fails
+e=v["ep-bad"]
+assert e["id_ok"] is True and e["url_ok"] is True and e["content_hash_ok"] is True, e
+assert e["excerpt_presence_ok"] is False, e
+assert e["reason"]=="excerpt_presence_below_threshold", e
+assert e["excerpt_presence_rate"]==0.0, e
+# partial: one of two excerpts present -> rate 0.5, below default 0.95
+p=v["ep-partial"]
+assert p["excerpt_presence_ok"] is False, p
+assert abs(p["excerpt_presence_rate"]-0.5)<1e-9, p
+assert p["reason"]=="excerpt_presence_below_threshold", p
+# cache miss: leg skips -> ok despite the claim
+assert "ep-nocache" in d["ok"], d
+assert "ep-nocache" not in v, v
+# per-run aggregate: present 1(good)+0(bad)+1(partial)=2 over 1+1+2=4 scored claims
+assert abs(d["excerpt_presence_rate"]-0.5)<1e-9, d["excerpt_presence_rate"]
+' && green "PASS: excerpt-presence leg flags absent/partial quotes, skips on cache miss, reports per-run rate" \
+  || { red "FAIL: excerpt-presence leg wrong"; echo "$OUT_EP"; errors=$((errors+1)); }
+
+# 10) --excerpt-threshold lowers the bar: ep-partial (0.5) now passes, ep-bad (0.0) still fails
+OUT_EP_THR="$(python3 "$SCRIPT" sweep --wiki-root "$KR_WIKI" --knowledge-root "$KR" --excerpt-threshold 0.4 --dispatch "$EP_DISPATCH")"
+echo "$OUT_EP_THR" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)["data"]
+slugs={x["slug"] for x in d["violations"]}
+assert "ep-partial" not in slugs, slugs        # 0.5 >= 0.4 now ok
+assert "ep-partial" in d["ok"], d
+assert "ep-bad" in slugs, slugs                # 0.0 < 0.4 still fails
+assert "ep-good" in d["ok"], d
+' && green "PASS: --excerpt-threshold tunes the gate (0.4 passes the 0.5 page, fails the 0.0 page)" \
+  || { red "FAIL: --excerpt-threshold not honored"; echo "$OUT_EP_THR"; errors=$((errors+1)); }
+
+# 11) backwards compat: WITHOUT --knowledge-root the excerpt leg is off, so the
+#     ep pages (id+url match, no content_hash) report zero violations and a null rate.
+OUT_EP_NOKR="$(python3 "$SCRIPT" sweep --wiki-root "$KR_WIKI" --dispatch "$EP_DISPATCH")"
+echo "$OUT_EP_NOKR" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)["data"]
+assert d["violations"]==[], d["violations"]
+assert set(d["ok"])=={"ep-good","ep-bad","ep-partial","ep-nocache"}, d["ok"]
+assert d["excerpt_presence_rate"] is None, d["excerpt_presence_rate"]
+' && green "PASS: no --knowledge-root -> excerpt leg off, rate null (today behavior)" \
+  || { red "FAIL: excerpt backwards-compat broke"; echo "$OUT_EP_NOKR"; errors=$((errors+1)); }
+
 if [ "$errors" -eq 0 ]; then
   green "ALL TESTS PASS"
   exit 0


### PR DESCRIPTION
## Summary

Adds a deterministic excerpt-presence sweep leg to `cogni-knowledge/scripts/ingest-integrity.py` (grounding L1) — verifies that each pre-extracted claim's `excerpt_quote` is actually present in the cached source body, catching fabricated or drifted excerpts at ingest time without any model call.

This is the grounding-L1 child of epic #876 (knowledge-pipeline uplift). It is a pure structural/deterministic check — no network, stdlib-only, consistent with the cross-plugin script contract.

## Changes

- `ingest-integrity.py` — new excerpt-presence leg in the integrity sweep (+135/−35)
- `tests/test_ingest_integrity.sh` — new coverage for the leg (all assertions pass)
- `cogni-knowledge/.claude-plugin/plugin.json` + `marketplace.json` — version bump (1.0.27)

## Provenance

Work was implemented and committed by an earlier autonomous `service-resolve` run; its push was held by the Step 7.5 `--strict` token-scope preflight under the prior classic PAT. With the runner now on a fine-grained PAT (preflight skips), the pristine single-commit branch is pushed and opened here unchanged.

Closes #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)
