### PR TITLE
cogni-knowledge: orchestrator-measured serial_tail for compose + verify

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.35",
+      "version": "1.0.36",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/references/run-metrics-wiring.md
+++ b/cogni-knowledge/references/run-metrics-wiring.md
@@ -72,17 +72,59 @@ phase can see. For a fan-out phase the pattern is **init → accumulate → pass
 3. **Pass** — at phase exit, pass `--max-agent-duration-ms <MAX_DURATION_MS>` to
    `run-metrics.py record`.
 
-**The agent must self-report `duration_ms` for this to be non-zero.** An agent
-self-captures a start timestamp only if it has the `Bash` tool — e.g.
+### Option A — agent self-reports `duration_ms`
+
+An agent self-captures a start timestamp only if it has the `Bash` tool — e.g.
 `START_MS=$(python3 -c 'import time; print(int(time.time()*1000))')` in its load
 phase, then `duration_ms = int(time.time()*1000) - START_MS` in its return
 envelope. `source-ingester` (the `ingest` phase) and `source-curator` (the
-`curate` phase) follow this pattern and are the live examples. A fan-out phase
-whose agents lack the `Bash` tool, and therefore cannot self-capture a start
-clock, has two options: give those agents the tool so they self-report, or have
-the orchestrator measure each dispatched task's wall clock itself (it already
-has `Bash`); until one is chosen, that phase's agents contribute `0` and the row
-stores `max_agent_duration_ms: 0` — honest, not misleading.
+`curate` phase) follow this pattern and are the live examples. Under Option A the
+orchestrator's **accumulate** step (above) reads each agent's reported
+`duration_ms` directly.
+
+### Option B — orchestrator measures each dispatch's wall clock
+
+A fan-out phase whose agents lack the `Bash` tool cannot self-capture a start
+clock, so the orchestrator (which already has `Bash`) measures each dispatched
+`Task`'s wall clock itself. This is the chosen mechanism for the **`compose`**
+and **`verify`** phases — `wiki-composer` / `wiki-verifier` / `revisor` have no
+`Bash` tool (the `revisor` dropped it deliberately for its zero-network
+contract), so giving them the tool just to instrument a metric was rejected in
+favour of orchestrator-side timing. The init → accumulate → pass shape is
+identical; only the *source* of each `duration_ms` differs.
+
+- **Per-dispatch (serial)** — stamp immediately before each `Task` and fold
+  immediately after it returns:
+
+  ```
+  START_MS=$(python3 -c 'import time; print(int(time.time()*1000))')
+  # … Task(agent, …) …
+  MAX_DURATION_MS=$(python3 -c "import time; print(max($MAX_DURATION_MS, int(time.time()*1000) - $START_MS))")
+  ```
+
+  `knowledge-compose` (the single composer dispatch + the optional Step 5.5
+  expansion re-dispatch) and `knowledge-verify`'s serial revisor rounds use this
+  form.
+
+- **Per-wave (parallel fan-out)** — stamp once before the single-message batch
+  of N `Task` calls, and fold the **batch** wall-clock once after all N return:
+
+  ```
+  WAVE_START_MS=$(python3 -c 'import time; print(int(time.time()*1000))')
+  # … one message: Task(agent, shard 1) … Task(agent, shard N) … (all return) …
+  MAX_DURATION_MS=$(python3 -c "import time; print(max($MAX_DURATION_MS, int(time.time()*1000) - $WAVE_START_MS))")
+  ```
+
+  `knowledge-verify`'s parallel `wiki-verifier` shard wave (Step 3.1c) uses this
+  form. The batch elapsed is **one timing sample for the whole wave** — an upper
+  bound on the slowest individual shard, not a per-shard max — but because a
+  parallel wave's wall-clock *is* the slowest shard's wall-clock, it is exactly
+  the per-phase `max` the serial-tail figure needs. Fail-soft throughout: an
+  unset `START_MS`/`WAVE_START_MS` contributes `0` and never aborts the phase.
+
+A phase whose agents lack `Bash` and that has **not yet** adopted Option B
+contributes `0` and the row stores `max_agent_duration_ms: 0` — honest, not
+misleading.
 
 ## Reading it back
 

--- a/cogni-knowledge/skills/knowledge-compose/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-compose/SKILL.md
@@ -115,6 +115,8 @@ Parse `data.binding.wiki_path` as `WIKI_ROOT`. Confirm `<WIKI_ROOT>/.cogni-wiki/
 
   Parse the envelope: on `success: true` read `data.ingested_count`. If it is `0`, abort with "no wiki sources cover this plan's sub-questions — ingest more sources (knowledge-ingest), broaden the plan, or check the bound wiki". On `success: false`, surface `error` and abort. The synthesized manifest carries `source_mode: "wiki"` and the same `ingested[]` shape (`{url, slug, title, publisher, summary, claims_extracted, sub_question_refs[]}`) the web path produces, so **Steps 1–7 run identically** — the composer reads it in Step 4 with no awareness it was wiki-sourced. `INGESTED_SOURCES` for the dry-run/summary is `data.ingested_count`.
 
+**Phase timing accumulators.** Capture `PHASE_START=$(date -u +%FT%TZ)` (the phase wall-clock the Step 8 ledger records) **and** initialise `MAX_DURATION_MS=0` (the slowest single composer dispatch, the orchestrator-measured Option B serial-tail signal) now, at the top of the run. They are run-level — set once here so a run that also re-dispatches the composer in Step 5.5 folds across both dispatches. The composer agents (`wiki-composer`) have no `Bash` tool to self-report `duration_ms`, so this phase measures each dispatched `Task`'s wall-clock itself (Option B); see `references/run-metrics-wiring.md`.
+
 ### 1. Resolve draft version N
 
 ```
@@ -196,7 +198,7 @@ This central path is the **fallback layer**: `knowledge-ingest` Step 4.6.4 also 
 
 ### 4. Dispatch wiki-composer (single Task call)
 
-Dispatch via the `Task` tool (matches the upstream `knowledge-ingest` / `knowledge-fetch` agent-dispatch convention):
+Stamp `START_MS=$(python3 -c 'import time; print(int(time.time()*1000))')` immediately before the dispatch (the Option B per-dispatch timing — see Step 0 + `references/run-metrics-wiring.md`). Dispatch via the `Task` tool (matches the upstream `knowledge-ingest` / `knowledge-fetch` agent-dispatch convention):
 
 ```
 Task(wiki-composer,
@@ -216,7 +218,7 @@ Task(wiki-composer,
 
 Parse the return envelope:
 
-- `ok: true` → continue to Step 4.5 (build the manifest).
+- `ok: true` → fold this dispatch's wall-clock into the accumulator: `MAX_DURATION_MS=$(python3 -c "import time; print(max($MAX_DURATION_MS, int(time.time()*1000) - $START_MS))")` (fail-soft — an unset `START_MS` contributes 0, never aborts), then continue to Step 4.5 (build the manifest).
 - `ok: false, error: "no_ingested_sources"` → re-emit the abort message and stop (shouldn't happen if Step 0 ran, but defence-in-depth).
 - `ok: false, error: "write_failed"` → surface the reason; do not retry blindly. The composer already retried once internally. Direct the user to inspect output token-budget conditions or re-run.
 - `ok: false, error: "outline_write_failed"` → surface; no recovery in this slice (Phase 1 couldn't even land the outline).
@@ -351,7 +353,7 @@ print(",".join(chosen))
 
 Capture this as `EXPAND_SECTIONS`. **The gate fires iff `EXPAND_SECTIONS` is non-empty.** If it is empty — the deficit sub-questions map only to sections already at budget and not zero-cited — skip with `expansion skipped: no thin/zero-cited section maps to the uncited evidence` — deepening a section already at budget would only pad.
 
-**Re-dispatch the composer ONCE** at `N+1` in expansion mode (same knob values as Step 4). Its purpose is to deepen the named sections **from the specific not-yet-cited wiki evidence** for their sub-questions, not to close a word count:
+Stamp `START_MS=$(python3 -c 'import time; print(int(time.time()*1000))')` immediately before the re-dispatch (same Option B timing as Step 4). **Re-dispatch the composer ONCE** at `N+1` in expansion mode (same knob values as Step 4). Its purpose is to deepen the named sections **from the specific not-yet-cited wiki evidence** for their sub-questions, not to close a word count:
 
 ```
 Task(wiki-composer,
@@ -376,7 +378,7 @@ cp "<project_path>/.metadata/citation-manifest.json" \
    "<project_path>/.metadata/.citation-manifest.pre-expand.json"
 ```
 
-On `ok: true`, **re-run Step 4.5** (`citation-store.py build … --draft-version <N+1>` with the same `--ingest-manifest` gate, writing the canonical `citation-manifest.json` from `citation-records-v<N+1>.txt`) **and Step 5** (the on-disk verifier) against `v<N+1>`. **Accept check (load-bearing) — keep `v<N+1>` only when both pass AND the expansion added at least one grounded citation:** `data.citations_count` from the `v<N+1>` build must exceed the `data.citations_count` Step 4.5 captured for `vN` (the one authoritative citation count — `len(citation-manifest::citations)`, never an LLM tally). An expansion that grew the prose but added no new citation is **padding** → treated as a failure below; words alone never survive. On success, `v<N+1>` becomes the canonical latest draft — set `N := N+1` so Steps 6/7 report on it, then drop the now-stale snapshot:
+On `ok: true`, fold this dispatch's wall-clock into the accumulator: `MAX_DURATION_MS=$(python3 -c "import time; print(max($MAX_DURATION_MS, int(time.time()*1000) - $START_MS))")` (fail-soft, same as Step 4), then **re-run Step 4.5** (`citation-store.py build … --draft-version <N+1>` with the same `--ingest-manifest` gate, writing the canonical `citation-manifest.json` from `citation-records-v<N+1>.txt`) **and Step 5** (the on-disk verifier) against `v<N+1>`. **Accept check (load-bearing) — keep `v<N+1>` only when both pass AND the expansion added at least one grounded citation:** `data.citations_count` from the `v<N+1>` build must exceed the `data.citations_count` Step 4.5 captured for `vN` (the one authoritative citation count — `len(citation-manifest::citations)`, never an LLM tally). An expansion that grew the prose but added no new citation is **padding** → treated as a failure below; words alone never survive. On success, `v<N+1>` becomes the canonical latest draft — set `N := N+1` so Steps 6/7 report on it, then drop the now-stale snapshot:
 
 ```
 rm -f "<project_path>/.metadata/.citation-manifest.pre-expand.json"
@@ -435,14 +437,15 @@ The advisory `wiki-reviewer` (finalize Step 10.7) independently re-scores the dr
 
 ### 8. Record run metrics (phase-exit ledger)
 
-Persist this phase's timing + cost to `<project_path>/.metadata/run-metrics.json` so the run leaves a durable per-phase ledger (read by `knowledge-resume` / `knowledge-dashboard` / a perf study). Capture `PHASE_START=$(date -u +%FT%TZ)` at the top of this skill's run (Step 0); then at exit:
+Persist this phase's timing + cost to `<project_path>/.metadata/run-metrics.json` so the run leaves a durable per-phase ledger (read by `knowledge-resume` / `knowledge-dashboard` / a perf study). Capture `PHASE_START=$(date -u +%FT%TZ)` and init `MAX_DURATION_MS=0` at the top of this skill's run (Step 0); the composer dispatches (Step 4, and Step 5.5 when it runs) fold their wall-clock into `MAX_DURATION_MS`; then at exit:
 
 ```
 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/run-metrics.py" record \
     --project-path "<project_path>" --phase compose \
     --started-at "$PHASE_START" --ended-at "$(date -u +%FT%TZ)" \
     --agent-count <1 composer, +1 if Step 5.5 expansion ran> \
-    --cost-usd <composer cost_estimate.estimated_usd (+ expansion when it ran)>
+    --cost-usd <composer cost_estimate.estimated_usd (+ expansion when it ran)> \
+    --max-agent-duration-ms <MAX_DURATION_MS — the slowest single composer dispatch (Option B orchestrator-measured)>
 ```
 
 Fail-soft — a record failure never blocks the phase. Full contract: `${CLAUDE_PLUGIN_ROOT}/references/run-metrics-wiring.md`.

--- a/cogni-knowledge/skills/knowledge-verify/SKILL.md
+++ b/cogni-knowledge/skills/knowledge-verify/SKILL.md
@@ -93,6 +93,8 @@ Parse `data.binding.wiki_path` as `WIKI_ROOT`. Confirm `<WIKI_ROOT>/.cogni-wiki/
 - `<project_path>/.metadata/citation-manifest.json` — "no citation manifest — run knowledge-compose first"
 - At least one `<project_path>/output/draft-v*.md` — "no draft on disk — run knowledge-compose first"
 
+**Phase timing accumulators.** Capture `PHASE_START=$(date -u +%FT%TZ)` (the phase wall-clock the Step 7 ledger records) **and** initialise `MAX_DURATION_MS=0` (the slowest dispatched agent, the orchestrator-measured Option B serial-tail signal) now, at the top of the run. They are run-level — set once here so the verifier shard wave (Step 3.1c) and every serial revisor round (Step 3.3) fold into the same accumulator. The verifier/revisor agents (`wiki-verifier`, `revisor`) have no `Bash` tool to self-report `duration_ms`, so this phase measures each dispatched `Task`'s wall-clock itself (Option B); for a parallel shard wave the batch wall-clock equals the slowest shard, which is exactly the per-phase max. See `references/run-metrics-wiring.md`.
+
 ### 0.5 Resolve MAX_ROUNDS
 
 Default `2`. If `--max-rounds` is passed:
@@ -231,7 +233,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/verify-store.py shard \
 
 `shard` runs **after** `prefilter` and preserves the prefilter fragment (its cleanup is scoped to numbered fragments). When `remaining_ids` is empty it writes zero shards (`shard_count: 0`) but still performs the cleanup. Capture `data.shard_count` and the `data.shards[]` rows — each carries a `citations_path` (hand to the verifier as `CITATIONS_PATH`) and a `verify_out_path` (hand it as `VERIFY_OUT_PATH`).
 
-**(c) Dispatch N verifiers in parallel.** If `data.shard_count == 0` (everything was pre-filtered or carried forward), skip dispatch and go to (d). Otherwise emit **one assistant message containing all N `Task(wiki-verifier, …)` calls** (this is what makes them run concurrently — the whole point of the fan-out). For each row in `data.shards[]`:
+**(c) Dispatch N verifiers in parallel.** If `data.shard_count == 0` (everything was pre-filtered or carried forward), skip dispatch and go to (d) — no dispatch, so nothing folds into `MAX_DURATION_MS` for this wave. Otherwise stamp `WAVE_START_MS=$(python3 -c 'import time; print(int(time.time()*1000))')` immediately before the batch (the Option B per-wave timing — see Step 0), then emit **one assistant message containing all N `Task(wiki-verifier, …)` calls** (this is what makes them run concurrently — the whole point of the fan-out). For each row in `data.shards[]`:
 
 ```
 Task(wiki-verifier,
@@ -245,7 +247,7 @@ Task(wiki-verifier,
 
 `wiki-verifier` lives at `${CLAUDE_PLUGIN_ROOT}/agents/wiki-verifier.md` — dispatched via `Task`, not `Skill`. Single-pass, zero-network — each instance reads the wiki and writes its own fragment to `VERIFY_OUT_PATH`. Parse each return envelope:
 
-- `ok: true` → fragment written; proceed once all shards return.
+- `ok: true` → fragment written; once **all** shards return, fold the wave's batch wall-clock into the accumulator: `MAX_DURATION_MS=$(python3 -c "import time; print(max($MAX_DURATION_MS, int(time.time()*1000) - $WAVE_START_MS))")` (the parallel-wave batch wall-clock equals the slowest shard, exactly the per-phase max; fail-soft — an unset `WAVE_START_MS` contributes 0), then proceed to (d).
 - `ok: false, error: "manifest_mismatch"` → re-emit the stale-manifest abort message and stop (defence-in-depth; Step 2 should have caught this).
 - `ok: false, error: "write_failed"` → surface verbatim; do not retry blindly (the verifier already retried once internally).
 
@@ -329,7 +331,7 @@ cp "<project_path>/.metadata/citation-manifest.json" \
    "<project_path>/.metadata/.citation-manifest.pre-r<REVISION_ROUND>.json"
 ```
 
-The draft `cp` guarantees every sentence the revisor does **not** touch is byte-identical across versions — the precondition for Step 3.1's round-≥1 carry-forward. Then dispatch:
+The draft `cp` guarantees every sentence the revisor does **not** touch is byte-identical across versions — the precondition for Step 3.1's round-≥1 carry-forward. Stamp `START_MS=$(python3 -c 'import time; print(int(time.time()*1000))')` immediately before the dispatch (the Option B per-round revisor timing — see Step 0). Then dispatch:
 
 ```
 Task(revisor,
@@ -343,7 +345,7 @@ Task(revisor,
 
 Parse the return envelope:
 
-- `ok: true` → **build the manifest from the revisor's records.** The revisor wrote `citation-records-v<NEW_DRAFT_VERSION>.txt`, not the manifest (so a rephrased German `„…"` sentence can't break `json.loads`). Serialize + self-check it exactly as Phase 5 does — pass each path as a **quoted literal CLI arg**, never a command-prefix env-var form (a `RECORDS_PATH=… python3 … --records "$RECORDS_PATH"` prefix expands `"$RECORDS_PATH"` before the assignment takes effect, so `--records` gets an empty string and the build aborts):
+- `ok: true` → fold this round's wall-clock into the accumulator: `MAX_DURATION_MS=$(python3 -c "import time; print(max($MAX_DURATION_MS, int(time.time()*1000) - $START_MS))")` (fail-soft — an unset `START_MS` contributes 0). Then **build the manifest from the revisor's records.** The revisor wrote `citation-records-v<NEW_DRAFT_VERSION>.txt`, not the manifest (so a rephrased German `„…"` sentence can't break `json.loads`). Serialize + self-check it exactly as Phase 5 does — pass each path as a **quoted literal CLI arg**, never a command-prefix env-var form (a `RECORDS_PATH=… python3 … --records "$RECORDS_PATH"` prefix expands `"$RECORDS_PATH"` before the assignment takes effect, so `--records` gets an empty string and the build aborts):
 
   ```
   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/citation-store.py build \
@@ -468,14 +470,15 @@ If the verifier surfaced `missing_pages[]`, surface `⚠ Missing pages: <slug1>,
 
 ### 7. Record run metrics (phase-exit ledger)
 
-Persist this phase's timing + cost to `<project_path>/.metadata/run-metrics.json` so the run leaves a durable per-phase ledger (read by `knowledge-resume` / `knowledge-dashboard` / a perf study). Capture `PHASE_START=$(date -u +%FT%TZ)` at the top of this skill's run (Step 0); then at exit:
+Persist this phase's timing + cost to `<project_path>/.metadata/run-metrics.json` so the run leaves a durable per-phase ledger (read by `knowledge-resume` / `knowledge-dashboard` / a perf study). Capture `PHASE_START=$(date -u +%FT%TZ)` and init `MAX_DURATION_MS=0` at the top of this skill's run (Step 0); the verifier shard wave (Step 3.1c) and each serial revisor round (Step 3.3) fold their wall-clock into `MAX_DURATION_MS`; then at exit:
 
 ```
 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/run-metrics.py" record \
     --project-path "<project_path>" --phase verify \
     --started-at "$PHASE_START" --ended-at "$(date -u +%FT%TZ)" \
     --agent-count <verifier shards dispatched + revisor rounds> \
-    --cost-usd <summed cost_estimate.estimated_usd across all verifier + revisor dispatches>
+    --cost-usd <summed cost_estimate.estimated_usd across all verifier + revisor dispatches> \
+    --max-agent-duration-ms <MAX_DURATION_MS — slowest verifier wave (= slowest shard) or revisor round (Option B orchestrator-measured)>
 ```
 
 Fail-soft — a record failure never blocks the phase. Full contract: `${CLAUDE_PLUGIN_ROOT}/references/run-metrics-wiring.md`.


### PR DESCRIPTION
Closes #889.

## Summary

Brings the **compose** and **verify** phases to parity with curate/ingest on the serial-tail signal, completing the remaining half of #889 (curate + ingest already wired it; the maintainer chose **Option B** — orchestrator-measured wall-clock, no agent tool change).

- **knowledge-compose** — init `MAX_DURATION_MS=0` at Step 0; stamp `START_MS` before the Step 4 composer dispatch and the Step 5.5 expansion re-dispatch, fold `max()` after each returns; pass `--max-agent-duration-ms <MAX_DURATION_MS>` in the Step 8 record block.
- **knowledge-verify** — init at Step 0; for the parallel `wiki-verifier` shard wave (Step 3.1c) stamp `WAVE_START_MS` before the batch and fold the batch wall-clock (= slowest shard = per-phase max) after all return; time each serial revisor round (Step 3.3) per-dispatch and fold; pass `--max-agent-duration-ms <MAX_DURATION_MS>` in the Step 7 record block.
- **references/run-metrics-wiring.md** — split the section into **Option A** (agent self-report) and a new **Option B** (orchestrator-measured) subsection with per-dispatch + per-wave idioms, and reconcile the prior "two options / until one is chosen" note now that compose+verify chose B.
- Bump cogni-knowledge **1.0.35 → 1.0.36** (plugin.json + marketplace.json).

## Scope decisions

This is the full remaining scope of #889. No tool change to `wiki-composer` / `wiki-verifier` / `revisor` (the revisor's zero-network contract stays intact). No `run-metrics.py` or `tests/test_run_metrics.sh` change — the `--max-agent-duration-ms` contract is already implemented and asserted.

## Test plan

- `cogni-knowledge/tests/test_run_metrics.sh` — all assertions green (unchanged; verified).
- `plugin.json` + `marketplace.json` both parse and read `1.0.36`.
- Maintainer-breadcrumb guard clean (0 new violations).
- (Manual) A fresh end-to-end run should now produce a non-zero `max_agent_duration_ms` on compose + verify rows, so `run-metrics.py report` shows a real per-phase `serial_tail`.

## Review notes (pre-existing drift — not introduced by this change)

The pre-commit skill-quality gate flagged accumulated drift the timing change did not touch and did not widen scope to fix:

- Both `knowledge-compose` and `knowledge-verify` carry oversized `frontmatter.description` blocks and modestly over-cap bodies — accumulated across many prior edits (`introduced_by_change: false`).
- `knowledge-verify` body carries two pre-existing `C3` finding-code references (Parameters table + a §3.1 callout). These are already in the breadcrumb baseline, so CI stays green; a future focused cleanup can delete the codes and state the per-shard cost target semantically.