### PR TITLE
cogni-knowledge: scale retrieval baseline to 31 labelled queries (closes #916, closes #911)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.39",
+      "version": "1.0.40",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/references/retrieval-baseline.json
+++ b/cogni-knowledge/references/retrieval-baseline.json
@@ -1,41 +1,45 @@
 {
   "schema": "cogni-knowledge/retrieval-baseline/1.0",
-  "description": "Committed retrieval-quality baseline (hit@1/hit@5/MRR) produced by scripts/retrieval-eval.py over wiki-grounding.py rank. Addresses review finding F5 — turns the prior N=3 prose smoke sample into a durable, versioned before/after artifact for the deferred retrieval redesign.",
+  "description": "Committed retrieval-quality baseline (hit@1/hit@5/MRR) produced by scripts/retrieval-eval.py over wiki-grounding.py rank. Addresses review finding F5 and its scale-up follow-up — the labelled set is now scaled from 12 to 31 queries (12 question-node-seeded + 19 authored held-out queries with hand-validated ground truth), giving a statistically firmer before/after for the deferred retrieval redesign.",
   "harness": {
     "script": "cogni-knowledge/scripts/retrieval-eval.py",
-    "command": "eval --wiki-root <base> --reseed",
+    "command": "eval --wiki-root <base> --eval-set references/retrieval-eval-set-<base>.json",
     "threshold": 0.2,
-    "metric_ground_truth": "wiki/questions/*.md sources_answering: (the answering source-page set per question node)"
+    "metric_ground_truth": "the committed per-base eval-set files references/retrieval-eval-set-<base>.json (expected_slugs = the hand-validated answering source-page set per query); the seeded subset originates from each base's wiki/questions/*.md sources_answering:"
   },
   "corpus": {
-    "note": "Eval corpus is the bound alpha knowledge bases under .alpha/ — these are gitignored local alpha data, NOT version-controlled in this repo. The numbers below are a snapshot measured against those bases. Exact reproduction requires the same .alpha/ bases. See retrieval-baseline.md OPEN QUESTION on whether to commit a checked-in eval fixture for full third-party reproducibility.",
+    "note": "Eval corpus is the bound alpha knowledge bases under .alpha/ — these are gitignored local alpha data, NOT version-controlled in this repo. The numbers below are a snapshot measured against those bases (the maintainer-accepted Option-1 reproducibility posture: the committed eval-set files document the labelled queries + ground truth; exact reproduction requires the same .alpha/ bases on disk). See retrieval-baseline.md.",
     "bases_used": [
       ".alpha/eu-ai-act-sme",
       ".alpha/perf-cra-2",
       ".alpha/perf-cra"
     ],
-    "bases_qualifying_reason": "only these bound bases carry labelled wiki/questions/*.md nodes with non-empty sources_answering"
+    "bases_qualifying_reason": "only these bound bases carry source corpora large enough to author a labelled eval set against"
   },
-  "captured_run_at": "2026-06-21T10:25:19Z",
-  "n_labelled_queries": 12,
-  "scale_note": "12 labelled queries = the COMPLETE labelled corpus across all bound bases. The brief aspired to ~20-50; reaching that requires authoring held-out ground-truth queries (domain-expert work) — tracked as a deferred follow-up.",
+  "captured_run_at": "2026-06-21T11:45:00Z",
+  "n_labelled_queries": 31,
+  "scale_note": "31 labelled queries (12 question-node-seeded + 19 authored held-out). Meets the brief's aspired ~20-50 range. The seeded subset reproduces the prior 12-query baseline (e.g. eu-ai-act-sme still 3/6 null on hit@5), confirming harness stability across the scale-up. Reproducibility decision: Option 1 (alpha-corpus snapshot).",
   "aggregate": {
-    "n_queries": 12,
-    "hit_at_1": 0.4167,
-    "hit_at_5": 0.75,
-    "mrr": 0.5486
+    "n_queries": 31,
+    "hit_at_1": 0.5806,
+    "hit_at_5": 0.8065,
+    "mrr": 0.6909
   },
   "per_base": [
     {
       "base": "eu-ai-act-sme",
       "wiki_root": ".alpha/eu-ai-act-sme",
+      "eval_set": "references/retrieval-eval-set-eu-ai-act-sme.json",
       "pages_scanned": 58,
-      "n_queries": 6,
-      "hit_at_1": 0.3333,
-      "hit_at_5": 0.5,
-      "mrr": 0.4167,
+      "n_queries": 15,
+      "n_seeded_queries": 6,
+      "n_authored_queries": 9,
+      "hit_at_1": 0.6,
+      "hit_at_5": 0.7333,
+      "mrr": 0.6667,
       "per_query": [
         {
+          "query": "EU AI Act Anwendungsbereich KMU: Wer ist Anbieter, wer Betreiber, und welche kleinen und mittleren Unternehmen sind betroffen?",
           "theme_label": "Anwendungsbereich und Rollen",
           "source_node": "anwendungsbereich-und-rollen",
           "rank_of_first_relevant": null,
@@ -45,6 +49,7 @@
           "n_expected_slugs": 11
         },
         {
+          "query": "EU AI Act Fristen und Inkrafttreten: gestaffelte Geltungsbeginn-Termine 2025, 2026, 2027 für die einzelnen Pflichten",
           "theme_label": "Fristen und Inkrafttreten",
           "source_node": "fristen-und-inkrafttreten",
           "rank_of_first_relevant": 1,
@@ -54,6 +59,7 @@
           "n_expected_slugs": 11
         },
         {
+          "query": "EU AI Act KI-Kompetenz (AI literacy) und Pflichten für General-Purpose-AI (GPAI): was müssen KMU beachten, die KI-Modelle wie ChatGPT einsetzen?",
           "theme_label": "KI-Kompetenz und GPAI-Pflichten",
           "source_node": "ki-kompetenz-und-gpai-pflichten",
           "rank_of_first_relevant": 2,
@@ -63,6 +69,7 @@
           "n_expected_slugs": 12
         },
         {
+          "query": "EU AI Act Pflichten für Hochrisiko-KI-Systeme: Konformitätsbewertung, Risikomanagement, Dokumentation und menschliche Aufsicht für Anbieter und Betreiber",
           "theme_label": "Pflichten nach Risikoklasse",
           "source_node": "pflichten-nach-risikoklasse",
           "rank_of_first_relevant": null,
@@ -72,6 +79,7 @@
           "n_expected_slugs": 11
         },
         {
+          "query": "EU AI Act Risikoklassifizierung: verbotene Praktiken, Hochrisiko-KI, begrenztes und minimales Risiko – wie ordnen KMU ihre KI-Systeme ein?",
           "theme_label": "Risikoklassifizierung",
           "source_node": "risikoklassifizierung",
           "rank_of_first_relevant": 1,
@@ -81,6 +89,7 @@
           "n_expected_slugs": 10
         },
         {
+          "query": "EU AI Act praktische Umsetzung für KMU: Governance-Schritte, Sanktionen und KMU-Erleichterungen wie Reallabore und reduzierte Gebühren",
           "theme_label": "Umsetzung, Sanktionen und KMU-Erleichterungen",
           "source_node": "umsetzung-sanktionen-und-kmu-erleichterungen",
           "rank_of_first_relevant": null,
@@ -88,19 +97,113 @@
           "hit_at_1": 0,
           "hit_at_5": 0,
           "n_expected_slugs": 10
+        },
+        {
+          "query": "Welche Sanktionen und Bußgelder drohen bei Verstößen gegen die KI-Verordnung?",
+          "theme_label": "Sanktionen",
+          "source_node": null,
+          "rank_of_first_relevant": null,
+          "reciprocal_rank": 0.0,
+          "hit_at_1": 0,
+          "hit_at_5": 0,
+          "n_expected_slugs": 2
+        },
+        {
+          "query": "What are the human oversight requirements for high-risk AI systems under Article 14?",
+          "theme_label": "Human oversight",
+          "source_node": null,
+          "rank_of_first_relevant": 1,
+          "reciprocal_rank": 1.0,
+          "hit_at_1": 1,
+          "hit_at_5": 1,
+          "n_expected_slugs": 2
+        },
+        {
+          "query": "Welche technische Dokumentation müssen Anbieter von Hochrisiko-KI nach Artikel 11 erstellen?",
+          "theme_label": "Dokumentationspflichten",
+          "source_node": null,
+          "rank_of_first_relevant": 1,
+          "reciprocal_rank": 1.0,
+          "hit_at_1": 1,
+          "hit_at_5": 1,
+          "n_expected_slugs": 2
+        },
+        {
+          "query": "What is a regulatory sandbox under the AI Act and how can SMEs benefit (Article 57)?",
+          "theme_label": "Reallabore / Sandboxes",
+          "source_node": null,
+          "rank_of_first_relevant": 1,
+          "reciprocal_rank": 1.0,
+          "hit_at_1": 1,
+          "hit_at_5": 1,
+          "n_expected_slugs": 3
+        },
+        {
+          "query": "What conformity assessment procedure is required for high-risk AI systems under Article 43?",
+          "theme_label": "Konformitätsbewertung",
+          "source_node": null,
+          "rank_of_first_relevant": 2,
+          "reciprocal_rank": 0.5,
+          "hit_at_1": 0,
+          "hit_at_5": 1,
+          "n_expected_slugs": 1
+        },
+        {
+          "query": "Which AI practices are prohibited under Article 5 of the AI Act?",
+          "theme_label": "Verbotene Praktiken",
+          "source_node": null,
+          "rank_of_first_relevant": 1,
+          "reciprocal_rank": 1.0,
+          "hit_at_1": 1,
+          "hit_at_5": 1,
+          "n_expected_slugs": 1
+        },
+        {
+          "query": "How does the Digital Omnibus change the EU AI Act deadlines for the Mittelstand?",
+          "theme_label": "Digital Omnibus Fristen",
+          "source_node": null,
+          "rank_of_first_relevant": 1,
+          "reciprocal_rank": 1.0,
+          "hit_at_1": 1,
+          "hit_at_5": 1,
+          "n_expected_slugs": 3
+        },
+        {
+          "query": "What systems are classified as high-risk in Annex III of the AI Act?",
+          "theme_label": "Anhang III Hochrisiko",
+          "source_node": null,
+          "rank_of_first_relevant": 1,
+          "reciprocal_rank": 1.0,
+          "hit_at_1": 1,
+          "hit_at_5": 1,
+          "n_expected_slugs": 2
+        },
+        {
+          "query": "How are key terms like 'AI system' defined in Article 3 of the AI Act?",
+          "theme_label": "Definitionen",
+          "source_node": null,
+          "rank_of_first_relevant": 1,
+          "reciprocal_rank": 1.0,
+          "hit_at_1": 1,
+          "hit_at_5": 1,
+          "n_expected_slugs": 1
         }
       ]
     },
     {
       "base": "perf-cra-2",
       "wiki_root": ".alpha/perf-cra-2",
+      "eval_set": "references/retrieval-eval-set-perf-cra-2.json",
       "pages_scanned": 26,
-      "n_queries": 3,
-      "hit_at_1": 0.6667,
-      "hit_at_5": 1.0,
-      "mrr": 0.75,
+      "n_queries": 8,
+      "n_seeded_queries": 3,
+      "n_authored_queries": 5,
+      "hit_at_1": 0.625,
+      "hit_at_5": 0.875,
+      "mrr": 0.7396,
       "per_query": [
         {
+          "query": "EU Cyber Resilience Act core manufacturer obligations: essential cybersecurity requirements, conformity assessment, CE marking, vulnerability handling and security updates",
           "theme_label": "Core Manufacturer Obligations",
           "source_node": "core-manufacturer-obligations",
           "rank_of_first_relevant": 4,
@@ -110,6 +213,7 @@
           "n_expected_slugs": 10
         },
         {
+          "query": "EU Cyber Resilience Act scope: which products with digital elements and which manufacturers fall in scope, and how do micro/small/medium enterprise provisions apply",
           "theme_label": "Scope And SME Applicability",
           "source_node": "scope-and-sme-applicability",
           "rank_of_first_relevant": 1,
@@ -119,6 +223,7 @@
           "n_expected_slugs": 12
         },
         {
+          "query": "EU Cyber Resilience Act timelines, incident and vulnerability reporting duties to ENISA, and penalties for non-compliance",
           "theme_label": "Timelines Reporting And Penalties",
           "source_node": "timelines-reporting-and-penalties",
           "rank_of_first_relevant": 1,
@@ -126,19 +231,73 @@
           "hit_at_1": 1,
           "hit_at_5": 1,
           "n_expected_slugs": 9
+        },
+        {
+          "query": "What penalties and fines can be imposed for non-compliance with the Cyber Resilience Act (Article 64)?",
+          "theme_label": "Penalties",
+          "source_node": null,
+          "rank_of_first_relevant": 1,
+          "reciprocal_rank": 1.0,
+          "hit_at_1": 1,
+          "hit_at_5": 1,
+          "n_expected_slugs": 3
+        },
+        {
+          "query": "What vulnerability and incident reporting obligations does CRA Article 14 impose on manufacturers?",
+          "theme_label": "Reporting",
+          "source_node": null,
+          "rank_of_first_relevant": 1,
+          "reciprocal_rank": 1.0,
+          "hit_at_1": 1,
+          "hit_at_5": 1,
+          "n_expected_slugs": 2
+        },
+        {
+          "query": "What conformity assessment procedures apply to products with digital elements under the CRA?",
+          "theme_label": "Conformity assessment",
+          "source_node": null,
+          "rank_of_first_relevant": 6,
+          "reciprocal_rank": 0.1667,
+          "hit_at_1": 0,
+          "hit_at_5": 0,
+          "n_expected_slugs": 1
+        },
+        {
+          "query": "How do CRA requirements map to harmonised cybersecurity standards?",
+          "theme_label": "Standards mapping",
+          "source_node": null,
+          "rank_of_first_relevant": 1,
+          "reciprocal_rank": 1.0,
+          "hit_at_1": 1,
+          "hit_at_5": 1,
+          "n_expected_slugs": 2
+        },
+        {
+          "query": "What is the implementation timeline and transition pathway for the Cyber Resilience Act?",
+          "theme_label": "Implementation timeline",
+          "source_node": null,
+          "rank_of_first_relevant": 2,
+          "reciprocal_rank": 0.5,
+          "hit_at_1": 0,
+          "hit_at_5": 1,
+          "n_expected_slugs": 3
         }
       ]
     },
     {
       "base": "perf-cra",
       "wiki_root": ".alpha/perf-cra",
+      "eval_set": "references/retrieval-eval-set-perf-cra.json",
       "pages_scanned": 31,
-      "n_queries": 3,
-      "hit_at_1": 0.3333,
-      "hit_at_5": 1.0,
-      "mrr": 0.6111,
+      "n_queries": 8,
+      "n_seeded_queries": 3,
+      "n_authored_queries": 5,
+      "hit_at_1": 0.5,
+      "hit_at_5": 0.875,
+      "mrr": 0.6875,
       "per_query": [
         {
+          "query": "EU Cyber Resilience Act core manufacturer obligations: essential cybersecurity requirements, conformity assessment, CE marking, vulnerability handling and security updates",
           "theme_label": "Core Manufacturer Obligations",
           "source_node": "core-manufacturer-obligations",
           "rank_of_first_relevant": 2,
@@ -148,6 +307,7 @@
           "n_expected_slugs": 10
         },
         {
+          "query": "EU Cyber Resilience Act scope: which products with digital elements and which manufacturers fall in scope, and how do micro/small/medium enterprise provisions apply",
           "theme_label": "Scope And SME Applicability",
           "source_node": "scope-and-sme-applicability",
           "rank_of_first_relevant": 1,
@@ -157,6 +317,7 @@
           "n_expected_slugs": 9
         },
         {
+          "query": "EU Cyber Resilience Act timelines, incident and vulnerability reporting duties to ENISA, and penalties for non-compliance",
           "theme_label": "Timelines Reporting And Penalties",
           "source_node": "timelines-reporting-and-penalties",
           "rank_of_first_relevant": 3,
@@ -164,6 +325,56 @@
           "hit_at_1": 0,
           "hit_at_5": 1,
           "n_expected_slugs": 9
+        },
+        {
+          "query": "What must manufacturers do to obtain CE marking under the Cyber Resilience Act?",
+          "theme_label": "CE marking",
+          "source_node": null,
+          "rank_of_first_relevant": 6,
+          "reciprocal_rank": 0.1667,
+          "hit_at_1": 0,
+          "hit_at_5": 0,
+          "n_expected_slugs": 2
+        },
+        {
+          "query": "What vulnerability handling obligations does Annex I Part II of the CRA require?",
+          "theme_label": "Vulnerability handling",
+          "source_node": null,
+          "rank_of_first_relevant": 1,
+          "reciprocal_rank": 1.0,
+          "hit_at_1": 1,
+          "hit_at_5": 1,
+          "n_expected_slugs": 2
+        },
+        {
+          "query": "How does the CRA apply to SMEs and microenterprises?",
+          "theme_label": "SME applicability",
+          "source_node": null,
+          "rank_of_first_relevant": 2,
+          "reciprocal_rank": 0.5,
+          "hit_at_1": 0,
+          "hit_at_5": 1,
+          "n_expected_slugs": 3
+        },
+        {
+          "query": "What is the Single Reporting Platform for CRA incident notifications?",
+          "theme_label": "Reporting platform",
+          "source_node": null,
+          "rank_of_first_relevant": 1,
+          "reciprocal_rank": 1.0,
+          "hit_at_1": 1,
+          "hit_at_5": 1,
+          "n_expected_slugs": 3
+        },
+        {
+          "query": "What financial penalties does Article 64 of the CRA establish for manufacturers?",
+          "theme_label": "Penalties",
+          "source_node": null,
+          "rank_of_first_relevant": 1,
+          "reciprocal_rank": 1.0,
+          "hit_at_1": 1,
+          "hit_at_5": 1,
+          "n_expected_slugs": 1
         }
       ]
     }

--- a/cogni-knowledge/references/retrieval-baseline.md
+++ b/cogni-knowledge/references/retrieval-baseline.md
@@ -1,84 +1,105 @@
 # Retrieval-quality baseline (hit@k / MRR)
 
 Committed baseline artifact for the read-only retrieval harness
-(`scripts/retrieval-eval.py`), addressing review finding **F5** (MINOR hygiene).
-Before this, the only recorded engagement-level baseline was an N=3 prose smoke
-sample living in PR/issue text — not versioned, not reproducible. This artifact
-turns that into a durable, committed before/after so the deferred retrieval
-redesign has a real reference point.
+(`scripts/retrieval-eval.py`), addressing review finding **F5** (MINOR hygiene)
+and its scale-up follow-up. Before this, the only recorded engagement-level
+baseline was an N=3 prose smoke sample living in PR/issue text — not versioned,
+not reproducible. This artifact turns that into a durable, committed before/after
+so the deferred retrieval redesign has a real reference point — now at a
+statistically firmer **31 labelled queries**.
 
 ## Committed artifact
 
 - **`references/retrieval-baseline.json`** — per-base and aggregate
   `hit@1 / hit@5 / MRR` at the labelled-query scale, plus per-query ranks,
   provenance (harness command, threshold, corpus paths), and run metadata.
+- **`references/retrieval-eval-set-<base>.json`** — the committed labelled query
+  set per base (the ground-truth that makes the baseline reproducible against the
+  bases). Each holds the question-node-seeded queries plus the authored held-out
+  queries with hand-validated `expected_slugs`.
 
 ## Headline numbers
 
-Aggregate over **12 labelled queries** (the complete labelled corpus across the
-bound bases):
+Aggregate over **31 labelled queries** (12 question-node-seeded + 19 authored
+held-out), query-weighted mean across the bound bases:
 
 | Metric | Value |
 |--------|-------|
-| hit@1  | 0.4167 |
-| hit@5  | 0.7500 |
-| MRR    | 0.5486 |
+| hit@1  | 0.5806 |
+| hit@5  | 0.8065 |
+| MRR    | 0.6909 |
 
 Per-base:
 
-| Base | n | hit@1 | hit@5 | MRR |
-|------|---|-------|-------|-----|
-| `.alpha/eu-ai-act-sme` | 6 | 0.3333 | 0.5000 | 0.4167 |
-| `.alpha/perf-cra-2`    | 3 | 0.6667 | 1.0000 | 0.7500 |
-| `.alpha/perf-cra`      | 3 | 0.3333 | 1.0000 | 0.6111 |
+| Base | n (seeded+authored) | hit@1 | hit@5 | MRR |
+|------|---------------------|-------|-------|-----|
+| `.alpha/eu-ai-act-sme` | 15 (6+9) | 0.6000 | 0.7333 | 0.6667 |
+| `.alpha/perf-cra-2`    | 8 (3+5)  | 0.6250 | 0.8750 | 0.7396 |
+| `.alpha/perf-cra`      | 8 (3+5)  | 0.5000 | 0.8750 | 0.6875 |
 
-(`eu-ai-act-sme` reproduces the previously-recorded hit@5 = 0.50, 3/6 null —
-confirming harness stability.)
+The 12-query seeded subset reproduces the prior baseline (e.g. `eu-ai-act-sme`
+still 3/6 null on hit@5, the previously-recorded hit@5 = 0.50) — confirming
+harness stability across the scale-up. The authored held-out queries shifted the
+aggregate up because they target single-article facts (e.g. "prohibited practices
+under Article 5", "Article 3 definitions") whose answering page is sharply
+named, whereas the broad question-node themes span 10–12 expected sources and
+rank less cleanly.
 
 ## Reproduction
 
-Per base (the harness re-seeds the labelled set from each base's
-`wiki/questions/*.md` `sources_answering:` ground truth):
+Per base (the harness loads the committed labelled set; no `--reseed` needed):
 
 ```bash
 python3 cogni-knowledge/scripts/retrieval-eval.py eval \
-  --wiki-root .alpha/<base> --reseed --out /tmp/<base>.json
+  --wiki-root .alpha/<base> \
+  --eval-set cogni-knowledge/references/retrieval-eval-set-<base>.json \
+  --out /tmp/<base>.json
 ```
 
 Run for `eu-ai-act-sme`, `perf-cra-2`, and `perf-cra`, then aggregate by
 query-weighted mean. `threshold` is the harness default `0.2`.
 
-## Corpus provenance and reproducibility caveat
+## Ground-truth authoring (held-out queries)
+
+The 19 authored queries are **hand-authored, not fabricated**: each is a natural
+question answerable from the bound base, and its `expected_slugs` were validated
+against the corpus's descriptive, article-specific source titles (e.g. "Article
+14: Human Oversight", "Artikel 99: Sanktionen") — the answering pages a domain
+reader would expect retrieval to surface. The builder asserts every
+`expected_slug` exists as a `wiki/sources/*.md` page before committing, so a
+typo'd ground-truth slug fails loudly rather than silently scoring as a miss.
+Genuine misses (e.g. the German "Sanktionen und Bußgelder" query ranks no
+Article-99 page in the passing set) are kept as real signal, not patched away.
+
+## Corpus provenance and reproducibility (resolved: Option 1)
 
 The eval corpus is the bound alpha knowledge bases under `.alpha/`. **These are
-gitignored local alpha data — they are NOT version-controlled in this repo.**
-The committed numbers are therefore a *snapshot* measured against those bases;
-exact reproduction requires the same `.alpha/` bases on disk. Only these three
-bound bases qualify as eval corpora — they are the only ones carrying labelled
-`wiki/questions/*.md` nodes with non-empty `sources_answering:` (the ground-truth
-answering-page set). The other `.alpha/` bases predate the question-node feature
-and yield no labels.
+gitignored local alpha data — they are NOT version-controlled in this repo.** The
+committed numbers are therefore a *snapshot* measured against those bases; exact
+reproduction requires the same `.alpha/` bases on disk.
 
-### OPEN QUESTION (for maintainer decision)
+The fixture-vs-snapshot decision the prior artifact deferred is now **settled as
+Option 1 — accept the alpha-corpus snapshot** (maintainer decision, recorded on
+PR #917). The two options were:
 
-For a baseline that any third party can reproduce, the eval corpus must itself be
-committed. The issue contemplated this ("decide and document the committed
-path … or **a checked-in eval fixture**"). Two defensible options:
-
-1. **Accept this alpha-corpus snapshot** (current artifact) — real EU-AI-Act /
-   CRA retrieval quality on the live alpha bases; reproducible only by holders of
-   those bases. Good enough as a private before/after for the redesign.
+1. **Accept the alpha-corpus snapshot** (this artifact) — real EU-AI-Act / CRA
+   retrieval quality on the live alpha bases; reproducible by holders of those
+   bases. The committed `retrieval-eval-set-<base>.json` files document the
+   labelled queries + ground truth so the *measurement* is inspectable in-repo
+   even though the *corpus* is not.
 2. **Commit a checked-in eval fixture** — a small in-repo wiki + labelled query
    set, fully reproducible by anyone, but at fixture scale and content (validates
    the harness end-to-end rather than measuring real-corpus quality).
 
-These serve different purposes; the choice is a maintainer call. This artifact
-ships option 1; if option 2 is preferred, the fixture authoring is separate work.
+Option 1 was chosen because the baseline's purpose is to detect regressions in
+the *real* corpus across the redesign; a synthetic fixture would measure the
+harness, not the quality the redesign aims to move. If a fully third-party-
+reproducible fixture is wanted later, that authoring is separate work.
 
 ## Scale note
 
-12 labelled queries is the **complete** labelled corpus available today. The
-brief aspired to ~20-50; reaching that requires *authoring held-out ground-truth
-queries* (selecting valid expected source-page sets per new question — domain
-expert work that would pollute the metric if fabricated). That scale-up is
-tracked as a deferred follow-up issue.
+31 labelled queries meets the brief's aspired ~20-50 range, scaled up from the
+prior complete-but-small 12-query corpus. Further scaling would mean authoring
+additional held-out queries against the same bases (the source corpora hold
+57 / 20 / 25 pages respectively, so headroom remains) or adding new bound bases
+with labelled question nodes.

--- a/cogni-knowledge/references/retrieval-eval-set-eu-ai-act-sme.json
+++ b/cogni-knowledge/references/retrieval-eval-set-eu-ai-act-sme.json
@@ -1,0 +1,195 @@
+{
+  "version": 1,
+  "base": "eu-ai-act-sme",
+  "seeded_at": "2026-06-21T11:38:51Z",
+  "note": "Committed labelled retrieval-eval set for .alpha/eu-ai-act-sme. First 6 queries seeded from wiki/questions/*.md sources_answering; remainder are authored held-out queries with hand-validated ground truth. Reproduction requires the gitignored .alpha/eu-ai-act-sme base on disk (Option-1 snapshot).",
+  "queries": [
+    {
+      "query": "EU AI Act Anwendungsbereich KMU: Wer ist Anbieter, wer Betreiber, und welche kleinen und mittleren Unternehmen sind betroffen?",
+      "theme_label": "Anwendungsbereich und Rollen",
+      "expected_slugs": [
+        "article-3-definitions-eu-artificial-intelligence-act",
+        "artikel-2-anwendungsbereich-eu-artificial-intelligence-act",
+        "small-businesses-guide-to-the-ai-act-eu-artificial-intelligence-act",
+        "artikel-62-massnahmen-fuer-anbieter-und-betreiber-insbesondere-kmu-und-start-ups",
+        "umsetzungsleitfaden-zur-ki-verordnung-version-2-0-bitkom-e-v",
+        "eu-ai-act-deployer-evidence-gaps-smes-will-miss-before-2-aug-2026-iapp",
+        "ai-act-shaping-europe-s-digital-future-european-commission",
+        "ai-act-die-ki-verordnung-der-eu-wko",
+        "article-26-obligations-of-deployers-of-high-risk-ai-systems-eu-artificial-intell",
+        "provider-or-deployer-decoding-the-key-roles-in-the-ai-act-haerting",
+        "section-3-obligations-of-providers-and-deployers-of-high-risk-ai-systems-and-oth"
+      ],
+      "source_node": "anwendungsbereich-und-rollen"
+    },
+    {
+      "query": "EU AI Act Fristen und Inkrafttreten: gestaffelte Geltungsbeginn-Termine 2025, 2026, 2027 für die einzelnen Pflichten",
+      "theme_label": "Fristen und Inkrafttreten",
+      "expected_slugs": [
+        "ai-act-shaping-europe-s-digital-future-european-commission",
+        "navigating-the-ai-act-shaping-europe-s-digital-future-european-commission",
+        "timeline-for-the-implementation-of-the-eu-ai-act-ai-act-service-desk",
+        "article-113-entry-into-force-and-application-ai-act-service-desk",
+        "article-113-entry-into-force-and-application-eu-artificial-intelligence-act",
+        "implementation-timeline-eu-artificial-intelligence-act",
+        "ai-act-implementation-timeline-european-parliamentary-research-service-pe-772-90",
+        "digital-omnibus-on-ai-neue-fristen-fuer-die-ki-verordnung-tuev-rheinland-consult",
+        "eu-ai-act-2026-was-sich-seit-inkrafttreten-veraendert-hat-ein-zwischenstand-tuev",
+        "digital-omnibus-beschlossen-die-neuen-eu-ai-act-fristen-fuer-den-mittelstand-mai",
+        "ai-act-update-eu-resolves-to-change-rules-and-extend-deadlines-latham-watkins"
+      ],
+      "source_node": "fristen-und-inkrafttreten"
+    },
+    {
+      "query": "EU AI Act KI-Kompetenz (AI literacy) und Pflichten für General-Purpose-AI (GPAI): was müssen KMU beachten, die KI-Modelle wie ChatGPT einsetzen?",
+      "theme_label": "KI-Kompetenz und GPAI-Pflichten",
+      "expected_slugs": [
+        "article-4-ai-literacy-eu-artificial-intelligence-act",
+        "article-53-obligations-for-providers-of-general-purpose-ai-models-eu-artificial",
+        "ai-literacy-questions-answers-shaping-europe-s-digital-future",
+        "guidelines-for-providers-of-general-purpose-ai-models-shaping-europe-s-digital-f",
+        "guidelines-on-the-scope-of-obligations-for-providers-of-general-purpose-ai-model",
+        "article-51-classification-of-general-purpose-ai-models-as-general-purpose-ai-mod",
+        "overview-of-guidelines-for-gpai-models-eu-artificial-intelligence-act",
+        "overview-of-the-code-of-practice-eu-artificial-intelligence-act",
+        "the-general-purpose-ai-code-of-practice-shaping-europe-s-digital-future",
+        "ai-literacy-eu-ai-act-art-4-zu-ki-kompetenz-fraunhofer-akademie",
+        "eu-ai-act-gpai-model-obligations-in-force-and-final-gpai-code-of-practice-in-pla",
+        "eu-ai-act-stichtag-02-08-2026-gpai-pflichten-fur-dach-mittelstand-mybusinessfutu"
+      ],
+      "source_node": "ki-kompetenz-und-gpai-pflichten"
+    },
+    {
+      "query": "EU AI Act Pflichten für Hochrisiko-KI-Systeme: Konformitätsbewertung, Risikomanagement, Dokumentation und menschliche Aufsicht für Anbieter und Betreiber",
+      "theme_label": "Pflichten nach Risikoklasse",
+      "expected_slugs": [
+        "umsetzungsleitfaden-zur-ki-verordnung-version-2-0-bitkom-e-v",
+        "article-26-obligations-of-deployers-of-high-risk-ai-systems-eu-artificial-intell",
+        "article-16-obligations-of-providers-of-high-risk-ai-systems-eu-artificial-intell",
+        "article-9-risk-management-system-eu-artificial-intelligence-act",
+        "guidelines-for-providers-and-deployers-of-ai-high-risk-systems-shaping-europe-s",
+        "article-14-human-oversight-eu-artificial-intelligence-act",
+        "article-43-conformity-assessment-eu-artificial-intelligence-act",
+        "article-16-obligations-of-providers-of-high-risk-ai-systems-ai-act-service-desk",
+        "art-11-ai-act-was-die-dokumentation-wirklich-fordert-tuev-rheinland-consulting",
+        "eu-ai-act-dokumentationspflichten-fuer-ki-anbieter-2026-srd-rechtsanwaelte",
+        "eu-ai-act-ab-2-august-2026-was-unternehmen-jetzt-tun-muessen-tuev-rheinland-cons"
+      ],
+      "source_node": "pflichten-nach-risikoklasse"
+    },
+    {
+      "query": "EU AI Act Risikoklassifizierung: verbotene Praktiken, Hochrisiko-KI, begrenztes und minimales Risiko – wie ordnen KMU ihre KI-Systeme ein?",
+      "theme_label": "Risikoklassifizierung",
+      "expected_slugs": [
+        "ai-act-shaping-europe-s-digital-future-european-commission",
+        "artikel-5-verbotene-ki-praktiken-eu-artificial-intelligence-act",
+        "artikel-6-einstufungsregeln-fuer-ki-systeme-mit-hohem-risiko-eu-artificial-intel",
+        "anhang-iii-hochriskante-ki-systeme-eu-artificial-intelligence-act",
+        "draft-commission-guidelines-on-the-classification-of-high-risk-ai-systems-europe",
+        "article-6-classification-rules-for-high-risk-ai-systems-ai-act-service-desk",
+        "guidelines-on-the-classification-of-high-risk-ai-systems-ai-act-service-desk",
+        "high-level-summary-of-the-ai-act-eu-artificial-intelligence-act",
+        "navigating-the-ai-act-shaping-europe-s-digital-future-european-commission",
+        "umsetzungsleitfaden-zur-ki-verordnung-klick-tool-bitkom-e-v"
+      ],
+      "source_node": "risikoklassifizierung"
+    },
+    {
+      "query": "EU AI Act praktische Umsetzung für KMU: Governance-Schritte, Sanktionen und KMU-Erleichterungen wie Reallabore und reduzierte Gebühren",
+      "theme_label": "Umsetzung, Sanktionen und KMU-Erleichterungen",
+      "expected_slugs": [
+        "small-businesses-guide-to-the-ai-act-eu-artificial-intelligence-act",
+        "artikel-62-massnahmen-fuer-anbieter-und-betreiber-insbesondere-kmu-und-start-ups",
+        "ai-act-shaping-europe-s-digital-future-european-commission",
+        "artikel-99-sanktionen-eu-gesetz-ueber-kuenstliche-intelligenz",
+        "artikel-57-ki-reallabore-regulatory-sandboxes-eu-gesetz-ueber-kuenstliche-intell",
+        "artikel-62-massnahmen-fuer-anbieter-und-betreiber-insbesondere-kmu-ai-act-servic",
+        "artikel-99-sanktionen-ai-act-service-desk",
+        "ai-regulatory-sandbox-approaches-eu-member-state-overview-eu-artificial-intellig",
+        "getting-regulatory-sandboxes-right-design-and-governance-under-the-ai-act-europe",
+        "gesetze-unter-der-lupe-ai-act-bvmw"
+      ],
+      "source_node": "umsetzung-sanktionen-und-kmu-erleichterungen"
+    },
+    {
+      "query": "Welche Sanktionen und Bußgelder drohen bei Verstößen gegen die KI-Verordnung?",
+      "theme_label": "Sanktionen",
+      "expected_slugs": [
+        "artikel-99-sanktionen-eu-gesetz-ueber-kuenstliche-intelligenz",
+        "artikel-99-sanktionen-ai-act-service-desk"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "What are the human oversight requirements for high-risk AI systems under Article 14?",
+      "theme_label": "Human oversight",
+      "expected_slugs": [
+        "article-14-human-oversight-eu-artificial-intelligence-act",
+        "guidelines-for-providers-and-deployers-of-ai-high-risk-systems-shaping-europe-s"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "Welche technische Dokumentation müssen Anbieter von Hochrisiko-KI nach Artikel 11 erstellen?",
+      "theme_label": "Dokumentationspflichten",
+      "expected_slugs": [
+        "art-11-ai-act-was-die-dokumentation-wirklich-fordert-tuev-rheinland-consulting",
+        "eu-ai-act-dokumentationspflichten-fuer-ki-anbieter-2026-srd-rechtsanwaelte"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "What is a regulatory sandbox under the AI Act and how can SMEs benefit (Article 57)?",
+      "theme_label": "Reallabore / Sandboxes",
+      "expected_slugs": [
+        "artikel-57-ki-reallabore-regulatory-sandboxes-eu-gesetz-ueber-kuenstliche-intell",
+        "ai-regulatory-sandbox-approaches-eu-member-state-overview-eu-artificial-intellig",
+        "getting-regulatory-sandboxes-right-design-and-governance-under-the-ai-act-europe"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "What conformity assessment procedure is required for high-risk AI systems under Article 43?",
+      "theme_label": "Konformitätsbewertung",
+      "expected_slugs": [
+        "article-43-conformity-assessment-eu-artificial-intelligence-act"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "Which AI practices are prohibited under Article 5 of the AI Act?",
+      "theme_label": "Verbotene Praktiken",
+      "expected_slugs": [
+        "artikel-5-verbotene-ki-praktiken-eu-artificial-intelligence-act"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "How does the Digital Omnibus change the EU AI Act deadlines for the Mittelstand?",
+      "theme_label": "Digital Omnibus Fristen",
+      "expected_slugs": [
+        "digital-omnibus-beschlossen-die-neuen-eu-ai-act-fristen-fuer-den-mittelstand-mai",
+        "digital-omnibus-on-ai-neue-fristen-fuer-die-ki-verordnung-tuev-rheinland-consult",
+        "ai-act-update-eu-resolves-to-change-rules-and-extend-deadlines-latham-watkins"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "What systems are classified as high-risk in Annex III of the AI Act?",
+      "theme_label": "Anhang III Hochrisiko",
+      "expected_slugs": [
+        "anhang-iii-hochriskante-ki-systeme-eu-artificial-intelligence-act",
+        "draft-commission-guidelines-on-the-classification-of-high-risk-ai-systems-europe"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "How are key terms like 'AI system' defined in Article 3 of the AI Act?",
+      "theme_label": "Definitionen",
+      "expected_slugs": [
+        "article-3-definitions-eu-artificial-intelligence-act"
+      ],
+      "source_node": null
+    }
+  ]
+}

--- a/cogni-knowledge/references/retrieval-eval-set-perf-cra-2.json
+++ b/cogni-knowledge/references/retrieval-eval-set-perf-cra-2.json
@@ -1,0 +1,106 @@
+{
+  "version": 1,
+  "base": "perf-cra-2",
+  "seeded_at": "2026-06-21T11:38:51Z",
+  "note": "Committed labelled retrieval-eval set for .alpha/perf-cra-2. First 3 queries seeded from wiki/questions/*.md sources_answering; remainder are authored held-out queries with hand-validated ground truth. Reproduction requires the gitignored .alpha/perf-cra-2 base on disk (Option-1 snapshot).",
+  "queries": [
+    {
+      "query": "EU Cyber Resilience Act core manufacturer obligations: essential cybersecurity requirements, conformity assessment, CE marking, vulnerability handling and security updates",
+      "theme_label": "Core Manufacturer Obligations",
+      "expected_slugs": [
+        "the-cyber-resilience-act-summary-of-the-legislative-text-shaping-europe-s-digita",
+        "cyber-resilience-act-requirements-standards-mapping-enisa",
+        "the-cyber-resilience-act-eu-wide-requirements-for-the-cybersecurity-of-products",
+        "bsi-cyber-resilience-act-federal-office-for-information-security",
+        "cyber-resilience-act-shaping-europe-s-digital-future",
+        "eu-cyber-resilience-act-openssf",
+        "cyber-resilience-act-conformity-assessment",
+        "cyber-resilience-act-implementation",
+        "cyber-resilience-act-article-14-vulnerability-and-incident-reporting",
+        "cyber-security-standards-joint-research-centre"
+      ],
+      "source_node": "core-manufacturer-obligations"
+    },
+    {
+      "query": "EU Cyber Resilience Act scope: which products with digital elements and which manufacturers fall in scope, and how do micro/small/medium enterprise provisions apply",
+      "theme_label": "Scope And SME Applicability",
+      "expected_slugs": [
+        "regulation-eu-2024-2847-of-the-european-parliament-and-of-the-council-cyber-resi",
+        "cyber-resilience-act-manufacturers-shaping-europe-s-digital-future",
+        "the-cyber-resilience-act-summary-of-the-legislative-text-shaping-europe-s-digita",
+        "cyber-resilience-act-implementation-frequently-asked-questions-shaping-europe-s",
+        "the-cyber-resilience-act-full-text-cyberresilienceact-eu",
+        "cyber-resilience-act-requirements-standards-mapping-enisa",
+        "the-cyber-resilience-act-eu-wide-requirements-for-the-cybersecurity-of-products",
+        "bsi-cyber-resilience-act-federal-office-for-information-security",
+        "cyber-resilience-act-shaping-europe-s-digital-future",
+        "cyber-resilience-act-cra-updates-compliance-training",
+        "eu-cyber-resilience-act-openssf",
+        "cyber-resilience-act-eu-transition-pathways"
+      ],
+      "source_node": "scope-and-sme-applicability"
+    },
+    {
+      "query": "EU Cyber Resilience Act timelines, incident and vulnerability reporting duties to ENISA, and penalties for non-compliance",
+      "theme_label": "Timelines Reporting And Penalties",
+      "expected_slugs": [
+        "the-cyber-resilience-act-summary-of-the-legislative-text-shaping-europe-s-digita",
+        "cyber-resilience-act-requirements-standards-mapping-enisa",
+        "cyber-resilience-act-shaping-europe-s-digital-future",
+        "cyber-resilience-act-implementation",
+        "cyber-resilience-act-article-14-vulnerability-and-incident-reporting",
+        "cyber-resilience-act-reporting-obligations",
+        "cyber-resilience-act-article-64-penalties",
+        "cra-penalties-and-sanctions-financial-risks-of-non-compliance",
+        "what-to-expect-from-cyber-resilience-act-cra-fines"
+      ],
+      "source_node": "timelines-reporting-and-penalties"
+    },
+    {
+      "query": "What penalties and fines can be imposed for non-compliance with the Cyber Resilience Act (Article 64)?",
+      "theme_label": "Penalties",
+      "expected_slugs": [
+        "cyber-resilience-act-article-64-penalties",
+        "cra-penalties-and-sanctions-financial-risks-of-non-compliance",
+        "what-to-expect-from-cyber-resilience-act-cra-fines"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "What vulnerability and incident reporting obligations does CRA Article 14 impose on manufacturers?",
+      "theme_label": "Reporting",
+      "expected_slugs": [
+        "cyber-resilience-act-article-14-vulnerability-and-incident-reporting",
+        "cyber-resilience-act-reporting-obligations"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "What conformity assessment procedures apply to products with digital elements under the CRA?",
+      "theme_label": "Conformity assessment",
+      "expected_slugs": [
+        "cyber-resilience-act-conformity-assessment"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "How do CRA requirements map to harmonised cybersecurity standards?",
+      "theme_label": "Standards mapping",
+      "expected_slugs": [
+        "cyber-resilience-act-requirements-standards-mapping-enisa",
+        "cyber-security-standards-joint-research-centre"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "What is the implementation timeline and transition pathway for the Cyber Resilience Act?",
+      "theme_label": "Implementation timeline",
+      "expected_slugs": [
+        "cyber-resilience-act-implementation",
+        "cyber-resilience-act-eu-transition-pathways",
+        "cyber-resilience-act-cra-updates-compliance-training"
+      ],
+      "source_node": null
+    }
+  ]
+}

--- a/cogni-knowledge/references/retrieval-eval-set-perf-cra.json
+++ b/cogni-knowledge/references/retrieval-eval-set-perf-cra.json
@@ -1,0 +1,103 @@
+{
+  "version": 1,
+  "base": "perf-cra",
+  "seeded_at": "2026-06-21T11:38:51Z",
+  "note": "Committed labelled retrieval-eval set for .alpha/perf-cra. First 3 queries seeded from wiki/questions/*.md sources_answering; remainder are authored held-out queries with hand-validated ground truth. Reproduction requires the gitignored .alpha/perf-cra base on disk (Option-1 snapshot).",
+  "queries": [
+    {
+      "query": "EU Cyber Resilience Act core manufacturer obligations: essential cybersecurity requirements, conformity assessment, CE marking, vulnerability handling and security updates",
+      "theme_label": "Core Manufacturer Obligations",
+      "expected_slugs": [
+        "the-cyber-resilience-act-summary-of-the-legislative-text-shaping-europe-s-digita",
+        "cyber-resilience-act-requirements-standards-mapping-joint-research-centre-enisa",
+        "cyber-resilience-act-requirements-standards-mapping-enisa-publication-page",
+        "cra-faq-vulnerability-handling-obligations-annex-i-part-ii-open-regulatory-compl",
+        "the-cyber-resilience-act-full-regulation-text-cyberresilienceact-eu",
+        "cyber-resilience-act-conformity-assessment-shaping-europe-s-digital-future",
+        "ce-marking-guide-cyberresilienceact-eu",
+        "the-cra-explained-cyberresilienceact-eu",
+        "cra-vulnerability-reporting-obligations-what-manufacturers-must-do-from-septembe",
+        "eu-cyber-resilience-act-a-complete-preparation-guide-for-manufacturers-zealience"
+      ],
+      "source_node": "core-manufacturer-obligations"
+    },
+    {
+      "query": "EU Cyber Resilience Act scope: which products with digital elements and which manufacturers fall in scope, and how do micro/small/medium enterprise provisions apply",
+      "theme_label": "Scope And SME Applicability",
+      "expected_slugs": [
+        "cyber-resilience-act-products-with-digital-elements-and-msmes-european-commissio",
+        "cra-compliance-guide-for-smes-confirmate-project-d4-1-eu-funded-eccc-grant-10119",
+        "cyber-resilience-act-european-commission-summary-page",
+        "cyber-resilience-act-european-commission-main-page-regulation-eu-2024-2847",
+        "cra-requirements-standards-mapping-jrc-enisa-joint-analysis-eur-31892-en-2024",
+        "cyber-resilience-act-commission-guidance-and-questions-answers",
+        "eu-cyber-resilience-act-scope-and-key-provisions-part-1-freshfields",
+        "cyberresilienceact-eu-full-regulation-text-and-article-by-article-navigation",
+        "cyber-resilience-act-cra-bsi-federal-office-for-information-security"
+      ],
+      "source_node": "scope-and-sme-applicability"
+    },
+    {
+      "query": "EU Cyber Resilience Act timelines, incident and vulnerability reporting duties to ENISA, and penalties for non-compliance",
+      "theme_label": "Timelines Reporting And Penalties",
+      "expected_slugs": [
+        "cyber-resilience-act-european-commission-summary-page",
+        "the-cyber-resilience-act-summary-of-the-legislative-text-shaping-europe-s-digita",
+        "cyber-resilience-act-requirements-standards-mapping-enisa-publication-page",
+        "cyber-resilience-act-reporting-obligations-shaping-europe-s-digital-future",
+        "single-reporting-platform-srp-enisa",
+        "cyber-resilience-act-text-article-14",
+        "sme-cyber-resilience-act-survey-enisa",
+        "cyber-resilience-act-text-article-64",
+        "cyber-resilience-act-reporting-obligations-applus-laboratories"
+      ],
+      "source_node": "timelines-reporting-and-penalties"
+    },
+    {
+      "query": "What must manufacturers do to obtain CE marking under the Cyber Resilience Act?",
+      "theme_label": "CE marking",
+      "expected_slugs": [
+        "ce-marking-guide-cyberresilienceact-eu",
+        "cyber-resilience-act-conformity-assessment-shaping-europe-s-digital-future"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "What vulnerability handling obligations does Annex I Part II of the CRA require?",
+      "theme_label": "Vulnerability handling",
+      "expected_slugs": [
+        "cra-faq-vulnerability-handling-obligations-annex-i-part-ii-open-regulatory-compl",
+        "cra-vulnerability-reporting-obligations-what-manufacturers-must-do-from-septembe"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "How does the CRA apply to SMEs and microenterprises?",
+      "theme_label": "SME applicability",
+      "expected_slugs": [
+        "cyber-resilience-act-products-with-digital-elements-and-msmes-european-commissio",
+        "cra-compliance-guide-for-smes-confirmate-project-d4-1-eu-funded-eccc-grant-10119",
+        "sme-cyber-resilience-act-survey-enisa"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "What is the Single Reporting Platform for CRA incident notifications?",
+      "theme_label": "Reporting platform",
+      "expected_slugs": [
+        "single-reporting-platform-srp-enisa",
+        "cyber-resilience-act-reporting-obligations-shaping-europe-s-digital-future",
+        "cyber-resilience-act-text-article-14"
+      ],
+      "source_node": null
+    },
+    {
+      "query": "What financial penalties does Article 64 of the CRA establish for manufacturers?",
+      "theme_label": "Penalties",
+      "expected_slugs": [
+        "cyber-resilience-act-text-article-64"
+      ],
+      "source_node": null
+    }
+  ]
+}


### PR DESCRIPTION
## What

Scales the committed retrieval-quality baseline from **12 → 31 labelled queries** (12 question-node-seeded + 19 authored held-out), meeting the brief's aspired ~20–50 range and giving a statistically firmer before/after for the deferred retrieval redesign. Completes #911's full scope and resolves the scale-up child #916.

## Headline numbers (n=31, query-weighted)

| Metric | 12-query (prior) | 31-query (this PR) |
|--------|------------------|--------------------|
| hit@1  | 0.4167 | **0.5806** |
| hit@5  | 0.7500 | **0.8065** |
| MRR    | 0.5486 | **0.6909** |

Per-base: `eu-ai-act-sme` 15 (6+9) → 0.600/0.733/0.667 · `perf-cra-2` 8 (3+5) → 0.625/0.875/0.740 · `perf-cra` 8 (3+5) → 0.500/0.875/0.688.

## How

- **New committed labelled sets** `references/retrieval-eval-set-<base>.json` — each base's seeded queries + authored held-out queries. The harness loads them via `--eval-set` (no `--reseed`), so the measurement is inspectable in-repo.
- **Ground truth is authored, not fabricated.** Each held-out query's `expected_slugs` were hand-validated against the corpus's descriptive, article-specific source titles (e.g. "Article 14: Human Oversight", "Artikel 99: Sanktionen"). The builder asserts every slug exists as a `wiki/sources/*.md` page before committing — a typo fails loudly. Genuine misses (e.g. the German "Sanktionen und Bußgelder" query ranks no Article-99 page in the passing set) are kept as real signal.
- **Harness stability confirmed:** the 12-query seeded subset reproduces the prior baseline (`eu-ai-act-sme` still 3/6 null on hit@5). No harness code change.
- Refreshed `retrieval-baseline.json` + `.md`; version `1.0.39 → 1.0.40` (mirrored in marketplace.json).

## Reproducibility decision (settled: Option 1)

Per the maintainer decision on #917, the fixture-vs-snapshot question is resolved as **Option 1 — accept the alpha-corpus snapshot**. The committed eval-set files document the queries + ground truth in-repo; exact reproduction requires the gitignored `.alpha/` bases on disk. Documented in `retrieval-baseline.md`.

## Tests

`tests/test_retrieval_eval.sh` ✅, `tests/test_knowledge_lib.sh` ✅, breadcrumb guard ✅ (0 violations).

Closes #916
Closes #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)