### PR TITLE
cogni-knowledge: link perspectives When & Where facets (kill spine dead-ends)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/perspectives_index.py
+++ b/cogni-knowledge/scripts/perspectives_index.py
@@ -29,8 +29,8 @@ The mapping:
   Who   → people + entities      (named subjects)
   What  → concepts + sources     (definitions + primary evidence)
   Why   → questions + syntheses  (inquiry drivers + conclusions)
-  When  → wiki/log.md             log-derived timeline (v1; grouped by month)
-  Where → source `market:` FM      sources grouped by market (v1; geo: is v2)
+  When  → wiki/log.md             log-derived timeline (v1; months link to the log)
+  Where → source `market:` FM      sources grouped by market (v1; link to sources/)
 
 The former `How` facet was dropped: its backing types (the cross-source
 `summary` + run-level `learning`) were retired as dead vocabulary, leaving it
@@ -183,6 +183,14 @@ WHEN_EMPTY_LINE = (
 )
 
 
+def _wiki_relative_log(wiki_root: Path) -> str:
+    """The activity log's path RELATIVE to the `wiki/` dir, so a link from
+    `wiki/perspectives.md` resolves: `meta/log.md` on a meta-canonical base,
+    legacy `log.md` on a flat base. A pure function of `_knowledge_lib.log_path`'s
+    resolution — the link target never drifts from the timeline's own source."""
+    return log_path(wiki_root).relative_to(Path(wiki_root) / "wiki").as_posix()
+
+
 def _build_when_timeline(wiki_root: Path) -> "list[str]":
     """The When-facet body: a deterministic, byte-stable timeline grouped by
     month (`YYYY-MM`, newest first) from the append-only `wiki/log.md` operation
@@ -214,13 +222,17 @@ def _build_when_timeline(wiki_root: Path) -> "list[str]":
     if not months:
         return [WHEN_EMPTY_LINE]
 
+    # The log was read above, so it exists — link each month to it (months carry
+    # no per-month deep anchor in v1; that defers to the claim-level event-date
+    # extension). Wiki-relative so the link from wiki/perspectives.md resolves.
+    rel_log = _wiki_relative_log(wiki_root)
     out = [WHEN_INTRO, ""]
     for ym in sorted(months, reverse=True):
         bucket = months[ym]
         n = bucket["total"]
         noun = "operation" if n == 1 else "operations"
         ops = " · ".join(sorted(bucket["ops"]))
-        out.append(f"- **{ym}** — {n} {noun} ({ops})")
+        out.append(f"- **{ym}** — [{n} {noun}]({rel_log}) ({ops})")
     return out
 
 
@@ -263,7 +275,10 @@ def _build_where_grouping(wiki_root: Path) -> "list[str]":
     for market in sorted(counts):
         n = counts[market]
         noun = "source" if n == 1 else "sources"
-        out.append(f"- **{market}** — {n} {noun}")
+        # Link the count to the sources sub-index — the AC-sanctioned fallback
+        # target (sources/index.md is theme-grouped, not market-scoped, so no
+        # per-market anchor exists today). Relative from wiki/perspectives.md.
+        out.append(f"- **{market}** — [{n} {noun}](sources/index.md)")
     return out
 
 

--- a/cogni-knowledge/tests/test_perspectives_index.sh
+++ b/cogni-knowledge/tests/test_perspectives_index.sh
@@ -191,8 +191,8 @@ WHERE_BLOCK="$(sed -n '/^## Where$/,$p' "$PAGE")"
 echo "$WHERE_BLOCK" | grep -q 'Sources grouped by the market' \
   && green "PASS: Where facet renders the market-grouping intro" \
   || { red "FAIL: Where grouping intro missing"; errors=$((errors+1)); }
-echo "$WHERE_BLOCK" | grep -q -- '- \*\*dach\*\* — 1 source' \
-  && green "PASS: Where groups the src-a source under its market (dach, singular)" \
+echo "$WHERE_BLOCK" | grep -qF -- '- **dach** — [1 source](sources/index.md)' \
+  && green "PASS: Where groups the src-a source under its market (dach, singular), linked to the sources sub-index" \
   || { red "FAIL: Where 'dach' grouping row missing/incorrect"; errors=$((errors+1)); }
 echo "$WHERE_BLOCK" | grep -q '_(no pages in this facet yet)_' \
   && { red "FAIL: Where facet wrongly rendered the honest-empty page line"; errors=$((errors+1)); } \
@@ -204,11 +204,11 @@ WHEN_BLOCK="$(sed -n '/^## When$/,/^## Where$/p' "$PAGE")"
 echo "$WHEN_BLOCK" | grep -q 'Activity timeline from the base' \
   && green "PASS: When facet renders the timeline intro" \
   || { red "FAIL: When timeline intro missing"; errors=$((errors+1)); }
-echo "$WHEN_BLOCK" | grep -q -- '- \*\*2026-06\*\* — 4 operations (compose · finalize · ingest · verify)' \
-  && green "PASS: When timeline groups 2026-06 by month with sorted op counts" \
+echo "$WHEN_BLOCK" | grep -qF -- '- **2026-06** — [4 operations](log.md) (compose · finalize · ingest · verify)' \
+  && green "PASS: When timeline groups 2026-06 by month with sorted op counts, linked to the activity log" \
   || { red "FAIL: 2026-06 timeline row missing/incorrect"; errors=$((errors+1)); }
-echo "$WHEN_BLOCK" | grep -q -- '- \*\*2026-05\*\* — 1 operation (setup)' \
-  && green "PASS: When timeline groups 2026-05 (singular 'operation')" \
+echo "$WHEN_BLOCK" | grep -qF -- '- **2026-05** — [1 operation](log.md) (setup)' \
+  && green "PASS: When timeline groups 2026-05 (singular 'operation'), linked to the activity log" \
   || { red "FAIL: 2026-05 timeline row missing/incorrect"; errors=$((errors+1)); }
 # Newest-first ordering: 2026-06 row must precede the 2026-05 row.
 echo "$WHEN_BLOCK" | grep -nE '2026-0[56]' | head -1 | grep -q '2026-06' \


### PR DESCRIPTION
Closes #945.

## Summary
- Link each **Where** facet bullet (`- **{market}** — {n} sources`) to the sources sub-index (`sources/index.md`), wrapping the `{n} {noun}` count text as the link — mirroring the type-facet `Explore` pattern. `sources/index.md` is the AC-sanctioned fallback (the sources sub-index is theme-grouped, not market-scoped, so no market anchor exists today).
- Link each **When** facet month bullet (`- **{ym}** — {n} operations (…)`) to the activity log, computing the wiki-relative target (`meta/log.md` on a meta-canonical base, legacy `log.md` on a flat base) deterministically from the already-imported `_knowledge_lib.log_path` via a small module-level helper `_wiki_relative_log`.
- Preserve both honest-empty signposts (the thin-facet `WHERE_EMPTY_LINE` for Where, `WHEN_EMPTY_LINE` for When) verbatim — they never gain a link.
- Update `tests/test_perspectives_index.sh` assertions to the new linked bullet form (switched the three to fixed-string `grep -qF` since the link brackets are BRE-special).

## Scope decisions
- **In:** both ACs (link When + link Where) in the one named script `scripts/perspectives_index.py`, the byte-stable test fixture assertions, and the version bump.
- **Out (deferred to the v2 event-date extension already named in the issue):** per-month deep anchors into the log and a market-scoped `sources/index.md#market` anchor — neither target exists today. Not filed as a follow-up (speculative, out of any epic DoD).
- The When link always resolves to an existing file: `_build_when_timeline` returns the honest-empty line early when the log is absent, so a month bullet is only ever rendered when the log exists.

## Test plan
- [x] `bash cogni-knowledge/tests/test_perspectives_index.sh` — all 33 checks pass (Where → `sources/index.md`; When months → resolved log path; honest-empty fallbacks unchanged; idempotent re-render byte-identical).
- [x] Re-render an unchanged wiki twice → byte-identical `wiki/perspectives.md` (idempotency / AC3).
- [x] No-market wiki still renders the thin-facet Where signpost with no link (AC1 regression).
- [x] No-`log.md` wiki still renders the When signpost with no link.
- [x] Version bumped to 1.0.51 (base 1.0.50 from origin/main after #944) and mirrored in root `marketplace.json`.

Part of epic #937 (Wiki reader-wayfinding uplift) — a sibling enhancement surfaced while QA-ing the shipped 5W1H spine, not a precondition for the epic's metric.