### PR TITLE
feat(cogni-knowledge): seed deterministic per-theme lead-in in root_index curated MAP

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/root_index.py
+++ b/cogni-knowledge/scripts/root_index.py
@@ -15,7 +15,7 @@ bullet dump:
   _Curated map …_
 
   ## <theme>
-  <carried PORTAL-LEADIN span or human lead-in, verbatim>
+  <carried PORTAL-LEADIN span or human lead-in, verbatim; else a seeded default PORTAL-LEADIN span>
   <!-- MACHINE-OWNED:ROOT-LINKS:START -->
   **Explore:** [Sources (40)](sources/index.md) · [Concepts (12)](concepts/index.md) · …
   <!-- MACHINE-OWNED:ROOT-LINKS:END -->
@@ -46,9 +46,12 @@ that decides which bullets `render`/`stage` file under each theme in
 concepts the concepts sub-index lists under that theme.
 
 **Idempotent + reflow/collapse-stable.** Re-rendering an unchanged wiki is a
-byte-identical no-op (the carried `PORTAL-LEADIN` machine spans — which carry a
-date — are preserved verbatim, never regenerated; the `ROOT-LINKS` count spans
-are deterministic from disk). The curated MAP carries NO `- [[slug]]` bullets
+byte-identical no-op (the carried `PORTAL-LEADIN` machine spans — narrator-authored
+ones carry a date, the engine-seeded default is stamp-free — are preserved verbatim,
+never regenerated; the `ROOT-LINKS` count spans are deterministic from disk). A theme
+that carries no lead-in at all is seeded a deterministic default `PORTAL-LEADIN` span
+on its first render and carried verbatim thereafter — a one-time transition, idempotent
+after. The curated MAP carries NO `- [[slug]]` bullets
 (so `wiki_index_update.py --reflow-only` has nothing to sort) and unique `##`
 headings (so `--collapse-only` has nothing to merge) — it is a fixpoint of the
 Step 10.5 `lint --fix=all` passes.
@@ -95,6 +98,13 @@ from sub_index import (  # noqa: E402
 ROOT_INDEX_MARKER = "<!-- MACHINE-OWNED:ROOT-INDEX -->"
 ROOT_LINKS_NAME = "ROOT-LINKS"
 OVERVIEW_NARRATIVE_NAME = "OVERVIEW-NARRATIVE"
+# The engine-owned per-theme lead-in span. A theme with no carried lead-in (no
+# human prose, no prior PORTAL-LEADIN span) is seeded a deterministic default
+# under this name so it is self-describing out of the box; the sentinel is what
+# the portal-narrator (knowledge-finalize) later refreshes into a content-specific
+# definition. Matches the `MACHINE-OWNED:PORTAL-LEADIN` sentinel the narrator,
+# wiki_index_update.py --set-leadin, and pipeline-summary.py already recognize.
+PORTAL_LEADIN_NAME = "PORTAL-LEADIN"
 UNCATEGORIZED = "Uncategorized"
 DEFAULT_H1 = "# Knowledge Base"
 INTRO_LINE = (
@@ -150,6 +160,25 @@ def _render_span(name: str, inner: str) -> str:
         f"<!-- MACHINE-OWNED:{name}:START -->\n"
         f"{inner}\n"
         f"<!-- MACHINE-OWNED:{name}:END -->"
+    )
+
+
+def _default_theme_leadin(theme: str) -> str:
+    """A deterministic, engine-owned default lead-in for a theme that carries none.
+
+    Generic by necessity — the engine knows the theme name, not the theme's
+    semantics — but it frames the section so a reader is not left inferring the
+    theme's scope from its title alone (the legibility gap the curated MAP's
+    title-only themes otherwise leave). Mirrors the per-facet `default_leadin`
+    seeds `perspectives_index.py` renders for the 5W1H facets. Seeded as a
+    `MACHINE-OWNED:PORTAL-LEADIN` span, so it is (1) carried verbatim by
+    `_carry_leadin` on the next render — a one-time transition, byte-idempotent
+    after — and (2) the sentinel the portal-narrator refreshes into a
+    content-specific definition at finalize.
+    """
+    return (
+        f"_Pages across this knowledge base grouped under the **{theme}** theme — "
+        f"open a per-type sub-index below to read them._"
     )
 
 
@@ -279,9 +308,17 @@ def _build_map(wiki_root: Path, existing_text: str) -> str:
     for theme in ordered:
         parts.append(f"## {theme}")
         parts.append("")
+        # Carry a human / narrator-authored lead-in (incl. a prior PORTAL-LEADIN
+        # span) forward verbatim; else seed the deterministic engine-owned default
+        # so the theme is self-describing out of the box (mirrors the perspectives
+        # facet defaults). Either way the span is engine-owned and carried verbatim
+        # on the next render, so seeding is a one-time, byte-idempotent transition.
         leadin = _carry_leadin(sec_body.get(theme, []))
         if leadin:
             parts.extend(leadin)
+            parts.append("")
+        else:
+            parts.append(_render_span(PORTAL_LEADIN_NAME, _default_theme_leadin(theme)))
             parts.append("")
         # Deep-link each type into THIS theme's `## <theme>` section of the
         # sub-index, so the per-theme Explore line is distinct per theme rather

--- a/cogni-knowledge/tests/test_root_index.sh
+++ b/cogni-knowledge/tests/test_root_index.sh
@@ -16,6 +16,9 @@
 #      the sub-indexes now).
 #   4. A carried PORTAL-LEADIN machine span survives a re-render byte-for-byte
 #      (date and all — never regenerated).
+#  4b. A theme that carries NO lead-in is seeded a deterministic engine-owned
+#      default PORTAL-LEADIN span (the legibility default, mirroring the
+#      perspectives facet defaults); an authored lead-in is not clobbered.
 #   5. The non-theme container headings (## Categories, ## Syntheses) are dropped
 #      (no page carries them as a theme_label); a synthesis appears as
 #      Syntheses (n) inside its backing-source theme instead.
@@ -253,6 +256,14 @@ assert_not_grep '^- \[\[scope-synth\]\]' "$IDX" "3 per-page synthesis bullet dro
 # === 4. carried PORTAL-LEADIN span (verbatim, date intact) ===
 assert_grep "refreshed:2026-06-01 bullets:3" "$IDX" "4 PORTAL-LEADIN carried with original date"
 assert_grep "Framing for the scope theme." "$IDX" "4 PORTAL-LEADIN inner prose carried"
+
+# === 4b. seeded default lead-in for a theme that carries none (#946) ===
+# KI Bußgelder has NO authored lead-in in the legacy root, so the renderer seeds a
+# deterministic engine-owned PORTAL-LEADIN span that names the theme — the
+# legibility default, mirroring the perspectives facet defaults. AC1.
+assert_grep "grouped under the \*\*KI Bußgelder\*\* theme" "$IDX" "4b no-lead-in theme seeded a default PORTAL-LEADIN one-liner"
+# AC2 (no clobber): the Scope theme's authored span is NOT replaced by the default.
+assert_not_grep "grouped under the \*\*Scope\*\* theme" "$IDX" "4b authored lead-in not clobbered by the seeded default"
 
 # === 5. container headings dropped ===
 assert_not_grep '^## Categories' "$IDX" "5 ## Categories container heading dropped"


### PR DESCRIPTION
## Summary

The curated root MAP (`wiki/index.md`) preserved a per-theme lead-in via `_carry_leadin` but never **seeded** one, so every knowledge base shipped title-only `## <theme>` headings until a human (or the portal-narrator at finalize) authored framing prose — the legibility gap the reader-wayfinding diagnostic flagged. Unlike the perspectives facets, which each carry a defining one-line lead-in, root themes left a reader to infer scope from the title alone.

This seeds a deterministic engine-owned default at render time so themes are self-describing out of the box.

## What changed

- **`cogni-knowledge/scripts/root_index.py`** — `_build_map`'s per-theme loop now seeds a `MACHINE-OWNED:PORTAL-LEADIN` span via `_render_span` + a new `_default_theme_leadin(theme)` helper **when `_carry_leadin` returns empty** (no human prose, no prior span). New `PORTAL_LEADIN_NAME` constant. Mirrors the established `perspectives_index.py:297-303` carry-or-seed pattern (`inner = carried if carried is not None else default_leadin`).
- **`cogni-knowledge/tests/test_root_index.sh`** — new assertion 4b (seeded default present for a no-lead-in theme; authored lead-in not clobbered).
- **version** — cogni-knowledge `1.0.51 → 1.0.52` (plugin.json + marketplace.json).

## Design

The seed lands **only** in the empty-leadin branch, so human / narrator lead-ins are carried verbatim (no clobber). The seeded span is itself a `PORTAL-LEADIN` machine span, so `_carry_leadin` carries it verbatim on the next render — a one-time, **byte-idempotent** transition — and the existing `portal-narrator` (knowledge-finalize Step 10.5 sub-step 3.5, #491) refreshes the engine-owned span into a content-specific definition. Option A (engine default) composes with the already-shipped Option B (narrator), rather than replacing it: a fresh base is framed at render time with zero agent cost; finalize then enriches.

The default is generic by necessity (the engine knows the theme name, not its semantics) but frames the section instead of leaving it title-only.

## Acceptance criteria

- ✅ AC1 — a theme with no authored lead-in renders a defining one-liner by default (new test 4b)
- ✅ AC2 — human / narrator-authored lead-ins carried verbatim, no clobber (test 4 + new 4b)
- ✅ AC3 — idempotent re-render (existing byte-identity test 7 + reflow/collapse-stability test 8)

## Testing

`test_root_index.sh` (38 assertions, all pass) + sibling suites `test_migrate_layout.sh`, `test_repair_mode.sh`, `test_structural_drift_health.sh` (all pass).

Closes #946