### PR TITLE
cogni-consult: assumption used_by[] reference edges + WARN promote gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/references/data-model.md
+++ b/cogni-consult/references/data-model.md
@@ -155,6 +155,7 @@ the authoring stages to prompt for registration is a later roadmap step.)
 | `value` | Yes | The rendered value, verbatim (string, unit included — e.g. `"€4.2bn"`); never `null` — the resolver rejects a null/absent value rather than rendering `None`. What the resolver substitutes for every placeholder occurrence |
 | `rationale` | No | How the value was derived — the audit trail in prose |
 | `citation` | No | Source-lineage triple (`source_url`, `entity_ref`, `propagated_at`) per the monorepo convention, so cogni-claims corrections can cascade to the assumption |
+| `used_by` | No | Reference edges: array of `{file, resolved_at}` citer records, one per file that resolved this assumption in place (`file` is engagement-relative; `resolved_at` is the UTC timestamp of the first recording). **Derive-at-write, never hand-authored** — `scripts/resolve-assumptions.py` appends it during an `--in-place` resolve, deduped on `file`. Full edge semantics: `references/dependency-model.md` |
 | `created` / `updated` | Yes | ISO dates of entry creation / last value edit |
 
 Resolution is **fail-loud** — the full failure contract is canonical in

--- a/cogni-consult/references/dependency-model.md
+++ b/cogni-consult/references/dependency-model.md
@@ -46,6 +46,42 @@ cross field boundaries: a deliverable in `go-to-market` can depend on one in
 of the upstream node; its canonical string form (used in tooling output and the CLI
 shorthand below) is `<action_field>/<deliverable>`.
 
+### `used_by[]` — the assumption reference edge (derive-at-write)
+
+Assumption records in the engagement-root `assumptions.json` carry the second
+edge type of this model: `used_by[]`, the list of files that cite the
+assumption via a `{{asm:<slug>}}` placeholder. Unlike `depends_on[]` it is
+**never hand-authored** — `scripts/resolve-assumptions.py` records the citer
+automatically whenever an in-place resolve substitutes the assumption's value.
+Each entry is:
+
+```json
+{ "file": "action-fields/market-evidence/market-sizing.md",
+  "resolved_at": "2026-07-09T05:10:00+00:00" }
+```
+
+| Field | Description |
+|-------|-------------|
+| `file` | The citing file's path relative to the engagement root |
+| `resolved_at` | UTC timestamp of the first resolve that recorded this citer |
+
+The two edge types deliberately sit at opposite ends of the derivation
+spectrum. `depends_on[]` → `blocks[]` is **declare-then-derive**: the
+consultant declares the forward edge, the inverse is computed at read time
+(below). `{{asm:id}}` citation → `used_by[]` is **derive-at-write**: the
+citation event is a past fact — which file resolved against the value, and
+when — that cannot be recomputed from current state (a rendered brief no
+longer contains the placeholder), so the resolver stores it at the moment it
+happens, the same stored-because-it-happened rationale as `lineage_status`.
+Writes are idempotent: a citer already present in `used_by[]` (matched on its
+relative path) is skipped, and when nothing new was cited the registry file is
+not rewritten, so repeated publish or design-thinking renders never churn the
+registry. Dry-run resolves (no `--in-place`) record nothing.
+
+`used_by[]` is what makes an assumption propagatable: once the registry knows
+every citer, a value correction can cascade staleness to exactly the files
+that rest on the old number.
+
 ### `blocks[]` is derived, never stored
 
 The inverse relation — "what does this deliverable block?" — is **not** written to

--- a/cogni-consult/references/dependency-model.md
+++ b/cogni-consult/references/dependency-model.md
@@ -76,7 +76,12 @@ happens, the same stored-because-it-happened rationale as `lineage_status`.
 Writes are idempotent: a citer already present in `used_by[]` (matched on its
 relative path) is skipped, and when nothing new was cited the registry file is
 not rewritten, so repeated publish or design-thinking renders never churn the
-registry. Dry-run resolves (no `--in-place`) record nothing.
+registry. The edge lands **before** the citing file is rewritten, so a failed
+edge write leaves the placeholders intact and the resolve safely retryable.
+Dry-run resolves (no `--in-place`) record nothing. Edge recording assumes the
+engagement's single-session write model (the same assumption every
+`field.json` write makes): concurrent in-place resolves against one
+engagement are not serialized, and the last registry writer wins.
 
 `used_by[]` is what makes an assumption propagatable: once the registry knows
 every citer, a value correction can cascade staleness to exactly the files

--- a/cogni-consult/references/publish-routing.md
+++ b/cogni-consult/references/publish-routing.md
@@ -194,6 +194,14 @@ assumption values — schema: `references/data-model.md`, Assumption Registry).
 The write is atomic (temp file + rename), so a failed run never truncates the
 built brief.
 
+An in-place resolve performs a **second atomic write**: each resolved
+assumption gains a `used_by[]` reference edge for the citing brief, so
+re-publishing is idempotent and dry-runs record nothing (full edge semantics:
+`references/dependency-model.md`, `used_by[]`). Should the edge write fail
+after the brief was written, the envelope is `success: false` with
+`failed_check: "used_by_write_failed"` and `data.output` naming the
+already-written brief.
+
 ```bash
 python3 "$CLAUDE_PLUGIN_ROOT/scripts/resolve-assumptions.py" \
   <engagement-dir> resolve <brief-path> --in-place

--- a/cogni-consult/references/publish-routing.md
+++ b/cogni-consult/references/publish-routing.md
@@ -197,10 +197,11 @@ built brief.
 An in-place resolve performs a **second atomic write**: each resolved
 assumption gains a `used_by[]` reference edge for the citing brief, so
 re-publishing is idempotent and dry-runs record nothing (full edge semantics:
-`references/dependency-model.md`, `used_by[]`). Should the edge write fail
-after the brief was written, the envelope is `success: false` with
-`failed_check: "used_by_write_failed"` and `data.output` naming the
-already-written brief.
+`references/dependency-model.md`, `used_by[]`). The edge is recorded
+**before** the brief is rewritten: a failed edge write returns
+`success: false` with `failed_check: "used_by_write_failed"` and leaves the
+brief's placeholders intact — nothing was written, and the run is safely
+retryable.
 
 ```bash
 python3 "$CLAUDE_PLUGIN_ROOT/scripts/resolve-assumptions.py" \

--- a/cogni-consult/scripts/resolve-assumptions.py
+++ b/cogni-consult/scripts/resolve-assumptions.py
@@ -58,9 +58,9 @@ def load_registry(engagement_dir):
               "but there is no registry to resolve them against (re-run "
               "engagement-init.sh to backfill an empty registry)")
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             raw = json.load(f)
-    except (json.JSONDecodeError, OSError) as exc:
+    except (json.JSONDecodeError, OSError, UnicodeError) as exc:
         _emit(False, {"failed_check": "registry_unreadable", "path": path},
               "assumptions.json could not be read/parsed: %s" % exc)
 
@@ -94,15 +94,20 @@ def load_registry(engagement_dir):
 def _atomic_write(path, text):
     """Write text to path via temp file + rename — never truncates the original.
 
-    Raises OSError on failure (the temp file is cleaned up first).
+    Always writes UTF-8 regardless of locale, and preserves an existing
+    file's permission bits (mkstemp defaults to owner-only 0600, which would
+    lock out shared checkouts and vault sync). Raises OSError or UnicodeError
+    on failure (the temp file is cleaned up first).
     """
     fd, tmp_path = tempfile.mkstemp(
         dir=os.path.dirname(os.path.abspath(path)), suffix=".tmp")
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(text)
+        if os.path.exists(path):
+            os.chmod(tmp_path, os.stat(path).st_mode & 0o7777)
         os.replace(tmp_path, path)
-    except OSError:
+    except (OSError, UnicodeError):
         try:
             os.unlink(tmp_path)
         except OSError:
@@ -117,37 +122,42 @@ def record_used_by(engagement_dir, unique_ids, citer_file):
     rather than derived at read time. Deduped on the citer's engagement-relative
     path: an already-recorded citer is skipped, and when nothing new was cited
     the registry file is not rewritten at all. Returns the number of edges added.
-    Raises OSError on a failed write (the caller decides how loud to fail).
+    Raises OSError/UnicodeError on a failed write and ValueError on a
+    hand-corrupted used_by field (the caller decides how loud to fail).
     """
     path = os.path.join(engagement_dir, "assumptions.json")
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         raw = json.load(f)
     citer = os.path.relpath(os.path.abspath(citer_file),
                             os.path.abspath(engagement_dir))
     wanted = set(unique_ids)
+    stamp = (datetime.datetime.now(datetime.timezone.utc)
+             .isoformat(timespec="seconds"))
     added = 0
     for entry in raw.get("assumptions", []):
         if entry.get("id") not in wanted:
             continue
         used_by = entry.setdefault("used_by", [])
-        if any(ref.get("file") == citer for ref in used_by):
+        if not isinstance(used_by, list):
+            raise ValueError(
+                "used_by on %s is not a list — the field is resolver-owned "
+                "(derive-at-write); restore it to a JSON array"
+                % entry.get("id"))
+        if any(isinstance(ref, dict) and ref.get("file") == citer
+               for ref in used_by):
             continue
-        used_by.append({
-            "file": citer,
-            "resolved_at": datetime.datetime.now(datetime.timezone.utc)
-                           .isoformat(timespec="seconds"),
-        })
+        used_by.append({"file": citer, "resolved_at": stamp})
         added += 1
     if added:
-        _atomic_write(path, json.dumps(raw, indent=2) + "\n")
+        _atomic_write(path, json.dumps(raw, ensure_ascii=False, indent=2) + "\n")
     return added
 
 
 def cmd_resolve(args):
     try:
-        with open(args.file) as f:
+        with open(args.file, encoding="utf-8") as f:
             text = f.read()
-    except OSError as exc:
+    except (OSError, UnicodeError) as exc:
         _emit(False, {"failed_check": "file_unreadable", "path": args.file},
               "target file could not be read: %s" % exc)
 
@@ -188,24 +198,29 @@ def cmd_resolve(args):
         "output": args.file if args.in_place else None,
     }
     if args.in_place:
-        # Atomic replace: never truncate the only copy of the built brief.
-        try:
-            _atomic_write(args.file, resolved)
-        except OSError as exc:
-            _emit(False, {"failed_check": "write_failed", "path": args.file},
-                  "resolved text could not be written (original file untouched): %s" % exc)
-        # Reference-edge emission: the file now cites these assumptions, so
-        # record the citer into each one's used_by[] (skip-if-present keeps
-        # repeated publish / design-thinking renders idempotent).
+        # Reference-edge emission FIRST: if the edge cannot be recorded, the
+        # target file still holds its placeholders and a retry resolves it
+        # again. Writing the file first would leave it placeholder-free on an
+        # edge failure, so the retry no-ops at placeholders_found:0 and the
+        # edge becomes permanently unrecordable. Skip-if-present keeps
+        # repeated publish / design-thinking renders idempotent. The broad
+        # except honors the fail-loud contract — a defective hand-edited
+        # used_by or corrupt registry must yield an envelope, not a traceback.
         try:
             data["used_by_added"] = record_used_by(
                 args.engagement_dir, unique_ids, args.file)
-        except OSError as exc:
+        except Exception as exc:
             _emit(False, {"failed_check": "used_by_write_failed",
-                          "path": os.path.join(args.engagement_dir, "assumptions.json"),
-                          "output": args.file},
-                  "resolved file was written, but the used_by[] reference edge "
-                  "could not be recorded in assumptions.json: %s" % exc)
+                          "path": os.path.join(args.engagement_dir, "assumptions.json")},
+                  "used_by[] reference edge could not be recorded in "
+                  "assumptions.json (target file untouched — safe to retry): %s" % exc)
+        # Atomic replace: never truncate the only copy of the built brief.
+        try:
+            _atomic_write(args.file, resolved)
+        except (OSError, UnicodeError) as exc:
+            _emit(False, {"failed_check": "write_failed", "path": args.file},
+                  "resolved text could not be written (original file untouched; "
+                  "the recorded used_by[] edge is idempotent on retry): %s" % exc)
     else:
         data["resolved_text"] = resolved
     _emit(True, data, "")

--- a/cogni-consult/scripts/resolve-assumptions.py
+++ b/cogni-consult/scripts/resolve-assumptions.py
@@ -9,7 +9,11 @@ for assumption values — see references/data-model.md) and replaces every
 `{{asm:<suffix>}}` placeholder in the target file with the `value` of the
 registry entry whose id is `asm-<suffix>`. Without --in-place the resolved
 text is returned in the envelope (a dry-run); with it, the file is rewritten
-atomically (temp file + rename). Read-only toward the registry and field.json.
+atomically (temp file + rename) and each resolved assumption's `used_by[]`
+in assumptions.json gains a reference edge for the citing file (derive-at-
+write, deduped on the citer's engagement-relative path, so repeated renders
+never duplicate an edge and an unchanged registry is never rewritten).
+A dry-run stays fully read-only toward the registry and field.json.
 
 Fail-loud contract: an unknown placeholder id, a malformed placeholder (an
 {{...asm...}} token that does not match the strict form), a placeholder still
@@ -25,6 +29,7 @@ Stdlib-only.
 """
 
 import argparse
+import datetime
 import json
 import os
 import re
@@ -86,6 +91,58 @@ def load_registry(engagement_dir):
     return registry
 
 
+def _atomic_write(path, text):
+    """Write text to path via temp file + rename — never truncates the original.
+
+    Raises OSError on failure (the temp file is cleaned up first).
+    """
+    fd, tmp_path = tempfile.mkstemp(
+        dir=os.path.dirname(os.path.abspath(path)), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        os.replace(tmp_path, path)
+    except OSError:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def record_used_by(engagement_dir, unique_ids, citer_file):
+    """Record the citer into each resolved assumption's used_by[] (derive-at-write).
+
+    A citation is a past fact, so the edge is stored on the assumption record
+    rather than derived at read time. Deduped on the citer's engagement-relative
+    path: an already-recorded citer is skipped, and when nothing new was cited
+    the registry file is not rewritten at all. Returns the number of edges added.
+    Raises OSError on a failed write (the caller decides how loud to fail).
+    """
+    path = os.path.join(engagement_dir, "assumptions.json")
+    with open(path) as f:
+        raw = json.load(f)
+    citer = os.path.relpath(os.path.abspath(citer_file),
+                            os.path.abspath(engagement_dir))
+    wanted = set(unique_ids)
+    added = 0
+    for entry in raw.get("assumptions", []):
+        if entry.get("id") not in wanted:
+            continue
+        used_by = entry.setdefault("used_by", [])
+        if any(ref.get("file") == citer for ref in used_by):
+            continue
+        used_by.append({
+            "file": citer,
+            "resolved_at": datetime.datetime.now(datetime.timezone.utc)
+                           .isoformat(timespec="seconds"),
+        })
+        added += 1
+    if added:
+        _atomic_write(path, json.dumps(raw, indent=2) + "\n")
+    return added
+
+
 def cmd_resolve(args):
     try:
         with open(args.file) as f:
@@ -132,21 +189,23 @@ def cmd_resolve(args):
     }
     if args.in_place:
         # Atomic replace: never truncate the only copy of the built brief.
-        tmp_path = None
         try:
-            fd, tmp_path = tempfile.mkstemp(
-                dir=os.path.dirname(os.path.abspath(args.file)), suffix=".tmp")
-            with os.fdopen(fd, "w") as f:
-                f.write(resolved)
-            os.replace(tmp_path, args.file)
+            _atomic_write(args.file, resolved)
         except OSError as exc:
-            if tmp_path is not None:
-                try:
-                    os.unlink(tmp_path)
-                except OSError:
-                    pass
             _emit(False, {"failed_check": "write_failed", "path": args.file},
                   "resolved text could not be written (original file untouched): %s" % exc)
+        # Reference-edge emission: the file now cites these assumptions, so
+        # record the citer into each one's used_by[] (skip-if-present keeps
+        # repeated publish / design-thinking renders idempotent).
+        try:
+            data["used_by_added"] = record_used_by(
+                args.engagement_dir, unique_ids, args.file)
+        except OSError as exc:
+            _emit(False, {"failed_check": "used_by_write_failed",
+                          "path": os.path.join(args.engagement_dir, "assumptions.json"),
+                          "output": args.file},
+                  "resolved file was written, but the used_by[] reference edge "
+                  "could not be recorded in assumptions.json: %s" % exc)
     else:
         data["resolved_text"] = resolved
     _emit(True, data, "")

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -395,7 +395,9 @@ in the text rather than cited as a `{{asm:<slug>}}` placeholder backed by the
 engagement-root `assumptions.json` registry. When one or more turn up, emit a
 WARN naming each literal and nudge the consultant to promote it — a single
 registry-add (mandatory fields: `id`, `name`, `value`; `created`/`updated`
-stamped alongside) plus swapping the literal for its placeholder. The check is
+stamped alongside; record shape in
+`$CLAUDE_PLUGIN_ROOT/references/data-model.md`, Assumption Registry) plus
+swapping the literal for its placeholder. The check is
 advisory and never a hard fail: the WARN surfaces in the session summary, the
 consultant decides, and completion proceeds either way — a promotable literal
 must never stall the flow.
@@ -422,7 +424,8 @@ an earlier stage is permitted) and continue; `state` stays `in-progress`.
 ### 8. Close the Session
 
 Summarize: the deliverable's final state, the artifact path, key decisions
-logged, and which personas challenged it. Recommend the next step — the next
+logged, which personas challenged it, and any un-promoted quantified-literal
+WARNs from the Test-stage promote check. Recommend the next step — the next
 unstarted deliverable in the WBS (via the WBS dashboard skill when present in
 the plugin, or by reading the field manifests directly).
 

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -387,6 +387,19 @@ outcome as an `adherence-review` decision-log entry keyed by
 Three-Layer Quality Gate — advisory, never blocking (auto-walk proceeds to
 completion; interactive mode may elect to loop back). A `null`-framework
 deliverable skips it entirely and completes with no adherence stop.
+
+Next, the promote check: scan the artifact for bare quantified literals that
+look promotable to an assumption — planning numbers a reader would expect to
+stay current (market sizes, rates, headcounts, price points) written directly
+in the text rather than cited as a `{{asm:<slug>}}` placeholder backed by the
+engagement-root `assumptions.json` registry. When one or more turn up, emit a
+WARN naming each literal and nudge the consultant to promote it — a single
+registry-add (mandatory fields: `id`, `name`, `value`; `created`/`updated`
+stamped alongside) plus swapping the literal for its placeholder. The check is
+advisory and never a hard fail: the WARN surfaces in the session summary, the
+consultant decides, and completion proceeds either way — a promotable literal
+must never stall the flow.
+
 Then: one `Edit` of `field.json` sets
 `state` → `"complete"` (keep `dt_stage` at `"test"`) and the `evidence_class`,
 and one `Edit` of `.metadata/execution-log.json` appends the `in-progress` →

--- a/cogni-consult/tests/test_resolve_assumptions.sh
+++ b/cogni-consult/tests/test_resolve_assumptions.sh
@@ -17,6 +17,10 @@
 #   8  duplicate-id        two entries sharing an id -> duplicate_assumption_id
 #   9  registry-missing    placeholders without assumptions.json -> registry_missing
 #  10  no-placeholders     placeholder-free file passes even without a registry
+#  11  used-by-first       --in-place records the citer in the id's used_by[]
+#  12  used-by-idempotent  re-resolving the same citer adds nothing, registry not rewritten
+#  13  used-by-dry-run     dry-run leaves assumptions.json byte-identical
+#  14  used-by-multi       a second citing file accumulates a second used_by[] entry
 #
 # Usage: bash cogni-consult/tests/test_resolve_assumptions.sh
 # Exits non-zero on any assertion failure.
@@ -156,6 +160,68 @@ F="$TMPROOT/plain.md"
 printf 'no placeholders here\n' > "$F"
 OUT=$(python3 "$SCRIPT" "$NOREG" resolve "$F" --in-place)
 assert_envelope "no-placeholders envelope" true "" "$OUT"
+
+# Shared fixture for the used_by[] reference-edge cases (11-14): a fresh
+# engagement dir so earlier cases' writes can't bleed in, with the citing
+# file inside the engagement so the recorded path is engagement-relative.
+UB="$TMPROOT/ub"; mkdir -p "$UB/action-fields/market"
+cat > "$UB/assumptions.json" <<'EOF'
+{"assumptions": [{"id": "asm-tam", "name": "TAM", "value": "4.2bn EUR",
+                  "created": "2026-07-08", "updated": "2026-07-08"}]}
+EOF
+
+# Assert used_by[] on asm-tam: entry count and each entry's file + resolved_at.
+# Args: <name> <expected-count> <expected-file-csv-or-empty>
+assert_used_by() {
+  local name="$1" want_count="$2" want_files="$3"
+  UB_COUNT="$want_count" UB_FILES="$want_files" python3 - "$UB/assumptions.json" <<'PYEOF' && pass "$name" || fail "$name" "$(cat "$UB/assumptions.json")"
+import json, os, sys
+entry = {e["id"]: e for e in json.load(open(sys.argv[1]))["assumptions"]}["asm-tam"]
+used_by = entry.get("used_by", [])
+ok = len(used_by) == int(os.environ["UB_COUNT"])
+want_files = [f for f in os.environ["UB_FILES"].split(",") if f]
+ok = ok and sorted(r["file"] for r in used_by) == sorted(want_files)
+ok = ok and all(r.get("resolved_at") for r in used_by)
+sys.exit(0 if ok else 1)
+PYEOF
+}
+
+# 11 used-by-first: --in-place records the citer
+F="$UB/action-fields/market/brief.md"
+printf 'TAM {{asm:tam}}\n' > "$F"
+OUT=$(python3 "$SCRIPT" "$UB" resolve "$F" --in-place)
+assert_envelope "used-by-first envelope" true "" "$OUT"
+echo "$OUT" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin)["data"]["used_by_added"] == 1 else 1)' \
+  && pass "used-by-first added=1" || fail "used-by-first added=1" "$OUT"
+assert_used_by "used-by-first entry" 1 "action-fields/market/brief.md"
+
+# 12 used-by-idempotent: same citer again -> no new edge, registry not rewritten
+cp "$UB/assumptions.json" "$TMPROOT/ub-before.json"
+printf 'TAM {{asm:tam}}\n' > "$F"
+OUT=$(python3 "$SCRIPT" "$UB" resolve "$F" --in-place)
+assert_envelope "used-by-idempotent envelope" true "" "$OUT"
+echo "$OUT" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin)["data"]["used_by_added"] == 0 else 1)' \
+  && pass "used-by-idempotent added=0" || fail "used-by-idempotent added=0" "$OUT"
+cmp -s "$UB/assumptions.json" "$TMPROOT/ub-before.json" \
+  && pass "used-by-idempotent registry byte-identical" \
+  || fail "used-by-idempotent registry byte-identical" "registry rewritten"
+
+# 13 used-by-dry-run: no --in-place -> registry untouched
+cp "$UB/assumptions.json" "$TMPROOT/ub-before.json"
+F="$UB/action-fields/market/dry.md"
+printf 'TAM {{asm:tam}}\n' > "$F"
+OUT=$(python3 "$SCRIPT" "$UB" resolve "$F")
+assert_envelope "used-by-dry-run envelope" true "" "$OUT"
+cmp -s "$UB/assumptions.json" "$TMPROOT/ub-before.json" \
+  && pass "used-by-dry-run registry untouched" \
+  || fail "used-by-dry-run registry untouched" "registry rewritten by dry-run"
+
+# 14 used-by-multi: a distinct citing file accumulates a second entry
+F2="$UB/action-fields/market/second.md"
+printf 'again {{asm:tam}}\n' > "$F2"
+OUT=$(python3 "$SCRIPT" "$UB" resolve "$F2" --in-place)
+assert_envelope "used-by-multi envelope" true "" "$OUT"
+assert_used_by "used-by-multi entries" 2 "action-fields/market/brief.md,action-fields/market/second.md"
 
 if [ "$failures" -gt 0 ]; then
   echo "$failures assertion(s) failed" >&2

--- a/cogni-consult/tests/test_resolve_assumptions.sh
+++ b/cogni-consult/tests/test_resolve_assumptions.sh
@@ -21,6 +21,7 @@
 #  12  used-by-idempotent  re-resolving the same citer adds nothing, registry not rewritten
 #  13  used-by-dry-run     dry-run leaves assumptions.json byte-identical
 #  14  used-by-multi       a second citing file accumulates a second used_by[] entry
+#  15  used-by-write-failed  failed edge write -> used_by_write_failed envelope, target untouched
 #
 # Usage: bash cogni-consult/tests/test_resolve_assumptions.sh
 # Exits non-zero on any assertion failure.
@@ -222,6 +223,28 @@ printf 'again {{asm:tam}}\n' > "$F2"
 OUT=$(python3 "$SCRIPT" "$UB" resolve "$F2" --in-place)
 assert_envelope "used-by-multi envelope" true "" "$OUT"
 assert_used_by "used-by-multi entries" 2 "action-fields/market/brief.md,action-fields/market/second.md"
+
+# 15 used-by-write-failed: edge write fails -> envelope, target file untouched
+# (edge is recorded BEFORE the target rewrite, so a failed edge write must
+# leave the placeholders intact and the run retryable). The engagement dir is
+# made read-only so the registry's temp-file write fails; the target lives
+# outside it so only the edge write can fail.
+WF="$TMPROOT/wf"; mkdir -p "$WF"
+cat > "$WF/assumptions.json" <<'EOF'
+{"assumptions": [{"id": "asm-tam", "name": "TAM", "value": "4.2bn EUR",
+                  "created": "2026-07-08", "updated": "2026-07-08"}]}
+EOF
+F="$TMPROOT/wf-brief.md"
+printf 'TAM {{asm:tam}}\n' > "$F"
+chmod 555 "$WF"
+OUT=$(python3 "$SCRIPT" "$WF" resolve "$F" --in-place)
+RC=$?
+chmod 755 "$WF"
+[ "$RC" -ne 0 ] && pass "used-by-write-failed exit" || fail "used-by-write-failed exit" "exit $RC"
+assert_envelope "used-by-write-failed envelope" false "used_by_write_failed" "$OUT"
+grep -q '{{asm:tam}}' "$F" \
+  && pass "used-by-write-failed target untouched" \
+  || fail "used-by-write-failed target untouched" "$(cat "$F")"
 
 if [ "$failures" -gt 0 ]; then
   echo "$failures assertion(s) failed" >&2


### PR DESCRIPTION
Closes #980.

Phase 1 of the assumption SSOT epic (#984). Populates the `used_by[]` graph on assumption records whenever a `{{asm:id}}` is cited, and surfaces promotion of bare literals as an advisory WARN at completion — never a hard block.

## Summary
- `scripts/resolve-assumptions.py`: on `--in-place` resolve, record each resolved assumption's citer into that assumption's `used_by[]` in `assumptions.json` (second atomic write via a new shared `_atomic_write` helper that also replaced the pre-existing inline block). Deduped on the citer's engagement-relative path, skip-if-present — repeated publish / DT-Test renders are idempotent and an unchanged registry is never rewritten. Corrects the now-stale "Read-only toward the registry" docstring claim. New `used_by_added` envelope field; edge-write failure after a successful target write fails loud as `used_by_write_failed` with `data.output` naming the written file.
- `references/dependency-model.md`: new `used_by[]` section — derive-at-write edge (stored because a citation is a past fact), contrasted with the declare-then-derive `depends_on[]`→`blocks[]` model.
- `references/data-model.md`: `used_by` row added to the assumptions.json schema table.
- `references/publish-routing.md`: canonical resolver contract notes the second atomic write + `used_by_write_failed` failure shape (semantics deferred to dependency-model.md).
- `skills/consult-design-thinking/SKILL.md` (### 7. Test): advisory WARN-only promote check for bare quantified literals, placed before the completion Edit; matches the section's existing "advisory, never blocking" rungs. Promote stays ≤1 action / ≤4 mandatory fields (id/name/value + auto-stamped dates).
- `tests/test_resolve_assumptions.sh`: cases 11-14 (first-citation write, idempotent re-run byte-identical, dry-run untouched, multi-citer accumulate) + Coverage block extended.
- Version bump 0.1.53 → 0.1.54 in `plugin.json` and `marketplace.json`.

## Scope decisions
- **In:** all three ACs — used_by[] emission (AC1), WARN-not-block completion gate (AC2), promote guardrail (AC3).
- **Out (not deferred — not needed):** a net-new `promote` subcommand. AC3 is a guardrail satisfied by the existing registry-add path; a subcommand would exceed the issue's "~1 script + 1 reference + 1 skill edit" surface.

## Test plan
- [x] `bash cogni-consult/tests/test_resolve_assumptions.sh` — all 26 assertions green (16 existing + 10 new)
- [x] `test_deliverable_graph.sh`, `test_dt_stage_advance.sh` — pass
- [x] `scripts/check-breadcrumbs.py` — 0 violations
- [x] plugin.json + marketplace.json both at 0.1.54
- [x] skill-quality-reviewer verdict: pass

Plan record: https://github.com/cogni-work/insight-wave/issues/980#issuecomment-4921664329

🤖 Generated with [Claude Code](https://claude.com/claude-code)