### PR TITLE
cogni-consult: surface project-plan + schedule in resume/dashboard read surfaces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -32,6 +32,7 @@ A consulting engagement orchestrator that treats action fields as the work-break
 5. **Seed and challenge with acting personas** — seed stakeholder personas from the scope *before* the first deliverable starts (the `personas_gate`), enrich them with evidence, and have them push back on deliverables in their own voice; when there are no external stakeholders worth modelling, take the defaults-only waiver instead (`consult-personas`)
 6. **Resume across sessions** — discover engagements, show WBS progress, and route to the most valuable next action (`consult-resume`)
 7. **See engagement status visually** — generate a themed, browsable HTML dashboard of the action-field WBS, deliverable states, design-thinking stages, and persona-review progress (`consult-dashboard`)
+8. **Plan the engagement timeline** — render a phased roadmap of the WBS deliverables sequenced from the dependency graph and durations, with critical path and an optional gantt, as an Obsidian-browsable markdown artifact (`consult-project-plan`)
 
 ## What it means for you
 
@@ -60,6 +61,7 @@ This plugin is part of the [insight-wave ecosystem](../docs/ecosystem-overview.m
 /cogni-consult:consult-design-thinking # run the DT loop on one deliverable
 /cogni-consult:consult-personas     # define/enrich personas, challenge a deliverable
 /cogni-consult:consult-dashboard    # themed HTML engagement status dashboard
+/cogni-consult:consult-project-plan # phased roadmap/timeline of the engagement WBS
 ```
 
 Natural language works too: "start a consulting engagement for ACME's DACH cloud expansion", "scope the engagement", "work the competitor-map deliverable", "have the partner persona challenge the draft", "where was I with the engagement?".
@@ -147,6 +149,7 @@ Publishing is **consultant-elected and never automatic** — it does not fire at
 | `consult-personas` | Skill | Acting personas: define from scope, enrich with evidence, act-as challenge against deliverables |
 | `consult-publish` | Skill | Consultant-elected publish seam: completed deliverable → presentation-ready brief (slides / web-poster / report / infographic) |
 | `consult-dashboard` | Skill | Themed HTML engagement dashboard: action-field WBS, deliverable state, design-thinking stage, persona-review progress |
+| `consult-project-plan` | Skill | Internal engagement roadmap/timeline: sequences the WBS deliverables from the dependency graph + durations into phases with a critical path and an optional gantt, written as an Obsidian-browsable markdown artifact (read-mostly) |
 | `consult-dashboard-refresher` | Agent | Regenerate the engagement dashboard HTML at a milestone (haiku, read-only, no theme prompt) |
 | `consult-framework-adherence-reviewer` | Agent | Score a completed deliverable against its stored `chosen_framework` and report structural drift (sonnet, read-only) — the framework-adherence rung of the design-thinking Test gate |
 | `consult-persona-challenger` | Agent | Challenge a deliverable as one acting stakeholder persona in voice and return a structured objection envelope (sonnet, read-only) — the per-persona fan-out consult-personas merges at the design-thinking Test gate |
@@ -155,7 +158,8 @@ Publishing is **consultant-elected and never automatic** — it does not fire at
 | `generate-engagement-readme.py` | Script | Write the Obsidian-browsable engagement-root README front door from the same read model as `engagement-status.sh` — invoked at scaffold time by `engagement-init.sh` and non-fatally at the dashboard milestones (design-thinking session close, WBS change, resume re-entry), the markdown parallel to `consult-dashboard-refresher` |
 | `engagement-status.sh` | Script | Derive field/deliverable rollups from `field.json` files → JSON |
 | `dt-stage-advance.sh` | Script | Guarded, logged design-thinking stage advance for one deliverable — validates the transition (single-step forward, same-stage re-set, or earlier-stage re-entry) before writing it |
-| `deliverable-graph.py` | Script | Deliverable dependency-graph engine over all `field.json` files: validate / trace / impact / refresh-order / cascade-stale |
+| `deliverable-graph.py` | Script | Deliverable dependency-graph engine over all `field.json` files: validate / trace / impact / refresh-order / schedule / cascade-stale |
+| `schedule-edit.py` | Script | Read/write one deliverable's optional scheduling fields (`start_date`, `due_date`, `duration`, `owner`, `milestone`) in `field.json` — the write surface backing the `consult-project-plan` roadmap |
 | `resolve-assumptions.py` | Script | Render-time resolver replacing `{{asm:id}}` placeholders with values from the engagement-root `assumptions.json` registry — fail-loud on unresolvable placeholders, wired into `consult-publish` |
 | `discover-projects.sh` | Script | Engagement discovery (delegates to the cogni-workspace helper) |
 | `consult-dashboard/scripts/generate-dashboard.py` | Script | Render the engagement HTML dashboard from `consult-project.json` + `field.json` files (read-only) |
@@ -201,7 +205,7 @@ cogni-consult/
 │                                  dashboard milestones (stdlib-only)
 ├── tests/                         Regression tests (deliverable graph, dt-stage
 │                                  advance, dashboard + README generators)
-└── skills/                        The eight skills listed under Components
+└── skills/                        The nine skills listed under Components
                                    (consult-dashboard bundles its generator + theme schema)
 ```
 

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -127,6 +127,13 @@ The generated HTML is a single self-contained page with these sections:
    via `consult-publish` shows a **`📤` publish sub-row** — one chip per published format naming
    the format, the brief path, and the publish date, with a **`→ render in Claude Design`** pointer
    (hand the brief to Claude Design to render). An unpublished deliverable shows no sub-row.
+   A deliverable that carries any of the optional scheduling fields (`start_date`, `due_date`,
+   `duration`, `owner`, `milestone`) in its `field.json` shows a **`🗓` schedule sub-row** — an
+   owner chip, a start→due range chip, and a duration chip, preceded by a **`◆ milestone`** marker
+   when the deliverable is a milestone. These fields are authored for the project-plan / schedule
+   read model (`consult-project-plan`, `deliverable-graph.py schedule`); a deliverable with none of
+   them set shows no schedule sub-row — the surface degrades silently, the same graceful pattern as
+   the publish sub-row. Read-only throughout: the dashboard never writes these fields.
 4. **Knowledge base** — the bound knowledge-base slug and the count of research synthesis files
    across scope and action fields.
 5. **Next action** — a single recommended next step derived from scope state and deliverable

--- a/cogni-consult/skills/consult-dashboard/scripts/generate-dashboard.py
+++ b/cogni-consult/skills/consult-dashboard/scripts/generate-dashboard.py
@@ -411,6 +411,37 @@ def render_publish_row(publish_list):
     return f'<div class="deliv-publish" title="Published briefs">📤 {"".join(chips)}{pointer}</div>'
 
 
+def render_schedule_row(d):
+    """Read-only display of the deliverable's optional scheduling fields
+    (start_date, due_date, duration, owner, milestone) authored for the
+    project plan / schedule read model. Absent fields render nothing, so a
+    deliverable with no scheduling data looks exactly as before — the same
+    graceful pattern as render_publish_row. Never writes engagement state."""
+    owner = d.get("owner")
+    start = d.get("start_date")
+    due = d.get("due_date")
+    duration = d.get("duration")
+    milestone = d.get("milestone") is True
+    if not (owner or start or due or duration is not None or milestone):
+        return ""
+    parts = []
+    if milestone:
+        parts.append(
+            '<span class="milestone-mark" title="Milestone — phase-boundary checkpoint">'
+            '◆ milestone</span>'
+        )
+    if owner:
+        parts.append(f'<span class="sched-chip" title="Owner">\U0001f464 {esc(str(owner))}</span>')
+    if start or due:
+        span = f'{esc(str(start)) if start else "?"} → {esc(str(due)) if due else "?"}'
+        parts.append(f'<span class="sched-chip" title="Start → Due">{span}</span>')
+    if duration is not None:
+        parts.append(
+            f'<span class="sched-chip" title="Duration (effort-days)">{esc(str(duration))}d</span>'
+        )
+    return f'<div class="deliv-schedule" title="Schedule">\U0001f5d3 {"".join(parts)}</div>'
+
+
 def render_field_card(field):
     delivs = field["deliverables"]
     rows = []
@@ -431,9 +462,10 @@ def render_field_card(field):
             chips = "".join(f'<span class="dep-chip">{l}</span>' for l in dep_labels)
             dep_hint = f'<div class="deliv-deps" title="Depends on (refresh these first)">⤴ depends on {chips}</div>'
         publish_row = render_publish_row(d.get("publish"))
+        schedule_row = render_schedule_row(d)
         rows.append(
             '<div class="deliv-row">'
-            f'<div class="deliv-title">{esc(d.get("title") or d.get("slug"))}{dep_hint}{publish_row}</div>'
+            f'<div class="deliv-title">{esc(d.get("title") or d.get("slug"))}{dep_hint}{schedule_row}{publish_row}</div>'
             f'<div class="deliv-state">{badge(st, STATE_ROLE.get(st, "muted"))}{stale_badge}</div>'
             f'<div class="deliv-dt">{dt_indicator(d.get("dt_stage"))}</div>'
             f'<div class="deliv-framework">{framework_cell(d.get("chosen_framework"))}</div>'
@@ -582,6 +614,9 @@ header.hero .hero-meta {{ margin-top: 1rem; display: flex; flex-wrap: wrap; gap:
 .deliv-title {{ font-size: .92rem; font-weight: 500; }}
 .deliv-deps {{ font-size: .72rem; color: var(--text-muted); margin-top: .2rem; display: flex; flex-wrap: wrap; align-items: center; gap: .25rem; }}
 .dep-chip {{ background: var(--surface2); border: 1px solid var(--border); border-radius: 999px; padding: .02rem .4rem; font-family: var(--font-mono); font-size: .68rem; }}
+.deliv-schedule {{ font-size: .72rem; color: var(--text-muted); margin-top: .2rem; display: flex; flex-wrap: wrap; align-items: center; gap: .3rem; }}
+.sched-chip {{ background: var(--surface2); border: 1px solid var(--border); border-radius: 999px; padding: .02rem .4rem; font-family: var(--font-mono); font-size: .68rem; }}
+.milestone-mark {{ color: var(--accent); font-size: .7rem; font-weight: 600; white-space: nowrap; }}
 .deliv-publish {{ font-size: .72rem; color: var(--text-muted); margin-top: .2rem; display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; }}
 .publish-entry {{ display: inline-flex; align-items: center; gap: .3rem; flex-wrap: wrap; }}
 .publish-chip {{ background: var(--surface2); border: 1px solid var(--border); border-radius: 6px; padding: .02rem .4rem; font-family: var(--font-mono); font-size: .68rem; color: var(--text-muted); }}

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -99,6 +99,20 @@ delegating to the `consult-dashboard-refresher` agent with
 stays read-only — the agent runs the read-only generator; it never edits
 engagement state.
 
+**Point at the project plan (only when scheduling data exists).** When the engagement
+carries a schedule, surface it here as a one-line read-only pointer. Detect it cheaply:
+a `<engagement-dir>/project-plan.md` already exists, **or**
+`python3 $CLAUDE_PLUGIN_ROOT/scripts/deliverable-graph.py "<engagement-dir>" schedule`
+returns a non-empty `data.schedule[]` with at least one scheduled (not `unscheduled`)
+entry. When it does, name the **next critical-path deliverable** — the first
+not-yet-`complete` deliverable whose key is in `data.critical_path[]` — and offer
+`/cogni-consult:consult-project-plan` to (re)render `project-plan.md` (phase timeline +
+critical path + optional gantt). When no deliverable carries scheduling fields (the
+`schedule` read is empty or every entry is `unscheduled`), say nothing — this pointer
+degrades silently and the dashboard above is unchanged. It is informational only: do not
+add it as a branch in the Step-5 next-action ladder — the project plan is a derived
+read model, not a competing recommendation.
+
 **Milestone README refresh.** On every re-entry, also run
 `python3 $CLAUDE_PLUGIN_ROOT/scripts/generate-engagement-readme.py "<engagement-dir>"`
 automatically (no prompt) to refresh the engagement-root README front door —

--- a/cogni-consult/tests/test_generate_dashboard.sh
+++ b/cogni-consult/tests/test_generate_dashboard.sh
@@ -183,6 +183,32 @@ assert_html_has "4c combo split rendered" "$HTML4" '<span class="fw-chip" title=
 # The legacy deliverable with no chosen_framework renders the empty-cell dash.
 assert_html_has "4d absent renders dash"  "$HTML4" '<span class="deliv-fw-empty" title="No framework chosen">'
 
+# --- Fixture 5: optional scheduling fields surfaced read-only ----------------------
+# A deliverable carrying scheduling fields (start_date/due_date/duration/owner/milestone)
+# shows a schedule sub-row + milestone marker; a deliverable with none of them shows no
+# schedule sub-row (silent degradation — the whole point of the read-only surface).
+D5="$TMPROOT/schedule"
+seed_engagement "$D5" '[
+  {"slug": "tam-model", "title": "TAM model", "state": "in-progress", "dt_stage": "define", "persona_review": "pending",
+   "owner": "AB", "start_date": "2026-07-15", "due_date": "2026-07-20", "duration": 5, "milestone": true},
+  {"slug": "buyer-survey", "title": "Buyer survey", "state": "pending", "dt_stage": "empathize", "persona_review": "pending"}
+]'
+OUT5="$(run "$D5")"
+HTML5="$D5/output/dashboard.html"
+assert_json "5a schedule success"          "$OUT5" "d['success'] is True"
+assert_html_has  "5b schedule sub-row"     "$HTML5" '<div class="deliv-schedule" title="Schedule">'
+assert_html_has  "5c owner chip"           "$HTML5" 'AB</span>'
+assert_html_has  "5d start-due range"      "$HTML5" '2026-07-15 → 2026-07-20'
+assert_html_has  "5e duration chip"        "$HTML5" '5d</span>'
+assert_html_has  "5f milestone marker"     "$HTML5" '◆ milestone'
+# Exactly one deliverable carries scheduling fields, so exactly one schedule sub-row.
+assert_html_has  "5g single schedule row"  "$HTML5" 'class="deliv-schedule"'
+if [ "$(grep -oF 'class="deliv-schedule"' "$HTML5" | wc -l | tr -d ' ')" = "1" ]; then
+  pass "5h unscheduled deliverable degrades silently"
+else
+  fail "5h unscheduled deliverable degrades silently" "expected exactly 1 deliv-schedule row in $HTML5"
+fi
+
 # --- Summary ----------------------------------------------------------------------
 if [ "$failures" -eq 0 ]; then
   echo "All generate-dashboard.py read-side tests passed."


### PR DESCRIPTION
Closes #1025.

Phase 4 (integration + docs) of the consult-project-plan roadmap (epic #1027): the engagement read surfaces now point to the project plan and schedule the earlier phases produced, and the docs are resynced. All surfaces stay **read-only** — no new writes to engagement state.

## Summary
- **consult-resume** — after the "Offer the visual dashboard" step, an elect-only pointer to the project plan that cites the critical-path next deliverable when scheduling data exists (`project-plan.md` present, or `deliverable-graph.py schedule` returns a non-empty scheduled set), and degrades silently when it doesn't (AC1). Not added as a Step-5 next-action routing branch — the plan is informational, not a competing recommendation.
- **consult-dashboard SKILL** — the "Action fields — work breakdown" section documents the per-deliverable schedule sub-row (owner / start→due / duration chips) + a `◆ milestone` marker (AC2).
- **generate-dashboard.py** — new `render_schedule_row` reads the five optional scheduling fields (`start_date`, `due_date`, `duration`, `owner`, `milestone`) directly off each deliverable dict (the same way `render_field_card` already reads `publish[]`/`depends_on`/`chosen_framework`) and renders a schedule chip + milestone marker, blank/graceful when none set; `load_engagement` unchanged (it already passes deliverable dicts through verbatim). New chip CSS sits beside `.dep-chip`/`.publish-chip`/`.fw-chip` (AC2).
- **README** — `consult-project-plan` now appears in What-it-does, Components, Quick start, and the Architecture tree (nine skills); Components also gains `schedule-edit.py` and the `deliverable-graph.py schedule` op (AC3).
- **Version** — cogni-consult `0.1.60` → `0.1.61` in `plugin.json` and `marketplace.json`.

## Tests
- `tests/test_generate_dashboard.sh` fixture 5 asserts the schedule sub-row + milestone marker render for a scheduled deliverable and that an unscheduled deliverable shows **no** schedule row (silent degrade). Full suite green:
  - test_generate_dashboard.sh, test_deliverable_graph.sh, test_dt_stage_advance.sh, test_generate_engagement_readme.sh, test_resolve_assumptions.sh, test_assumption_change_frequency.sh — all pass.
- Breadcrumb guard (`scripts/check-breadcrumbs.py`): 0 violations.

## Scope
- **In:** the two read surfaces, the dashboard renderer code change (required for AC2 — SKILL prose alone cannot render new fields), doc resync, version bump. One coherent read-only PR; nothing deferred (doc drift must not outlive the feature chain).
- **Out:** any write path (schedule edits belong to `schedule-edit.py` / the plan-editing surface); no new resume routing branch.

Plan record: https://github.com/cogni-work/insight-wave/issues/1025#issuecomment-4930064736