### PR TITLE
cogni-consult: surface bound knowledge base in README front door (closes #1039)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.62",
+      "version": "0.1.63",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/scripts/generate-engagement-readme.py
+++ b/cogni-consult/scripts/generate-engagement-readme.py
@@ -6,13 +6,15 @@ Reads the same read model as engagement-status.sh and
 skills/consult-dashboard/scripts/generate-dashboard.py — consult-project.json
 plus each action-fields/<slug>/field.json, with deliverable state as the
 single source of truth and field/engagement rollups derived at read time —
-and writes <engagement-dir>/README.md with four sections:
+and writes <engagement-dir>/README.md with five sections:
 
   1. H1 engagement name + SMART key question
   2. Status snapshot — scope state, per-field done/total, overall completion %
-  3. The single next recommended deliverable (next-action derivation with the
+  3. Knowledge base — the bound cogni-knowledge base + synthesis-file count,
+     mirroring the dashboard kb_line derivation so the two surfaces agree
+  4. The single next recommended deliverable (next-action derivation with the
      personas_gate step spliced in after staleness, before in-progress work)
-  4. A wayfinding link block with relative Obsidian links (only to targets
+  5. A wayfinding link block with relative Obsidian links (only to targets
      that exist, so a scaffold-only engagement emits no broken links)
 
 Read-only over all engagement state except the README.md it writes.
@@ -22,6 +24,7 @@ Output: JSON {"success": bool, "data": {...}, "error": "string"}
 """
 
 import argparse
+import glob
 import json
 import os
 import subprocess
@@ -82,12 +85,22 @@ def load_engagement(engagement_dir):
         except (json.JSONDecodeError, OSError) as exc:
             state = "unreadable"
             warnings.append(f"unreadable field file {fpath}: {exc}")
+        research_count = len(glob.glob(
+            os.path.join(engagement_dir, "action-fields", slug, "research", "*.md")))
         fields.append({
             "slug": slug,
             "title": title,
             "state": state,
             "deliverables": deliverables,
+            "research_count": research_count,
         })
+
+    # Synthesis-file count mirrors the dashboard kb_line derivation exactly
+    # (scope/research/*.md + each field's action-fields/<slug>/research/*.md) so
+    # the markdown front door and the HTML dashboard never disagree on the total.
+    scope_research_count = len(glob.glob(
+        os.path.join(engagement_dir, "scope", "research", "*.md")))
+    research_total = scope_research_count + sum(f["research_count"] for f in fields)
 
     return {
         "slug": project.get("slug"),
@@ -95,6 +108,8 @@ def load_engagement(engagement_dir):
         "key_question": project.get("key_question") or "",
         "updated": project.get("updated") or "",
         "scope_state": (project.get("workflow_state") or {}).get("scope", "pending"),
+        "knowledge_base": (project.get("plugin_refs") or {}).get("knowledge_base"),
+        "research_total": research_total,
         "action_fields": fields,
         "warnings": warnings,
     }
@@ -289,6 +304,18 @@ def render_readme(engagement_dir, eng, summary, action):
     if eng["warnings"]:
         lines += ["", "> ⚠ " + " · ".join(_md_cell(w) for w in eng["warnings"])]
 
+    # Knowledge base — the engagement's central, compounding research tool. Mirror
+    # the dashboard kb_line derivation (bound slug + synthesis count) rather than
+    # the HTML rendering, so the markdown front door reaches parity without
+    # duplicating markup.
+    kb = eng["knowledge_base"]
+    if kb:
+        kb_line = (f"Bound knowledge base: `{kb}` · {eng['research_total']} "
+                   "synthesis file(s) across scope + action fields")
+    else:
+        kb_line = "No knowledge base bound yet."
+    lines += ["", "## Knowledge base", "", kb_line]
+
     lines += ["", "## Next", "", action]
 
     # Wayfinding — every link resolves within the engagement dir by construction.
@@ -318,7 +345,15 @@ def render_readme(engagement_dir, eng, summary, action):
             )
             if deliv_link:
                 way.append(f"  - {deliv_link}")
+        research_link = _link_if_exists(
+            engagement_dir,
+            os.path.join(field_rel, "research"),
+            f"{f['title']} research",
+        )
+        if research_link:
+            way.append(f"  - {research_link}")
     for rel, label in (
+        (os.path.join("scope", "research"), "Scope research"),
         ("personas", "Personas"),
         ("sources", "Sources"),
         (os.path.join(".metadata", "decision-log.json"), "Decision log"),

--- a/cogni-consult/tests/test_generate_engagement_readme.sh
+++ b/cogni-consult/tests/test_generate_engagement_readme.sh
@@ -165,6 +165,9 @@ assert_md_has "1n action fields count"     "$MD1" "**Action fields:** 1 derived"
 assert_links_resolve "1j all links resolve" "$D1"
 # Deliverable without a .md artifact gets no link (would be broken).
 assert_md_lacks "1k no broken deliv link" "$MD1" "(action-fields/market-evidence/competitor-map.md)"
+# Knowledge base section renders; an unbound engagement shows the neutral line.
+assert_md_has "1o kb section"           "$MD1" "## Knowledge base"
+assert_md_has "1p kb neutral line"      "$MD1" "No knowledge base bound yet."
 # The run wrote README.md and nothing else (AC3).
 DIFF1="$(comm -13 <(printf '%s\n' "$BEFORE1") <(printf '%s\n' "$AFTER1"))"
 if [ "$DIFF1" = "./README.md" ]; then
@@ -286,6 +289,35 @@ if [ "$RC7f" -eq 0 ]; then
 else
   fail "7g zero exit on refresh" "expected exit 0 on marked-README refresh"
 fi
+
+# --- Fixture 8: bound knowledge base + research files → kb line + research wayfinding
+# seed_scoped binds no knowledge base, so patch in plugin_refs and seed two
+# synthesis files (one under scope/research, one under a field's research dir) to
+# exercise the bound-slug line, the synthesis count, and the research wayfinding links.
+D8="$TMPROOT/kb"
+seed_scoped "$D8" '[
+  {"slug": "market-sizing", "title": "Market sizing", "state": "complete", "dt_stage": "test"}
+]'
+echo '{"source": "scope-seeded", "name": "CFO"}' > "$D8/personas/cfo.json"
+python3 - "$D8" <<'PY'
+import json, os, sys
+d = sys.argv[1]
+p = os.path.join(d, "consult-project.json")
+proj = json.load(open(p))
+proj["plugin_refs"] = {"knowledge_base": "eu-ai-act"}
+json.dump(proj, open(p, "w"), indent=2)
+PY
+mkdir -p "$D8/scope/research" "$D8/action-fields/market-evidence/research"
+echo "# synthesis A" > "$D8/scope/research/a.md"
+echo "# synthesis B" > "$D8/action-fields/market-evidence/research/b.md"
+OUT8="$(run "$D8")"
+MD8="$D8/README.md"
+assert_json "8a kb success"             "$OUT8" "d['success'] is True"
+assert_md_has "8b kb section"           "$MD8" "## Knowledge base"
+assert_md_has "8c bound slug + count"   "$MD8" 'Bound knowledge base: `eu-ai-act` · 2 synthesis file(s) across scope + action fields'
+assert_md_has "8d scope research link"  "$MD8" "(scope/research)"
+assert_md_has "8e field research link"  "$MD8" "(action-fields/market-evidence/research)"
+assert_links_resolve "8f links resolve" "$D8"
 
 # --- Summary ----------------------------------------------------------------------
 if [ "$failures" -eq 0 ]; then


### PR DESCRIPTION
Closes #1039

## Summary

Extends `cogni-consult/scripts/generate-engagement-readme.py` so the engagement README front door surfaces the **bound knowledge base**, reaching parity with the HTML dashboard's `kb_line` (currently the base is visible only on the dashboard, not the markdown front door).

- New `## Knowledge base` section: `Bound knowledge base: <slug> · N synthesis file(s) across scope + action fields`, or `No knowledge base bound yet.` when unbound.
- Synthesis count globs `scope/research/*.md` + `action-fields/*/research/*.md` — the **same derivation as the dashboard**, so the two surfaces never disagree.
- Research directories surfaced in `## Wayfinding` via `_link_if_exists` (per-field `research/` dir + the scope `research/` dir), emitted only when present so a scaffold-only engagement stays link-clean.

Additive and fail-soft: `glob` on a missing dir yields an empty list (count 0), and `_link_if_exists` skips absent dirs. The `GENERATED_MARKER` overwrite guard and the read-only-except-README contract are preserved.

## Testing

`bash cogni-consult/tests/test_generate_engagement_readme.sh` — **39 assertions pass**, including new fixtures for the bound case (slug + count + research wayfinding links) and the unbound case (neutral line).

## Version

cogni-consult `0.1.62` → `0.1.63` (plugin.json + marketplace.json).

Part of the "engagement README front door" roadmap epic #1042 (phase-1 sibling of the merged scope-surfacing child). Independent of the other children.