### PR TITLE
cogni-consult: surface project plan in engagement README front door

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/scripts/generate-engagement-readme.py
+++ b/cogni-consult/scripts/generate-engagement-readme.py
@@ -6,7 +6,7 @@ Reads the same read model as engagement-status.sh and
 skills/consult-dashboard/scripts/generate-dashboard.py — consult-project.json
 plus each action-fields/<slug>/field.json, with deliverable state as the
 single source of truth and field/engagement rollups derived at read time —
-and writes <engagement-dir>/README.md with six sections:
+and writes <engagement-dir>/README.md with seven sections:
 
   1. H1 engagement name + SMART key question
   2. Status snapshot — scope state, per-field done/total, overall completion %
@@ -14,9 +14,12 @@ and writes <engagement-dir>/README.md with six sections:
      mirroring the dashboard kb_line derivation so the two surfaces agree
   4. Assumptions — the quantified planning registry (assumptions.json) with each
      entry's value, provenance type, and position on the verification ladder
-  5. The single next recommended deliverable (next-action derivation with the
+  5. Project plan — a compact schedule snapshot (next milestone + nearest due
+     dates) from the optional per-deliverable scheduling fields, linking the
+     rendered project-plan.md artifact rather than re-rendering it
+  6. The single next recommended deliverable (next-action derivation with the
      personas_gate step spliced in after staleness, before in-progress work)
-  6. A wayfinding link block with relative Obsidian links (only to targets
+  7. A wayfinding link block with relative Obsidian links (only to targets
      that exist, so a scaffold-only engagement emits no broken links)
 
 Read-only over all engagement state except the README.md it writes.
@@ -302,6 +305,50 @@ def _link_if_exists(engagement_dir, rel_path, label):
     return None
 
 
+def _project_plan_snapshot(eng, max_due=3):
+    """Compact schedule-snapshot lines (next milestone + nearest due dates) from
+    the optional per-deliverable scheduling fields (`milestone` / `due_date`)
+    that load_engagement passes through verbatim, or [] when nothing is
+    scheduled. Only not-yet-complete deliverables count toward "next" / "upcoming"
+    — a past due date on a finished deliverable is not upcoming work. Fail-soft: a
+    non-dict entry or a deliverable missing these optional fields is simply
+    skipped, never a traceback."""
+    scheduled = []
+    for f in eng["action_fields"]:
+        for d in f["deliverables"]:
+            if not isinstance(d, dict) or d.get("state", "pending") == "complete":
+                continue
+            due = d.get("due_date")
+            due = due if isinstance(due, str) and due else None
+            milestone = bool(d.get("milestone"))
+            if due or milestone:
+                scheduled.append({
+                    "title": d.get("title") or d.get("slug") or "Untitled",
+                    "due": due,
+                    "milestone": milestone,
+                })
+    if not scheduled:
+        return []
+    out = []
+    # Next milestone — the earliest-due milestone deliverable. Milestones with no
+    # due date sort after dated ones but still surface (dateless checkpoint).
+    milestones = [s for s in scheduled if s["milestone"]]
+    if milestones:
+        nxt = min(milestones, key=lambda s: (s["due"] is None, s["due"] or ""))
+        if nxt["due"]:
+            out.append(f"- **Next milestone:** {_md_cell(nxt['title'])} (due {nxt['due']})")
+        else:
+            out.append(f"- **Next milestone:** {_md_cell(nxt['title'])}")
+    # Upcoming due dates — the soonest dated deliverables, ascending.
+    dated = sorted((s for s in scheduled if s["due"]), key=lambda s: s["due"])
+    if dated:
+        rendered = ", ".join(
+            f"{_md_cell(s['title'])} ({s['due']})" for s in dated[:max_due]
+        )
+        out.append(f"- **Upcoming due dates:** {rendered}")
+    return out
+
+
 def render_readme(engagement_dir, eng, summary, action):
     lines = [f"# {eng['name']}"]
     if eng["key_question"]:
@@ -356,6 +403,19 @@ def render_readme(engagement_dir, eng, summary, action):
     else:
         lines.append("No assumptions registered yet.")
 
+    # Project plan — a compact schedule snapshot (next milestone + nearest due
+    # dates) derived from the optional per-deliverable scheduling fields
+    # (milestone / due_date). Always rendered (mirroring Knowledge base /
+    # Assumptions) so an unscheduled engagement degrades to a neutral line rather
+    # than dropping the section. The rendered project-plan.md artifact (written by
+    # consult-project-plan) is linked from Wayfinding, not re-rendered here.
+    lines += ["", "## Project plan", ""]
+    plan_lines = _project_plan_snapshot(eng)
+    if plan_lines:
+        lines += plan_lines
+    else:
+        lines.append("No project plan scheduled yet.")
+
     lines += ["", "## Next", "", action]
 
     # Wayfinding — every link resolves within the engagement dir by construction.
@@ -397,6 +457,7 @@ def render_readme(engagement_dir, eng, summary, action):
         ("personas", "Personas"),
         ("sources", "Sources"),
         ("assumptions.json", "Assumptions registry"),
+        ("project-plan.md", "Project plan"),
         (os.path.join(".metadata", "decision-log.json"), "Decision log"),
     ):
         link = _link_if_exists(engagement_dir, rel, label)

--- a/cogni-consult/tests/test_generate_engagement_readme.sh
+++ b/cogni-consult/tests/test_generate_engagement_readme.sh
@@ -7,11 +7,13 @@
 # both the JSON stdout and the generated README.md.
 #
 # Coverage:
-#   1  fully-scoped       all four sections render; every relative link in the
-#                         README resolves inside the engagement dir; the run
-#                         writes README.md and nothing else
+#   1  fully-scoped       every section renders (incl. Project plan schedule
+#                         snapshot from inline milestone/due_date fields); every
+#                         relative link in the README resolves inside the
+#                         engagement dir; the run writes README.md and nothing else
 #   2  scaffold-only      scope pending, no fields → status reads "scoping",
-#                         next-action recommends consult-scope, no field links
+#                         next-action recommends consult-scope, no field links,
+#                         Project plan degrades to its neutral line
 #   3  personas-gate      scoped engagement without a scope-seeded persona →
 #                         next-action recommends consult-personas before
 #                         deliverable work
@@ -143,7 +145,8 @@ EOF
 D1="$TMPROOT/full"
 seed_scoped "$D1" '[
   {"slug": "market-sizing", "title": "Market sizing", "state": "complete", "dt_stage": "test"},
-  {"slug": "competitor-map", "title": "Competitor map", "state": "pending"}
+  {"slug": "competitor-map", "title": "Competitor map", "state": "pending",
+   "due_date": "2027-01-15", "milestone": true}
 ]'
 echo '{"source": "scope-seeded", "name": "CFO"}' > "$D1/personas/cfo.json"
 echo "# Market sizing" > "$D1/action-fields/market-evidence/market-sizing.md"
@@ -155,6 +158,10 @@ cat > "$D1/assumptions.json" <<'EOF'
   {"id": "asm-tam", "name": "DACH TAM", "value": "€1.2B", "provenance_type": "claim", "status": "reviewed"}
 ]}
 EOF
+# Rendered project-plan.md artifact (written by consult-project-plan, stubbed
+# here) — exercises the Project-plan wayfinding link. Written before the BEFORE1
+# snapshot so the "writes only README.md" check (1l) still holds.
+echo "# Project plan" > "$D1/project-plan.md"
 BEFORE1="$(cd "$D1" && find . -type f | sort)"
 OUT1="$(run "$D1")"
 AFTER1="$(cd "$D1" && find . -type f | sort)"
@@ -182,6 +189,13 @@ assert_md_has "1q assumptions section"  "$MD1" "## Assumptions"
 assert_md_has "1r assumptions count"    "$MD1" "1 assumption registered."
 assert_md_has "1s assumptions row"      "$MD1" "| DACH TAM | €1.2B | claim | reviewed |"
 assert_md_has "1t assumptions wayfinding link" "$MD1" "(assumptions.json)"
+# Project plan section renders the schedule snapshot from the pending milestone
+# deliverable's inline scheduling fields, plus the resolving wayfinding link to
+# the stubbed project-plan.md artifact.
+assert_md_has "1u project plan section"  "$MD1" "## Project plan"
+assert_md_has "1v next milestone line"   "$MD1" "**Next milestone:** Competitor map (due 2027-01-15)"
+assert_md_has "1w upcoming due dates"    "$MD1" "**Upcoming due dates:** Competitor map (2027-01-15)"
+assert_md_has "1x project-plan wayfinding link" "$MD1" "(project-plan.md)"
 # The run wrote README.md and nothing else (AC3).
 DIFF1="$(comm -13 <(printf '%s\n' "$BEFORE1") <(printf '%s\n' "$AFTER1"))"
 if [ "$DIFF1" = "./README.md" ]; then
@@ -213,6 +227,11 @@ assert_md_has "2g action fields zero"   "$MD2" "**Action fields:** 0 derived"
 # Assumptions section renders even with no registry file — neutral line, no crash.
 assert_md_has "2h assumptions section"  "$MD2" "## Assumptions"
 assert_md_has "2i assumptions neutral"  "$MD2" "No assumptions registered yet."
+# Project plan section renders even with no scheduling fields and no project-plan.md
+# artifact — neutral line, and no broken wayfinding link (2e also guards this).
+assert_md_has "2j project plan section" "$MD2" "## Project plan"
+assert_md_has "2k project plan neutral" "$MD2" "No project plan scheduled yet."
+assert_md_lacks "2l no project-plan link" "$MD2" "(project-plan.md)"
 assert_links_resolve "2e links resolve" "$D2"
 
 # --- Fixture 3: personas gate pending blocks deliverable work ------------------------


### PR DESCRIPTION
Closes #1041.

## Summary
- Add an always-rendered `## Project plan` section to the engagement README front door, computing a compact schedule snapshot (next milestone + up to 3 nearest due dates) from the optional per-deliverable scheduling fields (`milestone` / `due_date`) already carried on each deliverable — no loader change, no `deliverable-graph.py` shell-out.
- Only not-yet-complete deliverables count toward "next"/"upcoming"; fail-soft neutral fallback ("No project plan scheduled yet.") when nothing is scheduled, mirroring the `## Assumptions` / `## Knowledge base` pattern.
- Append `project-plan.md` to `## Wayfinding` via the existing `_link_if_exists` (the link appears only when the artifact exists — never a broken link; the README links the rendered artifact rather than re-rendering it).
- Update the module docstring section enumeration (six → seven sections; Project plan as item 5, renumbering Next→6 / Wayfinding→7).
- Preserve the `GENERATED_MARKER` overwrite guard and the read-only-except-README contract.
- Bump `cogni-consult` 0.1.64 → 0.1.65 in plugin.json and mirror in marketplace.json.

This is the last child of epic #1042 — it closes the README front-door coverage: scope, knowledge base, assumptions, and the project plan are all reachable in one hop.

## Scope decisions
- Snapshot is computed purely from the inline `milestone` / `due_date` fields. The `deliverable-graph.py schedule` subcommand / critical-path is intentionally NOT invoked — the issue asks only for next-milestone + nearest-due, and staying inline keeps the surface minimal and avoids a subprocess dependency.
- Nothing deferred — section, wayfinding link, tests, and version bump are one reviewable PR.

## Test plan
- `bash cogni-consult/tests/test_generate_engagement_readme.sh` — all 61 assertions pass (7 new: 1u–1x positive snapshot + wayfinding link folded into Fixture 1; 2j–2l neutral path folded into Fixture 2).
- Fixture 1: pending milestone deliverable with `due_date` → snapshot line renders; stubbed `project-plan.md` → wayfinding link resolves; "writes only README.md" invariant preserved.
- Fixture 2: no scheduling fields, no `project-plan.md` → neutral line, no broken link.

Plan record: https://github.com/cogni-work/insight-wave/issues/1041#issuecomment-4933450884