### PR TITLE
Relicense 13 plugin manifests to Apache-2.0 + mirror versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.66",
+      "version": "1.0.67",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [
@@ -52,7 +52,7 @@
     {
       "name": "cogni-claims",
       "source": "./cogni-claims",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "maturity": "preview",
       "description": "Claim verification and management system. Verifies sourced claims against cited URLs, detects deviations, guides users through resolution, and provides interactive cobrowsing recovery for unreachable sources.",
       "keywords": [
@@ -68,7 +68,7 @@
     {
       "name": "cogni-narrative",
       "source": "./cogni-narrative",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "maturity": "preview",
       "description": "Story arc engine for insight-wave. Transforms structured research and portfolio output into executive narratives via 11 arc frameworks (Corporate Visions, JTBD Portfolio, Strategic Foresight, Trend Panorama, Smarter Service + 6) and 8 narrative techniques. Includes review scoring (0–100, A–F) and derivative formats (executive brief, talking points, one-pager). Bilingual EN/DE.",
       "keywords": [
@@ -90,7 +90,7 @@
     {
       "name": "cogni-copywriting",
       "source": "./cogni-copywriting",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "maturity": "preview",
       "description": "Document polishing with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), parallel-persona stakeholder review, readability optimization, sales Power Positions, JSON field polishing (copy-json), arc audit against cogni-narrative, and translate-then-polish across DE/EN/FR/IT/PL/NL/ES via an EN/DE pivot. Arc-mode translation across all seven languages.",
       "keywords": [
@@ -118,7 +118,7 @@
     {
       "name": "cogni-workspace",
       "source": "./cogni-workspace",
-      "version": "0.6.35",
+      "version": "0.6.36",
       "maturity": "preview",
       "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
       "keywords": [
@@ -133,7 +133,7 @@
     {
       "name": "cogni-trends",
       "source": "./cogni-trends",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "maturity": "preview",
       "description": "Strategic trend scouting and TIPS reporting pipeline. Combines the Smarter Service Trendradar (4 dimensions) with TIPS (Trends, Implications, Possibilities, Solutions): trend-scout → value-modeler → trend-research → trend-synthesis and/or trend-booklet → verify-trend-report. Evidence-backed CxO reports and reusable industry catalogs across DE/FR/IT/PL/NL/ES + US/UK.",
       "keywords": [
@@ -157,7 +157,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.51",
+      "version": "0.9.52",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
       "keywords": [
@@ -174,7 +174,7 @@
     {
       "name": "cogni-visual",
       "source": "./cogni-visual",
-      "version": "0.16.25",
+      "version": "0.16.26",
       "maturity": "preview",
       "description": "Transform polished narratives and structured data into visual deliverables — presentation briefs, slide decks, scrollable web narratives, poster storyboards, single-page infographics, and visual assets. Supports Excalidraw, Pencil MCP, PPTX, and HTML rendering.",
       "keywords": [
@@ -192,7 +192,7 @@
     {
       "name": "cogni-help",
       "source": "./cogni-help",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "maturity": "incubating",
       "description": "Central help hub for the insight-wave ecosystem. Interactive courses (workflow-tour curriculum), plugin discovery, cross-plugin workflow guides, troubleshooting, quick-reference cheatsheets, and GitHub issue filing.",
       "keywords": [
@@ -212,7 +212,7 @@
     {
       "name": "cogni-marketing",
       "source": "./cogni-marketing",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "maturity": "incubating",
       "description": "B2B marketing content engine bridging cogni-trends strategic themes (GTM paths) and cogni-portfolio propositions into channel-ready content. Supports thought leadership, demand generation, lead generation, sales enablement, and ABM across markets with configurable brand voice. Bilingual DE/EN.",
       "keywords": [
@@ -232,7 +232,7 @@
     {
       "name": "cogni-sales",
       "source": "./cogni-sales",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "maturity": "preview",
       "description": "B2B sales pitch generation using Corporate Visions Why Change methodology. Creates sales presentations and proposals for named customers (deal-specific) or market segments (reusable). Builds on cogni-portfolio data with optional TIPS strategic enrichment. Multilingual EN / DE / PT-BR.",
       "keywords": [
@@ -251,7 +251,7 @@
     {
       "name": "cogni-website",
       "source": "./cogni-website",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "maturity": "incubating",
       "description": "Assembles multi-page customer websites from portfolio, marketing, trend, and research content produced by other insight-wave plugins — outputting a deployable static site with shared navigation, theming, and responsive HTML.",
       "keywords": [

--- a/cogni-claims/.claude-plugin/plugin.json
+++ b/cogni-claims/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "cogni-claims",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Claim verification and management system. Verifies sourced claims against cited URLs, detects deviations, guides users through resolution, and provides interactive cobrowsing recovery for unreachable sources.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "claim-verification",
     "fact-checking",

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "consulting",
     "action-fields",

--- a/cogni-copywriting/.claude-plugin/plugin.json
+++ b/cogni-copywriting/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "cogni-copywriting",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Document polishing with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), parallel-persona stakeholder review, readability optimization, sales Power Positions, JSON field polishing (copy-json), arc audit against cogni-narrative, and translate-then-polish across DE/EN/FR/IT/PL/NL/ES via an EN/DE pivot. Arc-mode translation across all seven languages.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "copywriting",
     "document-polishing",

--- a/cogni-help/.claude-plugin/plugin.json
+++ b/cogni-help/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "cogni-help",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Central help hub for the insight-wave ecosystem. Interactive courses (workflow-tour curriculum), plugin discovery, cross-plugin workflow guides, troubleshooting, quick-reference cheatsheets, and GitHub issue filing.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "help",
     "guide",

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.66",
+  "version": "1.0.67",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "knowledge-base",
     "wiki-first",

--- a/cogni-marketing/.claude-plugin/plugin.json
+++ b/cogni-marketing/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "cogni-marketing",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "B2B marketing content engine bridging cogni-trends strategic themes (GTM paths) and cogni-portfolio propositions into channel-ready content. Supports thought leadership, demand generation, lead generation, sales enablement, and ABM across markets with configurable brand voice. Bilingual DE/EN.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "marketing",
     "content-marketing",

--- a/cogni-narrative/.claude-plugin/plugin.json
+++ b/cogni-narrative/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "cogni-narrative",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Story arc engine for insight-wave. Transforms structured research and portfolio output into executive narratives via 11 arc frameworks (Corporate Visions, JTBD Portfolio, Strategic Foresight, Trend Panorama, Smarter Service + 6) and 8 narrative techniques. Includes review scoring (0–100, A–F) and derivative formats (executive brief, talking points, one-pager). Bilingual EN/DE.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "narrative",
     "story-arc",

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.51",
+  "version": "0.9.52",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "portfolio",
     "messaging",

--- a/cogni-sales/.claude-plugin/plugin.json
+++ b/cogni-sales/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "cogni-sales",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "B2B sales pitch generation using Corporate Visions Why Change methodology. Creates sales presentations and proposals for named customers (deal-specific) or market segments (reusable). Builds on cogni-portfolio data with optional TIPS strategic enrichment. Multilingual EN / DE / PT-BR.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "sales",
     "pitch",

--- a/cogni-trends/.claude-plugin/plugin.json
+++ b/cogni-trends/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "cogni-trends",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Strategic trend scouting and TIPS reporting pipeline. Combines the Smarter Service Trendradar (4 dimensions) with TIPS (Trends, Implications, Possibilities, Solutions): trend-scout → value-modeler → trend-research → trend-synthesis and/or trend-booklet → verify-trend-report. Evidence-backed CxO reports and reusable industry catalogs across DE/FR/IT/PL/NL/ES + US/UK.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "tips",
     "trend-scout",

--- a/cogni-visual/.claude-plugin/plugin.json
+++ b/cogni-visual/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "cogni-visual",
-  "version": "0.16.25",
+  "version": "0.16.26",
   "description": "Transform polished narratives and structured data into visual deliverables \u2014 presentation briefs, slide decks, scrollable web narratives, poster storyboards, single-page infographics, and visual assets. Supports Excalidraw, Pencil MCP, PPTX, and HTML rendering.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "presentations",
     "slides",

--- a/cogni-website/.claude-plugin/plugin.json
+++ b/cogni-website/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "cogni-website",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Assembles multi-page customer websites from portfolio, marketing, trend, and research content produced by other insight-wave plugins \u2014 outputting a deployable static site with shared navigation, theming, and responsive HTML.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "website",
     "static-site",

--- a/cogni-workspace/.claude-plugin/plugin.json
+++ b/cogni-workspace/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "cogni-workspace",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"
   },
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "keywords": [
     "workspace",
     "themes",


### PR DESCRIPTION
Closes #1057.

Phase 3 (manifests) of the relicense epic #1059, running after the LICENSE-file swap (#1056, merged) so the declared SPDX license matches the actual LICENSE text.

## Summary
- Swap `"license": "AGPL-3.0-only"` → `"license": "Apache-2.0"` in all 13 plugin.json files.
- Bump each touched plugin.json patch version via surgical exact-string edit on the `"version"` line (no json.dump — preserves unicode).
- Mirror each bumped version into the matching plugin entry in `.claude-plugin/marketplace.json`.
- No `license` field added to marketplace.json (not requested).

## Version bumps
| plugin | old → new |
|---|---|
| cogni-claims | 0.10.5 → 0.10.6 |
| cogni-consult | 0.1.65 → 0.1.66 |
| cogni-copywriting | 0.6.3 → 0.6.4 |
| cogni-help | 0.0.10 → 0.0.11 |
| cogni-knowledge | 1.0.66 → 1.0.67 |
| cogni-marketing | 0.0.2 → 0.0.3 |
| cogni-narrative | 0.11.3 → 0.11.4 |
| cogni-portfolio | 0.9.51 → 0.9.52 |
| cogni-sales | 0.4.2 → 0.4.3 |
| cogni-trends | 0.6.8 → 0.6.9 |
| cogni-visual | 0.16.25 → 0.16.26 |
| cogni-website | 0.0.5 → 0.0.6 |
| cogni-workspace | 0.6.35 → 0.6.36 |

## Verification
- AC1: 13/13 plugin.json declare `Apache-2.0`.
- AC2: each patch version bumped and mirrored in marketplace.json (0 mismatches).
- AC3: 0 `AGPL-3.0-only` strings remain in any plugin.json.
- All 13 plugin.json + marketplace.json parse as valid JSON (no unicode corruption).
- No `license` field added to marketplace.json.