### PR TITLE
ci(cla): trust claude-cogni-work automation account as PR opener

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,7 +28,7 @@ jobs:
           # automation account, but the email itself can be set in any local git commit,
           # so commit-author=claude alone is not a strong identity signal. This guard
           # only honors that identity when the PR opener is also a trusted maintainer.
-          TRUSTED: sdh07
+          TRUSTED: sdh07,claude-cogni-work
         run: |
           set -euo pipefail
           DATA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author,commits)
@@ -55,7 +55,7 @@ jobs:
           remote-organization-name: cogni-work
           remote-repository-name: insight-wave
           branch: "main"
-          allowlist: sdh07,claude,dependabot[bot],github-actions[bot]
+          allowlist: sdh07,claude,claude-cogni-work,dependabot[bot],github-actions[bot]
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can merge this PR, you need to sign the [Contributor License Agreement](https://github.com/cogni-work/insight-wave/blob/main/CLA.md).
 


### PR DESCRIPTION
## Summary
The anti-spoofing guard in `cla.yml` ("Block spoofable claude-author identity from untrusted PR openers") only honors `claude`-authored (`noreply@anthropic.com`) commits when the PR opener is a trusted maintainer. PRs opened by the `claude-cogni-work` automation account that also carry a `claude`-authored commit trip the guard and fail the `cla` check — blocking merge even after the review gate passes (e.g. #1066).

This adds `claude-cogni-work` to:
- the guard's **`TRUSTED`** set — it is a controlled first-party automation account, not an untrusted external opener; and
- the CLA Assistant **`allowlist`** — it appears as a committer on those PRs, so the now-reached signing step would otherwise flag it unsigned.

## Why this is safe
`claude-cogni-work` is the maintainer-operated automation account, not an arbitrary external contributor. The guard's purpose — preventing an *untrusted* opener from smuggling `claude`-attributed commits — is unaffected; external openers are still gated.

## Effect
Unblocks the `cla` check on bot-opened PRs like #1066 (once this lands on `main`, since the check runs from the base branch via `pull_request_target`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)