### PR TITLE
cogni-marketing: fix agent frontmatter keys so agents register

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -212,7 +212,7 @@
     {
       "name": "cogni-marketing",
       "source": "./cogni-marketing",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "maturity": "incubating",
       "description": "B2B marketing content engine bridging cogni-trends strategic themes (GTM paths) and cogni-portfolio propositions into channel-ready content. Supports thought leadership, demand generation, lead generation, sales enablement, and ABM across markets with configurable brand voice. Bilingual DE/EN.",
       "keywords": [

--- a/cogni-marketing/.claude-plugin/plugin.json
+++ b/cogni-marketing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-marketing",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "B2B marketing content engine bridging cogni-trends strategic themes (GTM paths) and cogni-portfolio propositions into channel-ready content. Supports thought leadership, demand generation, lead generation, sales enablement, and ABM across markets with configurable brand voice. Bilingual DE/EN.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-marketing/agents/channel-adapter.md
+++ b/cogni-marketing/agents/channel-adapter.md
@@ -1,6 +1,6 @@
 ---
-identifier: channel-adapter
-whenToUse: >
+name: channel-adapter
+description: >
   Use this agent to adapt an existing content piece to a different channel or format.
   For example, converting a blog post into a LinkedIn promotion post, a whitepaper into
   an email announcement, or a webinar outline into a registration page. The agent preserves

--- a/cogni-marketing/agents/content-writer.md
+++ b/cogni-marketing/agents/content-writer.md
@@ -1,6 +1,6 @@
 ---
-identifier: content-writer
-whenToUse: >
+name: content-writer
+description: >
   Use this agent to generate individual marketing content pieces (blog posts, LinkedIn posts,
   whitepapers, battle cards, email sequences, etc.) for cogni-marketing skills. Each agent
   instance produces one content piece based on provided context (brand voice, TIPS data,
@@ -35,7 +35,7 @@ whenToUse: >
   </example>
 model: sonnet
 color: green
-tools: Read, Write, Edit, Bash, Glob, Grep, WebSearch, WebFetch
+tools: Read, Write, Glob, Grep, WebSearch, WebFetch
 ---
 
 # Content Writer Agent

--- a/cogni-marketing/agents/seo-researcher.md
+++ b/cogni-marketing/agents/seo-researcher.md
@@ -1,6 +1,6 @@
 ---
-identifier: seo-researcher
-whenToUse: >
+name: seo-researcher
+description: >
   Use this agent to research SEO keyword opportunities and competitor content for a specific
   GTM path and market. Produces keyword recommendations, content gap analysis, and competitive
   SERP insights. Delegated by the demand-generation and content-strategy skills.


### PR DESCRIPTION
Closes #1067.

## Summary
- Rename `identifier:` → `name:` and `whenToUse:` → `description:` on all three cogni-marketing agents (channel-adapter, content-writer, seo-researcher) — the Claude Code required keys, without which the agents silently fail to register and are unavailable to the skills that delegate to them.
- Preserve every `description` (formerly `whenToUse`) block verbatim, including the `<example>` blocks; no agent-body or behavior change.
- Trim `content-writer` tools to least privilege (`Read, Write, Glob, Grep, WebSearch, WebFetch`), dropping unused `Edit` and `Bash`.
- Patch-bump cogni-marketing 0.0.3 → 0.0.4 in plugin.json and mirror in marketplace.json (required after any agent change).

## Scope decisions
- In scope: the three key renames + the sanctioned content-writer tool trim named in the issue + the mandatory version bump. All mechanical and low-risk.
- Out of scope: nothing. Full issue scope; the tool trim was optional-in-same-PR and is included since it is a single-line least-privilege fix on a file already touched.

## Test plan
- [x] YAML frontmatter parses on all three agents; keys now `name`, `description`, `model`, `color`, `tools`.
- [x] No residual `identifier`/`whenToUse` keys remain.
- [x] `content-writer.md` `tools` line reads `Read, Write, Glob, Grep, WebSearch, WebFetch` (no `Edit`, no `Bash`).
- [x] Agent bodies unchanged beyond the two frontmatter keys (+ content-writer tools line): diff is 9 insertions / 9 deletions across 5 files.
- [x] plugin.json version `0.0.4`; marketplace.json cogni-marketing entry `0.0.4`.
- [ ] `plugin-dev:plugin-validator` on cogni-marketing — expect pass, zero errors (run by the review gate).

Plan record: https://github.com/cogni-work/insight-wave/issues/1067#issuecomment-4948541904