### PR TITLE
fix(cogni-marketing): rename agent frontmatter to name/description so agents register

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -212,7 +212,7 @@
     {
       "name": "cogni-marketing",
       "source": "./cogni-marketing",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "maturity": "incubating",
       "description": "B2B marketing content engine bridging cogni-trends strategic themes (GTM paths) and cogni-portfolio propositions into channel-ready content. Supports thought leadership, demand generation, lead generation, sales enablement, and ABM across markets with configurable brand voice. Bilingual DE/EN.",
       "keywords": [

--- a/cogni-marketing/.claude-plugin/plugin.json
+++ b/cogni-marketing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-marketing",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "B2B marketing content engine bridging cogni-trends strategic themes (GTM paths) and cogni-portfolio propositions into channel-ready content. Supports thought leadership, demand generation, lead generation, sales enablement, and ABM across markets with configurable brand voice. Bilingual DE/EN.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-marketing/agents/channel-adapter.md
+++ b/cogni-marketing/agents/channel-adapter.md
@@ -1,6 +1,6 @@
 ---
-identifier: channel-adapter
-whenToUse: >
+name: channel-adapter
+description: >
   Use this agent to adapt an existing content piece to a different channel or format.
   For example, converting a blog post into a LinkedIn promotion post, a whitepaper into
   an email announcement, or a webinar outline into a registration page. The agent preserves

--- a/cogni-marketing/agents/content-writer.md
+++ b/cogni-marketing/agents/content-writer.md
@@ -1,6 +1,6 @@
 ---
-identifier: content-writer
-whenToUse: >
+name: content-writer
+description: >
   Use this agent to generate individual marketing content pieces (blog posts, LinkedIn posts,
   whitepapers, battle cards, email sequences, etc.) for cogni-marketing skills. Each agent
   instance produces one content piece based on provided context (brand voice, TIPS data,
@@ -35,7 +35,7 @@ whenToUse: >
   </example>
 model: sonnet
 color: green
-tools: Read, Write, Edit, Bash, Glob, Grep, WebSearch, WebFetch
+tools: Read, Write, Glob, Grep, WebSearch, WebFetch
 ---
 
 # Content Writer Agent

--- a/cogni-marketing/agents/seo-researcher.md
+++ b/cogni-marketing/agents/seo-researcher.md
@@ -1,6 +1,6 @@
 ---
-identifier: seo-researcher
-whenToUse: >
+name: seo-researcher
+description: >
   Use this agent to research SEO keyword opportunities and competitor content for a specific
   GTM path and market. Produces keyword recommendations, content gap analysis, and competitive
   SERP insights. Delegated by the demand-generation and content-strategy skills.


### PR DESCRIPTION
## Summary

The three `cogni-marketing` agents used non-standard frontmatter keys (`identifier` / `whenToUse`) instead of Claude Code's required `name` / `description`, so they never registered and were silently unavailable to delegating skills. This single defect failed `cogni-marketing`'s `plugin-validator` gate and sank both sampled cogni-marketing skills in the baseline conformance sweep.

## Changes

- **channel-adapter.md**, **content-writer.md**, **seo-researcher.md** — rename `identifier:` → `name:` and `whenToUse:` → `description:`; description block content preserved verbatim (`model`/`color`/`tools` untouched).
- **content-writer.md** — trim `tools:` to least privilege `Read, Write, Glob, Grep, WebSearch, WebFetch` (drop unused `Edit`, `Bash`).
- **plugin.json** + **marketplace.json** — patch-bump cogni-marketing `0.0.3` → `0.0.4`.

## Acceptance criteria

- [x] All three agents carry `name` + `description` frontmatter and register in Claude Code.
- [x] No change to agent bodies / behavior beyond the key rename (+ tool-scope trim).
- [ ] `plugin-dev:plugin-validator` on `cogni-marketing` returns pass (verified by the post-PR review gate).

Plan record: https://github.com/cogni-work/insight-wave/issues/1067#issuecomment-4948541904

Closes #1067