### PR TITLE
docs(cla): refresh CLA.md scope list to the 13-plugin marketplace roster

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -14,6 +14,11 @@ Thank you for your interest in contributing to insight-wave core plugins. This C
 - cogni-help
 - cogni-marketing
 - cogni-sales
+- cogni-consult
+- cogni-knowledge
+- cogni-website
+
+_This list mirrors the core plugins in [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json) (13 plugins); update both together when the roster changes._
 
 This Agreement does **not** apply to third-party community plugins published on the insight-wave marketplace. See [MARKETPLACE_TERMS.md](MARKETPLACE_TERMS.md) for community plugin terms.
 


### PR DESCRIPTION
Closes #1070.

## Summary
Refresh `CLA.md`'s core-plugin scope list to match the current 13-plugin marketplace roster. The list previously named 10 plugins and predated the monorepo consolidation.

- Add `cogni-consult`, `cogni-knowledge`, `cogni-website` to the scope list.
- Add a one-line note that the list mirrors `.claude-plugin/marketplace.json` (13 plugins), to reduce future drift.

## Impact
Doc-accuracy only — **not** an enforcement change. `.github/workflows/cla.yml` already runs repo-wide on every PR, so contributions to the three plugins were already gated; this only fixes the documentation a contributor reads.

## Verification
- [x] CLA.md scope list now contains exactly the 13 marketplace plugins (set-equality check against `marketplace.json`: MATCH, zero diff either direction).
- [x] Repo-root governance doc — no plugin touched, no version bump.
- [x] Diff is +5 lines to `CLA.md`, no other files.

Plan record: https://github.com/cogni-work/insight-wave/issues/1070#issuecomment-4948737031