### PR TITLE
consult DT Test stage: advisory copywriter tone-polish rung + copywriter guardrails

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [
@@ -90,7 +90,7 @@
     {
       "name": "cogni-copywriting",
       "source": "./cogni-copywriting",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "maturity": "preview",
       "description": "Document polishing with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), parallel-persona stakeholder review, readability optimization, sales Power Positions, JSON field polishing (copy-json), arc audit against cogni-narrative, and translate-then-polish across DE/EN/FR/IT/PL/NL/ES via an EN/DE pivot. Arc-mode translation across all seven languages.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -388,6 +388,27 @@ Three-Layer Quality Gate — advisory, never blocking (auto-walk proceeds to
 completion; interactive mode may elect to loop back). A `null`-framework
 deliverable skips it entirely and completes with no adherence stop.
 
+Next, the advisory language-polish rung — the register-quality tier of the
+Three-Layer Quality Gate, alongside the framework-adherence rung above.
+Dispatch `Skill("cogni-copywriting:copywriter")` over the deliverable artifact
+with `FILE_PATH=<engagement-root>/action-fields/<field_slug>/<deliverable_slug>.md`
+and `--scope=tone` — register-only, so the deliverable's `chosen_framework`
+section headings are left intact and only the prose register is polished
+(clause length, Floskel and Denglish reduction per the copywriter's German
+style rules). The copywriter natively freezes every `{{asm:<slug>}}` placeholder
+and the `## Persona Challenges` table byte-identical and excludes the
+frontmatter `sources[]` lineage, so the tone pass cannot corrupt a
+resolver-critical token. Surface the returned polish to the consultant, who
+**accepts or rejects** it before any write lands, and record the outcome as a
+`copywriter-polish` decision-log entry keyed by `(action_field, deliverable)`
+for parity with the adherence-review rung (shape: `{"id": "d-NNN", "kind":
+"copywriter-polish", "action_field": <slug>, "deliverable": <slug>, "outcome":
+"accepted" | "rejected" | "skipped" | "error", "timestamp": <iso8601>}`). This rung is **advisory and strictly
+non-blocking**: whether the polish runs, is skipped, is rejected, or errors, the
+DT loop proceeds to completion unchanged — a language pass must never stall the
+flow. `output_language`-agnostic: it polishes whatever language the deliverable
+is written in, and a copywriter failure is swallowed as a WARN, never a halt.
+
 Next, the promote check: scan the artifact for bare quantified literals that
 look promotable to an assumption — planning numbers a reader would expect to
 stay current (market sizes, rates, headcounts, price points) written directly

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -402,9 +402,11 @@ resolver-critical token. The copywriter **writes the polish in place** and backs
 the original up to `<engagement-dir>/action-fields/<field-slug>/.<deliverable-slug>.md`
 (its dotfile backup), so surface the resulting diff to the consultant **after**
 the write and let them **accept or reject**: on reject, restore the deliverable
-from that backup dotfile so a rejected polish never lingers on disk; the
-`chosen_framework` headings are the accept/reject gate's safeguard against any
-heading rewording. Record the outcome as a
+from that backup dotfile so a rejected polish never lingers on disk; on accept
+(and on skip/error, where no polish was written) the backup dotfile is redundant
+and may be removed — the copywriter overwrites it on the next polish run either
+way. The `chosen_framework` headings are the accept/reject gate's safeguard
+against any heading rewording. Record the outcome as a
 `copywriter-polish` decision-log entry keyed by `(action_field, deliverable)`
 for parity with the adherence-review rung (shape: `{"id": "d-NNN", "kind":
 "copywriter-polish", "action_field": <field-slug>, "deliverable": <deliverable-slug>, "outcome":

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -391,18 +391,23 @@ deliverable skips it entirely and completes with no adherence stop.
 Next, the advisory language-polish rung — the register-quality tier of the
 Three-Layer Quality Gate, alongside the framework-adherence rung above.
 Dispatch `Skill("cogni-copywriting:copywriter")` over the deliverable artifact
-with `FILE_PATH=<engagement-root>/action-fields/<field_slug>/<deliverable_slug>.md`
-and `--scope=tone` — register-only, so the deliverable's `chosen_framework`
-section headings are left intact and only the prose register is polished
+with `FILE_PATH=<engagement-dir>/action-fields/<field-slug>/<deliverable-slug>.md`
+and `--scope=tone` — register-only, so tone scope skips restructuring and the
+framework structure is not re-imposed; only the prose register is polished
 (clause length, Floskel and Denglish reduction per the copywriter's German
 style rules). The copywriter natively freezes every `{{asm:<slug>}}` placeholder
 and the `## Persona Challenges` table byte-identical and excludes the
 frontmatter `sources[]` lineage, so the tone pass cannot corrupt a
-resolver-critical token. Surface the returned polish to the consultant, who
-**accepts or rejects** it before any write lands, and record the outcome as a
+resolver-critical token. The copywriter **writes the polish in place** and backs
+the original up to `<engagement-dir>/action-fields/<field-slug>/.<deliverable-slug>.md`
+(its dotfile backup), so surface the resulting diff to the consultant **after**
+the write and let them **accept or reject**: on reject, restore the deliverable
+from that backup dotfile so a rejected polish never lingers on disk; the
+`chosen_framework` headings are the accept/reject gate's safeguard against any
+heading rewording. Record the outcome as a
 `copywriter-polish` decision-log entry keyed by `(action_field, deliverable)`
 for parity with the adherence-review rung (shape: `{"id": "d-NNN", "kind":
-"copywriter-polish", "action_field": <slug>, "deliverable": <slug>, "outcome":
+"copywriter-polish", "action_field": <field-slug>, "deliverable": <deliverable-slug>, "outcome":
 "accepted" | "rejected" | "skipped" | "error", "timestamp": <iso8601>}`). This rung is **advisory and strictly
 non-blocking**: whether the polish runs, is skipped, is rejected, or errors, the
 DT loop proceeds to completion unchanged — a language pass must never stall the

--- a/cogni-copywriting/.claude-plugin/plugin.json
+++ b/cogni-copywriting/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-copywriting",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Document polishing with messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid), parallel-persona stakeholder review, readability optimization, sales Power Positions, JSON field polishing (copy-json), arc audit against cogni-narrative, and translate-then-polish across DE/EN/FR/IT/PL/NL/ES via an EN/DE pivot. Arc-mode translation across all seven languages.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-copywriting/CLAUDE.md
+++ b/cogni-copywriting/CLAUDE.md
@@ -180,6 +180,7 @@ Languages: any direction pivoting on EN or DE — `{de,en,fr,it,pl,nl,es}` with 
 | cogni-sales | downstream | Consumes copywriter as optional polish step for sales documents |
 | cogni-marketing | downstream | Consumes copywriter as optional polish step for marketing content |
 | cogni-knowledge | downstream | Consumes copywriter as optional polish step for research syntheses |
+| cogni-consult | downstream | Consumes copywriter as an advisory `--scope=tone` polish rung in the design-thinking Test stage; relies on the `{{asm:...}}` / `## Persona Challenges` protected-content guarantees |
 
 ## Pipeline Position
 

--- a/cogni-copywriting/skills/copywriter/SKILL.md
+++ b/cogni-copywriting/skills/copywriter/SKILL.md
@@ -282,7 +282,7 @@ Review enhances quality but never blocks delivery — if review fails, continue 
 
 - German characters preserved (ä, ö, ü, ß unchanged)
 - Citations preserved (count >= original)
-- Protected content unchanged
+- Protected content unchanged — including every `{{asm:...}}` placeholder and the `## Persona Challenges` table byte-identical; **fail loud** on any such mutation (frontmatter `sources[]` lineage exempt)
 - Readability: Flesch target (EN 50-60, DE 30-50 via Amstad formula) — applies only when `TARGET_LANG` is unset; translation runs use the relative-to-source rule in the Translation-specific validation block below.
 - Active voice: 80%+
 - Framework pattern applied (standard mode)

--- a/cogni-copywriting/skills/copywriter/SKILL.md
+++ b/cogni-copywriting/skills/copywriter/SKILL.md
@@ -28,6 +28,10 @@ Documents may contain content destined for other processing tools. Preserve thes
 - **Figure references and captions** — `Figure/Abbildung {N}` text and `**Figure N:** Title` lines
 - **Obsidian embeds** — `![[assets/*.svg]]`
 - **Kanban tables** — Tables with `| Dimension | Act | Plan | Observe |` headers, wikilinks, legends, and `<!-- kanban-board -->` placeholders
+- **Assumption placeholders** — `{{asm:<slug>}}` tokens (e.g. cogni-consult assumption references) must stay **byte-identical**. These are resolver-critical: a reworded token no longer matches the strict resolver form and fails loud, and a fully prose-ified token is unrecoverable. Freeze them verbatim by default — never reword, expand, translate, or reflow a `{{asm:...}}` token.
+- **Persona Challenges section** — the `## Persona Challenges` heading and every row of its table are preserved byte-identical (consult persona-challenge audit tables), same as kanban tables.
+
+The YAML frontmatter `sources[]` lineage block (`source_url` / `entity_ref` / `propagated_at`) is **out of scope** for the pass entirely — it is provenance metadata, not prose, and the copywriter never rewrites it.
 
 ## Workflow
 
@@ -168,7 +172,7 @@ Translate the entire document to `TARGET_LANG`, holding to these invariants:
 
 1. **Citation markers byte-identical** — every `[P\d+-\d+]`, `[P\d+-\d+](url)`, `<sup>[N]</sup>`, `[portfolio-validated]` stays exactly as written, URL included. Count must match the source.
 2. **URLs byte-identical** — never translate URLs, even in inline `[text](url)` links.
-3. **Protected content byte-identical** — `<diagram-placeholder>` XML blocks, `Figure N`/`Abbildung N` numeric refs, `![[assets/*.svg]]` Obsidian embeds, kanban tables with `| Dimension | Act | Plan | Observe |` headers.
+3. **Protected content byte-identical** — `<diagram-placeholder>` XML blocks, `Figure N`/`Abbildung N` numeric refs, `![[assets/*.svg]]` Obsidian embeds, kanban tables with `| Dimension | Act | Plan | Observe |` headers, every `{{asm:...}}` assumption placeholder, and the `## Persona Challenges` table. **Fail loud** if any `{{asm:...}}` token or `## Persona Challenges` row differs from the source (a mutated resolver token is unrecoverable); the frontmatter `sources[]` lineage is exempt (not rewritten).
 4. **Frontmatter technical IDs unchanged** — `arc_id`, `source_url`, `entity_ref`, schema keys, filenames. Update `target_language:` to the new value (add the field if absent).
 5. **Code blocks** — fenced and inline code never translated.
 6. **Power Position structure markers** — `**IS**:`, `**DOES**:`, `**MEANS**:` stay unchanged (structural, not vocabulary).
@@ -302,7 +306,7 @@ Review enhances quality but never blocks delivery — if review fails, continue 
   4. Source tag: `\[(portfolio-validated|claim-verified|[a-z-]+-validated)\]`
   (These mirror the four marker types enumerated in `translation-principles.md` § "Preserve byte-identical".)
 - **Frontmatter technical IDs unchanged** — `arc_id`, `source_url`, `entity_ref`, and any other technical identifier fields in the frontmatter are byte-identical to source values. The `target_language:` field is set to the new value (added if absent).
-- **Protected content byte-identical** — diagram-placeholder blocks, figure/Abbildung numeric refs, Obsidian embeds, kanban tables match the source byte-for-byte.
+- **Protected content byte-identical** — diagram-placeholder blocks, figure/Abbildung numeric refs, Obsidian embeds, kanban tables, every `{{asm:...}}` assumption placeholder, and the `## Persona Challenges` table match the source byte-for-byte (fail loud on any `{{asm:...}}`/persona-row mutation; `sources[]` frontmatter exempt).
 - **Readability relative to source** — when `TARGET_LANG` is set, score source and output on the **target-language Flesch scale**, then compare. Invocation (read `flesch_score` from each JSON result):
   - `python3 scripts/calculate_readability.py <source.md> --lang $TARGET_LANG` → `source_score` (= `flesch_score`)
   - `python3 scripts/calculate_readability.py <output.md> --lang $TARGET_LANG` → `output_score` (= `flesch_score`)
@@ -317,7 +321,7 @@ Review enhances quality but never blocks delivery — if review fails, continue 
 - **Every named entity retained** — every named organization, person, product, regulation, or place in the source is present in the output (do not generalize "the Bundesnetzagentur" to "the regulator").
 - **Every distinct claim retained** — no distinct factual assertion is silently dropped to save words. Merging two sentences is allowed; dropping the claim one of them made is not.
 - **Charset preserved** — per-language diacritics exactly per `references/01-core-principles/translation-principles.md` § "Per-Language Charset Rules"; never ASCII substitutes.
-- **Protected content byte-identical** — diagram-placeholder blocks, figure/Abbildung numeric refs, Obsidian `![[assets/*.svg]]` embeds, and kanban tables match the source byte-for-byte.
+- **Protected content byte-identical** — diagram-placeholder blocks, figure/Abbildung numeric refs, Obsidian `![[assets/*.svg]]` embeds, kanban tables, every `{{asm:...}}` assumption placeholder, and the `## Persona Challenges` table match the source byte-for-byte (fail loud on any `{{asm:...}}`/persona-row mutation; `sources[]` frontmatter exempt).
 - **Frontmatter technical IDs unchanged** — `arc_id`, slugs, synthesis IDs, `source_url`, `entity_ref`, and any other technical identifier fields are byte-identical to source values.
 - **Word count materially reduced** — the output is shorter than the source. If it is not, either the source was already minimal or the lossless passes were not applied aggressively enough.
 

--- a/cogni-copywriting/skills/copywriter/references/01-core-principles/german-style-principles.md
+++ b/cogni-copywriting/skills/copywriter/references/01-core-principles/german-style-principles.md
@@ -295,7 +295,29 @@ Be aware of these three sources of quality degradation and actively resist them.
 
 **2. Akademische Sprache.** Abstract, empty expressions that signal sophistication but convey nothing. "Unter Zugrundelegung der evaluierten Parameter" means "nach Pruefung" — write "nach Pruefung."
 
-**3. Unnoetige Anglizismen.** Use German words when they exist and are equally precise. "Meeting" is acceptable (kein gutes deutsches Aequivalent). "Downloaden" is not — use "herunterladen." Test: Does the German word exist and work? If yes, use it.
+**3. Unnoetige Anglizismen (Denglish).** Use German words when they exist and are equally precise. Floskel elimination (Section 4) does **not** target Denglish — anglicisms are a separate register threat and need their own pass. This is the most common failure mode in consulting-deliverable German, where English business jargon ("Named-Account-Motion," "Kill-Switch," "Self-Serve") leaks in wholesale.
+
+**Test (in order):**
+1. Does an equally precise German word exist? If yes, use it.
+2. Is the anglicism an established term with no good German equivalent (e.g. "Meeting," "Software," "Update")? If yes, keep it.
+3. Is it a hyphenated English compound ("Named-Account-Motion," "Term-Sheet")? These almost always have a German rendering — replace them.
+
+**Anglizismen-Ersatztabelle** (replace the left form with the right; extend as needed — the table is illustrative, not exhaustive):
+
+| Anglizismus | Deutsch |
+|-------------|---------|
+| downloaden | herunterladen |
+| Self-Serve / Self-Service | Selbstbedienung |
+| Kill-Switch | Notabschaltung |
+| Off-Ramp | Ausstiegspfad |
+| Named-Account-Motion | Kundenspezifische Ansprache |
+| Term-Sheet | Eckdatenpapier |
+| Best-Case | Bestfall |
+| back-loaded | nachgelagert |
+| Enablement | Befaehigung |
+| Message-Beweis | Botschaftsbeleg |
+
+Keep genuinely untranslatable terms ("Meeting," "Downloaden"→ note: "herunterladen" is the fix, "Meeting" stays). When in doubt, apply Test step 1: if the German word exists and works, use it.
 
 ---
 
@@ -339,6 +361,7 @@ Use this checklist as a final verification pass. Check items in order — earlie
 | 7 | Floskeln | 0 | Gegen Floskeltabelle pruefen (Section 4) |
 | 8 | Satzlaengen-Variation | Standardabweichung > 3 Woerter | Rhythmus anpassen (Maxime 11) |
 | 9 | Synonyme fuer Schluesselbegriffe | 0 | Einheitliche Terminologie (Maxime 4) |
+| 10 | Unnoetige Anglizismen | 0 | Gegen Anglizismen-Ersatztabelle pruefen (Section 6.3) |
 
 ## Integration with Readability Metrics
 

--- a/cogni-copywriting/skills/copywriter/references/01-core-principles/german-style-principles.md
+++ b/cogni-copywriting/skills/copywriter/references/01-core-principles/german-style-principles.md
@@ -317,7 +317,7 @@ Be aware of these three sources of quality degradation and actively resist them.
 | Enablement | Befaehigung |
 | Message-Beweis | Botschaftsbeleg |
 
-Keep genuinely untranslatable terms ("Meeting," "Downloaden"→ note: "herunterladen" is the fix, "Meeting" stays). When in doubt, apply Test step 1: if the German word exists and works, use it.
+Keep only genuinely untranslatable terms — "Meeting," "Software," "Update" stay; "Downloaden" does not (use "herunterladen," per the table above). When in doubt, apply Test step 1: if the German word exists and works, use it.
 
 ---
 


### PR DESCRIPTION
Closes #1075.

## Summary
- Insert a **non-blocking advisory copywriter tone-polish rung** into the consult design-thinking Test stage, right after the framework-adherence rung. It dispatches `Skill("cogni-copywriting:copywriter")` with `--scope=tone` over the current deliverable, offers the consultant accept/reject, and logs a `copywriter-polish` decision-log entry (shape pinned inline) for parity with the adherence rung. Strictly non-blocking — the DT loop proceeds whether the polish runs, is skipped, is rejected, or errors.
- **Durable copywriter guardrail:** `{{asm:...}}` assumption placeholders and the `## Persona Challenges` table are now first-class Protected Content, propagated into all three "Protected content byte-identical" validation-gate anchors so the gate **fails loud** on any mutation. Frontmatter `sources[]` lineage is explicitly exempt.
- **German register:** expanded the one-line anglicism note into a dedicated Denglish/anglicism-reduction rule with a replacement table and a new Quality Checklist row (#10).
- Added `cogni-consult` as a known downstream consumer in `cogni-copywriting/CLAUDE.md`.
- Bumped `cogni-consult` 0.1.68->0.1.69 and `cogni-copywriting` 0.6.4->0.6.5, mirrored in `marketplace.json`.

## Scope decisions
All three coordinated deliverables ship in one PR because the copywriter guardrails and German rule exist to make the new consult tone-polish rung safe; splitting them would leave the rung dispatching an under-protected copywriter. Full scope, nothing deferred.

## Review notes
- The skill-quality-reviewer pass over the whole `cogni-copywriting/skills/copywriter/SKILL.md` surfaced three **pre-existing** maintainer breadcrumbs (Slice/Phase/issue refs at ~L108/L112/L114) that this change does not touch. They are grandfathered in `check-breadcrumbs.py`'s baseline (CI will not fail) and are out of this issue's scope, so they are intentionally left for a dedicated cleanup rather than fixed here.

## Test plan
- [ ] Test stage offers the copywriter rung over the current deliverable and the DT loop proceeds whether the polish runs, is skipped, is rejected, or errors.
- [ ] A `copywriter-polish` decision-log entry is logged with parity to the `adherence-review` entry.
- [ ] Copywriter over a doc with `{{asm:...}}` tokens + a `## Persona Challenges` table keeps both byte-identical and the validation gate fails loud on a forced mutation; `sources[]` frontmatter exempt.
- [ ] German register shows a dedicated Anglizismen rule + Quality Checklist row #10.
- [ ] `cogni-consult` appears as a downstream row in `cogni-copywriting/CLAUDE.md`.
- [ ] plugin.json versions (0.1.69 / 0.6.5) match marketplace.json.

Plan record: https://github.com/cogni-work/insight-wave/issues/1075#issuecomment-4954560349