### PR TITLE
cogni-consult: anchor assumption-register on the READ side of strategy-advisor

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.72",
+  "version": "0.1.73",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/output-styles/strategy-advisor.md
+++ b/cogni-consult/output-styles/strategy-advisor.md
@@ -12,7 +12,7 @@ client's leadership team.
 - Be hypothesis-driven: form a point of view early and test it against evidence.
 - Challenge respectfully; if the premise or framing is weak, offer a sharper one.
 - Distinguish fact from hypothesis from assumption; label what isn't yet known.
-- Register load-bearing planning numbers as assumptions (`{{asm:}}`) so they stay editable and recompute — don't bury them as inline literals.
+- Treat the assumption registry as the source of truth for planning numbers: resolve `{{asm:}}` placeholders against it before calling a number missing, unset, or an open decision — a placeholder is a registered value, not a blank. Register load-bearing numbers as `{{asm:}}` so they stay editable and recompute; don't bury them as inline literals.
 
 ## Structure
 - Organize MECE. Present 2-3 genuinely distinct options with explicit tradeoffs,


### PR DESCRIPTION
Closes #1094.

## Summary

Extends the existing Stance bullet in `cogni-consult/output-styles/strategy-advisor.md` so the strategy-advisor voice covers the **read side** of the assumption registry, not only the write side. Before calling a planning number missing/unset/an open decision, the advisor must now **resolve** the `{{asm:}}` placeholder against the `assumptions.json` register — a placeholder is a registered value, not a blank — while the existing **register** instruction (load-bearing numbers as `{{asm:}}`, don't bury as inline literals) is preserved in substance within the same bullet.

This fixes the observed failure mode from the reporting session: a registered, low-confidence assumption (`asm-userclub-price` = 9 EUR/mo, `asm-buildersclub-price` = 400 EUR/yr) was mischaracterized as "keine Zahl" (absent) instead of *unvalidated* — two different things.

## Change

- `cogni-consult/output-styles/strategy-advisor.md` — the Stance block's assumption bullet now leads with the resolve-before-missing instruction and retains the register clause. The prior register-only bullet is replaced (not duplicated), so there is no double register language.
- `cogni-consult/.claude-plugin/plugin.json` — version 0.1.72 -> 0.1.73.
- `.claude-plugin/marketplace.json` — cogni-consult entry mirrored to 0.1.73.

## Scope decisions

- **In scope:** one combined resolve+register Stance bullet, matched to the block idiom (short imperative, semicolon-joined, ends with a period).
- **Preserved untouched:** the Scope note ("Set interaction voice only") per acceptance criterion (c) — a reasoning posture, not a publish-time mechanic (`resolve-assumptions.py` / `consult-publish` still own the mechanics). Structure and Voice blocks unchanged.
- **Explicitly excluded:** the deterministic skill-level lever (auto-generate `assumptions.md` on resume, resolve register in the dashboard) — already tracked by #1095, not duplicated here.
- **Full scope:** this PR delivers the entire issue; nothing deferred.

## Note for reviewers

The lead-designer/refiner planned against a stale local checkout that lacked the write-side register bullet, so the recorded plan describes *adding* a bullet. Against `origin/main` (and the worktree forked from it) that register bullet already exists, so the executed edit correctly **replaces** it with the combined resolve+register bullet — matching the issue author's stated intent ("Zeile 15 um die Lese-Seite erweitern") and avoiding duplicate register language.

## Acceptance criteria

- [x] Style explicitly instructs resolving `{{asm:}}` against the register before calling a value missing/open.
- [x] Register/write instruction preserved in substance.
- [x] Scope note (Set interaction voice only) untouched.