### PR TITLE
cogni-portfolio: pin agents to sonnet + add researcher cost_estimate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -157,7 +157,7 @@
     {
       "name": "cogni-portfolio",
       "source": "./cogni-portfolio",
-      "version": "0.9.52",
+      "version": "0.9.53",
       "maturity": "preview",
       "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
       "keywords": [

--- a/cogni-portfolio/.claude-plugin/plugin.json
+++ b/cogni-portfolio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-portfolio",
-  "version": "0.9.52",
+  "version": "0.9.53",
   "description": "Portfolio messaging and proposition planning for SMEs using the IS/DOES/MEANS (FAB) framework — market-specific value propositions with competitive analysis, customer profiling, and export-ready deliverables across eight pluggable industry taxonomies and first-class market coverage spanning DACH/EU, UK/US, LATAM (MX/BR), and China (CN).",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-portfolio/CLAUDE.md
+++ b/cogni-portfolio/CLAUDE.md
@@ -176,7 +176,7 @@ Quality gates block downstream generation when upstream entities fail. Features 
 
 | Tier | Model | Agents |
 |------|-------|--------|
-| Research | inherit (caller's model) | market-researcher, competitor-researcher, customer-researcher, proposition-generator, solution-architect, solution-planner |
+| Research | sonnet | market-researcher, competitor-researcher, customer-researcher, proposition-generator, solution-architect, solution-planner |
 | Content Generation | sonnet | customer-narrative-writer |
 | Deep Research | sonnet | feature-deep-diver, proposition-deep-diver, quality-enricher |
 | Quality Assessment | haiku | feature-quality-assessor, proposition-quality-assessor, feature-review-assessor, proposition-review-assessor, solution-review-assessor, customer-review-assessor, communicate-review-assessor, dashboard-refresher, feature-deduplication-detector |

--- a/cogni-portfolio/agents/competitor-researcher.md
+++ b/cogni-portfolio/agents/competitor-researcher.md
@@ -2,7 +2,7 @@
 name: competitor-researcher
 description: Research competitors for a specific proposition using web search.
 
-model: inherit
+model: sonnet
 color: yellow
 tools: ["Read", "Write", "WebSearch", "Bash"]
 ---
@@ -153,7 +153,7 @@ Choose the `field_path` based on what the claim asserts: `competitors[?name=="X"
 
 Submit claims for: pricing data, market share percentages, specific positioning quotes, and quantified strengths/weaknesses. Store the `source_url` used for each competitor in the competitor JSON entry too.
 
-Return a brief summary of the competitive landscape.
+Return a brief summary of the competitive landscape, plus a `cost_estimate` JSON block `{"input_words": <int>, "output_words": <int>, "estimated_usd": <float>}` — the words you read (proposition, feature, market, customer files, search results) and the words you produced; compute `estimated_usd` per the per-word→USD formula and Sonnet pricing constants in `cogni-workspace/references/agent-model-cost.md` (do not inline the coefficients).
 
 ## Revision Mode
 

--- a/cogni-portfolio/agents/customer-researcher.md
+++ b/cogni-portfolio/agents/customer-researcher.md
@@ -2,7 +2,7 @@
 name: customer-researcher
 description: Research named companies for a target market using web search.
 
-model: inherit
+model: sonnet
 color: orange
 tools: ["Read", "WebSearch", "Bash"]
 ---
@@ -82,7 +82,8 @@ The task prompt that spawned you includes a `plugin_root` path. Wherever these i
   "pain_points": ["Legacy infrastructure migration", "Multi-cloud complexity"],
   "current_stack": ["ServiceNow", "Splunk"],
   "source_urls": ["https://..."],
-  "researched_at": "2026-03-13"
+  "researched_at": "2026-03-13",
+  "cost_estimate": { "input_words": 0, "output_words": 0, "estimated_usd": 0.0 }
 }
 ```
 
@@ -152,4 +153,4 @@ These rules implement [Anthropic's recommended hallucination reduction technique
 - Flag uncertainty explicitly when data is estimated or from secondary sources
 - Current stack entries should be tools/platforms, not generic categories
 
-Return the structured JSON object and a brief 2-3 sentence summary of the company's fit.
+Return the structured JSON object and a brief 2-3 sentence summary of the company's fit. Include the `cost_estimate` block `{"input_words": <int>, "output_words": <int>, "estimated_usd": <float>}` in the returned JSON — the words you read and the words you produced; compute `estimated_usd` per the per-word→USD formula and Sonnet pricing constants in `cogni-workspace/references/agent-model-cost.md` (do not inline the coefficients).

--- a/cogni-portfolio/agents/market-researcher.md
+++ b/cogni-portfolio/agents/market-researcher.md
@@ -2,7 +2,7 @@
 name: market-researcher
 description: Research and size a target market using web search — produces TAM/SAM/SOM data.
 
-model: inherit
+model: sonnet
 color: cyan
 tools: ["Read", "Write", "WebSearch", "Bash"]
 ---
@@ -146,4 +146,4 @@ bash "$CLAUDE_PLUGIN_ROOT/scripts/append-claim.sh" "<project-dir>" '{
 
 Only submit claims that reference external web sources. Skip claims sourced from internal estimates or bottom-up calculations.
 
-Return a brief summary of findings with key sources.
+Return a brief summary of findings with key sources, plus a `cost_estimate` JSON block `{"input_words": <int>, "output_words": <int>, "estimated_usd": <float>}` — the words you read (market file, portfolio, search results) and the words you produced; compute `estimated_usd` per the per-word→USD formula and Sonnet pricing constants in `cogni-workspace/references/agent-model-cost.md` (do not inline the coefficients).

--- a/cogni-portfolio/agents/proposition-generator.md
+++ b/cogni-portfolio/agents/proposition-generator.md
@@ -2,7 +2,7 @@
 name: proposition-generator
 description: Generate IS/DOES/MEANS messaging for a single Feature x Market combination.
 
-model: inherit
+model: sonnet
 color: green
 tools: ["Read", "Write", "WebSearch", "Bash"]
 ---

--- a/cogni-portfolio/agents/solution-architect.md
+++ b/cogni-portfolio/agents/solution-architect.md
@@ -2,7 +2,7 @@
 name: solution-architect
 description: Propose delivery blueprints and assess shared solution eligibility for a product.
 
-model: inherit
+model: sonnet
 color: blue
 tools: ["Read", "Glob", "Grep", "Bash"]
 ---

--- a/cogni-portfolio/agents/solution-planner.md
+++ b/cogni-portfolio/agents/solution-planner.md
@@ -2,7 +2,7 @@
 name: solution-planner
 description: Plan implementation phases and pricing tiers for a single proposition.
 
-model: inherit
+model: sonnet
 color: blue
 tools: ["Read", "Write", "WebSearch", "Bash"]
 ---


### PR DESCRIPTION
Closes #1090.

## Summary

Two zero-behavior-change governance fixes for cogni-portfolio, in one PR (one version bump):

1. **Cost telemetry** — the 3 web researchers (market-researcher, competitor-researcher, customer-researcher) now emit a `cost_estimate` block `{input_words, output_words, estimated_usd}` in their returned summary JSON, computing `estimated_usd` per the canonical `cogni-workspace/references/agent-model-cost.md` formula (coefficients **not** inlined). customer-researcher already returns structured JSON (added as a field); market/competitor returned prose (a `cost_estimate` JSON block + citation sentence appended to their return instruction).
2. **Model pinning** — all 6 `model: inherit` agents (market-researcher, competitor-researcher, customer-researcher, proposition-generator, solution-architect, solution-planner) pinned to `model: sonnet`, their documented tier — closing the silent cost-leak if a caller ever ran opus.

Plus the version bump 0.9.52 → 0.9.53 in `plugin.json` + `.claude-plugin/marketplace.json`.

## Acceptance criteria

- [x] The 3 web researchers emit a `cost_estimate` block citing the canonical doc.
- [x] `grep -rl 'model: inherit' cogni-portfolio/agents/*.md` returns **0** matches; all 6 agents carry `model: sonnet`.
- [x] Single version bump mirrored in both manifests (0.9.53).
- [x] `cogni-portfolio-evals` agents untouched (0 files under that dir in the diff).

## Note for reviewers

One file beyond the issue's listed set — `cogni-portfolio/CLAUDE.md` — was updated for **doc-sync**: its "Agent Model Strategy" table listed these 6 agents as Research tier `inherit (caller's model)`, which the model-pin makes factually wrong. The row now reads `sonnet`, keeping the developer guide consistent with the change (matching the repo's version/doc-sync convention). No inlined pricing coefficients anywhere; breadcrumb guard clean (0 violations).