### PR TITLE
cogni-knowledge: refuse fetch-cache store under an unbound knowledge-root

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "cogni-knowledge",
       "source": "./cogni-knowledge",
-      "version": "1.0.68",
+      "version": "1.0.69",
       "maturity": "released",
       "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
       "keywords": [

--- a/cogni-knowledge/.claude-plugin/plugin.json
+++ b/cogni-knowledge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-knowledge",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "description": "Wiki-first research that compounds. Binds each run to a wiki knowledge base; future runs read what prior runs filed before hitting the web. v0.1.0 inverted pipeline (plan → curate → fetch → ingest → distill → compose → verify → finalize) with zero-network, citation-consistent claim verification — opt-in live-source resweep via `knowledge-refresh --resweep`. The shallow `knowledge-query` rung is read-only by default and can optionally file its answer back as an un-verified synthesis page via `--file-back`.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-knowledge/scripts/fetch-cache.py
+++ b/cogni-knowledge/scripts/fetch-cache.py
@@ -47,6 +47,7 @@ from _knowledge_lib import (  # noqa: E402
 SCHEMA_VERSION = "0.1.0"
 FETCH_CACHE_DIRNAME = "fetch-cache"
 BINDING_DIRNAME = ".cogni-knowledge"
+BINDING_FILENAME = "binding.json"
 # Matches cogni-claims' fetch_method enum (cogni-claims/CLAUDE.md:111,
 # skills/claims/SKILL.md) so a future shared verifier can read either cache's
 # entries without translation. `webfetch` / `cobrowse_interactive` are the two
@@ -140,6 +141,10 @@ def _cache_dir(knowledge_root: Path) -> Path:
     return knowledge_root / BINDING_DIRNAME / FETCH_CACHE_DIRNAME
 
 
+def _binding_path(knowledge_root: Path) -> Path:
+    return knowledge_root / BINDING_DIRNAME / BINDING_FILENAME
+
+
 def _url_key(url: str) -> str:
     return hashlib.sha256(normalize_url(url).encode("utf-8")).hexdigest()
 
@@ -173,6 +178,16 @@ def _age_days(stamp: str) -> float | None:
 
 def cmd_store(args: argparse.Namespace) -> int:
     knowledge_root = Path(args.knowledge_root).resolve()
+
+    if not _binding_path(knowledge_root).is_file():
+        return _emit(
+            False,
+            error=(
+                f"no binding at {knowledge_root} — refusing to create a cache "
+                "tree; pass an absolute --knowledge-root pointing at a bound "
+                "knowledge base (run knowledge-setup first, or check for cwd drift)"
+            ),
+        )
 
     if not args.url or not args.url.strip():
         return _emit(False, error="--url must be a non-empty, non-whitespace string")

--- a/cogni-knowledge/tests/test_fetch_cache.sh
+++ b/cogni-knowledge/tests/test_fetch_cache.sh
@@ -35,6 +35,7 @@ WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 KB="$WORK/kb"
 mkdir -p "$KB/.cogni-knowledge"
+printf '{"schema_version":"0.1.5"}' > "$KB/.cogni-knowledge/binding.json"
 
 errors=0
 
@@ -370,6 +371,7 @@ fi
 # 10. store + fetch via two equivalent URL forms — body round-trips.
 KB2="$WORK/kb2"
 mkdir -p "$KB2/.cogni-knowledge"
+printf '{"schema_version":"0.1.5"}' > "$KB2/.cogni-knowledge/binding.json"
 python3 "$SCRIPT" store \
   --knowledge-root "$KB2" \
   --url "https://EXAMPLE.com/Doc/?utm_source=foo" \
@@ -395,6 +397,7 @@ fi
 # 11. store + fetch a `direct` (non-web / local) source — round-trips with no reason.
 KB3="$WORK/kb3"
 mkdir -p "$KB3/.cogni-knowledge"
+printf '{"schema_version":"0.1.5"}' > "$KB3/.cogni-knowledge/binding.json"
 URL_LOCAL="file:///notes/interview-2026-06-06.txt"
 python3 "$SCRIPT" store \
   --knowledge-root "$KB3" \
@@ -425,6 +428,7 @@ fi
 # 11b. store + fetch a `webfetch_fulltext` (primary-tier fuller-body) source — round-trips, status ok, no reason.
 KB4="$WORK/kb4"
 mkdir -p "$KB4/.cogni-knowledge"
+printf '{"schema_version":"0.1.5"}' > "$KB4/.cogni-knowledge/binding.json"
 URL_FULLTEXT="https://eur-lex.example/legal-content/EN/TXT/?uri=annex-iii"
 python3 "$SCRIPT" store \
   --knowledge-root "$KB4" \
@@ -457,6 +461,7 @@ fi
 #      fetched entry, but is still persisted.
 KB5="$WORK/kb5"
 mkdir -p "$KB5/.cogni-knowledge"
+printf '{"schema_version":"0.1.5"}' > "$KB5/.cogni-knowledge/binding.json"
 URL_CONTAM="https://arxiv.example/pdf/2506.17208"
 CONTAM_BODY="Benchmark analysis (relevant to this curator's own sq-06 set) SWE-rebench (this same session's other candidate). Real content follows."
 STORE_CONTAM=$(python3 "$SCRIPT" store \
@@ -511,6 +516,29 @@ if echo "$BAD_METHOD" | grep -q "invalid choice: 'scrape'"; then
 else
   red "FAIL: unknown --fetch-method was not rejected"
   red "  got: $BAD_METHOD"
+  errors=$((errors + 1))
+fi
+
+# 13. store against an unbound knowledge-root (no .cogni-knowledge/binding.json)
+#     refuses to create a cache tree, names the resolved absolute path, and
+#     writes nothing (regression guard for the silent-mis-store bug).
+KB_UNBOUND="$WORK/kb-unbound"
+mkdir -p "$KB_UNBOUND"          # a bare dir — no .cogni-knowledge, no binding
+UNBOUND_ABS="$(cd "$KB_UNBOUND" && pwd)"
+UNBOUND_OUT=$(python3 "$SCRIPT" store \
+  --knowledge-root "$KB_UNBOUND" \
+  --url "https://example.org/unbound" \
+  --fetch-method direct \
+  --status ok \
+  --body "x" 2>&1 || true)
+if echo "$UNBOUND_OUT" | grep -q '"success": false' \
+   && echo "$UNBOUND_OUT" | grep -qF "$UNBOUND_ABS" \
+   && [ ! -d "$KB_UNBOUND/.cogni-knowledge/fetch-cache" ]; then
+  green "PASS: store against an unbound root refuses, names the abs path, writes nothing"
+else
+  red "FAIL: store against an unbound root did not refuse cleanly"
+  red "  got: $UNBOUND_OUT"
+  [ -d "$KB_UNBOUND/.cogni-knowledge/fetch-cache" ] && red "  stray fetch-cache tree was created at $KB_UNBOUND"
   errors=$((errors + 1))
 fi
 

--- a/cogni-knowledge/tests/test_ingest_integrity.sh
+++ b/cogni-knowledge/tests/test_ingest_integrity.sh
@@ -151,7 +151,9 @@ assert d["data"]["checked"]==5, d["data"]["checked"]
 # the page's frontmatter content_hash diverges from the cached body's hash.
 KR="$WORK/kr"
 KR_WIKI="$KR"                       # wiki-root == knowledge-root here (allowed)
-mkdir -p "$KR_WIKI/wiki/sources"   # fetch-cache.py store creates its own dir
+mkdir -p "$KR_WIKI/wiki/sources"
+mkdir -p "$KR/.cogni-knowledge"    # bound root: fetch-cache.py store now requires a binding
+printf '{"schema_version":"0.1.5"}' > "$KR/.cogni-knowledge/binding.json"
 
 # page with a content_hash: frontmatter line
 write_page_ch() {  # $1=slug $2=id $3=url $4=content_hash

--- a/cogni-knowledge/tests/test_pipeline_summary.sh
+++ b/cogni-knowledge/tests/test_pipeline_summary.sh
@@ -302,6 +302,7 @@ fi
 # --- cache-health: empty -------------------------------------------------
 KB="$WORK/kb"
 mkdir -p "$KB/.cogni-knowledge"
+printf '{"schema_version":"0.1.5"}' > "$KB/.cogni-knowledge/binding.json"
 EMPTY_OUT=$(python3 "$SCRIPT" cache-health --knowledge-root "$KB")
 if echo "$EMPTY_OUT" | python3 -c "
 import sys, json
@@ -373,6 +374,7 @@ fi
 # --- cache-health: backdated entry past max_age_days -> stale ------------
 KB2="$WORK/kb2"
 mkdir -p "$KB2/.cogni-knowledge"
+printf '{"schema_version":"0.1.5"}' > "$KB2/.cogni-knowledge/binding.json"
 python3 "$FETCH_CACHE" store \
   --knowledge-root "$KB2" \
   --url "https://example.org/old" \


### PR DESCRIPTION
Closes #1085.

## Summary
- `fetch-cache.py store` now refuses to materialize a cache tree when the resolved `--knowledge-root` has no `.cogni-knowledge/binding.json`, returning `{"success": false, ...}` with an error naming the resolved absolute path and writing nothing (no stray `.cogni-knowledge/fetch-cache/` tree).
- Adds `BINDING_FILENAME` + a `_binding_path()` helper near the existing `BINDING_DIRNAME` (fetch-cache.py:49), reusing the pattern from `knowledge-binding.py`.
- The guard sits immediately after `knowledge_root = Path(args.knowledge_root).resolve()` (cmd_store) and before the `--url`/`--status`/`--reason` validation, so a bound root's write path stays byte-identical.
- Leaves the shared `_knowledge_lib.atomic_write` and `cmd_fetch`/`cmd_evict`/`cmd_stat` untouched (they already fail soft).
- Bumps `cogni-knowledge` 1.0.68 → 1.0.69 (mirrored in marketplace.json).

## Scope decisions
- **Included:** all three acceptance criteria (fail-with-clear-error-and-write-nothing, error names the resolved absolute path, bound-root behavior byte-identical). These are one inseparable guard.
- **Included (test fixtures):** every knowledge-root test fixture that relied on the old unguarded-create behavior gets a seeded stub `binding.json`, plus a new negative-path assertion:
  - `test_fetch_cache.sh` — 5 fixtures (KB/KB2/KB3/KB4/KB5); seeding KB is load-bearing because the pre-existing negative-path validation assertions store against KB *before* the guard's position.
  - `test_ingest_integrity.sh` — the KR fixture had no `.cogni-knowledge` mkdir (it relied on store auto-creating the dir); adds the mkdir + stub binding.
  - `test_pipeline_summary.sh` — the cache-health fixtures (KB, KB2) also stored against unbound roots under `set -eu`; seeded (surfaced by running the full 76-file suite, not flagged by the initial diagnosis).
- **Approach:** hard refuse (matches triage-preferred posture and `cmd_fetch`'s existing existence guard) over the issue's alternative opt-in auto-create flag.
- **Deferred:** nothing.

## Test plan
- [x] Full cogni-knowledge suite green: 76/76 test files pass with the guard + seeds.
- [x] New negative-path assertion: `store` against a binding-less root returns `success:false`, the error contains the resolved absolute path, and no `.cogni-knowledge/fetch-cache/` tree is created.
- [x] Regression: `store` against a root WITH `binding.json` still returns `success:true` with an unchanged data envelope.
- [x] `plugin.json` (1.0.69) matches its `marketplace.json` mirror.

Plan record: https://github.com/cogni-work/insight-wave/issues/1085#issuecomment-4989192679