### PR TITLE
cogni-consult: surface the assumption register on resume + in the dashboard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "cogni-consult",
       "source": "./cogni-consult",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "maturity": "preview",
       "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
       "keywords": [

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-consult",
-  "version": "0.1.72",
+  "version": "0.1.73",
   "description": "Consulting engagement orchestrator where action fields are the work-breakdown-structure containers for every deliverable: each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement is the central research tool that compounds across all deliverables.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-consult/agents/consult-dashboard-refresher.md
+++ b/cogni-consult/agents/consult-dashboard-refresher.md
@@ -55,6 +55,26 @@ The generator is read-only — it never modifies an engagement file.
 - **On success** (exit code 0, JSON `success: true`): proceed to step 4.
 - **On error** (non-zero exit, or JSON `success: false`): return the generator's JSON envelope verbatim and stop. Do not retry.
 
+### 3.5 Resolve Assumption Placeholders
+
+After a successful generation, resolve any `{{asm:}}` assumption placeholders in
+the freshly written `dashboard.html` so the milestone-refreshed status view shows
+registered values instead of raw markers — the same read-only dry-run the
+`consult-dashboard` skill runs, so the interactive and milestone-refresh paths
+never drift:
+
+```bash
+python3 $CLAUDE_PLUGIN_ROOT/scripts/resolve-assumptions.py "<engagement_dir>" resolve "<engagement_dir>/output/dashboard.html"
+```
+
+Take `data.resolved_text` from the JSON envelope and overwrite `dashboard.html`
+with it; when `data.placeholders_found` is `0` there are no markers and no write
+is needed. **Omit `--in-place`** — the dry-run keeps `assumptions.json` untouched
+(it records no `used_by[]` edge for this overwrite-on-rerun render artifact),
+preserving the read-only-over-engagement-state contract. On a fail-loud resolver
+error (`success: false`), warn and continue with the unresolved dashboard rather
+than aborting the refresh.
+
 ### 4. Open in Browser
 
 If `open_browser` is true (the default):

--- a/cogni-consult/agents/consult-dashboard-refresher.md
+++ b/cogni-consult/agents/consult-dashboard-refresher.md
@@ -63,13 +63,19 @@ registered values instead of raw markers — the same read-only dry-run the
 `consult-dashboard` skill runs, so the interactive and milestone-refresh paths
 never drift:
 
+You only hold `Bash` and `Glob` (no `Write` tool), so do the overwrite through a
+`Bash` redirect: pipe the resolver's JSON into a `python3` one-liner that extracts
+`data.resolved_text` and writes it back over `dashboard.html`, guarded on
+`success` and `placeholders_found > 0` so a marker-free dashboard is a clean no-op:
+
 ```bash
-python3 $CLAUDE_PLUGIN_ROOT/scripts/resolve-assumptions.py "<engagement_dir>" resolve "<engagement_dir>/output/dashboard.html"
+python3 $CLAUDE_PLUGIN_ROOT/scripts/resolve-assumptions.py "<engagement_dir>" resolve "<engagement_dir>/output/dashboard.html" \
+  | python3 -c 'import json,sys; e=json.load(sys.stdin); d=e.get("data") or {}; open("<engagement_dir>/output/dashboard.html","w").write(d["resolved_text"]) if e.get("success") and d.get("placeholders_found",0)>0 else None'
 ```
 
-Take `data.resolved_text` from the JSON envelope and overwrite `dashboard.html`
-with it; when `data.placeholders_found` is `0` there are no markers and no write
-is needed. **Omit `--in-place`** — the dry-run keeps `assumptions.json` untouched
+`data.resolved_text` from the JSON envelope replaces `dashboard.html`; when
+`data.placeholders_found` is `0` there are no markers and no write happens.
+**Omit `--in-place`** — the dry-run keeps `assumptions.json` untouched
 (it records no `used_by[]` edge for this overwrite-on-rerun render artifact),
 preserving the read-only-over-engagement-state contract. On a fail-loud resolver
 error (`success: false`), warn and continue with the unresolved dashboard rather

--- a/cogni-consult/agents/consult-dashboard-refresher.md
+++ b/cogni-consult/agents/consult-dashboard-refresher.md
@@ -70,11 +70,13 @@ You only hold `Bash` and `Glob` (no `Write` tool), so do the overwrite through a
 
 ```bash
 python3 $CLAUDE_PLUGIN_ROOT/scripts/resolve-assumptions.py "<engagement_dir>" resolve "<engagement_dir>/output/dashboard.html" \
-  | python3 -c 'import json,sys; e=json.load(sys.stdin); d=e.get("data") or {}; open("<engagement_dir>/output/dashboard.html","w").write(d["resolved_text"]) if e.get("success") and d.get("placeholders_found",0)>0 else None'
+  | python3 -c 'import json,sys; e=json.load(sys.stdin); d=e.get("data") or {}; (open("<engagement_dir>/output/dashboard.html","w",encoding="utf-8").write(d["resolved_text"]) if e.get("success") and d.get("placeholders_found",0)>0 else (None if e.get("success") else sys.stderr.write((e.get("error") or "resolve failed")+chr(10))))'
 ```
 
-`data.resolved_text` from the JSON envelope replaces `dashboard.html`; when
-`data.placeholders_found` is `0` there are no markers and no write happens.
+`data.resolved_text` from the JSON envelope replaces `dashboard.html` (written
+UTF-8 so multilingual values survive); when `data.placeholders_found` is `0`
+there are no markers and no write happens, and on a fail-loud resolver error
+(`success: false`) the envelope's error is echoed to stderr as the warning.
 **Omit `--in-place`** — the dry-run keeps `assumptions.json` untouched
 (it records no `used_by[]` edge for this overwrite-on-rerun render artifact),
 preserving the read-only-over-engagement-state contract. On a fail-loud resolver

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -90,7 +90,11 @@ text back to `dashboard.html` yourself — this rewrites only the generated outp
 never the assumption registry:
 
 ```bash
-python3 $CLAUDE_PLUGIN_ROOT/scripts/resolve-assumptions.py "<engagement-dir>" resolve "<engagement-dir>/output/dashboard.html"
+# 1. Dry-run resolve → JSON on stdout (omit --in-place; assumptions.json stays untouched).
+# 2. Extract data.resolved_text and overwrite dashboard.html with it — but only when
+#    placeholders were actually found, so a marker-free dashboard is a clean no-op.
+python3 $CLAUDE_PLUGIN_ROOT/scripts/resolve-assumptions.py "<engagement-dir>" resolve "<engagement-dir>/output/dashboard.html" \
+  | python3 -c 'import json,sys; e=json.load(sys.stdin); d=e.get("data") or {}; open("<engagement-dir>/output/dashboard.html","w").write(d["resolved_text"]) if e.get("success") and d.get("placeholders_found",0)>0 else None'
 ```
 
 `resolve-assumptions.py` — the plugin-level `scripts/` resolver, distinct from the

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -84,23 +84,28 @@ HTML file at `<engagement-dir>/output/dashboard.html`, and prints
 `{"success": true, "data": {"path": ..., "theme": ..., "completion_pct": ...}, "error": ""}`.
 
 After the dashboard is written, resolve any `{{asm:}}` assumption placeholders it
-carries against the engagement's assumption register so registered values render
-instead of raw markers:
+carries so the status view shows registered values instead of raw markers. Run a
+**read-only dry-run** resolve (omit `--in-place`) and write the returned resolved
+text back to `dashboard.html` yourself — this rewrites only the generated output,
+never the assumption registry:
 
 ```bash
-python3 $CLAUDE_PLUGIN_ROOT/scripts/resolve-assumptions.py "<engagement-dir>" resolve "<engagement-dir>/output/dashboard.html" --in-place
+python3 $CLAUDE_PLUGIN_ROOT/scripts/resolve-assumptions.py "<engagement-dir>" resolve "<engagement-dir>/output/dashboard.html"
 ```
 
 `resolve-assumptions.py` — the plugin-level `scripts/` resolver, distinct from the
-skill-local `generate-dashboard.py` above — reads `assumptions.json` and replaces
-each `{{asm:<suffix>}}` marker with the registered value (and, where present, its
-status and provenance) so the status view shows resolved values rather than raw
-placeholders. It is fail-loud on an unknown or malformed placeholder (exit 1,
-`success:false` with a `data.failed_check` discriminator) — surface that as a
-warning rather than aborting the dashboard. A dashboard that carries no `{{asm:}}`
-markers is a clean no-op. Omit `--in-place` for a read-only dry-run that returns
-the resolved text plus each assumption's value/status/provenance in the JSON
-envelope without rewriting the file.
+skill-local `generate-dashboard.py` above — reads `assumptions.json` and returns
+each `{{asm:<suffix>}}` marker replaced by the registered value (and, where
+present, its status and provenance) in `data.resolved_text`. Take that text and
+overwrite `dashboard.html` with it; when `data.placeholders_found` is `0` the
+dashboard has no markers and no write is needed (a clean no-op). Deliberately
+**omit `--in-place`**: the in-place mode records a `used_by[]` reference edge back
+into `assumptions.json`, which would both mutate engagement state (breaking the
+read-only contract below) and pollute the register's backlink graph with an
+ephemeral, overwrite-on-rerun render artifact. The dry-run keeps `assumptions.json`
+untouched. The resolver is fail-loud on an unknown or malformed placeholder (exit
+1, `success:false` with a `data.failed_check` discriminator) — surface that as a
+warning rather than aborting the dashboard.
 
 **Legacy fallback**: the script also accepts `--theme <path-to-theme.md>` (best-effort
 markdown parse) for CI/automated runs. Precedence: `--design-variables` > `--theme` >
@@ -173,7 +178,7 @@ with "pending").
 
 ## Important Notes
 
-- The dashboard is **read-only** — it visualizes engagement state, it does not modify any file.
+- The dashboard is **read-only over engagement state** — it visualizes `consult-project.json`, `field.json`, and `assumptions.json` without ever modifying them. The only file it writes is its own generated `output/dashboard.html` (rendered by `generate-dashboard.py`, then rewritten in place with resolved assumption values via the dry-run resolve above — the resolver reads `assumptions.json` read-only and records no `used_by[]` edge).
 - The HTML file is fully self-contained (inline CSS, no external dependencies beyond an optional
   Google Fonts import).
 - Re-running the script overwrites the previous dashboard at `output/dashboard.html`.

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -83,6 +83,25 @@ and `action-fields/<slug>/research/`, loads the design-variables JSON, writes a 
 HTML file at `<engagement-dir>/output/dashboard.html`, and prints
 `{"success": true, "data": {"path": ..., "theme": ..., "completion_pct": ...}, "error": ""}`.
 
+After the dashboard is written, resolve any `{{asm:}}` assumption placeholders it
+carries against the engagement's assumption register so registered values render
+instead of raw markers:
+
+```bash
+python3 $CLAUDE_PLUGIN_ROOT/scripts/resolve-assumptions.py "<engagement-dir>" resolve "<engagement-dir>/output/dashboard.html" --in-place
+```
+
+`resolve-assumptions.py` — the plugin-level `scripts/` resolver, distinct from the
+skill-local `generate-dashboard.py` above — reads `assumptions.json` and replaces
+each `{{asm:<suffix>}}` marker with the registered value (and, where present, its
+status and provenance) so the status view shows resolved values rather than raw
+placeholders. It is fail-loud on an unknown or malformed placeholder (exit 1,
+`success:false` with a `data.failed_check` discriminator) — surface that as a
+warning rather than aborting the dashboard. A dashboard that carries no `{{asm:}}`
+markers is a clean no-op. Omit `--in-place` for a read-only dry-run that returns
+the resolved text plus each assumption's value/status/provenance in the JSON
+envelope without rewriting the file.
+
 **Legacy fallback**: the script also accepts `--theme <path-to-theme.md>` (best-effort
 markdown parse) for CI/automated runs. Precedence: `--design-variables` > `--theme` >
 built-in default.

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -94,7 +94,7 @@ never the assumption registry:
 # 2. Extract data.resolved_text and overwrite dashboard.html with it — but only when
 #    placeholders were actually found, so a marker-free dashboard is a clean no-op.
 python3 $CLAUDE_PLUGIN_ROOT/scripts/resolve-assumptions.py "<engagement-dir>" resolve "<engagement-dir>/output/dashboard.html" \
-  | python3 -c 'import json,sys; e=json.load(sys.stdin); d=e.get("data") or {}; open("<engagement-dir>/output/dashboard.html","w").write(d["resolved_text"]) if e.get("success") and d.get("placeholders_found",0)>0 else None'
+  | python3 -c 'import json,sys; e=json.load(sys.stdin); d=e.get("data") or {}; (open("<engagement-dir>/output/dashboard.html","w",encoding="utf-8").write(d["resolved_text"]) if e.get("success") and d.get("placeholders_found",0)>0 else (None if e.get("success") else sys.stderr.write((e.get("error") or "resolve failed")+chr(10))))'
 ```
 
 `resolve-assumptions.py` — the plugin-level `scripts/` resolver, distinct from the

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -19,7 +19,9 @@ allowed-tools: Read, Bash, Skill
 Re-enter a cogni-consult engagement: discover what exists, show progress
 against the action-fields WBS (fields × deliverables × status), and route to
 the most valuable next action. This skill is a read-only orienter — it never
-edits engagement state; every write belongs to the skill it routes to.
+edits engagement state; the only files it writes are the derived front-door
+artifacts (`README.md`, `assumptions.md`) regenerated from that state, and every
+other write belongs to the skill it routes to.
 
 ## Workflow
 
@@ -146,6 +148,15 @@ one here on its next re-entry — no migration step needed; a hand-authored
 marker footer is absent — that refusal is the same non-fatal warning case). Like
 the README, `assumptions.md` is a derived read model regenerated from the
 registry, not engagement state itself, so the read-only contract above holds.
+
+**Point at the register (only when it is non-empty).** When the generator returns
+`success: true` with `data.assumptions_count > 0`, surface a one-line read-only
+pointer to the regenerated `assumptions.md` — mirroring the project-plan pointer
+above so the refresh is visible rather than silent (e.g. *"Assumption register:
+`assumptions.md` (N registered) — value, provenance, and `used_by[]` backlinks"*).
+When the count is `0` (no registered assumptions) or the generator warned, say
+nothing — the pointer degrades silently. It is informational only: like the
+project-plan pointer, do not add it as a branch in the Step-5 next-action ladder.
 
 > **Strategy Advisor voice** — this plugin ships the Strategy Advisor output style (answer-first, MECE options). Enable it from the `/config` output-style picker; it's opt-in and fixed at session start, so set it now or `/clear` after.
 

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -132,6 +132,21 @@ artifact regenerated from engagement state, not engagement state itself, so the
 read-only contract over `consult-project.json`, `field.json`, personas, and logs
 holds.
 
+**Assumption register refresh.** On every re-entry, also run
+`python3 $CLAUDE_PLUGIN_ROOT/scripts/register-generator.py "<engagement-dir>"`
+automatically (no prompt) to regenerate the engagement-root `assumptions.md`
+register — the human-browsable table of every registered assumption's value,
+provenance, status, and `used_by[]` backlinks — from `assumptions.json`.
+Unconditional and non-fatal: the generator's `load_assumptions` is fail-soft (a
+missing, empty, or malformed registry degrades to an empty register, never an
+error), and on any failure, warn and continue. An engagement that carries a
+populated `assumptions.json` but never had its readable register generated gains
+one here on its next re-entry — no migration step needed; a hand-authored
+`assumptions.md` is never overwritten (the generator refuses when its generated
+marker footer is absent — that refusal is the same non-fatal warning case). Like
+the README, `assumptions.md` is a derived read model regenerated from the
+registry, not engagement state itself, so the read-only contract above holds.
+
 > **Strategy Advisor voice** — this plugin ships the Strategy Advisor output style (answer-first, MECE options). Enable it from the `/config` output-style picker; it's opt-in and fixed at session start, so set it now or `/clear` after.
 
 ### 5. Recommend the Next Action


### PR DESCRIPTION
Closes #1095.

## Summary
- **consult-resume:** add an "Assumption register refresh" rung that runs `register-generator.py "<engagement-dir>"` unconditionally and non-fatally on every re-entry, mirroring the existing README-refresh rung — every engagement gains its `assumptions.md` front door on next resume with no migration step.
- **consult-dashboard:** resolve `{{asm:}}` placeholders in the generated status view via `resolve-assumptions.py`, so registered value + status/provenance render instead of raw markers.
- Both levers reuse existing scripts (`register-generator.py`, `resolve-assumptions.py`) as-is; the generator's own never-overwrite-without-marker contract satisfies the idempotency acceptance criterion with no new logic.
- Patch bump cogni-consult 0.1.72 → 0.1.73 and mirror in marketplace.json.

## Scope decisions
- **In scope:** both deterministic read-path levers from the issue (resume generation + dashboard resolution) plus the required version bump — the complete issue, full scope.
- **Out of scope by design:** the style-side/advisor read fix tracked in the sister issue this was split from — not part of the deterministic lever and not touched here.
- **No script edits:** idempotency and the marker-footer non-overwrite contract are already guaranteed by `register-generator.py`, so acceptance criterion #2 needs no new code.

## Test plan
- [ ] On an engagement with a populated `assumptions.json` and no `assumptions.md`, run consult-resume and confirm a current `assumptions.md` is written.
- [ ] Drop the generator marker footer from an `assumptions.md`, resume again, and confirm it is NOT overwritten (warn + continue, non-fatal).
- [ ] Force a generator failure (e.g. malformed `assumptions.json`) and confirm resume warns and continues rather than aborting.
- [ ] Generate the dashboard for an engagement whose artifacts contain `{{asm:}}` markers and confirm the status view shows resolved value + status/provenance, not raw markers.
- [ ] Confirm `plugin.json` and `marketplace.json` both read 0.1.73.

<sub>Automated resolution via cogni-service. Resolution plan: https://github.com/cogni-work/insight-wave/issues/1095#issuecomment-4989749807</sub>