### PR TITLE
cogni-projects: data model + entity-authoring skill (Phase 1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -270,9 +270,9 @@
     {
       "name": "cogni-projects",
       "source": "./cogni-projects",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "maturity": "incubating",
-      "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory that later skills (staffing match, backfilling, partner-meeting dashboard) write into.",
+      "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory and authors the validated consultant, project, and assignment records that later skills (staffing match, backfilling, partner-meeting dashboard) read from.",
       "keywords": [
         "projects",
         "portfolio",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -270,7 +270,7 @@
     {
       "name": "cogni-projects",
       "source": "./cogni-projects",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "maturity": "incubating",
       "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory that later skills (staffing match, backfilling, partner-meeting dashboard) write into.",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -270,7 +270,7 @@
     {
       "name": "cogni-projects",
       "source": "./cogni-projects",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "maturity": "incubating",
       "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory and authors the validated consultant, project, and assignment records that later skills (staffing match, backfilling, partner-meeting dashboard) read from.",
       "keywords": [

--- a/cogni-projects/.claude-plugin/plugin.json
+++ b/cogni-projects/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cogni-projects",
-  "version": "0.0.2",
-  "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory that later skills (staffing match, backfilling, partner-meeting dashboard) write into.",
+  "version": "0.0.3",
+  "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory and authors the validated consultant, project, and assignment records that later skills (staffing match, backfilling, partner-meeting dashboard) read from.",
   "author": {
     "name": "Stephan de Haas",
     "email": "stephan@cogni-work.ai"

--- a/cogni-projects/.claude-plugin/plugin.json
+++ b/cogni-projects/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-projects",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory and authors the validated consultant, project, and assignment records that later skills (staffing match, backfilling, partner-meeting dashboard) read from.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-projects/.claude-plugin/plugin.json
+++ b/cogni-projects/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-projects",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory that later skills (staffing match, backfilling, partner-meeting dashboard) write into.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-projects/CLAUDE.md
+++ b/cogni-projects/CLAUDE.md
@@ -2,8 +2,9 @@
 
 Partner-facing project-portfolio steering for consulting firms. Models
 consultants, projects, and staffing so partners can match people to work by
-availability, profile fit, and strategic impact. This is the foundation
-scaffold — the data model and staffing engine land in later roadmap children.
+availability, profile fit, and strategic impact. The data model and entity
+authoring have landed; the staffing engine and the skills that read these
+entities arrive in later roadmap children.
 
 ## Plugin Architecture
 
@@ -13,18 +14,20 @@ cogni-projects/
 ├── README.md                         Plugin documentation (IS/DOES/MEANS messaging)
 ├── CLAUDE.md                         This developer guide
 ├── skills/
-│   └── projects-setup/SKILL.md       Initialize a portfolio directory (entry point)
+│   ├── projects-setup/SKILL.md       Initialize a portfolio directory (entry point)
+│   └── projects-entities/SKILL.md    Author + register one consultant/project/assignment
 ├── scripts/
-│   └── portfolio-init.sh             Idempotent portfolio scaffolder (stdlib-only)
-└── references/                       Schemas + framework docs (populated by later children)
+│   ├── portfolio-init.sh             Idempotent portfolio scaffolder (stdlib-only)
+│   ├── validate-entities.py          Entity frontmatter validator (stdlib-only)
+│   └── register-entity.py            Slug-keyed manifest upsert + execution-log append
+└── references/
+    └── data-model.md                 Consultant / project / assignment entity schemas
 ```
 
 Planned (not yet scaffolded — see the roadmap epic):
 
 - `skills/` for the staffing match engine, backfilling recommender, and the
   partner-meeting dashboard.
-- `references/data-model.md` defining the consultant / project / assignment
-  entity schemas that `projects-portfolio.json` and its entity dirs hold.
 
 ## Data Model
 

--- a/cogni-projects/references/data-model.md
+++ b/cogni-projects/references/data-model.md
@@ -185,10 +185,12 @@ keeps one assignment per consultant-project pair addressable by a stable slug.
 
 ## Manifest registration
 
-When `projects-entities` authors an entity it appends a **summary ref** into the
-matching array in `projects-portfolio.json` (deduped by `slug` on re-run) and
-bumps the manifest `updated` date. The ref is a compact pointer, not a copy of
-the frontmatter:
+When `projects-entities` authors an entity, `scripts/register-entity.py
+<portfolio-dir> <entity-file>` upserts a **summary ref** into the matching array
+in `projects-portfolio.json` (keyed on `slug`, so a re-run replaces rather than
+appends) and bumps the manifest `updated` date. That script is the only writer of
+these refs — do not hand-edit the manifest. The ref is a compact pointer, not a
+copy of the frontmatter:
 
 ```json
 {
@@ -247,6 +249,12 @@ erDiagram
 
 `scripts/validate-entities.py <path>` checks any entity file — or every entity
 under a portfolio directory — against this schema: required keys, valid enum
-values, kebab-case slug shape, ISO dates, and integer ranges. It returns the
+values, kebab-case slug shape, ISO dates and their `start_date <= end_date` /
+`available_from <= available_until` ordering, and integer ranges. It returns the
 repo-standard `{"success", "data", "error"}` envelope with `success: false` and
 a per-field `{entity, file, field, message}` list when an entity is malformed.
+
+It validates **frontmatter shape only**. An assignment's `consultant` and
+`project` values are not resolved to real entity files, so a passing run is not
+evidence those refs exist — read both referenced entities before authoring an
+assignment.

--- a/cogni-projects/references/data-model.md
+++ b/cogni-projects/references/data-model.md
@@ -1,0 +1,252 @@
+# cogni-projects Data Model
+
+The self-contained entity schema for a cogni-projects portfolio. Three entity
+types — **consultant**, **project**, and **assignment** — are authored as
+Obsidian-browsable markdown files with YAML frontmatter and registered into the
+portfolio manifest. This document is the canonical field contract shared by the
+`projects-entities` authoring skill, the `validate-entities.py` validator, and
+the later staffing-match / backfilling / dashboard skills.
+
+Partners author these records manually (no external system dependency in the
+MVP), so the schema is deliberately flat and human-writable.
+
+## Portfolio layout
+
+A portfolio is one `cogni-projects/<portfolio-slug>/` directory rooted by a
+`projects-portfolio.json` manifest (scaffolded by `projects-setup`):
+
+```
+cogni-projects/<portfolio-slug>/
+├── projects-portfolio.json    Root manifest — identity + consultants[]/projects[]/assignments[] refs
+├── consultants/               consultant entity records — <slug>.md
+├── projects/                  project entity records — <slug>.md
+├── assignments/               assignment entity records — <consultant>--<project>.md
+└── .metadata/                 append-only logs (execution, staffing, decisions)
+```
+
+Each entity lives in one markdown file under its type's subdirectory. The file's
+subdirectory determines its type, and the frontmatter `type` field must agree.
+
+## Frontmatter conventions
+
+- Frontmatter is a leading `---` … `---` fence at the top of the file.
+- Values are **flat**: scalars, ISO dates (`YYYY-MM-DD`), integers, and simple
+  string lists (`[a, b]` inline or `- item` block form). No nested objects —
+  this keeps the stdlib validator dependency-free (no PyYAML).
+- Slugs are **kebab-case** (`^[a-z0-9]+(-[a-z0-9]+)*$`), derived from the entity
+  name. Assignment slugs are composite: `<consultant-slug>--<project-slug>`.
+- Unknown frontmatter keys are ignored (a warning, not an error) so the schema
+  stays forward-compatible.
+
+---
+
+## consultant
+
+A person the firm can staff onto projects — their profile, seniority, skills,
+and availability window.
+
+Stored at `consultants/<slug>.md`.
+
+```markdown
+---
+type: consultant
+slug: mara-lindqvist
+name: Mara Lindqvist
+seniority: senior
+skills: [supply-chain, sap, change-management]
+grade: M3
+location: stockholm
+available_from: 2026-03-01
+available_until: 2026-09-30
+allocation_pct: 60
+updated: 2026-07-17
+---
+
+Free-form profile notes, engagement history, and certifications go in the body.
+```
+
+**Required fields:** `type` (= `consultant`), `slug`, `name`, `seniority`, `skills`.
+
+**Optional fields:** `grade`, `location`, `available_from`, `available_until`,
+`allocation_pct`, `updated`.
+
+Valid `seniority` values:
+
+| Value | Meaning |
+|-------|---------|
+| `junior` | Analyst / entry level |
+| `consultant` | Core delivery |
+| `senior` | Senior consultant / manager |
+| `principal` | Principal / senior manager |
+| `partner` | Partner / director |
+
+`allocation_pct` is an integer `0..100` — the consultant's current committed
+allocation. `available_from` / `available_until` bound the window in which the
+consultant can take new work (the "availability" the staffing engine reads).
+
+---
+
+## project
+
+A client engagement (or prospect) with staffing needs, a timeline, and a
+strategic-impact score.
+
+Stored at `projects/<slug>.md`.
+
+```markdown
+---
+type: project
+slug: nordic-retail-erp
+name: Nordic Retail ERP Rollout
+client: Nordic Retail Group
+strategic_impact: 4
+open_roles: [erp-lead, integration-architect, change-lead]
+start_date: 2026-04-01
+end_date: 2026-12-15
+status: active
+updated: 2026-07-17
+---
+
+Engagement scope, commercial context, and staffing notes go in the body.
+```
+
+**Required fields:** `type` (= `project`), `slug`, `name`, `client`, `strategic_impact`.
+
+**Optional fields:** `open_roles`, `start_date`, `end_date`, `status`, `updated`.
+
+`strategic_impact` is an integer `1..5` (1 = tactical, 5 = firm-defining) — the
+score the staffing engine weighs against availability so staffing optimizes firm
+strategy, not just utilization.
+
+Valid `status` values:
+
+| Value | Meaning |
+|-------|---------|
+| `prospective` | Pipeline / not yet won |
+| `active` | In delivery |
+| `closed` | Delivered or lost |
+
+`open_roles` is a list of role labels the project still needs staffed.
+
+---
+
+## assignment
+
+A consultant committed to a project for a role over a date window. The join that
+the staffing engine produces and the backfilling recommender reasons over.
+
+Stored at `assignments/<consultant-slug>--<project-slug>.md`.
+
+```markdown
+---
+type: assignment
+slug: mara-lindqvist--nordic-retail-erp
+consultant: mara-lindqvist
+project: nordic-retail-erp
+role: erp-lead
+start_date: 2026-04-01
+end_date: 2026-09-30
+allocation_pct: 60
+status: active
+updated: 2026-07-17
+---
+
+Notes on the assignment — ramp, handover, backfill plan.
+```
+
+**Required fields:** `type` (= `assignment`), `slug`, `consultant`, `project`,
+`role`, `start_date`, `end_date`.
+
+**Optional fields:** `allocation_pct`, `status`, `updated`.
+
+`consultant` and `project` are slug references to a `consultants/<slug>.md` and a
+`projects/<slug>.md` entity. `allocation_pct` is an integer `0..100`.
+
+Valid `status` values:
+
+| Value | Meaning |
+|-------|---------|
+| `planned` | Committed but not yet started |
+| `active` | Consultant currently on the project |
+| `completed` | Assignment finished |
+
+---
+
+## Naming conventions
+
+| Entity | Slug shape | Example |
+|--------|-----------|---------|
+| consultant | kebab-case, from the person's name | `mara-lindqvist` |
+| project | kebab-case, from the engagement name | `nordic-retail-erp` |
+| assignment | `<consultant-slug>--<project-slug>` | `mara-lindqvist--nordic-retail-erp` |
+
+The `--` double-hyphen separator in assignment slugs makes the join legible and
+keeps one assignment per consultant-project pair addressable by a stable slug.
+
+## Manifest registration
+
+When `projects-entities` authors an entity it appends a **summary ref** into the
+matching array in `projects-portfolio.json` (deduped by `slug` on re-run) and
+bumps the manifest `updated` date. The ref is a compact pointer, not a copy of
+the frontmatter:
+
+```json
+{
+  "consultants": [
+    {"slug": "mara-lindqvist", "name": "Mara Lindqvist", "file": "consultants/mara-lindqvist.md"}
+  ],
+  "projects": [
+    {"slug": "nordic-retail-erp", "name": "Nordic Retail ERP Rollout", "file": "projects/nordic-retail-erp.md"}
+  ],
+  "assignments": [
+    {"slug": "mara-lindqvist--nordic-retail-erp", "consultant": "mara-lindqvist", "project": "nordic-retail-erp", "file": "assignments/mara-lindqvist--nordic-retail-erp.md"}
+  ]
+}
+```
+
+The entity markdown file is the source of truth for full field values; the
+manifest ref is the index the dashboard and staffing skills scan without opening
+every file.
+
+## Entity relationships
+
+```mermaid
+erDiagram
+    CONSULTANT ||--o{ ASSIGNMENT : "staffed on"
+    PROJECT ||--o{ ASSIGNMENT : "needs"
+    CONSULTANT {
+        string slug PK
+        string name
+        enum seniority
+        list skills
+        int allocation_pct
+        date available_from
+        date available_until
+    }
+    PROJECT {
+        string slug PK
+        string name
+        string client
+        int strategic_impact
+        list open_roles
+        enum status
+    }
+    ASSIGNMENT {
+        string slug PK
+        string consultant FK
+        string project FK
+        string role
+        date start_date
+        date end_date
+        int allocation_pct
+        enum status
+    }
+```
+
+## Validation
+
+`scripts/validate-entities.py <path>` checks any entity file — or every entity
+under a portfolio directory — against this schema: required keys, valid enum
+values, kebab-case slug shape, ISO dates, and integer ranges. It returns the
+repo-standard `{"success", "data", "error"}` envelope with `success: false` and
+a per-field `{entity, file, field, message}` list when an entity is malformed.

--- a/cogni-projects/references/data-model.md
+++ b/cogni-projects/references/data-model.md
@@ -1,4 +1,4 @@
-# cogni-projects Data Model
+# cogni-projects Data Model Reference
 
 The self-contained entity schema for a cogni-projects portfolio. Three entity
 types — **consultant**, **project**, and **assignment** — are authored as
@@ -40,7 +40,9 @@ subdirectory determines its type, and the frontmatter `type` field must agree.
 
 ---
 
-## consultant
+## Entity Schemas
+
+### consultant
 
 A person the firm can staff onto projects — their profile, seniority, skills,
 and availability window.
@@ -86,7 +88,7 @@ consultant can take new work (the "availability" the staffing engine reads).
 
 ---
 
-## project
+### project
 
 A client engagement (or prospect) with staffing needs, a timeline, and a
 strategic-impact score.
@@ -130,12 +132,18 @@ Valid `status` values:
 
 ---
 
-## assignment
+### assignment
 
 A consultant committed to a project for a role over a date window. The join that
 the staffing engine produces and the backfilling recommender reasons over.
 
 Stored at `assignments/<consultant-slug>--<project-slug>.md`.
+
+Availability is modeled as consultant/assignment allocation-window **attributes**
+(`available_from` / `available_until` / `allocation_pct`) rather than a standalone
+fourth `availability` entity: the portfolio scaffold commits to `assignments/`
+directories and an `assignments[]` manifest array, so allocation windows live as
+fields on the consultant and assignment records that already carry them.
 
 ```markdown
 ---

--- a/cogni-projects/scripts/register-entity.py
+++ b/cogni-projects/scripts/register-entity.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Register a cogni-projects entity file into its portfolio manifest.
+
+Upserts the entity's summary ref into the matching projects-portfolio.json array
+(keyed on `slug`), bumps the manifest `updated` date, and appends a transition to
+.metadata/execution-log.json.
+
+Idempotent: re-registering the same slug replaces the existing ref in place
+rather than appending a second one, and reports action "updated" instead of
+"created". This is what makes a re-run of the authoring skill safe.
+
+Not transactional: the execution log and the manifest are two writes, log first.
+An interrupted run is repaired by re-running — the upsert is what makes that safe.
+
+Validates before registering, via validate-entities.py, so the manifest cannot
+take an entity the validator rejects even when this script is invoked directly.
+
+Stdlib-only (no PyYAML).
+
+Usage:
+  python3 register-entity.py <portfolio-dir> <entity-file>
+
+Output: a single JSON line following the repo contract
+  {"success": bool, "data": {...}, "error": str}
+Exit: 0 ok / 1 the entity failed validation / 2 usage or environment failure.
+"""
+
+import datetime
+import importlib.util
+import json
+import os
+import sys
+
+# validate-entities.py is not an importable module name (hyphens), so load it by
+# file location rather than duplicating its rules here — this script must gate on
+# exactly the schema the validator enforces.
+_v_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "validate-entities.py")
+_spec = importlib.util.spec_from_file_location("validate_entities", _v_path)
+if _spec is None or _spec.loader is None:
+    print(json.dumps({
+        "success": False, "data": {},
+        "error": "cannot load validator module: %s" % _v_path,
+    }))
+    sys.exit(2)
+_ve = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_ve)
+
+# The summary-ref fields each type carries into the manifest (see
+# references/data-model.md "Manifest registration"). These are an editorial
+# subset of the validator's `required` list — the ref is a pointer, not a copy —
+# so they are named here rather than derived. The array each type registers into
+# is the validator's own subdir name, so it is read from SCHEMA, not restated.
+REF_FIELDS = {
+    "consultant": ["slug", "name"],
+    "project": ["slug", "name"],
+    "assignment": ["slug", "consultant", "project"],
+}
+
+
+def _fail(message, code=2):
+    print(json.dumps(
+        {"success": False, "data": {}, "error": message}, ensure_ascii=False
+    ))
+    return code
+
+
+def main(argv):
+    if len(argv) != 2:
+        return _fail("usage: register-entity.py <portfolio-dir> <entity-file>")
+
+    portfolio_dir, entity_file = argv
+
+    manifest_path = os.path.join(portfolio_dir, "projects-portfolio.json")
+    if not os.path.isfile(manifest_path):
+        return _fail(
+            "portfolio manifest not found: %s (run /cogni-projects:projects-setup first)"
+            % manifest_path
+        )
+    if not os.path.isfile(entity_file):
+        return _fail("entity file not found: %s" % entity_file)
+
+    # Gate on the validator rather than re-checking its rules by hand: a weaker
+    # local copy would drift, and silently registering an entity the validator
+    # rejects is the exact failure registration is supposed to prevent.
+    errors, _warnings = _ve.validate_file(entity_file)
+    if errors:
+        return _fail(
+            "entity failed validation (%d error(s)) — run validate-entities.py "
+            "on it and fix each error before registering" % len(errors),
+            code=1,
+        )
+
+    try:
+        with open(entity_file, "r", encoding="utf-8") as f:
+            fm = _ve.parse_frontmatter(f.read())
+    except OSError as exc:
+        return _fail("cannot read entity file: %s" % exc)
+
+    # `type` is required for every type and the validator errors when it
+    # disagrees with the containing subdirectory, so a validated entity always
+    # carries the authoritative type here.
+    entity_type = fm.get("type")
+    if entity_type not in REF_FIELDS:
+        return _fail(
+            "unknown entity type %r (expected one of %s)"
+            % (entity_type, ", ".join(sorted(REF_FIELDS))),
+            code=1,
+        )
+
+    array_name = _ve.SCHEMA[entity_type]["subdir"]
+    slug = str(fm["slug"])
+    ref = {key: str(fm[key]) for key in REF_FIELDS[entity_type]}
+    # The ref points at the entity file relative to the portfolio root, so the
+    # dashboard and staffing skills can resolve it without knowing the cwd.
+    ref["file"] = os.path.relpath(
+        os.path.abspath(entity_file), os.path.abspath(portfolio_dir)
+    )
+
+    try:
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+    except (OSError, ValueError) as exc:
+        return _fail("cannot read portfolio manifest: %s" % exc)
+
+    array = manifest.setdefault(array_name, [])
+    if not isinstance(array, list):
+        return _fail("manifest %r is not a list" % array_name)
+
+    # Upsert keyed on slug — the idempotency contract.
+    index = next(
+        (i for i, e in enumerate(array) if isinstance(e, dict) and e.get("slug") == slug),
+        None,
+    )
+    if index is None:
+        array.append(ref)
+        action = "created"
+    else:
+        array[index] = ref
+        action = "updated"
+
+    today = datetime.date.today().isoformat()
+    manifest["updated"] = today
+
+    log_path = os.path.join(portfolio_dir, ".metadata", "execution-log.json")
+    log = {"transitions": []}
+    if os.path.isfile(log_path):
+        try:
+            with open(log_path, "r", encoding="utf-8") as f:
+                log = json.load(f)
+        except (OSError, ValueError) as exc:
+            return _fail("cannot read execution log: %s" % exc)
+    log.setdefault("transitions", []).append({
+        "slug": slug,
+        "entity_type": entity_type,
+        "action": action,
+        "file": ref["file"],
+        "at": today,
+    })
+
+    # ensure_ascii=False matches portfolio-init.sh's writer: these portfolios
+    # carry European names, and the repo convention forbids ASCII escapes.
+    try:
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        with open(log_path, "w", encoding="utf-8") as f:
+            json.dump(log, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+    except OSError as exc:
+        return _fail("cannot write portfolio state: %s" % exc)
+
+    print(json.dumps({
+        "success": True,
+        "data": {
+            "slug": slug,
+            "entity_type": entity_type,
+            "action": action,
+            "array": array_name,
+            "file": ref["file"],
+            "updated": today,
+        },
+        "error": "",
+    }, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/cogni-projects/scripts/register-entity.py
+++ b/cogni-projects/scripts/register-entity.py
@@ -112,9 +112,17 @@ def main(argv):
     ref = {key: str(fm[key]) for key in REF_FIELDS[entity_type]}
     # The ref points at the entity file relative to the portfolio root, so the
     # dashboard and staffing skills can resolve it without knowing the cwd.
-    ref["file"] = os.path.relpath(
-        os.path.abspath(entity_file), os.path.abspath(portfolio_dir)
-    )
+    rel = os.path.relpath(os.path.abspath(entity_file), os.path.abspath(portfolio_dir))
+    # Refuse an entity that lives outside the target portfolio. Validation cannot
+    # catch this — a foreign entity file is itself perfectly valid — but the ref
+    # would escape the root, and consumers resolve `file` relative to it, so one
+    # portfolio would silently read another's records.
+    if rel == os.pardir or rel.startswith(os.pardir + os.sep):
+        return _fail(
+            "entity file %s is not inside portfolio %s — an entity is registered "
+            "only into the portfolio that holds it" % (entity_file, portfolio_dir)
+        )
+    ref["file"] = rel
 
     try:
         with open(manifest_path, "r", encoding="utf-8") as f:

--- a/cogni-projects/scripts/validate-entities.py
+++ b/cogni-projects/scripts/validate-entities.py
@@ -65,6 +65,7 @@ SCHEMA = {
         },
         "ints": {"allocation_pct": (0, 100)},
         "dates": ["available_from", "available_until", "updated"],
+        "date_order": [("available_from", "available_until")],
         "lists": ["skills"],
         "slug_kind": "simple",
     },
@@ -77,6 +78,7 @@ SCHEMA = {
         },
         "ints": {"strategic_impact": (1, 5)},
         "dates": ["start_date", "end_date", "updated"],
+        "date_order": [("start_date", "end_date")],
         "lists": ["open_roles"],
         "slug_kind": "simple",
     },
@@ -92,6 +94,7 @@ SCHEMA = {
         },
         "ints": {"allocation_pct": (0, 100)},
         "dates": ["start_date", "end_date", "updated"],
+        "date_order": [("start_date", "end_date")],
         "lists": [],
         "slug_kind": "composite",
     },
@@ -297,6 +300,15 @@ def validate_file(filepath):
                 err(key, "must be a valid ISO date YYYY-MM-DD (got %r)" % fm[key],
                     entity=entity_type)
 
+    # Date ordering. An inverted window parses as two individually-valid ISO
+    # dates, so the shape check above cannot catch it; ISO-8601 strings order
+    # correctly under plain string comparison.
+    for earlier, later in spec["date_order"]:
+        start, end = fm.get(earlier), fm.get(later)
+        if _is_iso_date(start) and _is_iso_date(end) and start > end:
+            err(later, "%s (%s) must not precede %s (%s)"
+                % (later, end, earlier, start), entity=entity_type)
+
     # List-typed fields.
     for key in spec["lists"]:
         if key in fm and fm[key] not in ("", None) and not isinstance(fm[key], list):
@@ -322,7 +334,26 @@ def main(argv):
                 "error": "path not found: %s" % path,
             }))
             return 2
-        all_files.extend(_entity_files(path))
+        found = _entity_files(path)
+        # Fail closed on a mistargeted directory. A path that expands to no
+        # entity files would otherwise report success, which a caller gating
+        # manifest registration on it cannot tell apart from a clean validation —
+        # green-lighting an unvalidated entity. An entity subdirectory passed
+        # where the portfolio root belongs is the common shape of that mistake.
+        # A portfolio root whose entity dirs are merely still empty is a
+        # legitimate state, not a mistarget, so it stays a vacuous success.
+        if not found and not os.path.isfile(
+            os.path.join(path, "projects-portfolio.json")
+        ):
+            print(json.dumps({
+                "success": False, "data": {"errors": [], "warnings": []},
+                "error": "no entity files found under %s and it is not a portfolio "
+                         "root — expected an entity .md file, or a directory "
+                         "holding projects-portfolio.json alongside consultants/, "
+                         "projects/, or assignments/" % path,
+            }))
+            return 2
+        all_files.extend(found)
 
     errors, warnings = [], []
     for f in all_files:

--- a/cogni-projects/scripts/validate-entities.py
+++ b/cogni-projects/scripts/validate-entities.py
@@ -3,7 +3,11 @@
 
 Checks the YAML frontmatter of consultant / project / assignment entity files
 (see references/data-model.md) for schema conformance: required keys, valid
-enum values, kebab-case slug shape, ISO dates, and numeric ranges.
+enum values, kebab-case slug shape, ISO dates and their start <= end ordering,
+and numeric ranges.
+
+Frontmatter shape only: an assignment's consultant / project values are not
+resolved to real entity files.
 
 Stdlib-only (no PyYAML): a small frontmatter-subset parser handles the flat
 scalar + simple-list frontmatter the data model uses.
@@ -323,7 +327,7 @@ def main(argv):
         print(json.dumps({
             "success": False, "data": {"errors": [], "warnings": []},
             "error": "usage: validate-entities.py <path> [<path> ...]",
-        }))
+        }, ensure_ascii=False))
         return 2
 
     all_files = []
@@ -332,7 +336,7 @@ def main(argv):
             print(json.dumps({
                 "success": False, "data": {"errors": [], "warnings": []},
                 "error": "path not found: %s" % path,
-            }))
+            }, ensure_ascii=False))
             return 2
         found = _entity_files(path)
         # Fail closed on a mistargeted directory. A path that expands to no
@@ -351,7 +355,7 @@ def main(argv):
                          "root — expected an entity .md file, or a directory "
                          "holding projects-portfolio.json alongside consultants/, "
                          "projects/, or assignments/" % path,
-            }))
+            }, ensure_ascii=False))
             return 2
         all_files.extend(found)
 
@@ -370,7 +374,7 @@ def main(argv):
             "checked": len(all_files),
         },
         "error": "" if success else "%d validation error(s)" % len(errors),
-    }))
+    }, ensure_ascii=False))
     return 0 if success else 1
 
 

--- a/cogni-projects/scripts/validate-entities.py
+++ b/cogni-projects/scripts/validate-entities.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Validate cogni-projects entity markdown files against the data model.
+
+Checks the YAML frontmatter of consultant / project / assignment entity files
+(see references/data-model.md) for schema conformance: required keys, valid
+enum values, kebab-case slug shape, ISO dates, and numeric ranges.
+
+Stdlib-only (no PyYAML): a small frontmatter-subset parser handles the flat
+scalar + simple-list frontmatter the data model uses.
+
+Usage:
+  python3 validate-entities.py <path> [<path> ...]
+
+Each <path> is either a single entity .md file or a portfolio directory
+(cogni-projects/<portfolio-slug>/); a directory is expanded to every .md file
+under its consultants/ projects/ assignments/ subdirectories.
+
+Output: a single JSON line following the repo contract
+  {"success": bool, "data": {"errors": [...], "warnings": [...]}, "error": str}
+`success` is false when any error is found (or on a hard failure, with `error`
+set). Each error/warning is {"entity", "file", "field", "message"}.
+"""
+
+import datetime
+import json
+import os
+import re
+import sys
+
+# Frontmatter block: leading --- ... --- fence at the top of the file.
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+# kebab-case: lowercase alphanumerics in hyphen-separated segments.
+KEBAB_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+# Composite assignment slug: <consultant-slug>--<project-slug>.
+COMPOSITE_SLUG_RE = re.compile(
+    r"^[a-z0-9]+(?:-[a-z0-9]+)*--[a-z0-9]+(?:-[a-z0-9]+)*$"
+)
+ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _is_iso_date(value):
+    """True when value is a real ISO calendar date (shape AND validity)."""
+    if not (isinstance(value, str) and ISO_DATE_RE.match(value)):
+        return False
+    try:
+        datetime.date.fromisoformat(value)
+        return True
+    except ValueError:
+        return False
+
+# Per-type schema. `required` / `optional` list frontmatter keys; `enums` maps a
+# key to its allowed values; `ints` maps a key to an inclusive (lo, hi) range;
+# `dates` lists ISO-date keys; `lists` are keys that must parse as a list.
+SCHEMA = {
+    "consultant": {
+        "subdir": "consultants",
+        "required": ["type", "slug", "name", "seniority", "skills"],
+        "optional": [
+            "grade", "location", "available_from", "available_until",
+            "allocation_pct", "updated",
+        ],
+        "enums": {
+            "seniority": ["junior", "consultant", "senior", "principal", "partner"],
+        },
+        "ints": {"allocation_pct": (0, 100)},
+        "dates": ["available_from", "available_until", "updated"],
+        "lists": ["skills"],
+        "slug_kind": "simple",
+    },
+    "project": {
+        "subdir": "projects",
+        "required": ["type", "slug", "name", "client", "strategic_impact"],
+        "optional": ["open_roles", "start_date", "end_date", "status", "updated"],
+        "enums": {
+            "status": ["prospective", "active", "closed"],
+        },
+        "ints": {"strategic_impact": (1, 5)},
+        "dates": ["start_date", "end_date", "updated"],
+        "lists": ["open_roles"],
+        "slug_kind": "simple",
+    },
+    "assignment": {
+        "subdir": "assignments",
+        "required": [
+            "type", "slug", "consultant", "project", "role",
+            "start_date", "end_date",
+        ],
+        "optional": ["allocation_pct", "status", "updated"],
+        "enums": {
+            "status": ["planned", "active", "completed"],
+        },
+        "ints": {"allocation_pct": (0, 100)},
+        "dates": ["start_date", "end_date", "updated"],
+        "lists": [],
+        "slug_kind": "composite",
+    },
+}
+
+# Map an entity subdirectory name to its type, so a file's location can be used
+# to infer the expected `type` when the frontmatter is missing or mismatched.
+SUBDIR_TO_TYPE = {spec["subdir"]: etype for etype, spec in SCHEMA.items()}
+
+
+def _strip_scalar(raw):
+    """Strip surrounding quotes from a scalar frontmatter value."""
+    raw = raw.strip()
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ("'", '"'):
+        return raw[1:-1]
+    return raw
+
+
+def _coerce(value):
+    """Coerce a scalar string to int when it looks like one; else leave it."""
+    if isinstance(value, str) and re.fullmatch(r"-?\d+", value):
+        return int(value)
+    return value
+
+
+def parse_frontmatter(text):
+    """Parse the flat scalar + simple-list frontmatter subset the data model uses.
+
+    Supports `key: scalar`, `key: [a, b]` inline lists, and block lists:
+        key:
+          - a
+          - b
+    Returns a dict, or None when no frontmatter fence is present.
+    """
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return None
+    body = match.group(1)
+    data = {}
+    lines = body.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if not line.strip() or line.lstrip().startswith("#"):
+            i += 1
+            continue
+        # Block-list continuation lines are consumed by their parent key below.
+        m = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
+        if not m:
+            i += 1
+            continue
+        key, rest = m.group(1), m.group(2).strip()
+        if rest == "":
+            # Possible block list: gather following `  - item` lines.
+            items = []
+            j = i + 1
+            while j < len(lines) and re.match(r"^\s+-\s+", lines[j]):
+                items.append(_coerce(_strip_scalar(re.sub(r"^\s+-\s+", "", lines[j]))))
+                j += 1
+            if items:
+                data[key] = items
+                i = j
+                continue
+            data[key] = ""
+            i += 1
+            continue
+        if rest.startswith("[") and rest.endswith("]"):
+            inner = rest[1:-1].strip()
+            items = [
+                _coerce(_strip_scalar(p))
+                for p in _split_inline_list(inner)
+            ] if inner else []
+            data[key] = items
+        else:
+            data[key] = _coerce(_strip_scalar(rest))
+        i += 1
+    return data
+
+
+def _split_inline_list(inner):
+    """Split an inline list body on commas, respecting quoted segments."""
+    parts, buf, quote = [], [], None
+    for ch in inner:
+        if quote:
+            buf.append(ch)
+            if ch == quote:
+                quote = None
+        elif ch in ("'", '"'):
+            quote = ch
+            buf.append(ch)
+        elif ch == ",":
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    if buf:
+        parts.append("".join(buf))
+    return [p.strip() for p in parts if p.strip() != ""]
+
+
+def _entity_files(path):
+    """Expand a path to the entity .md files it covers.
+
+    A file path yields itself. A directory yields every .md file under its
+    consultants/ projects/ assignments/ subdirectories.
+    """
+    if os.path.isfile(path):
+        return [path]
+    files = []
+    for subdir in SUBDIR_TO_TYPE:
+        d = os.path.join(path, subdir)
+        if os.path.isdir(d):
+            for name in sorted(os.listdir(d)):
+                if name.endswith(".md"):
+                    files.append(os.path.join(d, name))
+    return files
+
+
+def validate_file(filepath):
+    """Validate one entity file. Returns (errors, warnings) as lists of dicts."""
+    errors, warnings = [], []
+    rel = filepath
+
+    def err(field, message, entity="unknown"):
+        errors.append(
+            {"entity": entity, "file": rel, "field": field, "message": message}
+        )
+
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            text = f.read()
+    except OSError as exc:
+        err("<file>", "cannot read file: %s" % exc)
+        return errors, warnings
+
+    fm = parse_frontmatter(text)
+    if fm is None:
+        err("<frontmatter>", "no YAML frontmatter block found (expected leading --- ... --- fence)")
+        return errors, warnings
+
+    # Infer the expected type from the file's subdirectory.
+    parent = os.path.basename(os.path.dirname(filepath))
+    inferred = SUBDIR_TO_TYPE.get(parent)
+    declared = fm.get("type")
+
+    entity_type = declared if declared in SCHEMA else inferred
+    if entity_type not in SCHEMA:
+        err("type", "unknown or missing entity type %r (expected one of %s)"
+            % (declared, ", ".join(sorted(SCHEMA))),
+            entity=str(declared))
+        return errors, warnings
+    if inferred and declared and declared != inferred:
+        err("type", "type %r does not match its %s/ directory (expected %r)"
+            % (declared, parent, inferred), entity=entity_type)
+
+    spec = SCHEMA[entity_type]
+
+    # Required keys present and non-empty.
+    for key in spec["required"]:
+        if key not in fm or fm[key] in ("", [], None):
+            err(key, "missing required field", entity=entity_type)
+
+    # Unknown keys are a warning, not an error (forward-compatible frontmatter).
+    known = set(spec["required"]) | set(spec["optional"])
+    for key in fm:
+        if key not in known:
+            warnings.append({
+                "entity": entity_type, "file": rel, "field": key,
+                "message": "unknown field (ignored)",
+            })
+
+    # Slug shape.
+    slug = fm.get("slug")
+    if isinstance(slug, str) and slug:
+        if spec["slug_kind"] == "composite":
+            if not COMPOSITE_SLUG_RE.match(slug):
+                err("slug", "assignment slug must be composite kebab-case "
+                    "<consultant>--<project> (got %r)" % slug, entity=entity_type)
+        elif not KEBAB_RE.match(slug):
+            err("slug", "slug must be kebab-case (got %r)" % slug, entity=entity_type)
+
+    # Enum values.
+    for key, allowed in spec["enums"].items():
+        if key in fm and fm[key] not in ("", None):
+            if fm[key] not in allowed:
+                err(key, "invalid value %r (allowed: %s)"
+                    % (fm[key], ", ".join(allowed)), entity=entity_type)
+
+    # Integer ranges.
+    for key, (lo, hi) in spec["ints"].items():
+        if key in fm and fm[key] not in ("", None):
+            val = fm[key]
+            if not isinstance(val, int):
+                err(key, "must be an integer (got %r)" % val, entity=entity_type)
+            elif not (lo <= val <= hi):
+                err(key, "out of range %d..%d (got %d)" % (lo, hi, val),
+                    entity=entity_type)
+
+    # ISO dates.
+    for key in spec["dates"]:
+        if key in fm and fm[key] not in ("", None):
+            if not _is_iso_date(fm[key]):
+                err(key, "must be a valid ISO date YYYY-MM-DD (got %r)" % fm[key],
+                    entity=entity_type)
+
+    # List-typed fields.
+    for key in spec["lists"]:
+        if key in fm and fm[key] not in ("", None) and not isinstance(fm[key], list):
+            err(key, "must be a list (got %r)" % type(fm[key]).__name__,
+                entity=entity_type)
+
+    return errors, warnings
+
+
+def main(argv):
+    if not argv:
+        print(json.dumps({
+            "success": False, "data": {"errors": [], "warnings": []},
+            "error": "usage: validate-entities.py <path> [<path> ...]",
+        }))
+        return 2
+
+    all_files = []
+    for path in argv:
+        if not os.path.exists(path):
+            print(json.dumps({
+                "success": False, "data": {"errors": [], "warnings": []},
+                "error": "path not found: %s" % path,
+            }))
+            return 2
+        all_files.extend(_entity_files(path))
+
+    errors, warnings = [], []
+    for f in all_files:
+        e, w = validate_file(f)
+        errors.extend(e)
+        warnings.extend(w)
+
+    success = len(errors) == 0
+    print(json.dumps({
+        "success": success,
+        "data": {
+            "errors": errors,
+            "warnings": warnings,
+            "checked": len(all_files),
+        },
+        "error": "" if success else "%d validation error(s)" % len(errors),
+    }))
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/cogni-projects/skills/projects-entities/SKILL.md
+++ b/cogni-projects/skills/projects-entities/SKILL.md
@@ -76,9 +76,13 @@ reference).
 ### Step 3: Read siblings, then write the entity file
 
 Read the existing entities in the target subdirectory so the new record is
-consistent with them (naming, skill vocabulary, role labels). Then write the
-single entity file with its YAML frontmatter per the data model. Write **only**
-the one entity file — never a summary, index, or batch file.
+consistent with them (naming, skill vocabulary, role labels). If a file already
+exists at the target slug and it is not the same entity being re-authored, stop
+and ask the user to disambiguate the slug — writing would replace that record,
+and Step 5's upsert would report an ordinary `updated`, leaving the collision
+indistinguishable from an intentional re-run. Then write the single entity file
+with its YAML frontmatter per the data model. Write **only** the one entity file
+— never a summary, index, or batch file.
 
 ### Step 4: Validate before registering
 

--- a/cogni-projects/skills/projects-entities/SKILL.md
+++ b/cogni-projects/skills/projects-entities/SKILL.md
@@ -61,12 +61,12 @@ Every entity, whatever its type, additionally requires `type` — which must mat
 its containing subdirectory, or the validator errors — and `slug`:
 
 - **consultant** — `name`, `seniority`, `skills`; optionally `grade`, `location`,
-  `available_from` / `available_until`, `allocation_pct`.
+  `available_from` / `available_until`, `allocation_pct`, `updated`.
 - **project** — `name`, `client`, `strategic_impact` (1–5); optionally
-  `open_roles`, `start_date` / `end_date`, `status`.
+  `open_roles`, `start_date` / `end_date`, `status`, `updated`.
 - **assignment** — the `consultant` and `project` slugs, `role`, `start_date`,
-  `end_date`; optionally `allocation_pct`, `status`. The slug is composite:
-  `<consultant-slug>--<project-slug>`.
+  `end_date`; optionally `allocation_pct`, `status`, `updated`. The slug is
+  composite: `<consultant-slug>--<project-slug>`.
 
 Derive the slug from the name (kebab-case) unless the user supplies one. For an
 assignment, confirm both referenced entities already exist under `consultants/`

--- a/cogni-projects/skills/projects-entities/SKILL.md
+++ b/cogni-projects/skills/projects-entities/SKILL.md
@@ -32,11 +32,13 @@ Each entity is one markdown file under its type's subdirectory of a portfolio:
 - **project** → `projects/<slug>.md`
 - **assignment** → `assignments/<consultant>--<project>.md`
 
-Authoring an entity does three things atomically: write the file, register a
-compact summary ref into the matching `projects-portfolio.json` array, and
-append a transition to `.metadata/execution-log.json`. Registration is
-**idempotent** — re-authoring the same slug updates the file and de-duplicates
-the manifest ref rather than appending a second one, so a resumed or repeated run
+Authoring an entity covers three effects: write the file, register a compact
+summary ref into the matching `projects-portfolio.json` array, and append a
+transition to `.metadata/execution-log.json`. Writing the file and registering it
+are separate tool calls, not a transaction — an interrupted run can leave an
+entity file on disk that the manifest does not yet reference. That state is
+repaired by **re-running the skill for the same slug**: registration is
+idempotent (`register-entity.py` upserts keyed on `slug`), so a repeated run
 never double-registers.
 
 ## Workflow
@@ -54,6 +56,9 @@ initialized portfolio, it does not scaffold one.
 Decide whether the user is authoring a **consultant**, **project**, or
 **assignment**, then gather the required fields for that type from
 `references/data-model.md` (ask only for what is missing):
+
+Every entity, whatever its type, additionally requires `type` — which must match
+its containing subdirectory, or the validator errors — and `slug`:
 
 - **consultant** — `name`, `seniority`, `skills`; optionally grade, location,
   availability window, allocation.
@@ -86,21 +91,31 @@ python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-pr
 The validator returns `{"success": bool, "data": {"errors": [...], "warnings":
 [...]}, "error": str}`. If `success` is `false`, fix each `data.errors[]` entry
 (they name the offending `field` and `message`) and re-run — do **not** register
-a malformed entity into the manifest.
+a malformed entity into the manifest. Run this step even though Step 5's script
+validates again: that script reports only an error count and points back here, so
+this is the run that gives you the per-field errors you need to fix the file.
+
+The validator checks **frontmatter shape only**: required keys, enums, slug
+casing, ISO dates and their ordering, numeric ranges. It does **not** resolve an
+assignment's `consultant` / `project` slugs to real entity files, so a passing
+run is not evidence the refs exist — reading both referenced entities in Step 2
+remains the guard against a dangling reference.
 
 ### Step 5: Register in the manifest and log the transition
 
-Once validation passes, update `projects-portfolio.json`:
+Once validation passes, register the entity. Do not hand-edit
+`projects-portfolio.json` — run the script, which upserts the summary ref keyed
+on `slug`, bumps the manifest `updated` date, and appends the
+`.metadata/execution-log.json` transition in a single invocation (it re-runs the
+validator itself, so it refuses an entity the Step 4 gate would have caught):
 
-1. Append a summary ref to the matching array (`consultants[]`, `projects[]`, or
-   `assignments[]`) — the compact `{slug, name/…, file}` shape in the data
-   model's "Manifest registration" section. **Dedupe by `slug`**: if an entry
-   with the same slug exists, replace it in place instead of appending.
-2. Bump the manifest `updated` field to today's date.
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-projects/*/ 2>/dev/null | head -1)}/scripts/register-entity.py" "cogni-projects/<slug>" "cogni-projects/<slug>/<subdir>/<entity>.md"
+```
 
-Then append a transition to `.metadata/execution-log.json` (`transitions[]`)
-recording the entity slug, type, and action (`created` / `updated`) so the audit
-trail stays complete.
+It returns the same `{"success", "data", "error"}` envelope; `data.action` is
+`created` or `updated`, which is how a re-run reports that it replaced an
+existing ref rather than adding a second one.
 
 ### Step 6: Summarize
 
@@ -110,8 +125,9 @@ and projects exist, to the staffing-match engine as it ships.
 
 ## Notes
 
-- **Scripts return `{success, data, error}` JSON**, stdlib-only — the validator
-  follows the plugin convention; do not add pip dependencies.
+- **Scripts return `{success, data, error}` JSON**, stdlib-only — both
+  `validate-entities.py` and `register-entity.py` follow the plugin convention;
+  do not add pip dependencies.
 - **The manifest is the source of truth** for what exists in the portfolio;
   entity files hold full field values. Keep them consistent — every authored
   file has exactly one manifest ref.

--- a/cogni-projects/skills/projects-entities/SKILL.md
+++ b/cogni-projects/skills/projects-entities/SKILL.md
@@ -46,7 +46,7 @@ never double-registers.
 ### Step 1: Locate the target portfolio
 
 Find the portfolio directory the user means. If they name a slug, use
-`cogni-projects/<slug>/`. Otherwise glob `cogni-projects/*/projects-portfolio.json`
+`cogni-projects/<portfolio-slug>/`. Otherwise glob `cogni-projects/*/projects-portfolio.json`
 and, when more than one portfolio exists, ask which one. If none exists, tell the
 user to run `/cogni-projects:projects-setup` first — this skill authors into an
 initialized portfolio, it does not scaffold one.
@@ -60,12 +60,12 @@ Decide whether the user is authoring a **consultant**, **project**, or
 Every entity, whatever its type, additionally requires `type` — which must match
 its containing subdirectory, or the validator errors — and `slug`:
 
-- **consultant** — `name`, `seniority`, `skills`; optionally grade, location,
-  availability window, allocation.
-- **project** — `name`, `client`, `strategic_impact` (1–5); optionally open
-  roles, timeline, status.
+- **consultant** — `name`, `seniority`, `skills`; optionally `grade`, `location`,
+  `available_from` / `available_until`, `allocation_pct`.
+- **project** — `name`, `client`, `strategic_impact` (1–5); optionally
+  `open_roles`, `start_date` / `end_date`, `status`.
 - **assignment** — the `consultant` and `project` slugs, `role`, `start_date`,
-  `end_date`; optionally allocation, status. The slug is composite:
+  `end_date`; optionally `allocation_pct`, `status`. The slug is composite:
   `<consultant-slug>--<project-slug>`.
 
 Derive the slug from the name (kebab-case) unless the user supplies one. For an
@@ -85,7 +85,7 @@ the one entity file — never a summary, index, or batch file.
 Run the validator against the new file and gate registration on its success:
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-projects/*/ 2>/dev/null | head -1)}/scripts/validate-entities.py" "cogni-projects/<slug>/<subdir>/<entity>.md"
+python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-projects/*/ 2>/dev/null | head -1)}/scripts/validate-entities.py" "cogni-projects/<portfolio-slug>/<subdir>/<entity>.md"
 ```
 
 The validator returns `{"success": bool, "data": {"errors": [...], "warnings":
@@ -93,7 +93,11 @@ The validator returns `{"success": bool, "data": {"errors": [...], "warnings":
 (they name the offending `field` and `message`) and re-run — do **not** register
 a malformed entity into the manifest. Run this step even though Step 5's script
 validates again: that script reports only an error count and points back here, so
-this is the run that gives you the per-field errors you need to fix the file.
+this is the run that surfaces the per-field errors needed to fix the file.
+
+Read `data.warnings[]` too. An `unknown field (ignored)` warning is usually a
+misspelled key — the value is being dropped, not stored — so correct it against
+the data model before registering.
 
 The validator checks **frontmatter shape only**: required keys, enums, slug
 casing, ISO dates and their ordering, numeric ranges. It does **not** resolve an
@@ -110,7 +114,7 @@ on `slug`, bumps the manifest `updated` date, and appends the
 validator itself, so it refuses an entity the Step 4 gate would have caught):
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-projects/*/ 2>/dev/null | head -1)}/scripts/register-entity.py" "cogni-projects/<slug>" "cogni-projects/<slug>/<subdir>/<entity>.md"
+python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-projects/*/ 2>/dev/null | head -1)}/scripts/register-entity.py" "cogni-projects/<portfolio-slug>" "cogni-projects/<portfolio-slug>/<subdir>/<entity>.md"
 ```
 
 It returns the same `{"success", "data", "error"}` envelope; `data.action` is

--- a/cogni-projects/skills/projects-entities/SKILL.md
+++ b/cogni-projects/skills/projects-entities/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 Author one consultant, project, or assignment record into a cogni-projects
 portfolio and register it in the portfolio manifest. This is the data-entry
 foundation the staffing-match engine, backfilling recommender, and
-partner-meeting dashboard all read from — every entity you write here is a row
+partner-meeting dashboard all read from — every entity authored here is a row
 those later skills reason over.
 
 Entities are Obsidian-browsable markdown files with YAML frontmatter. The full
@@ -55,10 +55,14 @@ initialized portfolio, it does not scaffold one.
 
 Decide whether the user is authoring a **consultant**, **project**, or
 **assignment**, then gather the required fields for that type from
-`references/data-model.md` (ask only for what is missing):
+[`../../references/data-model.md`](../../references/data-model.md) (ask only for
+what is missing):
 
 Every entity, whatever its type, additionally requires `type` — which must match
-its containing subdirectory, or the validator errors — and `slug`:
+its containing subdirectory, or the validator errors — and `slug`. The per-type
+lists below are a **quick reference** —
+[`../../references/data-model.md`](../../references/data-model.md) is canonical;
+if this list and the data model ever disagree, the data model wins:
 
 - **consultant** — `name`, `seniority`, `skills`; optionally `grade`, `location`,
   `available_from` / `available_until`, `allocation_pct`, `updated`.
@@ -70,8 +74,8 @@ its containing subdirectory, or the validator errors — and `slug`:
 
 Derive the slug from the name (kebab-case) unless the user supplies one. For an
 assignment, confirm both referenced entities already exist under `consultants/`
-and `projects/` — read them first (this is also how you avoid a dangling
-reference).
+and `projects/` — read them first, which is also the guard against a dangling
+reference.
 
 ### Step 3: Read siblings, then write the entity file
 
@@ -128,8 +132,9 @@ existing ref rather than adding a second one.
 ### Step 6: Summarize
 
 Report the file written, the manifest array it was registered in, and the
-validation result. Keep it short. Point to the next entity or, once consultants
-and projects exist, to the staffing-match engine as it ships.
+validation result. Keep it short. Point to the next entity to author — for
+example, once a consultant and a project both exist, authoring the assignment
+that joins them.
 
 ## Notes
 

--- a/cogni-projects/skills/projects-entities/SKILL.md
+++ b/cogni-projects/skills/projects-entities/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: projects-entities
+description: |
+  This skill should be used when the user wants to author or register a
+  consultant, project, or assignment record in a cogni-projects portfolio —
+  the entities the staffing engine scores over. Trigger on: "add a consultant",
+  "add a project", "create an assignment", "author a projects entity", "register
+  a consultant/project", "record a staffing assignment", "populate the projects
+  portfolio", or any request to write consultant/project/assignment data into a
+  cogni-projects portfolio — even if the user does not name the entity type.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Projects Entities
+
+Author one consultant, project, or assignment record into a cogni-projects
+portfolio and register it in the portfolio manifest. This is the data-entry
+foundation the staffing-match engine, backfilling recommender, and
+partner-meeting dashboard all read from — every entity you write here is a row
+those later skills reason over.
+
+Entities are Obsidian-browsable markdown files with YAML frontmatter. The full
+field contract lives in [`references/data-model.md`](../../references/data-model.md);
+read it before authoring so the frontmatter matches what `validate-entities.py`
+enforces.
+
+## Core concept
+
+Each entity is one markdown file under its type's subdirectory of a portfolio:
+
+- **consultant** → `consultants/<slug>.md`
+- **project** → `projects/<slug>.md`
+- **assignment** → `assignments/<consultant>--<project>.md`
+
+Authoring an entity does three things atomically: write the file, register a
+compact summary ref into the matching `projects-portfolio.json` array, and
+append a transition to `.metadata/execution-log.json`. Registration is
+**idempotent** — re-authoring the same slug updates the file and de-duplicates
+the manifest ref rather than appending a second one, so a resumed or repeated run
+never double-registers.
+
+## Workflow
+
+### Step 1: Locate the target portfolio
+
+Find the portfolio directory the user means. If they name a slug, use
+`cogni-projects/<slug>/`. Otherwise glob `cogni-projects/*/projects-portfolio.json`
+and, when more than one portfolio exists, ask which one. If none exists, tell the
+user to run `/cogni-projects:projects-setup` first — this skill authors into an
+initialized portfolio, it does not scaffold one.
+
+### Step 2: Determine the entity type and gather fields
+
+Decide whether the user is authoring a **consultant**, **project**, or
+**assignment**, then gather the required fields for that type from
+`references/data-model.md` (ask only for what is missing):
+
+- **consultant** — `name`, `seniority`, `skills`; optionally grade, location,
+  availability window, allocation.
+- **project** — `name`, `client`, `strategic_impact` (1–5); optionally open
+  roles, timeline, status.
+- **assignment** — the `consultant` and `project` slugs, `role`, `start_date`,
+  `end_date`; optionally allocation, status. The slug is composite:
+  `<consultant-slug>--<project-slug>`.
+
+Derive the slug from the name (kebab-case) unless the user supplies one. For an
+assignment, confirm both referenced entities already exist under `consultants/`
+and `projects/` — read them first (this is also how you avoid a dangling
+reference).
+
+### Step 3: Read siblings, then write the entity file
+
+Read the existing entities in the target subdirectory so the new record is
+consistent with them (naming, skill vocabulary, role labels). Then write the
+single entity file with its YAML frontmatter per the data model. Write **only**
+the one entity file — never a summary, index, or batch file.
+
+### Step 4: Validate before registering
+
+Run the validator against the new file and gate registration on its success:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-projects/*/ 2>/dev/null | head -1)}/scripts/validate-entities.py" "cogni-projects/<slug>/<subdir>/<entity>.md"
+```
+
+The validator returns `{"success": bool, "data": {"errors": [...], "warnings":
+[...]}, "error": str}`. If `success` is `false`, fix each `data.errors[]` entry
+(they name the offending `field` and `message`) and re-run — do **not** register
+a malformed entity into the manifest.
+
+### Step 5: Register in the manifest and log the transition
+
+Once validation passes, update `projects-portfolio.json`:
+
+1. Append a summary ref to the matching array (`consultants[]`, `projects[]`, or
+   `assignments[]`) — the compact `{slug, name/…, file}` shape in the data
+   model's "Manifest registration" section. **Dedupe by `slug`**: if an entry
+   with the same slug exists, replace it in place instead of appending.
+2. Bump the manifest `updated` field to today's date.
+
+Then append a transition to `.metadata/execution-log.json` (`transitions[]`)
+recording the entity slug, type, and action (`created` / `updated`) so the audit
+trail stays complete.
+
+### Step 6: Summarize
+
+Report the file written, the manifest array it was registered in, and the
+validation result. Keep it short. Point to the next entity or, once consultants
+and projects exist, to the staffing-match engine as it ships.
+
+## Notes
+
+- **Scripts return `{success, data, error}` JSON**, stdlib-only — the validator
+  follows the plugin convention; do not add pip dependencies.
+- **The manifest is the source of truth** for what exists in the portfolio;
+  entity files hold full field values. Keep them consistent — every authored
+  file has exactly one manifest ref.
+- **One entity per invocation** keeps each write reviewable and the execution log
+  legible. To author several, run the skill once per entity.


### PR DESCRIPTION
Closes #1113.

Phase-1 data-model foundation for epic #1119: defines the three core entity schemas, an authoring skill, and a stdlib validator on top of the #1112 scaffold.

## Summary
- Add `cogni-projects/references/data-model.md` — the YAML-frontmatter schema for all three entity types: **consultant** (skills, seniority, availability window, allocation), **project** (client, open roles, timeline, `strategic_impact` 1–5), and **assignment** (consultant×project join with role + date window). Mirrors the sibling data-model layout (`# … Data Model Reference` H1 → `## Entity Schemas` → per-entity `###` subsections): per-entity fenced example, Required/Optional field lists, enum tables, a kebab-case Naming Conventions table (composite `<consultant>--<project>` assignment slug), the manifest summary-ref shape, and a closing mermaid erDiagram.
- Add the domain-prefixed `projects-entities` skill — locate the portfolio, read siblings, write ONE entity markdown file into `consultants/|projects/|assignments/`, register a summary ref idempotently (dedupe by slug) into the matching `projects-portfolio.json` array + bump `updated`, append an `.metadata/execution-log.json` transition, and gate the write on the validator.
- Add `cogni-projects/scripts/validate-entities.py` — python3 stdlib (no PyYAML): a frontmatter-subset parser plus schema checks (missing required key, invalid enum, non-kebab slug, invalid ISO date, out-of-range integer). Returns the repo `{"success", "data": {"errors", "warnings"}, "error"}` envelope with per-field `{entity, file, field, message}` errors and `success:false` on any error. Accepts a single entity file or a whole portfolio directory.
- Add `cogni-projects/scripts/register-entity.py` — the single writer of manifest refs (see Scope decisions for why it is a separate script).
- Patch-bump `cogni-projects/.claude-plugin/plugin.json` 0.0.1 → 0.0.4 and mirror it in `.claude-plugin/marketplace.json`.

## Scope decisions
- **Three entities, not four.** The #1112 scaffold committed to the noun `assignment`/`assignments` (dir + manifest array + CLAUDE.md + README). The issue's "availability" is a consultant/assignment allocation-window **attribute**, not a fourth entity, so it is modeled as frontmatter fields (`available_from`/`available_until`/`allocation_pct`). This rationale now lives in `data-model.md`'s assignment section, not only in this PR body.
- **`register-entity.py` is a separate script (beyond the issue's "~1 skill + 1 references doc + 1 validation script").** SKILL.md Step 5 needs an atomic upsert + manifest `updated` bump + `.metadata/execution-log.json` append; scripting it keeps `projects-portfolio.json` single-writer rather than having the model hand-edit the manifest, and lets the register path independently re-validate (via importlib) so an invalid entity cannot be registered even by direct script invocation that bypasses the skill. It loads `validate-entities.py` rather than restating its rules, and SKILL.md performs no inline registration — no duplicated write logic.
- **Deferred (separate epic #1119 children, not sliced here):** the staffing match engine (#1114), backfilling recommender (#1115), and partner-meeting dashboard (#1116).
- **README/CLAUDE "What it does" regeneration** is out of this issue's ACs and flows through the cogni-docs pipeline (doc-audit/doc-generate) — not duplicated in this PR.

## Verification
- [x] `validate-entities.py` on a well-formed consultant/project/assignment → `{"success": true}`.
- [x] On a malformed entity (missing `name`, non-kebab `slug`, bad `seniority` enum, `allocation_pct` 150, `available_from` 2026-13-40) → `{"success": false}` with one per-field `{entity,file,field,message}` error each (invalid calendar dates are caught, not just bad shapes).
- [x] Whole-portfolio directory scan validates all three entity subdirs; assignment composite slug `<consultant>--<project>` accepted.
- [x] `plugin.json` and `marketplace.json` both show cogni-projects at 0.0.4; both JSON files parse.
- [x] `python3 -m py_compile` on the validator passes.
- [x] `projects-entities` is domain-prefixed and collision-free (unique `name:` across all SKILL.md in the monorepo; no duplicate skill names). `bash cogni-workspace/scripts/check-skill-names.sh` passes under CI's modern bash; it cannot run on the host (bash 3.2 lacks `declare -A`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
