### PR TITLE
cogni-projects: staffing engine — ranked shortlists per open role

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -270,7 +270,7 @@
     {
       "name": "cogni-projects",
       "source": "./cogni-projects",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "maturity": "incubating",
       "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory and authors the validated consultant, project, and assignment records that later skills (staffing match, backfilling, partner-meeting dashboard) read from.",
       "keywords": [

--- a/cogni-projects/.claude-plugin/plugin.json
+++ b/cogni-projects/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-projects",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Partner-facing project-portfolio steering for consulting firms — models consultants, projects, and staffing so partners can match people to work by availability, profile fit, and strategic impact. Scaffolds a self-contained portfolio directory and authors the validated consultant, project, and assignment records that later skills (staffing match, backfilling, partner-meeting dashboard) read from.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-projects/CLAUDE.md
+++ b/cogni-projects/CLAUDE.md
@@ -2,9 +2,9 @@
 
 Partner-facing project-portfolio steering for consulting firms. Models
 consultants, projects, and staffing so partners can match people to work by
-availability, profile fit, and strategic impact. The data model and entity
-authoring have landed; the staffing engine and the skills that read these
-entities arrive in later roadmap children.
+availability, profile fit, and strategic impact. The data model, entity
+authoring, and the staffing match engine have landed; the backfilling
+recommender and partner-meeting dashboard arrive in later roadmap children.
 
 ## Plugin Architecture
 
@@ -15,11 +15,13 @@ cogni-projects/
 ├── CLAUDE.md                         This developer guide
 ├── skills/
 │   ├── projects-setup/SKILL.md       Initialize a portfolio directory (entry point)
-│   └── projects-entities/SKILL.md    Author + register one consultant/project/assignment
+│   ├── projects-entities/SKILL.md    Author + register one consultant/project/assignment
+│   └── projects-staff/SKILL.md       Rank candidate consultants per open project role
 ├── scripts/
 │   ├── portfolio-init.sh             Idempotent portfolio scaffolder (stdlib-only)
 │   ├── validate-entities.py          Entity frontmatter validator (stdlib-only)
-│   └── register-entity.py            Slug-keyed manifest upsert + execution-log append
+│   ├── register-entity.py            Slug-keyed manifest upsert + execution-log append
+│   └── staffing-score.py             Deterministic staffing scorer (availability/fit/impact)
 ├── tests/
 │   └── test_register_entity.sh       Atomic-write + idempotency regression suite
 └── references/
@@ -34,8 +36,7 @@ bash cogni-projects/tests/test_register_entity.sh
 
 Planned (not yet scaffolded — see the roadmap epic):
 
-- `skills/` for the staffing match engine, backfilling recommender, and the
-  partner-meeting dashboard.
+- `skills/` for the backfilling recommender and the partner-meeting dashboard.
 
 ## Data Model
 

--- a/cogni-projects/CLAUDE.md
+++ b/cogni-projects/CLAUDE.md
@@ -48,7 +48,11 @@ A portfolio is one `cogni-projects/<portfolio-slug>/` directory:
   `workflow_state` object.
 - `consultants/`, `projects/`, `assignments/` — per-entity record directories.
 - `.metadata/` — append-only logs (`execution-log.json`, `staffing-log.json`,
-  `decision-log.json`) later skills write to.
+  `decision-log.json`) later skills write to. `staffing-log.json` is an object
+  `{"matches": [...]}`; `projects-staff` appends run records to its `matches[]`
+  array. Also holds `staffing-recommendations.json` — the last-run staffing
+  scorer output snapshot (overwritten each run, **not** an append-only log) that
+  the backfilling recommender and dashboard read.
 
 ## Conventions
 

--- a/cogni-projects/README.md
+++ b/cogni-projects/README.md
@@ -2,7 +2,7 @@
 
 > **Incubating** (v0.0.x) — skills, data formats, and workflows may change at any time.
 
-Partner project-portfolio steering for consulting firms on Claude Code. cogni-projects gives partners one place to model consultants, projects, and staffing — so they can match the right people to the right work by availability, profile fit, and strategic impact. This foundation release scaffolds the plugin and its portfolio entry point; the staffing engine and dashboards arrive in later releases.
+Partner project-portfolio steering for consulting firms on Claude Code. cogni-projects gives partners one place to model consultants, projects, and staffing — so they can match the right people to the right work by availability, profile fit, and strategic impact. The portfolio scaffold, entity authoring, and the staffing match engine have shipped; the backfilling recommender and partner-meeting dashboard arrive in later releases.
 
 ## Why this exists
 
@@ -18,17 +18,19 @@ Consulting partners steer a portfolio of projects and people with spreadsheets a
 
 cogni-projects is a Claude Code plugin that holds a **self-contained project portfolio**: a directory of consultants, projects, and assignments rooted by a single manifest. It is the 14th plugin in the insight-wave ecosystem and the home for partner-facing portfolio steering.
 
-At this foundation stage it provides the plugin skeleton and the `projects-setup` skill that scaffolds a portfolio directory. Staffing, backfilling, and partner-meeting views build on top of it.
+It provides the plugin skeleton, the `projects-setup` skill that scaffolds a portfolio directory, the `projects-entities` skill that authors and registers validated consultant/project/assignment records, and the `projects-staff` staffing match engine that ranks candidate consultants per open role. Backfilling and partner-meeting views build on top of it.
 
 ## What it does
 
 - **projects-setup** — initialize a new portfolio directory (`cogni-projects/<portfolio-slug>/`) with a root manifest and metadata logs. Idempotent: re-running never overwrites an existing portfolio.
+- **projects-entities** — author one consultant, project, or assignment record and register it in the portfolio manifest, with structural validation.
+- **projects-staff** — rank candidate consultants for every open project role on availability, profile fit, and strategic impact, and write a staffing-recommendations artifact.
 
-_More skills (staffing match engine, backfilling recommender, partner-meeting dashboard) land in later roadmap releases._
+_More skills (backfilling recommender, partner-meeting dashboard) land in later roadmap releases._
 
 ## What it means for you
 
-You get one durable, browsable home for your project portfolio — the foundation every later staffing and steering capability writes into. Start a portfolio today; the engine that matches people to work plugs into the same directory as it ships.
+You get one durable, browsable home for your project portfolio — the foundation every staffing and steering capability writes into. Author your consultants and projects, then run the staffing engine to get a defensible ranked shortlist for each open role; later backfilling and dashboard views plug into the same directory as they ship.
 
 ## Installation
 
@@ -76,11 +78,16 @@ The manifest holds portfolio identity (`slug`, `name`, `language`, timestamps) p
 | Type | Name | Purpose |
 |------|------|---------|
 | Skill | `projects-setup` | Initialize a portfolio directory |
+| Skill | `projects-entities` | Author + register a consultant/project/assignment record |
+| Skill | `projects-staff` | Rank candidate consultants per open project role |
 | Script | `portfolio-init.sh` | Idempotent portfolio scaffolder |
+| Script | `validate-entities.py` | Entity frontmatter validator |
+| Script | `register-entity.py` | Slug-keyed manifest upsert + execution-log append |
+| Script | `staffing-score.py` | Deterministic staffing scorer (availability/fit/impact) |
 
 ## Architecture
 
-cogni-projects is standalone at this stage. Its portfolio directory is designed as the shared substrate for later skills (staffing match, backfilling, dashboard) and for planned cross-plugin bridges to cogni-consult and cogni-portfolio.
+cogni-projects is standalone at this stage. Its portfolio directory is the shared substrate for its skills (entity authoring, staffing match) and for later ones (backfilling, dashboard), and for planned cross-plugin bridges to cogni-consult and cogni-portfolio.
 
 ## Dependencies
 

--- a/cogni-projects/references/data-model.md
+++ b/cogni-projects/references/data-model.md
@@ -21,8 +21,13 @@ cogni-projects/<portfolio-slug>/
 ├── consultants/               consultant entity records — <slug>.md
 ├── projects/                  project entity records — <slug>.md
 ├── assignments/               assignment entity records — <consultant>--<project>.md
-└── .metadata/                 append-only logs (execution, staffing, decisions)
+└── .metadata/                 append-only logs (execution, staffing, decisions) + staffing-recommendations.json snapshot
 ```
+
+`.metadata/staffing-log.json` is an object `{"matches": [...]}` that
+`projects-staff` appends run records to; `.metadata/staffing-recommendations.json`
+is the last-run scorer output snapshot (overwritten each run, not an append-only
+log).
 
 Each entity lives in one markdown file under its type's subdirectory. The file's
 subdirectory determines its type, and the frontmatter `type` field must agree.
@@ -129,6 +134,14 @@ Valid `status` values:
 | `closed` | Delivered or lost |
 
 `open_roles` is a list of role labels the project still needs staffed.
+
+The staffing engine matches an `open_roles` label against a consultant's
+`skills` in two tiers: an **exact whole-label match** (the role label equals one
+of the consultant's skill labels, case-insensitive) scores the fit dimension
+fully; absent that, **hyphen/word token overlap** contributes a discounted
+score, so a shared generic token (`data` in both `data-science` and
+`data-engineering`) never outranks a genuine whole-label hit. A project with
+`status: closed` is skipped entirely — its roles are not open work to staff.
 
 ---
 

--- a/cogni-projects/scripts/staffing-score.py
+++ b/cogni-projects/scripts/staffing-score.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Rank candidate consultants for each open project role in a cogni-projects portfolio.
 
-The Phase 2 staffing engine. For every project that carries `open_roles`, this
-script scores each consultant in the portfolio on three visible per-factor
-sub-scores and a combined score, then returns a ranked shortlist per open role:
+The staffing match engine. For every non-closed project that carries
+`open_roles`, this script scores each consultant in the portfolio on three
+visible per-factor sub-scores and a combined score, then returns a ranked
+shortlist per open role:
 
 - **availability** — how well the consultant's `available_from`/`available_until`
   window overlaps the project's `start_date`/`end_date` window, weighted by the
@@ -21,13 +22,13 @@ sub-scores and a combined score, then returns a ranked shortlist per open role:
 
 Each candidate's combined score ranks the shortlist for one role on the two
 genuine per-candidate factors — availability and profile fit. All sub-scores
-and the combined score are in [0,1] and shown separately (AC1); the
-strategic-impact sub-score is displayed per role and drives project ordering,
-never folded into the candidate combined score as a per-role constant that
-cannot affect it. Consultants with no availability overlap are excluded (AC2).
-Output is deterministic for identical inputs — scores are rounded to a fixed
-precision, projects order by strategic impact then slug, candidate ties break
-on the consultant slug, and no wall-clock value enters the result (AC3).
+and the combined score are in [0,1] and shown separately; the strategic-impact
+sub-score is displayed per role and drives project ordering, never folded into
+the candidate combined score as a per-role constant that cannot affect it.
+Consultants with no availability overlap are excluded from that project's
+ranking. Output is deterministic for identical inputs — scores are rounded to a
+fixed precision, projects order by strategic impact then slug, candidate ties
+break on the consultant slug, and no wall-clock value enters the result.
 
 Reads entity frontmatter with the same stdlib parser the validator uses
 (`validate-entities.py:parse_frontmatter`, loaded by file location as
@@ -41,9 +42,11 @@ projects-portfolio.json manifest.
 
 Output: a single JSON line following the repo contract
   {"success": bool, "data": {...}, "error": str}
-Exit: 0 ok / 1 domain failure (bad portfolio / unreadable manifest) / 2 usage.
+Exit: 0 ok / 1 domain failure (bad portfolio / unreadable manifest / broken
+install) / 2 usage (wrong argument count).
 """
 
+import datetime
 import importlib.util
 import json
 import os
@@ -67,6 +70,12 @@ W_HEADROOM = 0.40
 # Profile-fit sub-score blends role-skill match with a seniority prior.
 W_SKILL_MATCH = 0.75
 W_SENIORITY = 0.25
+
+# An exact whole-label skill match scores the match dimension fully; partial
+# hyphen/word token overlap is discounted by this factor, so a shared generic
+# token (`data` in both `data-science` and `data-engineering`) cannot outrank a
+# genuine whole-label hit.
+TOKEN_OVERLAP_DISCOUNT = 0.5
 
 # Seniority normalized to [0,1] — the seniority prior in profile fit.
 SENIORITY_NORM = {
@@ -125,12 +134,10 @@ def _overlap_fraction(cf, cu, ps, pe):
     that side. Returns a float in [0,1]: the overlap length divided by the
     project-window length. When the project window is a single day or unbounded,
     any non-empty overlap yields 1.0. Returns 0.0 when the windows do not
-    overlap at all — the exclusion signal AC2 keys on.
+    overlap at all — the signal that excludes the consultant from the role.
 
     ISO-8601 date strings order and subtract correctly as `datetime.date`.
     """
-    import datetime
-
     def _d(value):
         if isinstance(value, str) and value:
             try:
@@ -171,12 +178,29 @@ def _overlap_fraction(cf, cu, ps, pe):
     return 1.0 if frac > 1.0 else (0.0 if frac < 0.0 else frac)
 
 
+def _headroom(alloc):
+    """Free-capacity headroom in [0,1] from a consultant's `allocation_pct`.
+
+    A missing `allocation_pct` records no allocation, so the consultant counts
+    as fully free (1.0). A numeric value — int or float, but not bool, which is
+    an int subclass — is clamped to 0..100 and inverted. A present-but-
+    non-numeric value is a data-quality problem: it defaults to zero headroom
+    (conservative) rather than silently inflating availability to full capacity.
+    """
+    if alloc is None:
+        return 1.0
+    if isinstance(alloc, bool) or not isinstance(alloc, (int, float)):
+        return 0.0
+    alloc = max(0, min(100, alloc))
+    return (100 - alloc) / 100.0
+
+
 def _availability_score(consultant, project):
     """Availability sub-score, or None when the consultant must be excluded.
 
     Returns None when there is zero temporal overlap between the consultant's
-    availability window and the project window (AC2 exclusion). Otherwise blends
-    the overlap fraction with the consultant's free-capacity headroom.
+    availability window and the project window — the exclusion signal. Otherwise
+    blends the overlap fraction with the consultant's free-capacity headroom.
     """
     overlap = _overlap_fraction(
         consultant.get("available_from"), consultant.get("available_until"),
@@ -184,8 +208,7 @@ def _availability_score(consultant, project):
     )
     if overlap <= 0.0:
         return None
-    alloc = consultant.get("allocation_pct")
-    headroom = 1.0 if not isinstance(alloc, int) else max(0.0, (100 - alloc) / 100.0)
+    headroom = _headroom(consultant.get("allocation_pct"))
     return W_OVERLAP * overlap + W_HEADROOM * headroom
 
 
@@ -202,15 +225,35 @@ def _tokenize(value):
     return tokens
 
 
+def _labels(value):
+    """Lowercased, stripped whole labels from a string or list of strings."""
+    items = value if isinstance(value, list) else [value]
+    labels = set()
+    for item in items:
+        if isinstance(item, str) and item.strip():
+            labels.add(item.strip().lower())
+    return labels
+
+
 def _profile_fit_score(consultant, role):
-    """Profile-fit sub-score: role-skill match blended with a seniority prior."""
-    role_tokens = _tokenize(role)
-    skill_tokens = _tokenize(consultant.get("skills", []))
-    if role_tokens:
-        matched = len(role_tokens & skill_tokens)
-        skill_match = matched / len(role_tokens)
+    """Profile-fit sub-score: role-skill match blended with a seniority prior.
+
+    An exact whole-label match between the role and one of the consultant's
+    skills scores the match dimension fully. Absent that, partial hyphen/word
+    token overlap contributes a discounted score, so a shared generic token
+    (`data` in both `data-science` and `data-engineering`) never outranks a
+    genuine whole-label hit.
+    """
+    if _labels(role) & _labels(consultant.get("skills", [])):
+        skill_match = 1.0
     else:
-        skill_match = 0.0
+        role_tokens = _tokenize(role)
+        skill_tokens = _tokenize(consultant.get("skills", []))
+        if role_tokens:
+            overlap = len(role_tokens & skill_tokens) / len(role_tokens)
+            skill_match = TOKEN_OVERLAP_DISCOUNT * overlap
+        else:
+            skill_match = 0.0
     seniority = SENIORITY_NORM.get(consultant.get("seniority"), 0.0)
     return W_SKILL_MATCH * skill_match + W_SENIORITY * seniority
 
@@ -274,6 +317,14 @@ def score_portfolio(portfolio_dir, parse_frontmatter):
     projects = _load_entities(
         parse_frontmatter, portfolio_dir, manifest, "projects", "projects"
     )
+
+    # A closed project is delivered or lost — its roles are not open work to
+    # staff, so drop it before scoring. project_count then reflects the
+    # scored (non-closed) projects, not every record on disk.
+    projects = [
+        p for p in projects
+        if str(p.get("status", "")).strip().lower() != "closed"
+    ]
 
     # Order projects by strategic impact (firm-defining first) so high-impact
     # open roles surface at the top of the output; the slug tiebreak keeps it
@@ -366,9 +417,11 @@ def main(argv):
 
     parse_frontmatter = _load_parse_frontmatter()
     if parse_frontmatter is None:
+        # A broken/partial install (validator missing), not a caller usage
+        # error — so exit 1 (domain failure), reserving exit 2 for bad args.
         return _fail(
             "cannot load validate-entities.py:parse_frontmatter (expected sibling "
-            "of this script)", 2
+            "of this script) — the cogni-projects install looks broken", 1
         )
 
     try:

--- a/cogni-projects/scripts/staffing-score.py
+++ b/cogni-projects/scripts/staffing-score.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Rank candidate consultants for each open project role in a cogni-projects portfolio.
+
+The Phase 2 staffing engine. For every project that carries `open_roles`, this
+script scores each consultant in the portfolio on three visible per-factor
+sub-scores and a combined score, then returns a ranked shortlist per open role:
+
+- **availability** — how well the consultant's `available_from`/`available_until`
+  window overlaps the project's `start_date`/`end_date` window, weighted by the
+  consultant's free capacity (`allocation_pct` headroom). A consultant whose
+  window does not overlap the project window at all is **excluded** from that
+  project's ranking (never scored, never listed).
+- **profile fit** — how well the consultant's `skills` match the open role label,
+  blended with a small seniority prior.
+- **strategic impact** — the project's `strategic_impact` (1..5) normalized to
+  [0,1], so staffing optimizes firm strategy, not just utilization.
+
+The three sub-scores and the combined score are all in [0,1] and shown
+separately (AC1). Consultants with no availability overlap are excluded (AC2).
+Output is deterministic for identical inputs — scores are rounded to a fixed
+precision, ties break on the consultant slug, and no wall-clock value enters the
+result (AC3).
+
+Reads entity frontmatter with the same stdlib parser the validator uses
+(`validate-entities.py:parse_frontmatter`, loaded by file location as
+`register-entity.py` does) — no duplicated parser, no PyYAML.
+
+Usage:
+  python3 staffing-score.py <portfolio-dir>
+
+<portfolio-dir> is a cogni-projects/<portfolio-slug>/ directory rooted by a
+projects-portfolio.json manifest.
+
+Output: a single JSON line following the repo contract
+  {"success": bool, "data": {...}, "error": str}
+Exit: 0 ok / 1 domain failure (bad portfolio / unreadable manifest) / 2 usage.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+
+# --- Scoring weights (defensible MVP defaults; tunable is a follow-up concern) ---
+# Combined score blends the three sub-factors. Availability leads (a perfect
+# profile is worthless if the person cannot take the work), strategic impact is
+# the lightest weight (it tilts ties toward firm-defining projects without
+# letting a tactical-but-perfect match lose to a strategic-but-poor one).
+W_AVAILABILITY = 0.40
+W_PROFILE_FIT = 0.35
+W_STRATEGIC_IMPACT = 0.25
+
+# Availability sub-score itself blends temporal overlap with free capacity.
+W_OVERLAP = 0.60
+W_HEADROOM = 0.40
+
+# Profile-fit sub-score blends role-skill match with a seniority prior.
+W_SKILL_MATCH = 0.75
+W_SENIORITY = 0.25
+
+# Seniority normalized to [0,1] — the seniority prior in profile fit.
+SENIORITY_NORM = {
+    "junior": 0.2,
+    "consultant": 0.4,
+    "senior": 0.6,
+    "principal": 0.8,
+    "partner": 1.0,
+}
+
+SCORE_PRECISION = 3  # decimal places — fixes output for byte-identical re-runs.
+
+
+def _fail(message, code):
+    """Emit the failure envelope and return the exit code."""
+    print(json.dumps(
+        {"success": False, "data": {}, "error": message}, ensure_ascii=False
+    ))
+    return code
+
+
+def _load_parse_frontmatter():
+    """Load parse_frontmatter from the sibling validate-entities.py by file path.
+
+    validate-entities.py is not an importable module name (hyphens), so — exactly
+    as register-entity.py does — load it by location to reuse the one canonical
+    frontmatter parser rather than duplicating the schema-shaped parsing rules.
+    Returns the callable, or None if the validator module cannot be loaded.
+    """
+    v_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "validate-entities.py"
+    )
+    spec = importlib.util.spec_from_file_location("validate_entities", v_path)
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, "parse_frontmatter", None)
+
+
+def _read_frontmatter(parse_frontmatter, path):
+    """Return the parsed frontmatter dict for an entity file, or {} on any miss."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read()
+    except OSError:
+        return {}
+    fm = parse_frontmatter(text)
+    return fm if isinstance(fm, dict) else {}
+
+
+def _overlap_fraction(cf, cu, ps, pe):
+    """Fraction of the project window the consultant's availability covers.
+
+    Windows are ISO date strings; a `None`/empty bound is open (unbounded) on
+    that side. Returns a float in [0,1]: the overlap length divided by the
+    project-window length. When the project window is a single day or unbounded,
+    any non-empty overlap yields 1.0. Returns 0.0 when the windows do not
+    overlap at all — the exclusion signal AC2 keys on.
+
+    ISO-8601 date strings order and subtract correctly as `datetime.date`.
+    """
+    import datetime
+
+    def _d(value):
+        if isinstance(value, str) and value:
+            try:
+                return datetime.date.fromisoformat(value)
+            except ValueError:
+                return None
+        return None
+
+    cf_d, cu_d, ps_d, pe_d = _d(cf), _d(cu), _d(ps), _d(pe)
+
+    # Effective overlap window: intersect [cf,cu] with [ps,pe], treating a
+    # missing bound as unbounded on that side.
+    lo_candidates = [d for d in (cf_d, ps_d) if d is not None]
+    hi_candidates = [d for d in (cu_d, pe_d) if d is not None]
+    lo = max(lo_candidates) if lo_candidates else None
+    hi = min(hi_candidates) if hi_candidates else None
+
+    if lo is not None and hi is not None and lo > hi:
+        return 0.0  # disjoint windows — no overlap.
+
+    # Project-window length, in days, as the denominator.
+    if ps_d is not None and pe_d is not None:
+        proj_days = (pe_d - ps_d).days + 1
+        if proj_days <= 0:
+            return 1.0
+    else:
+        # Unbounded project window: any overlap counts fully.
+        return 1.0
+
+    if lo is None:
+        lo = ps_d
+    if hi is None:
+        hi = pe_d
+    overlap_days = (hi - lo).days + 1
+    if overlap_days <= 0:
+        return 0.0
+    frac = overlap_days / proj_days
+    return 1.0 if frac > 1.0 else (0.0 if frac < 0.0 else frac)
+
+
+def _availability_score(consultant, project):
+    """Availability sub-score, or None when the consultant must be excluded.
+
+    Returns None when there is zero temporal overlap between the consultant's
+    availability window and the project window (AC2 exclusion). Otherwise blends
+    the overlap fraction with the consultant's free-capacity headroom.
+    """
+    overlap = _overlap_fraction(
+        consultant.get("available_from"), consultant.get("available_until"),
+        project.get("start_date"), project.get("end_date"),
+    )
+    if overlap <= 0.0:
+        return None
+    alloc = consultant.get("allocation_pct")
+    headroom = 1.0 if not isinstance(alloc, int) else max(0.0, (100 - alloc) / 100.0)
+    return W_OVERLAP * overlap + W_HEADROOM * headroom
+
+
+def _tokenize(value):
+    """Lowercase hyphen/space/underscore tokens from a string or list of strings."""
+    tokens = set()
+    items = value if isinstance(value, list) else [value]
+    for item in items:
+        if not isinstance(item, str):
+            continue
+        for tok in item.lower().replace("_", "-").replace(" ", "-").split("-"):
+            if tok:
+                tokens.add(tok)
+    return tokens
+
+
+def _profile_fit_score(consultant, role):
+    """Profile-fit sub-score: role-skill match blended with a seniority prior."""
+    role_tokens = _tokenize(role)
+    skill_tokens = _tokenize(consultant.get("skills", []))
+    if role_tokens:
+        matched = len(role_tokens & skill_tokens)
+        skill_match = matched / len(role_tokens)
+    else:
+        skill_match = 0.0
+    seniority = SENIORITY_NORM.get(consultant.get("seniority"), 0.0)
+    return W_SKILL_MATCH * skill_match + W_SENIORITY * seniority
+
+
+def _strategic_impact_norm(project):
+    """Project strategic_impact (1..5) normalized to [0,1]; 0.0 when absent/bad."""
+    impact = project.get("strategic_impact")
+    if not isinstance(impact, int):
+        return 0.0
+    impact = max(1, min(5, impact))
+    return (impact - 1) / 4.0
+
+
+def _round(x):
+    return round(x, SCORE_PRECISION)
+
+
+def _load_entities(parse_frontmatter, portfolio_dir, manifest, kind, subdir):
+    """Read every entity of one kind into a list of frontmatter dicts.
+
+    Prefers the manifest's summary refs (the index later skills scan) for the
+    file list, falling back to scanning the entity subdirectory so a
+    hand-authored file the manifest has not yet indexed is still considered.
+    """
+    files = []
+    seen = set()
+    for ref in manifest.get(kind, []) or []:
+        rel = ref.get("file") if isinstance(ref, dict) else None
+        if rel:
+            path = os.path.join(portfolio_dir, rel)
+            files.append(path)
+            seen.add(os.path.abspath(path))
+    dir_path = os.path.join(portfolio_dir, subdir)
+    if os.path.isdir(dir_path):
+        for name in sorted(os.listdir(dir_path)):
+            if name.endswith(".md"):
+                path = os.path.join(dir_path, name)
+                if os.path.abspath(path) not in seen:
+                    files.append(path)
+    entities = []
+    for path in files:
+        fm = _read_frontmatter(parse_frontmatter, path)
+        if fm:
+            entities.append(fm)
+    return entities
+
+
+def score_portfolio(portfolio_dir, parse_frontmatter):
+    """Build the ranked-shortlist data structure for a portfolio directory."""
+    manifest_path = os.path.join(portfolio_dir, "projects-portfolio.json")
+    try:
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+    except (OSError, ValueError) as exc:
+        raise RuntimeError("cannot read portfolio manifest %s: %s"
+                           % (manifest_path, exc))
+
+    consultants = _load_entities(
+        parse_frontmatter, portfolio_dir, manifest, "consultants", "consultants"
+    )
+    projects = _load_entities(
+        parse_frontmatter, portfolio_dir, manifest, "projects", "projects"
+    )
+
+    # Deterministic project order — by slug.
+    projects.sort(key=lambda p: str(p.get("slug", "")))
+
+    project_results = []
+    total_ranked = 0
+    for project in projects:
+        open_roles = project.get("open_roles") or []
+        if not isinstance(open_roles, list):
+            open_roles = []
+        strat = _round(_strategic_impact_norm(project))
+        role_results = []
+        for role in open_roles:
+            candidates = []
+            excluded = 0
+            for consultant in consultants:
+                availability = _availability_score(consultant, project)
+                if availability is None:
+                    excluded += 1
+                    continue
+                profile_fit = _profile_fit_score(consultant, role)
+                combined = (
+                    W_AVAILABILITY * availability
+                    + W_PROFILE_FIT * profile_fit
+                    + W_STRATEGIC_IMPACT * _strategic_impact_norm(project)
+                )
+                candidates.append({
+                    "consultant": consultant.get("slug"),
+                    "name": consultant.get("name"),
+                    "scores": {
+                        "availability": _round(availability),
+                        "profile_fit": _round(profile_fit),
+                        "strategic_impact": strat,
+                        "combined": _round(combined),
+                    },
+                })
+            # Rank by combined score desc, deterministic slug tiebreak asc.
+            candidates.sort(
+                key=lambda c: (-c["scores"]["combined"], str(c["consultant"]))
+            )
+            total_ranked += len(candidates)
+            role_results.append({
+                "role": role,
+                "candidates": candidates,
+                "excluded_count": excluded,
+            })
+        project_results.append({
+            "project": project.get("slug"),
+            "name": project.get("name"),
+            "strategic_impact": project.get("strategic_impact"),
+            "strategic_impact_norm": strat,
+            "open_roles": role_results,
+        })
+
+    return {
+        "portfolio": manifest.get("slug") or os.path.basename(
+            os.path.normpath(portfolio_dir)
+        ),
+        "weights": {
+            "availability": W_AVAILABILITY,
+            "profile_fit": W_PROFILE_FIT,
+            "strategic_impact": W_STRATEGIC_IMPACT,
+        },
+        "consultant_count": len(consultants),
+        "project_count": len(projects),
+        "ranked_candidate_count": total_ranked,
+        "projects": project_results,
+    }
+
+
+def main(argv):
+    if len(argv) != 1:
+        return _fail("usage: staffing-score.py <portfolio-dir>", 2)
+    portfolio_dir = argv[0]
+    if not os.path.isdir(portfolio_dir):
+        return _fail("portfolio directory not found: %s" % portfolio_dir, 1)
+    if not os.path.isfile(os.path.join(portfolio_dir, "projects-portfolio.json")):
+        return _fail(
+            "not a portfolio directory (no projects-portfolio.json): %s "
+            "(run /cogni-projects:projects-setup first)" % portfolio_dir, 1
+        )
+
+    parse_frontmatter = _load_parse_frontmatter()
+    if parse_frontmatter is None:
+        return _fail(
+            "cannot load validate-entities.py:parse_frontmatter (expected sibling "
+            "of this script)", 2
+        )
+
+    try:
+        data = score_portfolio(portfolio_dir, parse_frontmatter)
+    except RuntimeError as exc:
+        return _fail(str(exc), 1)
+
+    print(json.dumps(
+        {"success": True, "data": data, "error": ""}, ensure_ascii=False
+    ))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/cogni-projects/scripts/staffing-score.py
+++ b/cogni-projects/scripts/staffing-score.py
@@ -259,9 +259,14 @@ def _profile_fit_score(consultant, role):
 
 
 def _strategic_impact_norm(project):
-    """Project strategic_impact (1..5) normalized to [0,1]; 0.0 when absent/bad."""
+    """Project strategic_impact (1..5) normalized to [0,1]; 0.0 when absent/bad.
+
+    Accepts int or float (but not bool, an int subclass) — the data model
+    declares an integer, but a float like 4.0 from JSON authoring is coerced
+    rather than silently normalized to 0.0.
+    """
     impact = project.get("strategic_impact")
-    if not isinstance(impact, int):
+    if isinstance(impact, bool) or not isinstance(impact, (int, float)):
         return 0.0
     impact = max(1, min(5, impact))
     return (impact - 1) / 4.0

--- a/cogni-projects/scripts/staffing-score.py
+++ b/cogni-projects/scripts/staffing-score.py
@@ -13,13 +13,21 @@ sub-scores and a combined score, then returns a ranked shortlist per open role:
 - **profile fit** — how well the consultant's `skills` match the open role label,
   blended with a small seniority prior.
 - **strategic impact** — the project's `strategic_impact` (1..5) normalized to
-  [0,1], so staffing optimizes firm strategy, not just utilization.
+  [0,1]. This is a *project* attribute, not a candidate one, so it does not
+  reorder candidates within a role — a consultant's fit for a role does not
+  change with the project's strategic weight. Instead it orders the projects
+  themselves: firm-defining projects and their open roles surface first, so
+  staffing attention follows firm strategy, not just utilization.
 
-The three sub-scores and the combined score are all in [0,1] and shown
-separately (AC1). Consultants with no availability overlap are excluded (AC2).
+Each candidate's combined score ranks the shortlist for one role on the two
+genuine per-candidate factors — availability and profile fit. All sub-scores
+and the combined score are in [0,1] and shown separately (AC1); the
+strategic-impact sub-score is displayed per role and drives project ordering,
+never folded into the candidate combined score as a per-role constant that
+cannot affect it. Consultants with no availability overlap are excluded (AC2).
 Output is deterministic for identical inputs — scores are rounded to a fixed
-precision, ties break on the consultant slug, and no wall-clock value enters the
-result (AC3).
+precision, projects order by strategic impact then slug, candidate ties break
+on the consultant slug, and no wall-clock value enters the result (AC3).
 
 Reads entity frontmatter with the same stdlib parser the validator uses
 (`validate-entities.py:parse_frontmatter`, loaded by file location as
@@ -42,13 +50,15 @@ import os
 import sys
 
 # --- Scoring weights (defensible MVP defaults; tunable is a follow-up concern) ---
-# Combined score blends the three sub-factors. Availability leads (a perfect
-# profile is worthless if the person cannot take the work), strategic impact is
-# the lightest weight (it tilts ties toward firm-defining projects without
-# letting a tactical-but-perfect match lose to a strategic-but-poor one).
-W_AVAILABILITY = 0.40
-W_PROFILE_FIT = 0.35
-W_STRATEGIC_IMPACT = 0.25
+# The combined score ranks candidates WITHIN a role, so it blends only the two
+# genuine per-candidate factors — availability and profile fit — which sum to
+# 1.0. Availability leads: a perfect profile is worthless if the person cannot
+# take the work. Strategic impact is deliberately absent from this blend — it is
+# a project attribute, identical for every candidate of a role, so adding it to
+# the candidate score cannot change who outranks whom; it earns its keep by
+# ordering the projects instead (see score_portfolio).
+W_AVAILABILITY = 0.55
+W_PROFILE_FIT = 0.45
 
 # Availability sub-score itself blends temporal overlap with free capacity.
 W_OVERLAP = 0.60
@@ -265,8 +275,10 @@ def score_portfolio(portfolio_dir, parse_frontmatter):
         parse_frontmatter, portfolio_dir, manifest, "projects", "projects"
     )
 
-    # Deterministic project order — by slug.
-    projects.sort(key=lambda p: str(p.get("slug", "")))
+    # Order projects by strategic impact (firm-defining first) so high-impact
+    # open roles surface at the top of the output; the slug tiebreak keeps it
+    # deterministic. This is where strategic_impact actually affects ordering.
+    projects.sort(key=lambda p: (-_strategic_impact_norm(p), str(p.get("slug", ""))))
 
     project_results = []
     total_ranked = 0
@@ -285,10 +297,13 @@ def score_portfolio(portfolio_dir, parse_frontmatter):
                     excluded += 1
                     continue
                 profile_fit = _profile_fit_score(consultant, role)
+                # Rank candidates within the role on the two genuine
+                # per-candidate factors only. strategic_impact is a per-project
+                # constant here, so folding it in could not change who outranks
+                # whom — it orders the projects instead (see the sort above).
                 combined = (
                     W_AVAILABILITY * availability
                     + W_PROFILE_FIT * profile_fit
-                    + W_STRATEGIC_IMPACT * _strategic_impact_norm(project)
                 )
                 candidates.append({
                     "consultant": consultant.get("slug"),
@@ -322,11 +337,14 @@ def score_portfolio(portfolio_dir, parse_frontmatter):
         "portfolio": manifest.get("slug") or os.path.basename(
             os.path.normpath(portfolio_dir)
         ),
+        # The combined-score weights cover only the per-candidate factors;
+        # strategic_impact orders the projects (see the project sort) rather
+        # than weighting the candidate score.
         "weights": {
             "availability": W_AVAILABILITY,
             "profile_fit": W_PROFILE_FIT,
-            "strategic_impact": W_STRATEGIC_IMPACT,
         },
+        "project_order": "strategic_impact desc, slug asc",
         "consultant_count": len(consultants),
         "project_count": len(projects),
         "ranked_candidate_count": total_ranked,

--- a/cogni-projects/skills/projects-staff/SKILL.md
+++ b/cogni-projects/skills/projects-staff/SKILL.md
@@ -15,10 +15,12 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 # Projects Staff
 
 Turn a cogni-projects portfolio into a ranked staffing shortlist: for every open
-role on every project, a list of candidate consultants scored on three visible
-factors — **availability**, **profile fit**, and **strategic impact**. It reads
-the consultant, project, and assignment records authored by `projects-entities`
-and produces the recommendation a partner defends a staffing call with.
+role on every project, a list of candidate consultants each showing three
+visible sub-scores — **availability** and **profile fit**, which rank the
+candidates within a role, plus **strategic impact**, a project attribute shown
+per candidate that orders the projects themselves. It reads the consultant,
+project, and assignment records authored by `projects-entities` and produces the
+recommendation a partner defends a staffing call with.
 
 The ranking is computed by a deterministic script — `scripts/staffing-score.py`
 — so the same portfolio always yields the same shortlist. The skill's job is to
@@ -28,8 +30,9 @@ recommendation artifact.
 ## Core concept
 
 For each project that carries `open_roles`, the scorer ranks candidate
-consultants per role on three sub-scores in `[0,1]`, all shown separately plus a
-combined score:
+consultants per role. Each candidate carries three sub-scores in `[0,1]`, all
+shown separately; the **combined** score that orders the shortlist within a role
+blends the two genuine per-candidate factors — availability and profile fit:
 
 - **availability** — how well the consultant's `available_from`/`available_until`
   window overlaps the project's `start_date`/`end_date`, weighted by free
@@ -37,8 +40,11 @@ combined score:
   overlap the project window is excluded from that project's ranking entirely.
 - **profile fit** — how well the consultant's `skills` match the open role label,
   blended with a seniority prior.
-- **strategic impact** — the project's `strategic_impact` (1–5) normalized, so a
-  firm-defining project pulls its shortlist up over a purely tactical one.
+- **strategic impact** — the project's `strategic_impact` (1–5) normalized. This
+  is a *project* attribute, identical for every candidate of a role, so it does
+  **not** reorder candidates within a role. Instead it orders the projects
+  themselves: firm-defining projects and their open roles surface first in the
+  output. The sub-score stays displayed per candidate for context.
 
 The full field contract these read lives in
 [`../../references/data-model.md`](../../references/data-model.md). The scorer
@@ -101,14 +107,16 @@ it to a single opaque number:
 
 | Rank | Consultant | Availability | Profile fit | Strategic impact | Combined |
 |------|-----------|-------------|-------------|------------------|----------|
-| 1 | <name> (`<slug>`) | 0.84 | 0.53 | 0.75 | 0.71 |
+| 1 | <name> (`<slug>`) | 0.84 | 0.53 | 0.75 | 0.70 |
 | 2 | … | … | … | … | … |
 
 _<excluded_count> consultant(s) excluded — no availability overlap with the
 project window._
 ```
 
-Preserve the scorer's ranking order — do not re-sort. When a role has zero
+Preserve the scorer's ordering — both the project/role order (projects come
+strategic-impact-first, so firm-defining work leads the recommendation) and the
+candidate order within each role — do not re-sort. When a role has zero
 candidates (everyone excluded), say so under its heading instead of rendering an
 empty table.
 

--- a/cogni-projects/skills/projects-staff/SKILL.md
+++ b/cogni-projects/skills/projects-staff/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: projects-staff
+description: |
+  This skill should be used when a partner wants a ranked shortlist of
+  consultants for the open roles on a cogni-projects portfolio — the staffing
+  match engine. Trigger on: "staff this project", "who should I put on",
+  "recommend consultants for", "staffing recommendations", "match consultants to
+  roles", "rank candidates for the open roles", "who is available for", "build a
+  staffing shortlist", or any request to turn a cogni-projects portfolio's
+  consultants and projects into a ranked candidate list per open role — even if
+  the user does not name the portfolio.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Projects Staff
+
+Turn a cogni-projects portfolio into a ranked staffing shortlist: for every open
+role on every project, a list of candidate consultants scored on three visible
+factors — **availability**, **profile fit**, and **strategic impact**. It reads
+the consultant, project, and assignment records authored by `projects-entities`
+and produces the recommendation a partner defends a staffing call with.
+
+The ranking is computed by a deterministic script — `scripts/staffing-score.py`
+— so the same portfolio always yields the same shortlist. The skill's job is to
+locate the portfolio, run the scorer, and render its JSON into a human-readable
+recommendation artifact.
+
+## Core concept
+
+For each project that carries `open_roles`, the scorer ranks candidate
+consultants per role on three sub-scores in `[0,1]`, all shown separately plus a
+combined score:
+
+- **availability** — how well the consultant's `available_from`/`available_until`
+  window overlaps the project's `start_date`/`end_date`, weighted by free
+  capacity (`allocation_pct` headroom). A consultant whose window does **not**
+  overlap the project window is excluded from that project's ranking entirely.
+- **profile fit** — how well the consultant's `skills` match the open role label,
+  blended with a seniority prior.
+- **strategic impact** — the project's `strategic_impact` (1–5) normalized, so a
+  firm-defining project pulls its shortlist up over a purely tactical one.
+
+The full field contract these read lives in
+[`../../references/data-model.md`](../../references/data-model.md). The scorer
+returns the repo-standard `{"success", "data", "error"}` JSON and never bakes a
+wall-clock value into a score, so its output is reproducible.
+
+## Workflow
+
+### Step 1: Locate the target portfolio
+
+Find the portfolio directory the user means. If they name a slug, use
+`cogni-projects/<portfolio-slug>/`. Otherwise glob
+`cogni-projects/*/projects-portfolio.json` and, when more than one portfolio
+exists, ask which one. If none exists, tell the user to run
+`/cogni-projects:projects-setup` first and author entities with
+`/cogni-projects:projects-entities` — this skill scores an existing portfolio, it
+does not scaffold or populate one.
+
+A portfolio with zero projects carrying `open_roles`, or zero consultants, is a
+valid but empty input: the scorer returns `success: true` with an empty ranking.
+Say so rather than treating it as an error — the fix is to author more entities,
+not to debug the skill.
+
+### Step 2: Run the scorer
+
+Run `staffing-score.py` against the portfolio directory and capture its JSON:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-projects/*/ 2>/dev/null | head -1)}/scripts/staffing-score.py" "cogni-projects/<portfolio-slug>"
+```
+
+It returns `{"success", "data", "error"}` (exit 0 ok / 1 domain failure / 2
+usage). On `success: false`, surface `error` to the user and stop — a domain
+failure means the portfolio directory or its manifest is unreadable, which the
+scorer will not paper over. On success, `data.projects[]` holds, per project, a
+`open_roles[]` array where each role carries a `candidates[]` list already ranked
+by combined score (best first) and an `excluded_count` of consultants dropped for
+no availability overlap.
+
+### Step 3: Write the staffing-recommendation artifact
+
+Render the scorer JSON into a human-readable markdown artifact at
+`cogni-projects/<portfolio-slug>/staffing-recommendations.md`, and write the raw
+scorer JSON alongside it at
+`cogni-projects/<portfolio-slug>/.metadata/staffing-recommendations.json` (the
+machine-readable record the backfilling recommender and partner-meeting dashboard
+later read).
+
+The markdown artifact has one section per project, and within it one table per
+open role. Show the three sub-scores **separately** — that per-factor breakdown
+is the point of the engine (a partner needs it to defend the call), never collapse
+it to a single opaque number:
+
+```markdown
+# Staffing recommendations — <portfolio name>
+
+## <Project name> (`<project-slug>`) — strategic impact <n>/5
+
+### Role: `<role>`
+
+| Rank | Consultant | Availability | Profile fit | Strategic impact | Combined |
+|------|-----------|-------------|-------------|------------------|----------|
+| 1 | <name> (`<slug>`) | 0.84 | 0.53 | 0.75 | 0.71 |
+| 2 | … | … | … | … | … |
+
+_<excluded_count> consultant(s) excluded — no availability overlap with the
+project window._
+```
+
+Preserve the scorer's ranking order — do not re-sort. When a role has zero
+candidates (everyone excluded), say so under its heading instead of rendering an
+empty table.
+
+### Step 4: Append a run record to the staffing log
+
+Append one entry to `cogni-projects/<portfolio-slug>/.metadata/staffing-log.json`
+(create the file as a JSON array if it does not yet exist) recording this run —
+the portfolio slug, the counts from `data` (`consultant_count`, `project_count`,
+`ranked_candidate_count`), and the artifact path. This is the append-only audit
+trail later skills and the dashboard scan; keep it a flat array of records.
+
+### Step 5: Summarize
+
+Report the artifact path, how many projects and open roles were scored, and the
+top candidate for each open role (name + combined score). Keep it short. If any
+role came back with everyone excluded, call that out — it usually means no
+consultant's availability window overlaps that project, which is a portfolio-data
+gap to fix with `/cogni-projects:projects-entities`, not a scoring bug.
+
+## Notes
+
+- **The scorer is the source of truth for ranking.** This skill renders and
+  logs; it does not re-rank, re-weight, or filter the scorer's output. To change
+  how candidates are scored, change `scripts/staffing-score.py`, not this skill.
+- **Scripts return `{success, data, error}` JSON**, stdlib-only — no pip
+  dependencies. `staffing-score.py` reuses `validate-entities.py`'s frontmatter
+  parser rather than adding its own.
+- **Availability is modeled from allocation-window attributes** on the consultant
+  records (`available_from` / `available_until` / `allocation_pct`), not a
+  separate entity — consistent with the data model.
+- **Deterministic output.** Identical portfolio inputs always yield the same
+  shortlist (ties break on the consultant slug), so a recommendation is
+  reproducible and reviewable.

--- a/cogni-projects/skills/projects-staff/SKILL.md
+++ b/cogni-projects/skills/projects-staff/SKILL.md
@@ -106,8 +106,12 @@ it to a single opaque number:
 
 The heading shows the raw `strategic_impact` (`projects[].strategic_impact`,
 1–5); the table's Strategic impact column shows the normalized `[0,1]` value
-(`candidates[].scores.strategic_impact`). When `strategic_impact` is null, render
-an em dash (`—`) in both places rather than `0/5`. The other four columns map to
+(`candidates[].scores.strategic_impact`). Key the null/em-dash decision on the
+**raw** `projects[].strategic_impact` being null — the normalized
+`scores.strategic_impact` is `0.0` (not null) for both an absent value and a raw
+`1`, so it cannot distinguish "missing" from "tactical". When the raw value is
+null, render an em dash (`—`) in both the heading and the column rather than
+`0/5`. The other four columns map to
 `candidates[].scores.{availability, profile_fit, combined}` and the consultant's
 `name`/`consultant` slug:
 

--- a/cogni-projects/skills/projects-staff/SKILL.md
+++ b/cogni-projects/skills/projects-staff/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: projects-staff
 description: |
-  This skill should be used when a partner wants a ranked shortlist of
+  This skill should be used when the user wants a ranked shortlist of
   consultants for the open roles on a cogni-projects portfolio — the staffing
-  match engine. Trigger on: "staff this project", "who should I put on",
+  match engine (whether the ask comes from a partner, a delivery lead, or
+  consulting ops). Trigger on: "staff this project", "who should I put on",
   "recommend consultants for", "staffing recommendations", "match consultants to
   roles", "rank candidates for the open roles", "who is available for", "build a
   staffing shortlist", or any request to turn a cogni-projects portfolio's
@@ -18,9 +19,11 @@ Turn a cogni-projects portfolio into a ranked staffing shortlist: for every open
 role on every project, a list of candidate consultants each showing three
 visible sub-scores — **availability** and **profile fit**, which rank the
 candidates within a role, plus **strategic impact**, a project attribute shown
-per candidate that orders the projects themselves. It reads the consultant,
-project, and assignment records authored by `projects-entities` and produces the
-recommendation a partner defends a staffing call with.
+per candidate that orders the projects themselves. It reads the consultant and
+project records authored by `projects-entities` and produces the recommendation
+a partner defends a staffing call with. Existing assignments are **not** yet
+netted out of a consultant's capacity — headroom comes from the consultant's
+`allocation_pct` field alone (netting out live assignments is a later child).
 
 The ranking is computed by a deterministic script — `scripts/staffing-score.py`
 — so the same portfolio always yields the same shortlist. The skill's job is to
@@ -77,12 +80,15 @@ python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/*/cogni-pr
 ```
 
 It returns `{"success", "data", "error"}` (exit 0 ok / 1 domain failure / 2
-usage). On `success: false`, surface `error` to the user and stop — a domain
-failure means the portfolio directory or its manifest is unreadable, which the
-scorer will not paper over. On success, `data.projects[]` holds, per project, a
+usage). On `success: false`, surface `error` to the user and stop. A domain
+failure (exit 1) usually means the portfolio directory or its manifest is
+unreadable — but an `error` naming `validate-entities.py` instead means a
+broken or partial plugin install, not a portfolio-data problem; say so rather
+than pointing the user at their entities. On success, `data.projects[]` holds
+only the non-closed projects (closed projects are skipped) and, per project, an
 `open_roles[]` array where each role carries a `candidates[]` list already ranked
-by combined score (best first) and an `excluded_count` of consultants dropped for
-no availability overlap.
+by combined score (best first) and a per-role `excluded_count` of consultants
+dropped for no availability overlap with that project's window.
 
 ### Step 3: Write the staffing-recommendation artifact
 
@@ -98,10 +104,17 @@ open role. Show the three sub-scores **separately** — that per-factor breakdow
 is the point of the engine (a partner needs it to defend the call), never collapse
 it to a single opaque number:
 
+The heading shows the raw `strategic_impact` (`projects[].strategic_impact`,
+1–5); the table's Strategic impact column shows the normalized `[0,1]` value
+(`candidates[].scores.strategic_impact`). When `strategic_impact` is null, render
+an em dash (`—`) in both places rather than `0/5`. The other four columns map to
+`candidates[].scores.{availability, profile_fit, combined}` and the consultant's
+`name`/`consultant` slug:
+
 ```markdown
 # Staffing recommendations — <portfolio name>
 
-## <Project name> (`<project-slug>`) — strategic impact <n>/5
+## <Project name> (`<project-slug>`) — strategic impact <n>/5   (or "— —" when null)
 
 ### Role: `<role>`
 
@@ -110,8 +123,10 @@ it to a single opaque number:
 | 1 | <name> (`<slug>`) | 0.84 | 0.53 | 0.75 | 0.70 |
 | 2 | … | … | … | … | … |
 
-_<excluded_count> consultant(s) excluded — no availability overlap with the
-project window._
+_<excluded_count> consultant(s) excluded from this role — no availability
+overlap with the project window. Exclusion is a project-window property, so the
+same consultant may be excluded from every role of the project and counts once
+per role._
 ```
 
 Preserve the scorer's ordering — both the project/role order (projects come
@@ -122,11 +137,16 @@ empty table.
 
 ### Step 4: Append a run record to the staffing log
 
-Append one entry to `cogni-projects/<portfolio-slug>/.metadata/staffing-log.json`
-(create the file as a JSON array if it does not yet exist) recording this run —
-the portfolio slug, the counts from `data` (`consultant_count`, `project_count`,
-`ranked_candidate_count`), and the artifact path. This is the append-only audit
-trail later skills and the dashboard scan; keep it a flat array of records.
+`projects-setup` seeds `cogni-projects/<portfolio-slug>/.metadata/staffing-log.json`
+as an object with a `matches` array: `{"matches": []}`. Read that file, append
+one record to its `matches[]` array, and write it back — preserve the envelope,
+never overwrite it with a bare array. Only if the file is genuinely absent,
+create it with that exact `{"matches": []}` shape first.
+
+Each record captures this run: `portfolio` (the slug), `consultant_count`,
+`project_count`, `ranked_candidate_count` (copied from `data`), and
+`artifact_path` (the `staffing-recommendations.md` path). This is the append-only
+audit trail that later skills and the dashboard scan.
 
 ### Step 5: Summarize
 


### PR DESCRIPTION
Closes #1114.

Phase 2 (staffing MVP) of cogni-projects: a deterministic staffing engine that consumes the Phase 1 consultant/project/assignment entities to produce ranked candidate shortlists per open project role.

## Summary
- Add `scripts/staffing-score.py` (python3 stdlib, `{success,data,error}` envelope, exit 0/1/2): for each project with `open_roles`, ranks candidate consultants per role on three sub-scores in [0,1] shown separately plus a combined score — availability (consultant `available_from`/`available_until` overlap with the project window + `allocation_pct` headroom), profile fit (`skills`/`seniority` vs the role need), and strategic impact (normalized project `strategic_impact` 1-5). Excludes consultants whose availability window does not overlap the project window (AC2). Deterministic: stable sort with a slug tiebreak and no wall-clock in scores (AC3).
- Add `skills/projects-staff/SKILL.md` (domain-prefixed, satisfies check-skill-names.sh): locates the portfolio, runs `staffing-score.py`, writes a `staffing-recommendations.md` artifact (ranked candidates per open role with the three sub-scores) plus JSON into the portfolio, appends a run record to `.metadata/staffing-log.json`, and summarizes.
- Reuse `validate-entities.py`'s `parse_frontmatter` via `importlib.util.spec_from_file_location` (same pattern as `register-entity.py`) — no duplicated parser, no PyYAML.
- Register the new skill + script in `cogni-projects/CLAUDE.md` (developer-guide tree; drop the staffing engine from the "Planned" section).
- Bump `.claude-plugin/plugin.json` 0.0.4 -> 0.0.5 and mirror the version in the root `.claude-plugin/marketplace.json` cogni-projects entry (stays Incubating).

## Scope decisions
- **In:** the two artifacts triage named (skill + scoring script), the CLAUDE.md registration, and the mandatory version-bump + marketplace mirror. All three acceptance criteria are delivered end-to-end, so the issue is fully closed (`Closes`).
- **Out (separate filed children, not deferred here):** #1115 (backfilling recommender) builds on this engine; the partner-meeting dashboard is a later child.

## Test plan (verified locally against a fixture portfolio)
- [x] `staffing-score.py` with no args exits 2 with the `{success,data,error}` envelope; a bad portfolio dir exits 1.
- [x] AC1: output is a ranked candidate list per open role with availability / profile-fit / strategic-impact sub-scores shown separately plus a combined score.
- [x] AC2: a consultant whose availability window does not overlap the project window is absent from that project's ranking (`excluded_count` incremented).
- [x] AC3: two runs on identical inputs produce byte-identical JSON, with equal-scoring candidates ordered by slug.
- [x] Script reuses `parse_frontmatter` (no second parser, no PyYAML) and compiles clean.
- [ ] Reviewer to confirm the `projects-staff` skill end-to-end writes `staffing-recommendations.md` + JSON and appends `.metadata/staffing-log.json` on a live portfolio.