### PR TITLE
cogni-workspace: shared theme-value guard for dashboard renderers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -118,7 +118,7 @@
     {
       "name": "cogni-workspace",
       "source": "./cogni-workspace",
-      "version": "0.6.37",
+      "version": "0.6.38",
       "maturity": "preview",
       "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
       "keywords": [

--- a/cogni-workspace/.claude-plugin/plugin.json
+++ b/cogni-workspace/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cogni-workspace",
-  "version": "0.6.37",
+  "version": "0.6.38",
   "description": "Foundation-layer plugin for insight-wave marketplace plugins. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, an interactive workspace-configuration dashboard, Obsidian vault integration, and a bundled vendor-curated insight-wave reference wiki queryable via the ask skill.",
   "author": {
     "name": "Stephan de Haas",

--- a/cogni-workspace/scripts/sanitize-theme.py
+++ b/cogni-workspace/scripts/sanitize-theme.py
@@ -3,7 +3,7 @@
 
 Operator-supplied ``--design-variables`` values are interpolated into a
 generated ``<style>`` block. A value carrying CSS-structural or markup
-characters — e.g. ``"background": "#000</style><script>alert(1)</script>"`` —
+characters — e.g. ``"background": "#000000</style><script>alert(1)</script>"`` —
 could break out of the stylesheet in the self-contained HTML output, while
 entity-derived values are HTML-escaped. This helper lets every renderer reject
 such a value and fall back to its built-in palette for that key, so the guard

--- a/cogni-workspace/scripts/sanitize-theme.py
+++ b/cogni-workspace/scripts/sanitize-theme.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Shared theme-value guard for cogni dashboard/report renderers.
+
+Operator-supplied ``--design-variables`` values are interpolated into a
+generated ``<style>`` block. A value carrying CSS-structural or markup
+characters — e.g. ``"background": "#000</style><script>alert(1)</script>"`` —
+could break out of the stylesheet in the self-contained HTML output, while
+entity-derived values are HTML-escaped. This helper lets every renderer reject
+such a value and fall back to its built-in palette for that key, so the guard
+lives in one place instead of being copy-pasted per renderer.
+
+Two consumption surfaces:
+
+  * **In-plugin import** (the fast path used by renderers): load this file by
+    path and call :func:`is_safe_value` / :func:`sanitize_values`. Renderers in
+    *other* plugins cannot rely on a normal ``import`` (separate plugin cache
+    dirs), so the natural consumers are cogni-workspace's own renderers; the
+    cross-plugin sharing mechanism is a separate, deferred decision.
+  * **CLI report**: ``python3 sanitize-theme.py <design-variables.json>`` prints
+    a ``{"success","data","error"}`` envelope naming which keys would be
+    rejected — the stdlib-only, dependency-free contract every cogni script
+    follows.
+
+Profiles
+--------
+``strict`` (the only profile shipped today, and the default)
+    Denylist ``<>{}();@\\``, max length 120. Rejects stylesheet/markup breakout
+    **and** the ``url()`` / ``@import`` external-fetch surface (a self-contained
+    artifact that phones home on open). Correct for ``colors`` / ``status`` /
+    border tokens, which never legitimately need those characters. It is
+    deliberately **not** applied to font or shadow values that legitimately
+    carry ``rgba(...)`` or ``@import url(...)`` — a ``font-aware`` profile that
+    permits those while still blocking breakout is future work.
+
+Single quotes stay legal under ``strict``: a font stack (``'Segoe UI', Roboto``)
+needs them and they cannot terminate a ``<style>`` block on their own.
+"""
+
+import json
+import sys
+
+# profile name -> (forbidden character set, max length)
+_PROFILES = {
+    "strict": (set("<>{}();@\\"), 120),
+}
+DEFAULT_PROFILE = "strict"
+
+
+def is_safe_value(value, profile=DEFAULT_PROFILE):
+    """Return True when ``value`` is safe to interpolate into a ``<style>`` block.
+
+    A value is safe when it is a non-empty string within the profile's length
+    bound and carries none of the profile's forbidden characters. Non-strings
+    (numbers, dicts, None) are unsafe — theme values reach the stylesheet as raw
+    text, so only vetted strings may pass.
+    """
+    forbidden, max_len = _PROFILES.get(profile, _PROFILES[DEFAULT_PROFILE])
+    return (
+        isinstance(value, str)
+        and 0 < len(value) <= max_len
+        and not (forbidden & set(value))
+    )
+
+
+def sanitize_values(values, defaults, profile=DEFAULT_PROFILE):
+    """Filter a ``{key: value}`` override map against a fallback map.
+
+    Returns ``(clean, rejected)`` where ``clean`` carries the safe overrides
+    merged onto ``defaults`` (a rejected or absent key keeps the ``defaults``
+    value), and ``rejected`` is the sorted list of keys whose override was
+    dropped. ``defaults`` is the source of truth for the key set — an override
+    key absent from ``defaults`` is ignored, never introduced.
+    """
+    clean = dict(defaults)
+    rejected = []
+    if isinstance(values, dict):
+        for key in defaults:
+            if key not in values:
+                continue
+            if is_safe_value(values[key], profile):
+                clean[key] = values[key]
+            else:
+                rejected.append(key)
+    return clean, sorted(rejected)
+
+
+def _cli(argv):
+    """Report which color/status override values a design-variables file would lose."""
+    args = [a for a in argv if not a.startswith("--")]
+    profile = DEFAULT_PROFILE
+    for a in argv:
+        if a.startswith("--profile="):
+            profile = a.split("=", 1)[1]
+    if not args:
+        return {"success": False, "data": None,
+                "error": "usage: sanitize-theme.py <design-variables.json> [--profile=strict]"}
+    if profile not in _PROFILES:
+        return {"success": False, "data": None,
+                "error": "unknown profile %r (available: %s)" % (profile, ", ".join(sorted(_PROFILES)))}
+    try:
+        with open(args[0], "r", encoding="utf-8") as f:
+            overrides = json.load(f)
+    except (OSError, ValueError) as exc:
+        return {"success": False, "data": None, "error": "cannot read %s: %s" % (args[0], exc)}
+    if not isinstance(overrides, dict):
+        return {"success": False, "data": None, "error": "design-variables must be a JSON object"}
+
+    rejected = {}
+    checked = 0
+    for section in ("colors", "status"):
+        src = overrides.get(section)
+        if isinstance(src, dict):
+            for key, value in src.items():
+                checked += 1
+                if not is_safe_value(value, profile):
+                    rejected.setdefault(section, []).append(key)
+    for section in rejected:
+        rejected[section] = sorted(rejected[section])
+    return {"success": True,
+            "data": {"profile": profile, "checked": checked, "rejected": rejected},
+            "error": None}
+
+
+if __name__ == "__main__":
+    result = _cli(sys.argv[1:])
+    print(json.dumps(result))
+    # Envelope is always printed; a usage/read error also exits non-zero so a
+    # shell caller can branch on `$?`, matching the cogni script convention.
+    sys.exit(0 if result["success"] else 2)

--- a/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
+++ b/cogni-workspace/skills/workspace-dashboard/scripts/generate-dashboard.py
@@ -19,12 +19,38 @@ Returns JSON: {"status": "ok", "path": "<output-path>", "theme": "<name>",
 import argparse
 import glob
 import html
+import importlib.util
 import json
 import os
 import re
 import subprocess
 import sys
 from datetime import datetime, timezone
+
+
+# ---------------------------------------------------------------------------
+# Shared theme-value guard (cogni-workspace/scripts/sanitize-theme.py)
+# ---------------------------------------------------------------------------
+# Load the shared guard by path — it lives at the plugin root, a sibling of this
+# skill's scripts dir. Theming is a nicety, never a hard dependency, so a load
+# failure degrades to no guard (values pass through) rather than crashing the
+# render; the guard's own home plugin always ships it, so this is a defensive
+# floor for a corrupted install, not the expected path.
+def _load_theme_guard():
+    guard_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..", "..", "..", "scripts", "sanitize-theme.py",
+    )
+    try:
+        spec = importlib.util.spec_from_file_location("cogni_sanitize_theme", guard_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except (OSError, ImportError, AttributeError):
+        return None
+
+
+_THEME_GUARD = _load_theme_guard()
 
 
 # ---------------------------------------------------------------------------
@@ -137,20 +163,46 @@ def parse_theme_md(theme_path):
 
 
 def merge_tokens(design_variables, parsed_theme):
-    """Pick the strongest available token source. Order: design-vars > theme.md > default."""
+    """Pick the strongest available token source. Order: design-vars > theme.md > default.
+
+    Returns ``(theme, warnings)``. When design-variables supply ``colors`` /
+    ``status`` overrides, each value is vetted by the shared theme-value guard
+    (``cogni-workspace/scripts/sanitize-theme.py``) before it can reach the
+    ``<style>`` block: a value carrying stylesheet or markup breakout characters
+    is dropped and the built-in palette value is kept for that key, with the
+    rejection surfaced as a warning. Font, shadow, and ``@import`` values are
+    left untouched — they legitimately carry ``rgba(...)`` / ``url(...)`` and are
+    handled under a separate, deferred font-aware policy. If the guard fails to
+    load, override values pass through unguarded (theming is never a hard
+    dependency).
+    """
+    warnings = []
     if design_variables:
+        if _THEME_GUARD is not None:
+            colors, rejected_colors = _THEME_GUARD.sanitize_values(
+                design_variables.get("colors", {}), DEFAULT_THEME["colors"])
+            status, rejected_status = _THEME_GUARD.sanitize_values(
+                design_variables.get("status", {}), DEFAULT_THEME["status"])
+            rejected = rejected_colors + rejected_status
+            if rejected:
+                warnings.append(
+                    "design-variables: ignored unsafe value(s) for %s — using the "
+                    "built-in palette for those keys" % ", ".join(rejected))
+        else:
+            colors = design_variables.get("colors", DEFAULT_THEME["colors"])
+            status = design_variables.get("status", DEFAULT_THEME["status"])
         return {
             "name": design_variables.get("theme_name", "custom"),
-            "colors": design_variables.get("colors", DEFAULT_THEME["colors"]),
-            "status": design_variables.get("status", DEFAULT_THEME["status"]),
+            "colors": colors,
+            "status": status,
             "fonts": design_variables.get("fonts", DEFAULT_THEME["fonts"]),
             "google_fonts_import": design_variables.get("google_fonts_import", ""),
             "radius": design_variables.get("radius", DEFAULT_THEME["radius"]),
             "shadows": design_variables.get("shadows", DEFAULT_THEME["shadows"]),
-        }
+        }, warnings
     if parsed_theme:
-        return parsed_theme
-    return json.loads(json.dumps(DEFAULT_THEME))
+        return parsed_theme, warnings
+    return json.loads(json.dumps(DEFAULT_THEME)), warnings
 
 
 # ---------------------------------------------------------------------------
@@ -1128,7 +1180,7 @@ def main():
 
     design_variables = load_design_variables(args.design_variables)
     parsed_theme = parse_theme_md(args.theme) if args.theme else None
-    theme = merge_tokens(design_variables, parsed_theme)
+    theme, theme_warnings = merge_tokens(design_variables, parsed_theme)
 
     plugins = discover_plugins(workspace_root, mode)
     themes = discover_themes(workspace_root)
@@ -1181,6 +1233,7 @@ def main():
         "mcp_servers": len(mcp_servers) if mcp_servers else 0,
         "markets": len(markets_meta),
         "hooks": len(hooks_rows),
+        "theme_warnings": theme_warnings,
     }, indent=2))
     return 0
 

--- a/cogni-workspace/tests/test-sanitize-theme.sh
+++ b/cogni-workspace/tests/test-sanitize-theme.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Regression test for the shared theme-value guard (scripts/sanitize-theme.py)
+# and its wiring into the workspace-dashboard renderer.
+#
+# Contract under test (issue #1129): an operator-supplied --design-variables
+# value carrying a stylesheet/markup breakout (e.g. "#000</style><script>...")
+# must be rejected before it reaches the generated <style> block, with the
+# renderer falling back to its built-in palette for that key.
+#
+# stdlib-only: bash + python3, no pip deps. Mirrors the cogni conventions in
+# cogni-projects/tests/test-render-dashboard.sh.
+
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WS_ROOT="$(cd "$HERE/.." && pwd)"
+GUARD="$WS_ROOT/scripts/sanitize-theme.py"
+RENDERER="$WS_ROOT/skills/workspace-dashboard/scripts/generate-dashboard.py"
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { echo "OK   $1"; }
+fail() { echo "FAIL $1"; failures=$((failures + 1)); }
+
+# assert_py "<label>" "<python expr, True to pass>" — GUARD path is on sys.path.
+assert_py() {
+  local label="$1" expr="$2"
+  if python3 - "$GUARD" <<PY
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("g", sys.argv[1])
+g = importlib.util.module_from_spec(spec); spec.loader.exec_module(g)
+sys.exit(0 if ($expr) else 1)
+PY
+  then pass "$label"; else fail "$label"; fi
+}
+
+# assert_lacks "<label>" "<needle>" "<file>"
+assert_lacks() {
+  if [ -f "$3" ] && ! grep -qF "$2" "$3"; then pass "$1"; else fail "$1 (found '$2' or missing file)"; fi
+}
+# assert_has "<label>" "<needle>" "<file>"
+assert_has() {
+  if [ -f "$3" ] && grep -qF "$2" "$3"; then pass "$1"; else fail "$1 (missing '$2')"; fi
+}
+
+echo "=== guard unit behavior ==="
+assert_py "1a hex color is safe"        'g.is_safe_value("#000000") is True'
+assert_py "1b style breakout rejected"  'g.is_safe_value("#000</style><script>alert(1)</script>") is False'
+assert_py "1c url() beacon rejected"    'g.is_safe_value("url(https://evil.example/track.png)") is False'
+assert_py "1d empty rejected"           'g.is_safe_value("") is False'
+assert_py "1e non-string rejected"      'g.is_safe_value(123) is False'
+assert_py "1f overlong rejected"        'g.is_safe_value("#" + "a"*200) is False'
+assert_py "1g font stack single-quotes ok" "g.is_safe_value(\"'Segoe UI', Roboto\") is True"
+assert_py "1h unknown profile falls back to strict" 'g.is_safe_value("#000</style>", "nope") is False'
+
+echo "=== sanitize_values fallback ==="
+assert_py "2a rejected key keeps default" \
+  'g.sanitize_values({"background":"#000</style>"}, {"background":"#FAFAF8"})[0]["background"] == "#FAFAF8"'
+assert_py "2b safe key applied" \
+  'g.sanitize_values({"background":"#123456"}, {"background":"#FAFAF8"})[0]["background"] == "#123456"'
+assert_py "2c rejected key reported" \
+  'g.sanitize_values({"background":"#000</style>"}, {"background":"#FAFAF8"})[1] == ["background"]'
+assert_py "2d absent-in-defaults key ignored" \
+  'g.sanitize_values({"rogue":"x"}, {"background":"#FAFAF8"})[0] == {"background":"#FAFAF8"}'
+
+echo "=== CLI envelope ==="
+cat > "$TMPROOT/dv-evil.json" <<'EOF'
+{"colors": {"background": "#000</style><script>alert(1)</script>", "primary": "#111111"}, "status": {"danger": "#f00"}}
+EOF
+CLI_OUT="$(python3 "$GUARD" "$TMPROOT/dv-evil.json")"
+echo "$CLI_OUT" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d["success"] and d["data"]["rejected"].get("colors")==["background"] else 1)' \
+  && pass "3a CLI reports rejected color key" || fail "3a CLI reports rejected color key"
+python3 "$GUARD" >/dev/null 2>&1 && fail "3b CLI no-arg errors" || pass "3b CLI no-arg errors"
+
+echo "=== wired renderer end-to-end ==="
+WS="$TMPROOT/ws"; mkdir -p "$WS"
+run_render() { python3 "$RENDERER" "$WS" --design-variables "$1" --output "$WS/out.html" >/tmp/render-out.json 2>/tmp/render-err.txt; }
+
+# Malicious color value must not reach the output; renderer must still succeed.
+run_render "$TMPROOT/dv-evil.json"
+if python3 -c 'import json,sys; d=json.load(open("/tmp/render-out.json")); sys.exit(0 if d.get("status")=="ok" else 1)'; then pass "4a malicious render succeeds"; else fail "4a malicious render succeeds"; fi
+assert_lacks "4b </style><script> not in output" '</style><script>' "$WS/out.html"
+assert_has   "4c built-in background applied instead" '#FAFAF8' "$WS/out.html"
+python3 -c 'import json,sys; d=json.load(open("/tmp/render-out.json")); sys.exit(0 if d.get("theme_warnings") else 1)' \
+  && pass "4d rejection surfaced as warning" || fail "4d rejection surfaced as warning"
+
+# Safe theme still applies, and the legitimate @import url(...) font path is untouched.
+cat > "$TMPROOT/dv-safe.json" <<'EOF'
+{"colors": {"background": "#123456"}, "google_fonts_import": "@import url('https://fonts.googleapis.com/css2?family=Outfit&display=swap');"}
+EOF
+run_render "$TMPROOT/dv-safe.json"
+assert_has "4e safe color applied" '#123456' "$WS/out.html"
+assert_has "4f legitimate @import url() font preserved" "@import url('https://fonts.googleapis.com" "$WS/out.html"
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "All sanitize-theme tests passed."
+  exit 0
+else
+  echo "$failures test(s) failed."
+  exit 1
+fi

--- a/cogni-workspace/tests/test-sanitize-theme.sh
+++ b/cogni-workspace/tests/test-sanitize-theme.sh
@@ -2,8 +2,8 @@
 # Regression test for the shared theme-value guard (scripts/sanitize-theme.py)
 # and its wiring into the workspace-dashboard renderer.
 #
-# Contract under test (issue #1129): an operator-supplied --design-variables
-# value carrying a stylesheet/markup breakout (e.g. "#000</style><script>...")
+# Contract under test: an operator-supplied --design-variables
+# value carrying a stylesheet/markup breakout (e.g. "#000000</style><script>...")
 # must be rejected before it reaches the generated <style> block, with the
 # renderer falling back to its built-in palette for that key.
 #
@@ -45,27 +45,27 @@ assert_has() {
 
 echo "=== guard unit behavior ==="
 assert_py "1a hex color is safe"        'g.is_safe_value("#000000") is True'
-assert_py "1b style breakout rejected"  'g.is_safe_value("#000</style><script>alert(1)</script>") is False'
+assert_py "1b style breakout rejected"  'g.is_safe_value("#000000</style><script>alert(1)</script>") is False'
 assert_py "1c url() beacon rejected"    'g.is_safe_value("url(https://evil.example/track.png)") is False'
 assert_py "1d empty rejected"           'g.is_safe_value("") is False'
 assert_py "1e non-string rejected"      'g.is_safe_value(123) is False'
 assert_py "1f overlong rejected"        'g.is_safe_value("#" + "a"*200) is False'
 assert_py "1g font stack single-quotes ok" "g.is_safe_value(\"'Segoe UI', Roboto\") is True"
-assert_py "1h unknown profile falls back to strict" 'g.is_safe_value("#000</style>", "nope") is False'
+assert_py "1h unknown profile falls back to strict" 'g.is_safe_value("#000000</style>", "nope") is False'
 
 echo "=== sanitize_values fallback ==="
 assert_py "2a rejected key keeps default" \
-  'g.sanitize_values({"background":"#000</style>"}, {"background":"#FAFAF8"})[0]["background"] == "#FAFAF8"'
+  'g.sanitize_values({"background":"#000000</style>"}, {"background":"#FAFAF8"})[0]["background"] == "#FAFAF8"'
 assert_py "2b safe key applied" \
   'g.sanitize_values({"background":"#123456"}, {"background":"#FAFAF8"})[0]["background"] == "#123456"'
 assert_py "2c rejected key reported" \
-  'g.sanitize_values({"background":"#000</style>"}, {"background":"#FAFAF8"})[1] == ["background"]'
+  'g.sanitize_values({"background":"#000000</style>"}, {"background":"#FAFAF8"})[1] == ["background"]'
 assert_py "2d absent-in-defaults key ignored" \
   'g.sanitize_values({"rogue":"x"}, {"background":"#FAFAF8"})[0] == {"background":"#FAFAF8"}'
 
 echo "=== CLI envelope ==="
 cat > "$TMPROOT/dv-evil.json" <<'EOF'
-{"colors": {"background": "#000</style><script>alert(1)</script>", "primary": "#111111"}, "status": {"danger": "#f00"}}
+{"colors": {"background": "#000000</style><script>alert(1)</script>", "primary": "#111111"}, "status": {"danger": "#f00"}}
 EOF
 CLI_OUT="$(python3 "$GUARD" "$TMPROOT/dv-evil.json")"
 echo "$CLI_OUT" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d["success"] and d["data"]["rejected"].get("colors")==["background"] else 1)' \


### PR DESCRIPTION
Refs #1129 (partial — the remaining cross-renderer scope is tracked in #1130/#1131, so this links `Refs` rather than `Closes`).

## Summary
Operator-supplied `--design-variables` `colors`/`status` values were interpolated raw into the generated `<style>` block, so a crafted value like `"background": "#000</style><script>alert(1)</script>"` could break out of the stylesheet — the same class already fixed in `cogni-projects/scripts/render-dashboard.py`.

- **Add `cogni-workspace/scripts/sanitize-theme.py`** — a shared, stdlib-only theme-value guard (strict denylist `<>{}();@\`, max length 120) with a `{success,data,error}` CLI envelope and importable `is_safe_value` / `sanitize_values` functions. This is the shared home the issue asks for.
- **Add `cogni-workspace/tests/test-sanitize-theme.sh`** — one shared regression test over the guard, its CLI envelope, and the wired renderer: asserts a `</style><script>` value never reaches the output, the built-in palette is used instead, and the legitimate `@import url(...)` Google-Fonts path is preserved.
- **Wire `workspace-dashboard`** — `merge_tokens` now routes design-variable `colors`/`status` values through the guard (same-plugin file-path import, graceful no-op if the guard can't load — theming is never a hard dependency), falling back to the built-in palette per rejected key and surfacing a `theme_warnings` note in the result envelope.
- Bump `cogni-workspace` `0.6.37 → 0.6.38` (mirrored in `marketplace.json`).

## Scope decisions
**In:** the shared helper, its shared test, and the one renderer that can consume it with zero cross-plugin fragility (`workspace-dashboard`, in-plugin). The demonstrated breakout vector is a **color** value, which the strict guard neutralizes directly.

**Deferred (filed, not dropped):**
- #1130 — wire the 5 sibling renderers (consult/portfolio/trends dashboards, enrich-report, render-html-slides) through the shared guard + per-renderer regression fixtures.
- #1131 — a **font-aware** guard profile for `@import url(...)` / shadow values.

Font, shadow, and `@import` values are intentionally left unguarded here: `workspace-dashboard` (and trends / enrich-report) legitimately emit `@import url('https://fonts.googleapis.com/...')` and `rgba(...)`, which the strict `()`/`@` denylist would reject. Guarding those needs the font-aware profile (#1131).

## Open questions
- **E1** — cross-plugin sharing mechanism for the 5 sibling renderers: a subprocess call to `sanitize-theme.py` via the `${WORKSPACE_PLUGIN_ROOT:-…}` idiom (get-market-config.py precedent, one call per render) vs a small vendored guard per renderer backed by this one shared contract test. The repo's only cross-plugin sharing precedent is for centrally-sourced *data*, not a pure function. Slice 1 uses only same-plugin file-path import, so it is valid under either outcome.
- **E2** — font/shadow-value policy: retain external `url()`/`@import` (font-fetching renderers pull Google Fonts) vs tighten/inline to keep artifacts self-contained (the phone-home-beacon surface cogni-projects deliberately rejected). The two renderer families have opposite threat models.

## Test plan
- [x] `bash cogni-workspace/tests/test-sanitize-theme.sh` — 20 assertions pass (guard unit behavior, `sanitize_values` fallback, CLI envelope, wired-renderer end-to-end incl. the `</style><script>` breakout and the preserved `@import url(...)` font path).
- [x] `python3 -m py_compile` on the guard and the renderer.
- [x] `cogni-workspace` version `0.6.38` mirrored in `marketplace.json`.
