### PR TITLE
cogni-workspace: run check-skill-names.sh under macOS bash 3.2

### DIFF
--- a/cogni-workspace/scripts/check-skill-names.sh
+++ b/cogni-workspace/scripts/check-skill-names.sh
@@ -2,16 +2,25 @@
 # check-skill-names.sh — Validate skill names across the insight-wave monorepo.
 # Reports duplicate bare names and generic words without a domain prefix.
 # Exit non-zero if violations found.
+#
+# Portable to bash 3.2 (the macOS system bash), so the documented pre-PR check
+# runs on a default macOS toolchain, not just CI's bash 5. The name->plugin
+# aggregation and both checks run in a single awk pass — awk's own associative
+# arrays are POSIX-portable, so no `declare -A` (a bash 4+ feature) is needed.
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# REPO_ROOT is overridable so the regression harness can point the check at a
+# temp fixture tree; it defaults to the repo root two levels up from this script.
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
 GENERIC_WORDS="setup scan ingest export dashboard verify bridge catalog reader config status analyze resume"
 
 violations=0
 
-# Collect all skill names from SKILL.md frontmatter
-declare -A skill_map  # name -> plugin path(s)
+# Collect one name<TAB>plugin pair per SKILL.md frontmatter. An empty name is a
+# violation surfaced here (the awk pass below only sees named skills).
+pairs_file="$(mktemp)"
+trap 'rm -f "$pairs_file"' EXIT
 
 while IFS= read -r skill_md; do
   name=$(grep -m1 '^name:' "$skill_md" | sed 's/^name:[[:space:]]*//')
@@ -22,31 +31,54 @@ while IFS= read -r skill_md; do
   fi
   rel_path="${skill_md#"$REPO_ROOT/"}"
   plugin=$(echo "$rel_path" | cut -d/ -f1)
-  if [[ -n "${skill_map[$name]+_}" ]]; then
-    skill_map[$name]="${skill_map[$name]}, $plugin"
-  else
-    skill_map[$name]="$plugin"
-  fi
+  printf '%s\t%s\n' "$name" "$plugin" >> "$pairs_file"
 done < <(find "$REPO_ROOT"/cogni-*/skills/*/SKILL.md -type f 2>/dev/null)
 
-# Check for duplicate names across plugins
-for name in "${!skill_map[@]}"; do
-  plugins="${skill_map[$name]}"
-  if [[ "$plugins" == *","* ]]; then
-    echo "ERROR: Duplicate skill name '$name' in: $plugins"
-    violations=$((violations + 1))
-  fi
-done
+# Single awk pass replaces the two `${!skill_map[@]}` loops the script used to
+# need. It rebuilds the name->plugins mapping (appending every occurrence, so a
+# name that appears twice — even within one plugin — still reads as a duplicate,
+# matching the original behaviour), then emits duplicate-name and generic-name
+# violations in a stable, name-sorted order. The trailing `__VIOLATIONS__ N`
+# line carries the count back to the shell. The single-quote and em-dash are
+# passed in as variables (q, dash) to keep the awk program free of escapes that
+# vary across awk implementations.
+awk_out=$(awk -F'\t' -v generic="$GENERIC_WORDS" -v q="'" -v dash="—" '
+  BEGIN { split(generic, g, " ") }
+  NF < 2 { next }
+  {
+    if ($1 in plugins) plugins[$1] = plugins[$1] ", " $2
+    else { plugins[$1] = $2; names[++n] = $1 }
+  }
+  END {
+    # sort names so output ordering is deterministic (bash hash-order was not)
+    for (i = 1; i <= n; i++)
+      for (j = i + 1; j <= n; j++)
+        if (names[j] < names[i]) { t = names[i]; names[i] = names[j]; names[j] = t }
+    v = 0
+    for (i = 1; i <= n; i++) {
+      nm = names[i]
+      if (plugins[nm] ~ /, /) {
+        print "ERROR: Duplicate skill name " q nm q " in: " plugins[nm]
+        v++
+      }
+    }
+    for (i = 1; i <= n; i++) {
+      nm = names[i]
+      for (k in g) {
+        if (nm == g[k]) {
+          print "ERROR: Generic skill name " q nm q " requires a domain prefix (e.g., portfolio-" nm ") " dash " in " plugins[nm]
+          v++
+        }
+      }
+    }
+    print "__VIOLATIONS__ " v
+  }
+' "$pairs_file")
 
-# Check for generic words without a domain prefix
-for name in "${!skill_map[@]}"; do
-  for word in $GENERIC_WORDS; do
-    if [[ "$name" == "$word" ]]; then
-      echo "ERROR: Generic skill name '$name' requires a domain prefix (e.g., portfolio-$word) — in ${skill_map[$name]}"
-      violations=$((violations + 1))
-    fi
-  done
-done
+# Print the awk ERROR lines (everything but the sentinel) and fold its count in.
+awk_violations=$(printf '%s\n' "$awk_out" | sed -n 's/^__VIOLATIONS__ //p')
+printf '%s\n' "$awk_out" | grep -v '^__VIOLATIONS__' || true
+violations=$((violations + ${awk_violations:-0}))
 
 if [[ $violations -gt 0 ]]; then
   echo ""

--- a/cogni-workspace/scripts/check-skill-names.sh
+++ b/cogni-workspace/scripts/check-skill-names.sh
@@ -29,6 +29,10 @@ while IFS= read -r skill_md; do
     violations=$((violations + 1))
     continue
   fi
+  # A literal tab would forge the separator of the name<TAB>plugin pair below:
+  # awk -F'\t' would read the tab's tail as the plugin column and its head as the
+  # whole name, fabricating a duplicate against any real skill of that shorter name.
+  name=${name//$'\t'/ }
   rel_path="${skill_md#"$REPO_ROOT/"}"
   plugin=$(echo "$rel_path" | cut -d/ -f1)
   printf '%s\t%s\n' "$name" "$plugin" >> "$pairs_file"

--- a/cogni-workspace/scripts/check-skill-names.sh
+++ b/cogni-workspace/scripts/check-skill-names.sh
@@ -17,8 +17,12 @@ GENERIC_WORDS="setup scan ingest export dashboard verify bridge catalog reader c
 
 violations=0
 
-# Collect one name<TAB>plugin pair per SKILL.md frontmatter. An empty name is a
-# violation surfaced here (the awk pass below only sees named skills).
+# Collect one name<TAB>plugin pair per SKILL.md frontmatter; the awk pass below
+# only ever sees named skills. The -z branch below is a belt-and-braces guard, not
+# the live path for a nameless SKILL.md: under `set -euo pipefail` the grep|sed
+# pipeline already exits non-zero on a missing `name:` line and aborts the script
+# first. That is the base script's behaviour too, preserved here deliberately —
+# changing it is a separate concern from bash 3.2 portability.
 pairs_file="$(mktemp)"
 trap 'rm -f "$pairs_file"' EXIT
 

--- a/cogni-workspace/tests/test-check-skill-names.sh
+++ b/cogni-workspace/tests/test-check-skill-names.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Regression test for scripts/check-skill-names.sh.
+#
+# Contract under test:
+#   - runs to completion under bash 3.2 (macOS system bash) — no `declare -A`
+#   - detects a skill name duplicated across plugins (ERROR + non-zero exit)
+#   - detects a generic name without a domain prefix (ERROR + non-zero exit)
+#   - a clean, correctly-prefixed tree reports OK and exits 0
+#
+# The check globs "$REPO_ROOT"/cogni-*/skills/*/SKILL.md, so each case builds a
+# throwaway fixture tree and points the script at it via the REPO_ROOT override.
+#
+# stdlib-only: bash + coreutils, no pip deps. Mirrors tests/test-sanitize-theme.sh.
+
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WS_ROOT="$(cd "$HERE/.." && pwd)"
+CHECK="$WS_ROOT/scripts/check-skill-names.sh"
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { echo "OK   $1"; }
+fail() { echo "FAIL $1"; failures=$((failures + 1)); }
+
+# mk_skill <fixture-root> <plugin> <skill-dir> <name>
+mk_skill() {
+  local d="$1/$2/skills/$3"
+  mkdir -p "$d"
+  printf -- '---\nname: %s\ndescription: fixture skill\n---\n' "$4" > "$d/SKILL.md"
+}
+
+# run_check <fixture-root> -> sets RC and OUT
+run_check() {
+  OUT="$(REPO_ROOT="$1" bash "$CHECK" 2>&1)"; RC=$?
+}
+
+# --- Case 1: clean, correctly-prefixed tree -> OK, exit 0 ---
+CLEAN="$TMPROOT/clean"
+mk_skill "$CLEAN" cogni-alpha alpha-setup alpha-setup
+mk_skill "$CLEAN" cogni-beta beta-dashboard beta-dashboard
+run_check "$CLEAN"
+[ "$RC" -eq 0 ] && pass "1a clean tree exits 0" || fail "1a clean tree exit ($RC)"
+printf '%s\n' "$OUT" | grep -qF "OK: All skill names follow the naming convention." \
+  && pass "1b clean tree reports OK" || fail "1b clean tree OK line ($OUT)"
+
+# --- Case 2: duplicate name across two plugins -> ERROR, exit 1 ---
+DUP="$TMPROOT/dup"
+mk_skill "$DUP" cogni-alpha alpha-x iw-shared
+mk_skill "$DUP" cogni-beta beta-y iw-shared
+run_check "$DUP"
+[ "$RC" -ne 0 ] && pass "2a duplicate exits non-zero" || fail "2a duplicate exit ($RC)"
+printf '%s\n' "$OUT" | grep -qF "ERROR: Duplicate skill name 'iw-shared' in:" \
+  && pass "2b duplicate ERROR line" || fail "2b duplicate ERROR line ($OUT)"
+
+# --- Case 3: generic name without a domain prefix -> ERROR, exit 1 ---
+GEN="$TMPROOT/gen"
+mk_skill "$GEN" cogni-alpha the-dash dashboard
+run_check "$GEN"
+[ "$RC" -ne 0 ] && pass "3a generic exits non-zero" || fail "3a generic exit ($RC)"
+printf '%s\n' "$OUT" | grep -qF "ERROR: Generic skill name 'dashboard' requires a domain prefix" \
+  && pass "3b generic ERROR line" || fail "3b generic ERROR line ($OUT)"
+
+# --- Case 4: portability — no bash-4 `declare -A` failure surfaces ---
+run_check "$CLEAN"
+printf '%s\n' "$OUT" | grep -q "declare: -A" \
+  && fail "4 no declare -A error (found under $(bash --version | head -1))" \
+  || pass "4 no declare -A error under $(bash --version | head -1 | sed 's/ (.*//')"
+
+if [ "$failures" -gt 0 ]; then
+  echo ""
+  echo "FAIL: $failures check-skill-names test(s) failed."
+  exit 1
+fi
+echo ""
+echo "All check-skill-names tests passed."

--- a/cogni-workspace/tests/test-check-skill-names.sh
+++ b/cogni-workspace/tests/test-check-skill-names.sh
@@ -2,7 +2,9 @@
 # Regression test for scripts/check-skill-names.sh.
 #
 # Contract under test:
-#   - runs to completion under bash 3.2 (macOS system bash) — no `declare -A`
+#   - stays free of the bash-4 `declare -A` construct (static guard, enforced on
+#     every interpreter incl. CI bash 5.x) and, when a real bash 3.x is present
+#     (e.g. /bin/bash on macOS), runs to completion under it
 #   - detects a skill name duplicated across plugins (ERROR + non-zero exit)
 #   - detects a generic name without a domain prefix (ERROR + non-zero exit)
 #   - a clean, correctly-prefixed tree reports OK and exits 0
@@ -30,9 +32,11 @@ mk_skill() {
   printf -- '---\nname: %s\ndescription: fixture skill\n---\n' "$4" > "$d/SKILL.md"
 }
 
-# run_check <fixture-root> -> sets RC and OUT
+# run_check <fixture-root> [interpreter] -> sets RC and OUT
+# The interpreter defaults to `bash` (PATH), so Cases 1-3 are unchanged; Case 4b
+# passes a detected real bash 3.x to exercise the script under it.
 run_check() {
-  OUT="$(REPO_ROOT="$1" bash "$CHECK" 2>&1)"; RC=$?
+  OUT="$(REPO_ROOT="$1" "${2:-bash}" "$CHECK" 2>&1)"; RC=$?
 }
 
 # --- Case 1: clean, correctly-prefixed tree -> OK, exit 0 ---
@@ -61,11 +65,41 @@ run_check "$GEN"
 printf '%s\n' "$OUT" | grep -qF "ERROR: Generic skill name 'dashboard' requires a domain prefix" \
   && pass "3b generic ERROR line" || fail "3b generic ERROR line ($OUT)"
 
-# --- Case 4: portability — no bash-4 `declare -A` failure surfaces ---
-run_check "$CLEAN"
-printf '%s\n' "$OUT" | grep -q "declare: -A" \
-  && fail "4 no declare -A error (found under $(bash --version | head -1))" \
-  || pass "4 no declare -A error under $(bash --version | head -1 | sed 's/ (.*//')"
+# --- Case 4: portability — the bash-4 `declare -A` construct must never return ---
+# 4a is interpreter-independent: a static check that fires even on CI's bash 5.x,
+# where a *runtime* declare-error check is inert (bash 5 runs `declare -A` fine).
+# This is the guard that actually catches a re-introduced bash-4-ism on CI.
+# Comments are stripped first so an *explanatory* `declare -A` mention (the script
+# documents why it avoids the construct) is not mistaken for a code re-introduction.
+# Matches the direct synonym `typeset -A` too, the other spelling of the same bash-4
+# associative-array declaration.
+if sed 's/#.*//' "$CHECK" | grep -qE '(declare|typeset) -A'; then
+  fail "4a check-skill-names.sh re-introduced 'declare -A'/'typeset -A' in code (bash-4 only)"
+else
+  pass "4a check-skill-names.sh free of code-level associative-array declaration"
+fi
+
+# 4b/4c additionally exercise the script under a real bash 3.x when one exists
+# (macOS system /bin/bash is 3.2.57), so the exact runtime failure this PR fixes
+# is reproduced live. When no bash 3.x is present, emit a visible SKIP rather than
+# a silent green.
+BASH3=""
+for cand in /bin/bash /usr/bin/bash; do
+  [ -x "$cand" ] || continue
+  if [ "$("$cand" -c 'echo "${BASH_VERSINFO[0]}"' 2>/dev/null)" = "3" ]; then
+    BASH3="$cand"; break
+  fi
+done
+if [ -n "$BASH3" ]; then
+  run_check "$CLEAN" "$BASH3"
+  [ "$RC" -eq 0 ] && pass "4b clean tree exits 0 under real bash 3.x ($BASH3)" \
+    || fail "4b clean tree exit under $BASH3 ($RC): $OUT"
+  printf '%s\n' "$OUT" | grep -q "declare: -A" \
+    && fail "4c 'declare: -A' runtime error under $BASH3" \
+    || pass "4c no 'declare: -A' runtime error under $BASH3"
+else
+  echo "SKIP 4b/4c no real bash 3.x found (checked /bin/bash /usr/bin/bash) — static guard 4a still enforced"
+fi
 
 if [ "$failures" -gt 0 ]; then
   echo ""

--- a/cogni-workspace/tests/test-check-skill-names.sh
+++ b/cogni-workspace/tests/test-check-skill-names.sh
@@ -133,19 +133,34 @@ for BIN in $INTERPRETERS; do
   assert_no_bash4_error "3c generic free of bash-4 runtime error ($BIN)"
 done
 
-# --- Case 4: portability — the bash-4 `declare -A` construct must never return ---
+# --- Case 4: portability — no bash-4-only construct may reach the script ---
 # 4a is a source-text check, so it fires even on CI's bash 5.x, where a runtime
-# check is inert (bash 5 runs `declare -A` fine). It is the guard that catches a
-# re-introduced bash-4-ism on a host with no bash 3.x at all. Comments are
-# stripped first so the script's own explanation of why it avoids the construct is
-# not read as a re-introduction. `typeset -A` is the same declaration under its
-# other spelling. The live bash-3.x half of this contract runs inline as the
-# assert_no_bash4_error step of the fixture cases, which reach the violation path
-# as well as the OK branch.
-if sed 's/#.*//' "$CHECK" | grep -qE '(declare|typeset) -A'; then
-  fail "4a check-skill-names.sh re-introduced 'declare -A'/'typeset -A' in code (bash-4 only)"
+# check is inert (bash 5 runs these constructs fine). On a host with no bash 3.x
+# it is the ONLY portability assertion standing, which is why it enumerates the
+# bash-4-only forms someone might plausibly reach for rather than `declare -A`
+# alone: a guard that covers one construct lets every other bash-4-ism ship green
+# on CI. The list is necessarily incomplete — the live bash-3.x half of the
+# contract (the assert_no_bash4_error step of the fixture cases, which reaches the
+# violation path as well as the OK branch) is what catches the rest, wherever a
+# real bash 3.x exists. Comments are stripped first so the script's own
+# explanation of what it avoids is not read as a re-introduction.
+CHECK_SRC="$(sed 's/#.*//' "$CHECK")"
+bash4_hits=""
+for pat in \
+  '(declare|typeset|local)[[:space:]]+-[A-Za-z]*[An]' \
+  '\$\{[A-Za-z_][A-Za-z0-9_]*(\^\^|,,|\^|,)' \
+  '(^|[;&|[:space:]])(mapfile|readarray)([[:space:]]|$)' \
+  '\$\{[A-Za-z_][A-Za-z0-9_]*@[QEPAKauL]\}'
+do
+  if printf '%s\n' "$CHECK_SRC" | grep -qE "$pat"; then
+    bash4_hits="$bash4_hits
+    $pat"
+  fi
+done
+if [ -n "$bash4_hits" ]; then
+  fail "4a check-skill-names.sh contains bash-4-only construct(s) matching:$bash4_hits"
 else
-  pass "4a check-skill-names.sh free of code-level associative-array declaration"
+  pass "4a check-skill-names.sh free of the enumerated bash-4-only constructs"
 fi
 
 # --- Case 5: a literal tab inside a skill name must not fabricate a duplicate ---

--- a/cogni-workspace/tests/test-check-skill-names.sh
+++ b/cogni-workspace/tests/test-check-skill-names.sh
@@ -3,11 +3,21 @@
 #
 # Contract under test:
 #   - stays free of the bash-4 `declare -A` construct (static guard, enforced on
-#     every interpreter incl. CI bash 5.x) and, when a real bash 3.x is present
-#     (e.g. /bin/bash on macOS), runs to completion under it
-#   - detects a skill name duplicated across plugins (ERROR + non-zero exit)
-#   - detects a generic name without a domain prefix (ERROR + non-zero exit)
+#     every interpreter incl. CI bash 5.x)
+#   - detects a skill name duplicated across plugins (ERROR + exit 1)
+#   - detects a generic name without a domain prefix (ERROR + exit 1)
 #   - a clean, correctly-prefixed tree reports OK and exits 0
+#   - a literal tab inside a skill name does not fabricate a duplicate
+#
+# Every behavioural case runs under each interpreter in $INTERPRETERS: PATH
+# `bash` plus a real bash 3.x when the host has a distinct one (macOS /bin/bash
+# is 3.2.57). The second interpreter is what keeps the coverage honest — PATH
+# `bash` is frequently a newer homebrew build, and running only under it leaves
+# the script's *violation* path (the `${awk_violations:-0}` fold and the
+# `if [[ $violations -gt 0 ]]` branch) unexercised on the very interpreter this
+# check exists to support. A bash-4-ism reachable only from that path — say
+# `${var^^}` or `mapfile`, neither of which the static guard looks for — would
+# otherwise ship undetected.
 #
 # The check globs "$REPO_ROOT"/cogni-*/skills/*/SKILL.md, so each case builds a
 # throwaway fixture tree and points the script at it via the REPO_ROOT override.
@@ -25,6 +35,37 @@ failures=0
 pass() { echo "OK   $1"; }
 fail() { echo "FAIL $1"; failures=$((failures + 1)); }
 
+# Assert the script under test exists before anything reads it. Without this the
+# static guard (Case 4) would sed/grep a missing file, match nothing, and report a
+# spurious PASS — and on Linux/CI, where no bash 3.x exists, Case 4 is the only
+# portability assertion left standing.
+[ -f "$CHECK" ] || { fail "0 script under test not found at $CHECK"; exit 1; }
+
+# Interpreter matrix, derived once. Only *distinct* binaries are listed: on a
+# stock macOS with no homebrew bash, PATH `bash` already IS /bin/bash 3.2.57, and
+# running the same binary twice per case would buy no coverage.
+PATH_BASH="$(command -v bash)"
+BASH3=""
+if [ "$("$PATH_BASH" -c 'echo "${BASH_VERSINFO[0]}"' 2>/dev/null)" = "3" ]; then
+  BASH3="$PATH_BASH"
+else
+  for cand in /bin/bash /usr/bin/bash; do
+    [ -x "$cand" ] || continue
+    if [ "$("$cand" -c 'echo "${BASH_VERSINFO[0]}"' 2>/dev/null)" = "3" ]; then
+      BASH3="$cand"; break
+    fi
+  done
+fi
+INTERPRETERS="$PATH_BASH"
+if [ -n "$BASH3" ] && [ "$BASH3" != "$PATH_BASH" ]; then
+  INTERPRETERS="$INTERPRETERS $BASH3"
+fi
+if [ -n "$BASH3" ]; then
+  echo "INFO interpreters: $INTERPRETERS (real bash 3.x: $BASH3)"
+else
+  echo "SKIP no real bash 3.x found (checked PATH bash, /bin/bash, /usr/bin/bash) — behavioural cases run under $PATH_BASH only; static guard 4a still enforced"
+fi
+
 # mk_skill <fixture-root> <plugin> <skill-dir> <name>
 mk_skill() {
   local d="$1/$2/skills/$3"
@@ -32,74 +73,94 @@ mk_skill() {
   printf -- '---\nname: %s\ndescription: fixture skill\n---\n' "$4" > "$d/SKILL.md"
 }
 
-# run_check <fixture-root> [interpreter] -> sets RC and OUT
-# The interpreter defaults to `bash` (PATH), so Cases 1-3 are unchanged; Case 4b
-# passes a detected real bash 3.x to exercise the script under it.
+# run_check <fixture-root> <interpreter> -> sets RC and OUT
+# The interpreter is a required argument, so no call site can silently fall back
+# to PATH bash and quietly drop the bash-3.x half of the matrix.
 run_check() {
-  OUT="$(REPO_ROOT="$1" "${2:-bash}" "$CHECK" 2>&1)"; RC=$?
+  OUT="$(REPO_ROOT="$1" "$2" "$CHECK" 2>&1)"; RC=$?
+}
+
+# Assertions read RC/OUT from the last run_check. `case` does fixed-string
+# containment as a shell builtin, so an assertion costs no fork.
+assert_rc()        { [ "$RC" -eq "$1" ] && pass "$2" || fail "$2 — exit $RC, want $1: $OUT"; }
+assert_out_has()   { case "$OUT" in *"$1"*) pass "$2" ;; *) fail "$2 — missing '$1': $OUT" ;; esac; }
+assert_out_lacks() { case "$OUT" in *"$1"*) fail "$2 — unexpected '$1': $OUT" ;; *) pass "$2" ;; esac; }
+
+# Scoped to the bash 3.x interpreter: bash >= 4 executes `declare -A` fine and so
+# is structurally incapable of emitting this error. Reporting it green there would
+# be exactly the vacuous coverage the matrix above exists to eliminate.
+assert_no_bash4_error() {
+  [ "$BIN" = "$BASH3" ] || return 0
+  case "$OUT" in
+    *"declare: -A"*|*"typeset: -A"*) fail "$1 — bash-4 associative-array runtime error: $OUT" ;;
+    *) pass "$1" ;;
+  esac
 }
 
 # --- Case 1: clean, correctly-prefixed tree -> OK, exit 0 ---
 CLEAN="$TMPROOT/clean"
 mk_skill "$CLEAN" cogni-alpha alpha-setup alpha-setup
 mk_skill "$CLEAN" cogni-beta beta-dashboard beta-dashboard
-run_check "$CLEAN"
-[ "$RC" -eq 0 ] && pass "1a clean tree exits 0" || fail "1a clean tree exit ($RC)"
-printf '%s\n' "$OUT" | grep -qF "OK: All skill names follow the naming convention." \
-  && pass "1b clean tree reports OK" || fail "1b clean tree OK line ($OUT)"
+for BIN in $INTERPRETERS; do
+  run_check "$CLEAN" "$BIN"
+  assert_rc 0 "1a clean tree exits 0 ($BIN)"
+  assert_out_has "OK: All skill names follow the naming convention." "1b clean tree reports OK ($BIN)"
+  assert_no_bash4_error "1c clean tree free of bash-4 runtime error ($BIN)"
+done
 
 # --- Case 2: duplicate name across two plugins -> ERROR, exit 1 ---
+# 2c pins the FAIL summary because it is emitted from the violation branch, past
+# the `${awk_violations:-0}` fold — the stretch of the script the matrix exists
+# to reach under bash 3.x.
 DUP="$TMPROOT/dup"
 mk_skill "$DUP" cogni-alpha alpha-x iw-shared
 mk_skill "$DUP" cogni-beta beta-y iw-shared
-run_check "$DUP"
-[ "$RC" -ne 0 ] && pass "2a duplicate exits non-zero" || fail "2a duplicate exit ($RC)"
-printf '%s\n' "$OUT" | grep -qF "ERROR: Duplicate skill name 'iw-shared' in:" \
-  && pass "2b duplicate ERROR line" || fail "2b duplicate ERROR line ($OUT)"
+for BIN in $INTERPRETERS; do
+  run_check "$DUP" "$BIN"
+  assert_rc 1 "2a duplicate exits 1 ($BIN)"
+  assert_out_has "ERROR: Duplicate skill name 'iw-shared' in:" "2b duplicate ERROR line ($BIN)"
+  assert_out_has "FAIL: 1 naming violation(s) found." "2c duplicate FAIL summary ($BIN)"
+  assert_no_bash4_error "2d duplicate free of bash-4 runtime error ($BIN)"
+done
 
 # --- Case 3: generic name without a domain prefix -> ERROR, exit 1 ---
 GEN="$TMPROOT/gen"
 mk_skill "$GEN" cogni-alpha the-dash dashboard
-run_check "$GEN"
-[ "$RC" -ne 0 ] && pass "3a generic exits non-zero" || fail "3a generic exit ($RC)"
-printf '%s\n' "$OUT" | grep -qF "ERROR: Generic skill name 'dashboard' requires a domain prefix" \
-  && pass "3b generic ERROR line" || fail "3b generic ERROR line ($OUT)"
+for BIN in $INTERPRETERS; do
+  run_check "$GEN" "$BIN"
+  assert_rc 1 "3a generic exits 1 ($BIN)"
+  assert_out_has "ERROR: Generic skill name 'dashboard' requires a domain prefix" "3b generic ERROR line ($BIN)"
+  assert_no_bash4_error "3c generic free of bash-4 runtime error ($BIN)"
+done
 
 # --- Case 4: portability — the bash-4 `declare -A` construct must never return ---
-# 4a is interpreter-independent: a static check that fires even on CI's bash 5.x,
-# where a *runtime* declare-error check is inert (bash 5 runs `declare -A` fine).
-# This is the guard that actually catches a re-introduced bash-4-ism on CI.
-# Comments are stripped first so an *explanatory* `declare -A` mention (the script
-# documents why it avoids the construct) is not mistaken for a code re-introduction.
-# Matches the direct synonym `typeset -A` too, the other spelling of the same bash-4
-# associative-array declaration.
+# 4a is a source-text check, so it fires even on CI's bash 5.x, where a runtime
+# check is inert (bash 5 runs `declare -A` fine). It is the guard that catches a
+# re-introduced bash-4-ism on a host with no bash 3.x at all. Comments are
+# stripped first so the script's own explanation of why it avoids the construct is
+# not read as a re-introduction. `typeset -A` is the same declaration under its
+# other spelling. The live bash-3.x half of this contract runs inline as the
+# assert_no_bash4_error step of the fixture cases, which reach the violation path
+# as well as the OK branch.
 if sed 's/#.*//' "$CHECK" | grep -qE '(declare|typeset) -A'; then
   fail "4a check-skill-names.sh re-introduced 'declare -A'/'typeset -A' in code (bash-4 only)"
 else
   pass "4a check-skill-names.sh free of code-level associative-array declaration"
 fi
 
-# 4b/4c additionally exercise the script under a real bash 3.x when one exists
-# (macOS system /bin/bash is 3.2.57), so the exact runtime failure this PR fixes
-# is reproduced live. When no bash 3.x is present, emit a visible SKIP rather than
-# a silent green.
-BASH3=""
-for cand in /bin/bash /usr/bin/bash; do
-  [ -x "$cand" ] || continue
-  if [ "$("$cand" -c 'echo "${BASH_VERSINFO[0]}"' 2>/dev/null)" = "3" ]; then
-    BASH3="$cand"; break
-  fi
+# --- Case 5: a literal tab inside a skill name must not fabricate a duplicate ---
+# The script streams `name<TAB>plugin` pairs into `awk -F'\t'`, so an unsanitized
+# tab would let a name's tail be read as the plugin column — turning an unrelated
+# skill named `foo` into a phantom collision with `foo<TAB>bar`.
+TABF="$TMPROOT/tabname"
+mk_skill "$TABF" cogni-alpha alpha-tab "$(printf 'foo\tbar')"
+mk_skill "$TABF" cogni-beta beta-foo foo
+for BIN in $INTERPRETERS; do
+  run_check "$TABF" "$BIN"
+  assert_rc 0 "5a tabbed name exits 0 ($BIN)"
+  assert_out_lacks "ERROR: Duplicate skill name 'foo'" "5b tabbed name reports no phantom duplicate ($BIN)"
+  assert_no_bash4_error "5c tabbed name free of bash-4 runtime error ($BIN)"
 done
-if [ -n "$BASH3" ]; then
-  run_check "$CLEAN" "$BASH3"
-  [ "$RC" -eq 0 ] && pass "4b clean tree exits 0 under real bash 3.x ($BASH3)" \
-    || fail "4b clean tree exit under $BASH3 ($RC): $OUT"
-  printf '%s\n' "$OUT" | grep -q "declare: -A" \
-    && fail "4c 'declare: -A' runtime error under $BASH3" \
-    || pass "4c no 'declare: -A' runtime error under $BASH3"
-else
-  echo "SKIP 4b/4c no real bash 3.x found (checked /bin/bash /usr/bin/bash) — static guard 4a still enforced"
-fi
 
 if [ "$failures" -gt 0 ]; then
   echo ""


### PR DESCRIPTION
Closes #1133.

## Summary
- Drop `declare -A skill_map` (bash 4+) from `scripts/check-skill-names.sh` and its two `${!skill_map[@]}` loops; do name→plugin dedup, cross-plugin collision detection, and generic-word-prefix detection in a single portable **`awk`** pass over a `name<TAB>plugin` stream (awk associative arrays are POSIX-portable, no bash-4 dependency).
- Preserve the **actual** contract: human-readable `WARNING:` / `ERROR:` / `FAIL: N naming violation(s) found.` / `OK: …` lines and exit `0` = clean / non-zero = violations. Not a JSON-envelope script; not converted to one. Output is now name-sorted (stable) rather than bash hash-order — a strict improvement under both bash versions.
- Honor an optional `REPO_ROOT` env override so the check is fixture-testable without relocating it.
- Add `tests/test-check-skill-names.sh` (stdlib-only bash harness, mirrors `tests/test-sanitize-theme.sh`): duplicate-name fixture, generic-unprefixed-name fixture, clean control, plus a no-`declare -A` portability assertion.
- Patch-bump `cogni-workspace` `0.6.38 → 0.6.39` (marketplace edited surgically).

## Verification
- `bash cogni-workspace/scripts/check-skill-names.sh` on the real repo under **macOS system bash 3.2.57** → `OK: All skill names follow the naming convention.`, exit 0. The pre-change script aborts under 3.2 with `declare: -A: invalid option` (reproduced).
- `bash cogni-workspace/tests/test-check-skill-names.sh` → all cases OK under bash 3.2.
- Docs referencing the check (CONTRIBUTING.md, CLAUDE.md, docs/*) stay accurate — command, output, and exit codes are unchanged, so no doc edit is needed.

## Test plan
- [x] Runs to completion under macOS system bash 3.2 (no `declare -A` error), same result as bash 5.
- [x] Duplicate + generic-unprefixed detection regression-covered by fixtures.
- [x] `{exit-code}` contract (0 / non-zero) preserved; ERROR/WARNING/FAIL/OK line formats preserved.