### PR TITLE
ci: move the plugin version bump post-merge

### DIFF
--- a/.github/workflows/cogni-version-bump.yml
+++ b/.github/workflows/cogni-version-bump.yml
@@ -1,0 +1,290 @@
+# Post-merge auto version bump.
+#
+# The version bump moved OUT of feature branches (see the root CLAUDE.md
+# "Version Management" section and scripts/check-version-bump.py). Feature PRs no
+# longer touch `<plugin>/.claude-plugin/plugin.json` or its mirrored entry in the
+# root `.claude-plugin/marketplace.json`; those paired version lines were the
+# canonical merge-conflict class — the instant one PR merged, every other open
+# PR's version lines became a textual conflict. insight-wave had it worse than a
+# one-manifest-per-plugin repo, because marketplace.json is a SINGLE file all 14
+# plugins share, so the conflict was repo-wide rather than per-plugin. This
+# workflow is the sole actor that advances a version: on every push to main it
+# patch-increments each plugin the merge actually touched, in both manifests,
+# once, with no PR racing it.
+#
+# Authorization. This pushes straight to main with the built-in GITHUB_TOKEN,
+# raised to `contents: write` by the `permissions:` block below. The repo's
+# Actions setting "default workflow permissions: read" sets only the DEFAULT
+# grant for workflows that declare no `permissions:` key; a workflow-level block
+# overrides it. The `admin` ruleset on refs/heads/main carries only `deletion`
+# and `non_fast_forward` rules — no pull-request requirement — so a fast-forward
+# push by github-actions[bot] is permitted. No PAT, no Actions secret, no bypass
+# allowlist. If that ruleset ever gains a PR requirement, drop a fine-grained PAT
+# (Contents: write, this repo only) into the Actions secret VERSION_BUMP_TOKEN
+# and the checkout below picks it up with no other change.
+#
+# Loop-guards, three of them, because losing one must not re-arm the loop:
+#   1. This workflow's own commit is `bump(...)`; the job-level `if` skips any
+#      push whose head commit message starts with `bump(`.
+#   2. An in-script re-check re-asserts (1) against the fetched HEAD — the job
+#      `if` is falsy when head_commit is null, which some push shapes produce.
+#   3. Inherent: a push made with GITHUB_TOKEN does not trigger further workflow
+#      runs. Harmless here — neither lint.yml (pull_request) nor cla.yml
+#      (issue_comment / pull_request_target) is push-triggered, so this workflow
+#      is the only thing that would have re-fired. This guard disappears if a PAT
+#      is ever installed, which is exactly why 1 and 2 are both kept.
+#
+# Non-goal: `maturity` and the maturity keyword inside `keywords[]` are derived
+# from the version RANGE. A patch bump only ever increments a numeric last
+# component, so it structurally cannot cross a maturity boundary and neither
+# field is ever touched. Boundary crossings stay human, per CLAUDE.md.
+
+name: Version bump
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Compute and verify the bump but write, commit and push nothing"
+        type: boolean
+        default: true
+      range:
+        description: "Git range for the touched-file set (default: HEAD^..HEAD)"
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+
+# Serialize: two merges landing close together must EACH get their own bump,
+# never dropped. Never cancel in progress — a cancelled bump is a silently
+# skipped version.
+concurrency:
+  group: version-bump-main
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Post-merge patch bump
+    runs-on: ubuntu-latest
+    # Primary loop-guard: never run on our own bump( commit. head_commit is null
+    # for some push shapes and for workflow_dispatch; startsWith(null, ...) is
+    # false, so the job still runs and the in-script guard below covers it.
+    if: ${{ !startsWith(github.event.head_commit.message, 'bump(') }}
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v4
+        with:
+          # Load-bearing: the pre-push verification compares the freshly bumped
+          # HEAD against the pre-bump origin/main tip. A shallow clone has no
+          # origin/main ref, so that verification could only degrade to a vacuous
+          # pass — and the vacuity assertion below would then fail the run.
+          fetch-depth: 0
+          ref: main
+          token: ${{ secrets.VERSION_BUMP_TOKEN || github.token }}
+
+      - name: Compute the touched-file set
+        id: touched
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+          RANGE_INPUT: ${{ inputs.range }}
+        run: |
+          set -uo pipefail
+          ZERO='0000000000000000000000000000000000000000'
+
+          # Secondary loop-guard, for the null-head_commit push shapes the job
+          # `if` cannot see: skip when the tip commit is already one of ours.
+          HEAD_MSG="$(git log -1 --pretty=%s)"
+          case "$HEAD_MSG" in
+            'bump('*)
+              echo "tip is a bump( commit — nothing to do"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0 ;;
+          esac
+
+          # Which range tells us WHICH plugins the merge touched:
+          #   * an explicit workflow_dispatch range wins;
+          #   * an all-zero AFTER is a branch delete — nothing to bump;
+          #   * an all-zero BEFORE is a branch create / force push, so fall back
+          #     to the head commit's own diff;
+          #   * otherwise the ordinary before..after range.
+          if [ -n "${RANGE_INPUT:-}" ]; then
+            RANGE="$RANGE_INPUT"
+          elif [ -z "${AFTER:-}" ]; then
+            RANGE="HEAD^..HEAD"
+          elif [ "$AFTER" = "$ZERO" ]; then
+            echo "push carries no head commit — nothing to do"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          elif [ -z "${BEFORE:-}" ] || [ "$BEFORE" = "$ZERO" ]; then
+            RANGE="${AFTER}^..${AFTER}"
+          else
+            RANGE="${BEFORE}..${AFTER}"
+          fi
+
+          if ! git diff --name-only "$RANGE" > changed-files.txt 2> diff.err; then
+            echo "::warning::range '$RANGE' unusable ($(head -c 200 diff.err)); falling back to HEAD^..HEAD"
+            if ! git diff --name-only "HEAD^..HEAD" > changed-files.txt 2>/dev/null; then
+              echo "::warning::no usable diff range — nothing to bump"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "touched files ($RANGE):"
+          cat changed-files.txt
+
+      - name: Apply the patch bump
+        id: bump
+        if: steps.touched.outputs.skip != 'true'
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -uo pipefail
+          ARGS="--changed-file changed-files.txt"
+          if [ "${DRY_RUN:-}" = "true" ]; then ARGS="$ARGS --dry-run"; fi
+
+          python3 scripts/apply-version-bump.py $ARGS > bump.json 2> bump.err
+          RC=$?
+          cat bump.json
+          cat bump.err >&2
+
+          if [ "$RC" -eq 2 ]; then
+            echo "::error::apply-version-bump.py errored — nothing was written"
+            exit 1
+          fi
+
+          # One annotation per skipped plugin. Tab-delimited and read with
+          # `while IFS= read` — never `for s in $(...)`, because a skip reason
+          # contains spaces that word-splitting would smear across lines.
+          python3 - <<'PY' > skips.tsv
+          import json
+          for s in json.load(open("bump.json"))["data"]["skipped"]:
+              print("%s\t%s: %s" % (s["severity"], s["plugin"], s["reason"]))
+          PY
+          while IFS=$'\t' read -r SEV MSG; do
+            [ -n "${MSG:-}" ] || continue
+            echo "::${SEV}::version-bump skipped ${MSG}"
+          done < skips.tsv
+
+          COUNT="$(python3 -c 'import json;print(len(json.load(open("bump.json"))["data"]["bumped"]))')"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          # RC 1 means a touched plugin was skipped with severity "error" — almost
+          # always mirror drift. The healthy plugins WERE written, so the run is
+          # failed at the very end instead, letting their bump still reach main.
+          echo "deferred_failure=$RC" >> "$GITHUB_OUTPUT"
+
+          if [ "$COUNT" = "0" ]; then
+            echo "no touched plugin to bump — nothing to do"
+          fi
+
+      - name: Commit, verify, and push
+        if: ${{ steps.bump.outputs.count != '' && steps.bump.outputs.count != '0' && inputs.dry_run != true }}
+        run: |
+          set -uo pipefail
+
+          # A single-plugin bump names the plugin and its new version, satisfying
+          # both the loop-guard (`bump(` prefix) and the repo's commit format.
+          MSG="$(python3 - <<'PY'
+          import json
+          b = json.load(open("bump.json"))["data"]["bumped"]
+          if len(b) == 1:
+              x = b[0]
+              print("bump(%s): v%s — post-merge auto-increment" % (x["plugin"], x["new"]))
+          else:
+              names = ", ".join("%s v%s" % (x["plugin"], x["new"]) for x in b)
+              print("bump(multi): %s — post-merge auto-increment" % names)
+          PY
+          )"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Stage ONLY the manifests this bump owns — never `git add -A`, so the
+          # runner's scratch files (bump.json, changed-files.txt, skips.tsv,
+          # diff.err) cannot ride along in the bump commit.
+          python3 -c 'import json;[print(p) for p in json.load(open("bump.json"))["data"]["paths_to_stage"]]' \
+            | while IFS= read -r f; do [ -n "$f" ] && git add "$f"; done
+
+          # Prove it rather than trust it: the index must hold only the root
+          # marketplace manifest and per-plugin plugin.json files.
+          UNEXPECTED="$(git diff --cached --name-only \
+            | grep -vE '^(\.claude-plugin/marketplace\.json|[^/]+/\.claude-plugin/plugin\.json)$' || true)"
+          if [ -n "$UNEXPECTED" ]; then
+            echo "::error::unexpected staged path(s) in the bump commit: $UNEXPECTED"
+            exit 1
+          fi
+
+          git commit -qm "$MSG"
+
+          # Verify before pushing: every plugin the bump commit touched must be
+          # strictly greater than the pre-bump origin/main tip, and the
+          # plugin.json <-> marketplace.json mirror must hold repo-wide.
+          #
+          # Graded twice from ONE invocation. check-version-bump.py exits 0 both
+          # when the gate passed AND when it could not compare anything (status
+          # "degraded" — base ref unresolvable), so the exit code alone cannot
+          # tell "clean" from "never actually checked". Without the status check
+          # a degraded verify would wave a bad bump straight through.
+          verify() {
+            python3 scripts/check-version-bump.py --mode post-merge \
+              > verify.json 2> verify.err
+            local rc=$?
+            cat verify.json
+            cat verify.err >&2
+            [ "$rc" -eq 0 ] || return 1
+            python3 - <<'PY'
+          import json, sys
+          d = json.load(open("verify.json")).get("data") or {}
+          if d.get("status") == "degraded":
+              sys.exit("post-merge verification is VACUOUS (status: degraded) — %s\n"
+                       "It compared nothing. This usually means fetch-depth: 0 was "
+                       "removed from the checkout step." % d.get("degraded_reason"))
+          print("post-merge verification ran for real (status: %s)" % d.get("status"))
+          PY
+          }
+
+          if ! verify; then
+            echo "::error::post-merge version verification failed — refusing to push"
+            exit 1
+          fi
+
+          # Retry the push: a racing human merge can advance main between our
+          # fetch and our push. `concurrency` serializes our OWN runs; a human
+          # merge is outside that group.
+          for attempt in 1 2 3 4; do
+            if git push origin HEAD:main; then
+              echo "pushed: $MSG"
+              exit 0
+            fi
+            echo "push attempt $attempt failed; rebasing on origin/main and retrying"
+            # Explicit refspec: a bare `git fetch origin main` does not reliably
+            # update refs/remotes/origin/main under the refspec actions/checkout
+            # configures, and the re-verify below anchors on exactly that ref.
+            git fetch origin +refs/heads/main:refs/remotes/origin/main || true
+            if ! git rebase origin/main; then
+              echo "::error::rebase conflict on the bump — aborting; the version does not advance"
+              git rebase --abort
+              exit 1
+            fi
+            # The rebase moved the anchor, so re-assert the bump is still strictly
+            # greater against the freshly advanced main. Fail closed rather than
+            # push a stale bump.
+            if ! verify; then
+              echo "::error::post-rebase verification failed — refusing to push"
+              exit 1
+            fi
+            sleep "$((attempt * 2))"
+          done
+          echo "::error::could not push the bump after 4 attempts"
+          exit 1
+
+      - name: Fail the run on a hard skip
+        if: ${{ steps.bump.outputs.deferred_failure == '1' }}
+        run: |
+          echo "::error::At least one touched plugin was skipped with severity=error (see the annotations above) — almost always plugin.json <-> marketplace.json mirror drift. The healthy plugins were bumped and pushed; reconcile the flagged plugin by hand, then re-run this workflow with an explicit range input."
+          exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,3 +36,55 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/check-external-dispatch.py
+
+  version-bump-gate:
+    name: Version-bump gate (feature branches must not touch versions)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Load-bearing here, unlike the two guards above. This gate anchors on
+          # the MERGE-BASE with origin/main; the default shallow checkout has no
+          # origin/main ref and no merge-base, under which the gate can only
+          # degrade to a vacuous pass. Do not remove — the vacuity assertion in
+          # the step below fails the build if this is dropped.
+          fetch-depth: 0
+          # Check out the PR HEAD, not the auto-generated merge ref. Merge-base
+          # anchoring is what makes "untouched" immune to main's version
+          # advancing after the fork; on a merge ref the merge-base collapses
+          # onto main's tip and that property is lost. Empty on
+          # workflow_dispatch, where checkout falls back to the default ref.
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Assert no plugin version was touched on this branch
+        run: |
+          set -uo pipefail
+          python3 scripts/check-version-bump.py > version-gate.json 2> version-gate.err
+          rc=$?
+          cat version-gate.json
+          cat version-gate.err >&2
+
+          if [ "$rc" -eq 2 ]; then
+            echo "::error::version-bump gate errored"
+            exit 1
+          fi
+
+          # Graded twice from ONE invocation. The script exits 0 both when the
+          # gate passed AND when it could not compare anything (status
+          # "degraded" — base ref unresolvable), so the exit code alone cannot
+          # tell "clean" from "never actually checked". Deliberately NOT a
+          # second invocation: re-running the script would grade a different run
+          # than the one that gated the build.
+          python3 - <<'PY'
+          import json, sys
+          d = json.load(open("version-gate.json")).get("data") or {}
+          if d.get("status") == "degraded":
+              sys.exit("version-bump gate is VACUOUS (status: degraded) — %s\n"
+                       "It compared nothing. This usually means fetch-depth: 0 "
+                       "was removed from the checkout step." % d.get("degraded_reason"))
+          print("version-bump gate ran for real (status: %s)" % d.get("status"))
+          PY
+          vrc=$?
+          [ "$vrc" -eq 0 ] || exit 1
+          exit "$rc"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,10 +104,13 @@ Key integration patterns:
 
 ## Version Management
 
-- Plugin version lives in `.claude-plugin/plugin.json` `version` field (semver)
-- Bump the patch version after any change to skills, agents, or structure
-- Marketplace sync is driven by git commit hash, but plugin versions must also be mirrored in marketplace.json for Claude Desktop update detection
-- When bumping a plugin version in plugin.json, also update the matching entry in marketplace.json
+**Do not bump a version in a feature branch.** The patch bump is applied post-merge, automatically, per plugin actually touched.
+
+- Plugin version lives in `.claude-plugin/plugin.json` `version` field (semver), mirrored on the plugin's entry in the repo-root `.claude-plugin/marketplace.json` — Claude Desktop reads the marketplace copy for update detection, so the two must always agree
+- `.github/workflows/cogni-version-bump.yml` owns the bump. On every push to `main` it patch-increments each plugin the merge touched, editing **both** manifests in one `bump(...)` commit. `scripts/apply-version-bump.py` does the edit; nothing is written unless the rewritten JSON re-parses and differs *only* in the intended version values
+- A feature branch that still touches a version reintroduces the merge-conflict class the post-merge move eliminated: when every PR bumped at authoring time, the instant one PR merged, every other open PR's version lines became a textual conflict. insight-wave had it worse than a one-manifest-per-plugin repo, because marketplace.json is a single file all 14 plugins share — so the conflict was repo-wide, not per-plugin
+- `scripts/check-version-bump.py` enforces this at PR time (CI: "Version-bump gate" in `.github/workflows/lint.yml`). It flags `version-touched` on any version change vs the fork point, and `version-mirror-desync` whenever plugin.json and marketplace.json disagree. Fix a `version-touched` finding by reverting the version line in **both** files
+- The auto-bump is patch-only and structurally cannot cross a maturity boundary, so `maturity` and the maturity keyword in `keywords[]` are never touched by it. **Boundary crossings stay human** — make them on a `bump/…` branch, which the PR-time gate exempts
 
 ### Plugin Maturity Model
 
@@ -158,6 +161,7 @@ Managed by `cogni-workspace:install-mcp`. Plugin `.mcp.json` files reference ins
 
 - CLA required on first PR to core plugins (CLA Assistant bot prompts on PR)
 - Feature branches from `main`; one feature or fix per PR
+- Do **not** bump `plugin.json` / `marketplace.json` versions in the branch — the post-merge workflow applies the bump (see Version Management)
 - Validate skill names with `cogni-workspace/scripts/check-skill-names.sh` before PR
 - Keep maintainer breadcrumbs out of SKILL.md / agent files — `scripts/check-breadcrumbs.py` (CI: "Maintainer-breadcrumb guard" in `.github/workflows/lint.yml`) fails on newly introduced issue/PR refs (`#NNN`), version tags, or milestone/slice/finding codes. It ratchets against `scripts/baselines/breadcrumb-baseline.json`, so only *new* breadcrumbs trip it; fix by removing the breadcrumb and stating the rationale semantically (provenance lives in git history, CHANGELOG, and `references/`)
 - Generic skill names (`setup`, `scan`, `resume`, `dashboard`, `verify`) must be prefixed with the domain term

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,26 @@ A genuine load-bearing compatibility fact (e.g. "requires `gh` ≥ 2.40 because�
 python3 scripts/check-breadcrumbs.py --update-baseline
 ```
 
+### Version-Bump Gate
+
+**Do not bump a plugin version in your branch.** Every plugin's version lives in two places — `<plugin>/.claude-plugin/plugin.json` and the plugin's entry in the repo-root `.claude-plugin/marketplace.json` — and the `Version bump` workflow advances both, automatically, on merge to `main`, for each plugin your PR actually touched.
+
+The bump moved post-merge because that version line was the canonical merge-conflict class: when every PR bumped at authoring time, the instant one PR merged, every other open PR's version lines conflicted. Since `marketplace.json` is a single file shared by all 14 plugins, that conflict was repo-wide rather than per-plugin.
+
+The CI `Lint` workflow runs `scripts/check-version-bump.py` on every PR and fails on:
+
+- **`version-touched`** — your branch changed a version. Fix: revert the version line in **both** `plugin.json` and `marketplace.json` to the value on `main`.
+- **`version-mirror-desync`** — the two files disagree for some plugin. Fix: set them to the same value.
+
+Run it locally before a PR:
+
+```bash
+python3 scripts/check-version-bump.py     # fails (exit 1) on a touched version
+bash tests/test_check_version_bump.sh     # self-test the gate itself
+```
+
+A deliberate **maturity boundary crossing** (`0.x` → `1.0.0`, `1.x` → `2.0.0`) is the one case a human edits a version by hand. Make it on a `bump/…` branch — the gate exempts those, and the auto-bump is patch-only so it never crosses a boundary on its own.
+
 ---
 
 ## Publishing a Marketplace Plugin

--- a/docs/contributing/plugin-development.md
+++ b/docs/contributing/plugin-development.md
@@ -65,6 +65,8 @@ Create `my-plugin/.claude-plugin/plugin.json`:
 
 Use semantic versioning. Start at `0.1.0`. The `description` field appears in marketplace listings — describe the function, not the value.
 
+That initial version is the one version you author by hand. Every bump after it is applied post-merge by the `Version bump` workflow, which advances `plugin.json` and the `marketplace.json` mirror together for each plugin a merge touched. Do not bump a version in a feature branch — the PR-time version-bump gate fails on it.
+
 ### Create a `CLAUDE.md`
 
 Write a developer reference document at `my-plugin/CLAUDE.md`. This is the first file a developer reads when working on your plugin. Include:
@@ -302,6 +304,7 @@ To list your plugin, submit a PR to the insight-wave repository that adds your p
 - [ ] `LICENSE` file is present with Apache-2.0 text
 - [ ] Skill names pass the naming convention check
 - [ ] No external package dependencies in scripts
+- [ ] No version line changed — `plugin.json` and `marketplace.json` versions are advanced post-merge by the `Version bump` workflow
 
 ### Contribution Terms
 

--- a/scripts/apply-version-bump.py
+++ b/scripts/apply-version-bump.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""apply-version-bump.py — post-merge patch bump for every plugin a merge touched.
+
+The write half of the version contract whose read half is `check-version-bump.py`.
+Feature branches no longer author the `version` line (that single line was the
+canonical merge-conflict class — the instant one PR merged, every other open PR's
+version line became a textual conflict). This script is the sole actor that
+advances a version: `.github/workflows/cogni-version-bump.yml` runs it on every
+push to main and it patch-increments each plugin the merge actually touched, once.
+
+insight-wave mirrors every version into the root `.claude-plugin/marketplace.json`
+for Claude Desktop's update detection, so a bump is a PAIRED edit — `plugin.json`
+and the plugin's `marketplace.json` entry, or neither. A half-applied bump ships an
+invisible update, so this script never writes one file without the other.
+
+Safety properties, in the order they matter:
+
+  * ENUMERATION. Plugins come only from `marketplace.json` `plugins[].source`,
+    never a glob — stale `plugin.json` copies live under `.claude/worktrees/**`.
+
+  * PATCH-ONLY. Only the last version component is incremented, and only when it
+    is a plain non-negative integer. This structurally cannot cross a maturity
+    boundary (`0.0.x` stays `0.0.x`); boundary crossings stay human, per CLAUDE.md.
+
+  * SURGICAL EDIT. The version value is replaced by an anchored `re.subn` on the
+    file text rather than a `json.dump` round-trip. A round-trip would reformat
+    hand-maintained files and — without `ensure_ascii=False` — escape every
+    non-ASCII character in 14 descriptions.
+
+  * SCOPED MARKETPLACE EDIT. `marketplace.json` holds all 14 entries in one file,
+    so an unscoped regex could rewrite the wrong plugin, or the root
+    `metadata.version`. The replacement is confined to the text span between this
+    plugin's `"name": "<plugin>"` key and the next entry's `"name": "` key.
+
+  * VERIFY BEFORE WRITE. Nothing is written until the proposed new text is
+    re-parsed and structurally compared against the old parse: same keys, same
+    entry order, every field of every entry byte-identical except exactly the
+    intended `version` values. Any deviation aborts the whole run with exit 2 and
+    leaves the tree untouched. This is what makes a mis-scoped regex a loud
+    failure rather than a silent 14-entry corruption.
+
+A plugin whose pair is already out of sync, whose version tail is non-numeric, or
+whose anchor cannot be located exactly once is SKIPPED with a reason rather than
+guessed at — and skipping is total: neither file is written for that plugin.
+
+This script never shells out to git. The caller computes the touched-file set —
+the workflow does it in bash, where the push-shape edge cases (zero shas, a
+manual range, the fallback chain) are easiest to log — and hands it over as a
+plain list. That keeps every branch here exercisable from a fixture.
+
+Usage:
+    # normal (workflow) use
+    python3 scripts/apply-version-bump.py --changed-file changed-files.txt
+
+    # testing — supply the changed paths directly
+    python3 scripts/apply-version-bump.py --changed cogni-projects/README.md
+    python3 scripts/apply-version-bump.py --changed ... --dry-run
+
+Output: {"success": bool, "data": {"bumped": [...], "skipped": [...]}, "error": ""}
+Exit 0 = ran cleanly (including "nothing to bump"), 1 = a touched plugin was
+skipped with severity "error" (healthy plugins were still written — the caller
+pushes them, then fails), 2 = script or verification error, nothing written.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def fail(msg):
+    print(json.dumps({"success": False, "data": None, "error": msg},
+                     indent=2, ensure_ascii=False))
+    return 2
+
+
+def patch_increment(version):
+    """'1.2.9' -> '1.2.10'. None when the tail is not a plain integer."""
+    if not isinstance(version, str):
+        return None
+    comps = version.split(".")
+    if len(comps) < 2 or not comps[-1].isdigit():
+        return None
+    return ".".join(comps[:-1] + [str(int(comps[-1]) + 1)])
+
+
+def replace_version(text, old, new, start=0, end=None):
+    """Anchored single replacement of a `"version": "<old>"` value within a span.
+    Returns the new text, or None when the anchor is not found exactly once.
+
+    The replacement is a CALLABLE, never a replacement string. `new` is digits and
+    dots today, but a replacement string re-interprets backslashes and `\\g<N>`,
+    and that class of bug has no business living next to a 14-entry manifest.
+    """
+    end = len(text) if end is None else end
+    span = text[start:end]
+    pattern = r'("version"\s*:\s*")' + re.escape(old) + r'(")'
+    if len(re.findall(pattern, span)) != 1:
+        return None
+    new_span, n = re.subn(pattern, lambda m: m.group(1) + new + m.group(2),
+                          span, count=1)
+    if n != 1:
+        return None
+    return text[:start] + new_span + text[end:]
+
+
+def entry_span(text, plugin):
+    """Text span of one plugins[] entry: from its `"name": "<plugin>"` key up to
+    the next entry's `"name": "` key. Keeps the edit away from sibling entries and
+    from the root `metadata.version`, which precedes plugins[]."""
+    needle = '"name": "{}"'.format(plugin)
+    start = text.find(needle)
+    if start == -1 or text.find(needle, start + 1) != -1:
+        return None  # absent, or ambiguous
+    nxt = text.find('"name": "', start + len(needle))
+    return start, (nxt if nxt != -1 else len(text))
+
+
+def verify_plugin_json(old_text, new_text, new_version):
+    old, new = json.loads(old_text), json.loads(new_text)
+    if new.get("version") != new_version:
+        return "version did not land as {}".format(new_version)
+    if {k: v for k, v in old.items() if k != "version"} != \
+       {k: v for k, v in new.items() if k != "version"}:
+        return "a field other than `version` changed"
+    return None
+
+
+def verify_marketplace(old_text, new_text, expected):
+    """expected: {plugin_name: new_version}. Everything else must be identical."""
+    old, new = json.loads(old_text), json.loads(new_text)
+    if set(old) != set(new):
+        return "top-level keys changed"
+    for key in old:
+        if key != "plugins" and old[key] != new[key]:
+            return "root key `{}` changed".format(key)
+    o_plugins, n_plugins = old.get("plugins") or [], new.get("plugins") or []
+    if len(o_plugins) != len(n_plugins):
+        return "plugin count changed"
+    for o, n in zip(o_plugins, n_plugins):
+        name = o.get("name")
+        if n.get("name") != name:
+            return "entry order changed at `{}`".format(name)
+        want = expected.get(name, o.get("version"))
+        if n.get("version") != want:
+            return "entry `{}` version is {}, expected {}".format(
+                name, n.get("version"), want)
+        if {k: v for k, v in o.items() if k != "version"} != \
+           {k: v for k, v in n.items() if k != "version"}:
+            return "entry `{}` changed a field other than `version`".format(name)
+    return None
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description="Patch-bump the version of every plugin a merge touched, in "
+                    "both plugin.json and marketplace.json.")
+    parser.add_argument("--root", default=None,
+                        help="Repo root (default: the repo containing this script).")
+    parser.add_argument("--changed-file", default=None,
+                        help="File of newline-separated repo-relative paths the "
+                             "merge touched; '-' reads stdin.")
+    parser.add_argument("--changed", nargs="*", default=None,
+                        help="Changed paths, supplied directly (testing).")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Compute and verify, but write nothing.")
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.root).resolve() if args.root \
+        else Path(__file__).resolve().parent.parent
+
+    market_path = repo_root / ".claude-plugin" / "marketplace.json"
+    if not market_path.is_file():
+        return fail("marketplace manifest not found at {}".format(market_path))
+    try:
+        market_text = market_path.read_text(encoding="utf-8")
+        manifest = json.loads(market_text)
+    except (json.JSONDecodeError, OSError) as exc:
+        return fail("marketplace.json does not parse as JSON: {}".format(exc))
+
+    if args.changed is not None:
+        changed = [c.strip() for c in args.changed if c.strip()]
+    elif args.changed_file:
+        try:
+            blob = sys.stdin.read() if args.changed_file == "-" \
+                else Path(args.changed_file).read_text(encoding="utf-8")
+        except OSError as exc:
+            return fail("cannot read changed-file list: {}".format(exc))
+        changed = [line.strip() for line in blob.splitlines() if line.strip()]
+    else:
+        return fail("one of --changed-file or --changed is required")
+
+    bumped, skipped = [], []
+    market_new_text = market_text
+    expected = {}
+    pending_plugin_writes = []  # (path, new_text)
+
+    for entry in manifest.get("plugins") or []:
+        source = (entry.get("source") or "").lstrip("./")
+        if not source:
+            continue
+        name = entry.get("name") or source
+
+        if not any(p == source or p.startswith("{}/".format(source))
+                   for p in changed):
+            continue
+
+        rel_manifest = "{}/.claude-plugin/plugin.json".format(source)
+        plugin_path = repo_root / rel_manifest
+
+        def skip(reason, severity="warning"):
+            skipped.append({"plugin": name, "severity": severity, "reason": reason})
+
+        if not plugin_path.is_file():
+            skip("plugin.json not found at {}".format(rel_manifest))
+            continue
+        try:
+            plugin_text = plugin_path.read_text(encoding="utf-8")
+            old_version = json.loads(plugin_text).get("version")
+        except (json.JSONDecodeError, OSError) as exc:
+            skip("plugin.json does not parse: {}".format(exc))
+            continue
+
+        # Mirror precondition. Which of the two is authoritative is not this
+        # script's call to make, so bump neither and surface it for a human.
+        if old_version != entry.get("version"):
+            skip("mirror drift: plugin.json says {} but marketplace.json says {} "
+                 "— reconcile by hand, then re-run; the version cannot advance "
+                 "until they agree".format(old_version, entry.get("version")),
+                 severity="error")
+            continue
+
+        new_version = patch_increment(old_version)
+        if new_version is None:
+            skip("unexpected version shape '{}'".format(old_version))
+            continue
+
+        plugin_new_text = replace_version(plugin_text, old_version, new_version)
+        if plugin_new_text is None:
+            skip("could not locate exactly one version value in {}".format(
+                rel_manifest), severity="error")
+            continue
+        problem = verify_plugin_json(plugin_text, plugin_new_text, new_version)
+        if problem:
+            return fail("{}: verification failed — {}".format(rel_manifest, problem))
+
+        # Re-derived from the WORKING text on every iteration, not computed once
+        # up front: a `...9 -> ...10` bump grows the file by a byte and shifts
+        # every later span, so a cached span would misplace the next plugin's
+        # edit in a multi-plugin merge.
+        span = entry_span(market_new_text, name)
+        if span is None:
+            skip("could not locate a unique marketplace.json entry for {}".format(name),
+                 severity="error")
+            continue
+        candidate = replace_version(market_new_text, old_version, new_version,
+                                    span[0], span[1])
+        if candidate is None:
+            skip("could not locate exactly one version value in the "
+                 "marketplace.json entry for {}".format(name), severity="error")
+            continue
+
+        market_new_text = candidate
+        expected[name] = new_version
+        pending_plugin_writes.append((plugin_path, plugin_new_text))
+        bumped.append({"plugin": name, "source": source,
+                       "old": old_version, "new": new_version})
+
+    if bumped:
+        # One structural check over the accumulated marketplace edits. Runs before
+        # anything is written, so a mis-scoped replacement aborts with a clean tree.
+        problem = verify_marketplace(market_text, market_new_text, expected)
+        if problem:
+            return fail("marketplace.json verification failed — {}".format(problem))
+
+        if not args.dry_run:
+            for path, text in pending_plugin_writes:
+                path.write_text(text, encoding="utf-8")
+            market_path.write_text(market_new_text, encoding="utf-8")
+
+    paths = [b["source"] + "/.claude-plugin/plugin.json" for b in bumped]
+    if bumped:
+        paths.append(".claude-plugin/marketplace.json")
+
+    # A hard skip means a touched plugin's version silently stops advancing —
+    # that must be loud. The healthy plugins in the same merge were still
+    # written, so the caller pushes them and fails the run afterwards rather than
+    # stalling every other plugin behind one drifted manifest.
+    hard = [s for s in skipped if s["severity"] == "error"]
+
+    print(json.dumps({
+        "success": not hard,
+        "data": {
+            "bumped": bumped,
+            "skipped": skipped,
+            "paths_to_stage": paths,
+            "dry_run": bool(args.dry_run),
+        },
+        "error": "",
+    }, indent=2, ensure_ascii=False))
+
+    for s in skipped:
+        print("{}: version-bump skipped {}: {}".format(
+            s["severity"].upper(), s["plugin"], s["reason"]), file=sys.stderr)
+    for b in bumped:
+        print("bumped {} {} -> {}".format(b["plugin"], b["old"], b["new"]),
+              file=sys.stderr)
+    return 1 if hard else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-version-bump.py
+++ b/scripts/check-version-bump.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""check-version-bump.py — deterministic guard on plugin `version` lines.
+
+Two independent assertions, both anchored on `.claude-plugin/marketplace.json`
+as the single enumeration source of truth:
+
+  1. MIRROR INVARIANT (every plugin, every mode, always).
+     Each plugin's `<source>/.claude-plugin/plugin.json` `version` must equal the
+     mirrored `version` on its root `marketplace.json` entry. Claude Desktop reads
+     the marketplace copy for update detection, so advancing one without the other
+     ships an invisible update. This check needs no git history, so it still runs
+     (and still fails the build) when the git-anchored check below degrades.
+
+  2. TOUCH / INCREMENT (git-anchored, mode-dependent).
+
+     * `pr` mode (default) — a feature branch must NOT touch the version of any
+       plugin whose files it changes. The bump is applied post-merge by
+       `.github/workflows/cogni-version-bump.yml`, per plugin actually touched.
+
+       Why the inversion. When every PR bumped the version at authoring time, that
+       single line was the canonical merge-conflict class: the instant one PR
+       merged, main's version advanced and every other open PR's version line
+       became a textual conflict — a stale-below-main value or a same-value sibling
+       collision. N-1 of N in-flight PRs were structurally guaranteed to conflict,
+       and each merge cascaded into the next. Moving the bump post-merge removes
+       the line the PRs fought over; this gate enforces that at PR time.
+
+     * `post-merge` mode — restores the strict-greater assertion so the bump
+       workflow can verify its own freshly written increment before pushing:
+       `version-not-incremented` when equal, `version-regressed` when lower.
+
+Both git references are fork-point relative, on purpose:
+
+  * WHICH plugins to check — the touched set, from the three-dot diff
+    `git diff --name-only <base>...HEAD`.
+  * WHAT to compare against — the version at the MERGE-BASE, via
+    `git show $(git merge-base <base> HEAD):<source>/.claude-plugin/plugin.json`.
+
+Anchoring on the merge-base rather than the base ref TIP is what makes "untouched"
+drift-immune. Main's version now advances on every merge, so a legitimately
+untouched PR that forked earlier sits BELOW the current tip — a tip anchor would
+false-flag it as `version-touched`. The fork point is the value the PR's own diff
+is measured against, so head == fork-point is exactly "this branch did not touch
+the version". In post-merge mode HEAD descends straight from the base tip, so the
+merge-base and the tip coincide and the strict-greater assertion is unaffected.
+
+Plugins are enumerated ONLY from `marketplace.json` `plugins[].source` — never a
+glob. Stale `plugin.json` copies live under `.claude/worktrees/**`, and a
+glob-based scan would read those.
+
+Degradation is deliberate. An unresolvable base ref (offline runner, shallow
+clone — git exits 128) yields `status: "degraded"` and exit 0 for the git-anchored
+half. A guard that hard-failed when it cannot see the baseline would block every
+legitimate PR on a constrained runner, which is worse than not checking. The cost
+is that a degraded run provides no touch signal at all, so CALLERS MUST ASSERT
+`data.status != "degraded"` themselves — `.github/workflows/lint.yml` does exactly
+that, which is what keeps `fetch-depth: 0` from being silently droppable.
+
+Usage:
+    python3 scripts/check-version-bump.py [--root DIR] [--mode pr|post-merge]
+                                          [--base-ref REF]
+
+    --root defaults to the repo containing this script.
+    VERSION_BUMP_BASE_REF  overrides --base-ref (default: origin/main).
+    VERSION_BUMP_MODE      overrides --mode.
+    VERSION_BUMP_BRANCH    overrides the branch name used for the ^bump/ exemption.
+
+stdlib only; runs under any python3. Exit 0 = clean (or git-degraded with no
+mirror violation), 1 = violation(s) found, 2 = script error.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+METRIC_VERSION = "1"
+DEFAULT_BASE_REF = "origin/main"
+
+# Human-readable remediation per violation code, printed to stderr so a failing
+# CI job tells the contributor what to do without a round-trip to the docs.
+FIX_HINTS = {
+    "version-touched": (
+        "Revert the version line — feature branches must not touch it. The "
+        "post-merge cogni-version-bump workflow applies the patch bump on merge."
+    ),
+    "version-mirror-desync": (
+        "plugin.json and marketplace.json disagree. Set both to the same value; "
+        "they are mirrored for Claude Desktop update detection."
+    ),
+    "version-not-incremented": (
+        "post-merge: the auto-bump did not advance this plugin's version."
+    ),
+    "version-regressed": (
+        "post-merge: the auto-bump decreased this plugin's version."
+    ),
+    "version-unparseable": "Version value is not a comparable dot-separated string.",
+    "manifest-missing": "plugin.json is absent despite changed files under the plugin.",
+    "manifest-invalid": "plugin.json does not parse as JSON.",
+}
+
+
+def git(repo_root, *args):
+    """Run a git command in repo_root. Returns (exit_code, stdout, stderr)."""
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def parse_version(raw):
+    """Dot-separated version -> comparable tuple.
+
+    Numeric components compare numerically; a non-numeric component falls back to
+    a string compare at that position. Returns None for an unusable value.
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    parts = []
+    for comp in raw.strip().split("."):
+        if comp.isdigit():
+            parts.append((0, int(comp), ""))
+        else:
+            parts.append((1, 0, comp))
+    return tuple(parts)
+
+
+def compare(head, base):
+    """-1 / 0 / 1 for head vs base, padding to equal length. None if unparseable."""
+    h, b = parse_version(head), parse_version(base)
+    if h is None or b is None:
+        return None
+    pad = max(len(h), len(b))
+    h = h + ((0, 0, ""),) * (pad - len(h))
+    b = b + ((0, 0, ""),) * (pad - len(b))
+    return (h > b) - (h < b)
+
+
+def read_version(path):
+    """(version, error_code) from a plugin.json path."""
+    if not path.is_file():
+        return None, "manifest-missing"
+    try:
+        return json.loads(path.read_text(encoding="utf-8")).get("version"), None
+    except (json.JSONDecodeError, OSError):
+        return None, "manifest-invalid"
+
+
+def current_branch(repo_root):
+    """Branch name for the ^bump/ exemption: explicit override, else the Actions
+    PR source branch, else the checked-out branch. Empty when detached/unknown."""
+    override = os.environ.get("VERSION_BUMP_BRANCH") or os.environ.get("GITHUB_HEAD_REF")
+    if override:
+        return override.strip()
+    rc, out, _ = git(repo_root, "rev-parse", "--abbrev-ref", "HEAD")
+    return out.strip() if rc == 0 else ""
+
+
+def fail(msg):
+    print(json.dumps({"success": False, "data": None, "error": msg},
+                     indent=2, ensure_ascii=False))
+    return 2
+
+
+def emit(data):
+    """Print the JSON envelope to stdout and a human summary to stderr."""
+    violations = data["violations"]
+    print(json.dumps({"success": not violations, "data": data, "error": ""},
+                     indent=2, ensure_ascii=False), flush=True)
+
+    print(
+        "\nversion-bump gate [{}] mode={}: {} plugin(s) scanned, {} touched, "
+        "{} violation(s) vs {}".format(
+            data["status"], data["mode"], data["plugins_scanned"],
+            len(data["plugins_touched"]), data["count"], data["base_ref"]),
+        file=sys.stderr,
+    )
+    if data["status"] == "degraded":
+        print("  degraded: {}".format(data.get("degraded_reason", "")), file=sys.stderr)
+    if violations:
+        print("\nFAIL: {} version violation(s):".format(len(violations)), file=sys.stderr)
+        for v in violations:
+            print("  {} [{}] {}".format(v["path"], v["check"], v["detail"]), file=sys.stderr)
+        print("\nFix:", file=sys.stderr)
+        for code in sorted({v["check"] for v in violations}):
+            print("  {}: {}".format(code, FIX_HINTS.get(code, "")), file=sys.stderr)
+    return 1 if violations else 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description="Guard plugin version lines: mirror invariant plus a "
+                    "git-anchored touch (pr) or increment (post-merge) check.")
+    parser.add_argument("--root", default=None,
+                        help="Repo root holding .claude-plugin/marketplace.json "
+                             "(default: the repo containing this script).")
+    parser.add_argument("--mode", choices=("pr", "post-merge"), default=None,
+                        help="pr (default): versions must be untouched vs the fork "
+                             "point. post-merge: versions must be strictly greater.")
+    parser.add_argument("--base-ref", default=None,
+                        help="Ref to compare against (default: origin/main).")
+    args = parser.parse_args(argv)
+
+    mode =(args.mode or os.environ.get("VERSION_BUMP_MODE") or "pr").strip().lower()
+    if mode not in ("pr", "post-merge"):
+        mode = "pr"
+    base_ref = (args.base_ref or os.environ.get("VERSION_BUMP_BASE_REF")
+                or DEFAULT_BASE_REF)
+
+    repo_root = Path(args.root).resolve() if args.root \
+        else Path(__file__).resolve().parent.parent
+
+    manifest_path = repo_root / ".claude-plugin" / "marketplace.json"
+    if not manifest_path.is_file():
+        return fail("marketplace manifest not found at {}".format(manifest_path))
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        return fail("marketplace.json does not parse as JSON: {}".format(exc))
+
+    plugins = manifest.get("plugins") or []
+    violations = []
+
+    # --- 1. Mirror invariant (no git required, so it survives degradation) ----
+    for entry in plugins:
+        source = (entry.get("source") or "").lstrip("./")
+        if not source:
+            continue
+        name = entry.get("name") or source
+        rel_manifest = "{}/.claude-plugin/plugin.json".format(source)
+        plugin_version, err = read_version(repo_root / rel_manifest)
+        market_version = entry.get("version")
+        if err:
+            violations.append({
+                "plugin": name, "path": rel_manifest,
+                "head_version": None, "base_version": None, "check": err,
+                "detail": "{} could not be read for the mirror check".format(rel_manifest),
+            })
+            continue
+        if plugin_version != market_version:
+            violations.append({
+                "plugin": name, "path": ".claude-plugin/marketplace.json",
+                "head_version": plugin_version, "base_version": market_version,
+                "check": "version-mirror-desync",
+                "detail": "{} is {} but its marketplace.json entry says {}".format(
+                    rel_manifest, plugin_version, market_version),
+            })
+
+    def envelope(status, touched, degraded_reason=None):
+        data = {
+            "clean": not violations,
+            "status": status,
+            "mode": mode,
+            "count": len(violations),
+            "violations": violations,
+            "plugins_scanned": len(plugins),
+            "plugins_touched": touched,
+            "base_ref": base_ref,
+            "metric_version": METRIC_VERSION,
+        }
+        if degraded_reason:
+            data["degraded_reason"] = degraded_reason
+        return data
+
+    # --- 2. Git-anchored touch / increment check -----------------------------
+    rc, _, err = git(repo_root, "rev-parse", "--verify", "--quiet",
+                     "{}^{{commit}}".format(base_ref))
+    if rc != 0:
+        return emit(envelope(
+            "degraded", [],
+            "base ref '{}' not available (offline, shallow clone, or unfetched)"
+            .format(base_ref)))
+
+    # ^bump/-branch exemption (pr mode only). A branch whose whole purpose is to
+    # touch the version is exempt; in post-merge mode we run on main and want the
+    # assertion, so the exemption is deliberately pr-only.
+    if mode == "pr":
+        branch = current_branch(repo_root)
+        if branch.startswith("bump/"):
+            data = envelope("ok", [])
+            data["exempt_branch"] = branch
+            return emit(data)
+
+    rc, out, err = git(repo_root, "diff", "--name-only", "{}...HEAD".format(base_ref))
+    if rc != 0:
+        return emit(envelope(
+            "degraded", [],
+            "could not diff against '{}': {}".format(base_ref, (err or "").strip()[:200])))
+    changed = [line.strip() for line in out.splitlines() if line.strip()]
+
+    rc, mb_out, _ = git(repo_root, "merge-base", base_ref, "HEAD")
+    compare_ref = mb_out.strip() if rc == 0 and mb_out.strip() else base_ref
+
+    touched = []
+    for entry in plugins:
+        source = (entry.get("source") or "").lstrip("./")
+        if not source:
+            continue
+        name = entry.get("name") or source
+        rel_manifest = "{}/.claude-plugin/plugin.json".format(source)
+
+        # A plugin with no changed files is a no-op. This is what keeps a
+        # legitimately untouched plugin (head == base) from being read as the
+        # illegitimate same-value sibling collision (also head == base).
+        if not any(p == source or p.startswith("{}/".format(source)) for p in changed):
+            continue
+        touched.append(name)
+
+        head_version, err = read_version(repo_root / rel_manifest)
+        if err:
+            continue  # already recorded by the mirror pass
+
+        rc, base_text, _ = git(repo_root, "show", "{}:{}".format(compare_ref, rel_manifest))
+        if rc != 0:
+            # Absent at the fork point => a brand-new plugin. Nothing to compare
+            # against, so it cannot have been touched or regressed.
+            continue
+        try:
+            base_version = json.loads(base_text).get("version")
+        except json.JSONDecodeError:
+            continue
+
+        cmp = compare(head_version, base_version)
+        if cmp is None:
+            violations.append({
+                "plugin": name, "path": rel_manifest,
+                "head_version": head_version, "base_version": base_version,
+                "check": "version-unparseable",
+                "detail": "cannot compare version '{}' against '{}'".format(
+                    head_version, base_version),
+            })
+        elif mode == "post-merge":
+            if cmp == 0:
+                violations.append({
+                    "plugin": name, "path": rel_manifest,
+                    "head_version": head_version, "base_version": base_version,
+                    "check": "version-not-incremented",
+                    "detail": "post-merge: version {} equals {} — the auto-bump did "
+                              "not advance {}/'s version.".format(
+                                  head_version, base_ref, source),
+                })
+            elif cmp < 0:
+                violations.append({
+                    "plugin": name, "path": rel_manifest,
+                    "head_version": head_version, "base_version": base_version,
+                    "check": "version-regressed",
+                    "detail": "post-merge: version {} is BELOW {}'s {} — the "
+                              "auto-bump decreased it.".format(
+                                  head_version, base_ref, base_version),
+                })
+        elif cmp != 0:
+            violations.append({
+                "plugin": name, "path": rel_manifest,
+                "head_version": head_version, "base_version": base_version,
+                "check": "version-touched",
+                "detail": "version changed from {} to {} on this branch, but feature "
+                          "branches must not touch {}/'s version — the post-merge "
+                          "cogni-version-bump workflow owns the bump. Revert the "
+                          "version line to {} (in plugin.json and marketplace.json)."
+                          .format(base_version, head_version, source, base_version),
+            })
+
+    return emit(envelope("ok", touched))
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_apply_version_bump.sh
+++ b/tests/test_apply_version_bump.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# test_apply_version_bump.sh — self-test for the post-merge version bumper.
+#
+# The bumper rewrites TWO manifests per plugin: `<plugin>/.claude-plugin/plugin.json`
+# and that plugin's entry inside the single shared root `.claude-plugin/marketplace.json`.
+# The shared file is the risk: an unscoped regex could rewrite a sibling entry or the
+# root `metadata.version`. Cases:
+#   1. Single-plugin bump -> both manifests advance, together.
+#   2. Digit carry 0.0.9 -> 0.0.10 (the byte-growth case that shifts later spans).
+#   3. Version collision -> two plugins share a version string; only the touched
+#      one moves. This is the test an unscoped regex fails.
+#   4. metadata.version immunity -> root metadata carries the same version string
+#      as a bumped plugin and must not move.
+#   5. Multi-plugin merge -> three plugins in one run, spans re-derived after each
+#      edit so a carry in plugin #1 cannot misplace plugin #3's edit.
+#   6. Non-numeric tail -> skipped as a warning, exit 0, nothing written.
+#   7. Mirror drift -> skipped as an error, exit 1, that plugin untouched, but a
+#      co-touched healthy plugin still bumps (partial progress, loud failure).
+#   8. Untouched plugin -> never bumped.
+#   9. --dry-run -> computes and verifies, writes nothing.
+#  10. Formatting + non-ASCII preserved byte-for-byte (no json.dump round-trip).
+#  11. Real tree, --dry-run, empty touched set -> clean no-op.
+#
+# bash 3.2 + stdlib python3 only. No git required (the touched set is passed in).
+
+set -eu
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+BUMPER="$REPO_ROOT/scripts/apply-version-bump.py"
+
+red()   { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+
+FAILED=0
+check() {  # check <label> <condition-exit-code>
+  if [ "$2" -eq 0 ]; then
+    green "PASS: $1"
+  else
+    red "FAIL: $1"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Builds a fixture repo at $1. Three plugins:
+#   alpha  1.0.70  — ordinary
+#   beta   0.0.9   — carry case, and shares its version string with gamma
+#   gamma  0.0.9   — collision partner; description carries non-ASCII
+# Root metadata.version is also 0.0.9, so it collides too (case 4).
+make_fixture() {
+  local root="$1"
+  mkdir -p "$root/.claude-plugin" "$root/alpha/.claude-plugin" \
+           "$root/beta/.claude-plugin" "$root/gamma/.claude-plugin"
+  cat > "$root/.claude-plugin/marketplace.json" <<'JSON'
+{
+  "name": "fixture",
+  "metadata": {
+    "description": "fixture marketplace",
+    "version": "0.0.9"
+  },
+  "plugins": [
+    {
+      "name": "alpha",
+      "source": "./alpha",
+      "version": "1.0.70",
+      "maturity": "released",
+      "description": "Alpha — plain ASCII.",
+      "keywords": ["alpha", "released"]
+    },
+    {
+      "name": "beta",
+      "source": "./beta",
+      "version": "0.0.9",
+      "maturity": "incubating",
+      "description": "Beta — carry case.",
+      "keywords": ["beta", "incubating"]
+    },
+    {
+      "name": "gamma",
+      "source": "./gamma",
+      "version": "0.0.9",
+      "maturity": "incubating",
+      "description": "Gamma — Größe, Prüfung, ä ö ü ß, é è ê ç.",
+      "keywords": ["gamma", "incubating"]
+    }
+  ]
+}
+JSON
+  printf '{\n  "name": "alpha",\n  "version": "1.0.70",\n  "description": "Alpha"\n}\n' \
+    > "$root/alpha/.claude-plugin/plugin.json"
+  printf '{\n  "name": "beta",\n  "version": "0.0.9",\n  "description": "Beta"\n}\n' \
+    > "$root/beta/.claude-plugin/plugin.json"
+  printf '{\n  "name": "gamma",\n  "version": "0.0.9",\n  "description": "Gamma — ä ö ü ß"\n}\n' \
+    > "$root/gamma/.claude-plugin/plugin.json"
+  : > "$root/alpha/file.md"
+  : > "$root/beta/file.md"
+  : > "$root/gamma/file.md"
+}
+
+# version_of <root> <plugin>  -> "<plugin.json version>|<marketplace version>"
+version_of() {
+  python3 - "$1" "$2" <<'PY'
+import json, sys, pathlib
+root, plugin = pathlib.Path(sys.argv[1]), sys.argv[2]
+pj = json.loads((root / plugin / ".claude-plugin" / "plugin.json").read_text())["version"]
+mk = json.loads((root / ".claude-plugin" / "marketplace.json").read_text())
+mv = [e for e in mk["plugins"] if e["name"] == plugin][0]["version"]
+print("%s|%s" % (pj, mv))
+PY
+}
+
+meta_version_of() {
+  python3 -c "import json,sys;print(json.load(open(sys.argv[1]+'/.claude-plugin/marketplace.json'))['metadata']['version'])" "$1"
+}
+
+# ---------------------------------------------------------------------------
+# Cases 1–5: a three-plugin run exercising carry, collision, metadata immunity
+# and span re-derivation all at once.
+# ---------------------------------------------------------------------------
+R="$WORK/multi"
+make_fixture "$R"
+set +e
+python3 "$BUMPER" --root "$R" --changed alpha/file.md beta/file.md gamma/file.md \
+  > "$WORK/multi.json" 2>/dev/null
+MULTI_RC=$?
+set -e
+
+check "case 1/5: multi-plugin run exits 0" "$([ "$MULTI_RC" -eq 0 ] && echo 0 || echo 1)"
+check "case 1: alpha 1.0.70 -> 1.0.71 in both manifests" \
+  "$([ "$(version_of "$R" alpha)" = "1.0.71|1.0.71" ] && echo 0 || echo 1)"
+check "case 2: beta carry 0.0.9 -> 0.0.10 in both manifests" \
+  "$([ "$(version_of "$R" beta)" = "0.0.10|0.0.10" ] && echo 0 || echo 1)"
+check "case 3: gamma (collides with beta on 0.0.9) -> 0.0.10 in both manifests" \
+  "$([ "$(version_of "$R" gamma)" = "0.0.10|0.0.10" ] && echo 0 || echo 1)"
+check "case 4: root metadata.version stays 0.0.9" \
+  "$([ "$(meta_version_of "$R")" = "0.0.9" ] && echo 0 || echo 1)"
+
+# ---------------------------------------------------------------------------
+# Case 10: formatting and non-ASCII survive — only version VALUES may differ.
+# ---------------------------------------------------------------------------
+R2="$WORK/fmt"
+make_fixture "$R2"
+cp "$R2/.claude-plugin/marketplace.json" "$WORK/marketplace.before"
+python3 "$BUMPER" --root "$R2" --changed gamma/file.md >/dev/null 2>&1
+DIFF_LINES="$(diff "$WORK/marketplace.before" "$R2/.claude-plugin/marketplace.json" \
+  | grep -c '^[<>]' || true)"
+check "case 10: exactly 2 changed lines in marketplace.json (one -, one +)" \
+  "$([ "$DIFF_LINES" -eq 2 ] && echo 0 || echo 1)"
+check "case 10: non-ASCII description preserved verbatim" \
+  "$(grep -q 'Größe, Prüfung, ä ö ü ß, é è ê ç' "$R2/.claude-plugin/marketplace.json" && echo 0 || echo 1)"
+check "case 10: keywords array untouched" \
+  "$(grep -q '"keywords": \["gamma", "incubating"\]' "$R2/.claude-plugin/marketplace.json" && echo 0 || echo 1)"
+check "case 8: untouched alpha still 1.0.70" \
+  "$([ "$(version_of "$R2" alpha)" = "1.0.70|1.0.70" ] && echo 0 || echo 1)"
+
+# ---------------------------------------------------------------------------
+# Case 6: non-numeric version tail -> warning skip, exit 0, nothing written.
+# ---------------------------------------------------------------------------
+R3="$WORK/nonnumeric"
+make_fixture "$R3"
+python3 - "$R3" <<'PY'
+import json, pathlib, sys, re
+root = pathlib.Path(sys.argv[1])
+for p in (root / "alpha/.claude-plugin/plugin.json",):
+    p.write_text(p.read_text().replace('"1.0.70"', '"0.1.0-rc1"'))
+m = root / ".claude-plugin/marketplace.json"
+m.write_text(m.read_text().replace('"version": "1.0.70"', '"version": "0.1.0-rc1"'))
+PY
+set +e
+python3 "$BUMPER" --root "$R3" --changed alpha/file.md > "$WORK/nn.json" 2>/dev/null
+NN_RC=$?
+set -e
+NN_SEV="$(python3 -c "import json,sys;d=json.load(open(sys.argv[1]))['data'];print(d['skipped'][0]['severity'] if d['skipped'] else 'NONE')" "$WORK/nn.json")"
+check "case 6: non-numeric tail exits 0" "$([ "$NN_RC" -eq 0 ] && echo 0 || echo 1)"
+check "case 6: non-numeric tail skipped as warning" \
+  "$([ "$NN_SEV" = "warning" ] && echo 0 || echo 1)"
+check "case 6: nothing written for the skipped plugin" \
+  "$([ "$(version_of "$R3" alpha)" = "0.1.0-rc1|0.1.0-rc1" ] && echo 0 || echo 1)"
+
+# ---------------------------------------------------------------------------
+# Case 7: mirror drift -> error skip, exit 1, but a co-touched healthy plugin
+# still bumps. Partial progress, loud failure.
+# ---------------------------------------------------------------------------
+R4="$WORK/drift"
+make_fixture "$R4"
+python3 - "$R4" <<'PY'
+import pathlib, sys
+p = pathlib.Path(sys.argv[1]) / "alpha/.claude-plugin/plugin.json"
+p.write_text(p.read_text().replace('"1.0.70"', '"1.0.69"'))  # drift vs marketplace
+PY
+set +e
+python3 "$BUMPER" --root "$R4" --changed alpha/file.md beta/file.md \
+  > "$WORK/drift.json" 2>/dev/null
+DRIFT_RC=$?
+set -e
+DRIFT_SEV="$(python3 -c "import json,sys;d=json.load(open(sys.argv[1]))['data'];print(d['skipped'][0]['severity'] if d['skipped'] else 'NONE')" "$WORK/drift.json")"
+check "case 7: mirror drift exits 1" "$([ "$DRIFT_RC" -eq 1 ] && echo 0 || echo 1)"
+check "case 7: mirror drift skipped as error" \
+  "$([ "$DRIFT_SEV" = "error" ] && echo 0 || echo 1)"
+check "case 7: drifted alpha left untouched" \
+  "$([ "$(version_of "$R4" alpha)" = "1.0.69|1.0.70" ] && echo 0 || echo 1)"
+check "case 7: co-touched healthy beta still bumped" \
+  "$([ "$(version_of "$R4" beta)" = "0.0.10|0.0.10" ] && echo 0 || echo 1)"
+
+# ---------------------------------------------------------------------------
+# Case 9: --dry-run writes nothing.
+# ---------------------------------------------------------------------------
+R5="$WORK/dry"
+make_fixture "$R5"
+python3 "$BUMPER" --root "$R5" --changed alpha/file.md --dry-run >/dev/null 2>&1
+check "case 9: --dry-run leaves both manifests untouched" \
+  "$([ "$(version_of "$R5" alpha)" = "1.0.70|1.0.70" ] && echo 0 || echo 1)"
+
+# ---------------------------------------------------------------------------
+# Case 11: real tree, --dry-run, empty touched set -> clean no-op.
+# ---------------------------------------------------------------------------
+set +e
+python3 "$BUMPER" --root "$REPO_ROOT" --changed README.md --dry-run \
+  > "$WORK/real.json" 2>/dev/null
+REAL_RC=$?
+set -e
+REAL_N="$(python3 -c "import json,sys;print(len(json.load(open(sys.argv[1]))['data']['bumped']))" "$WORK/real.json")"
+check "case 11: real tree, no plugin touched -> exit 0, zero bumps" \
+  "$([ "$REAL_RC" -eq 0 ] && [ "$REAL_N" -eq 0 ] && echo 0 || echo 1)"
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+  green "All apply-version-bump tests passed."
+else
+  red "$FAILED test(s) failed."
+  exit 1
+fi

--- a/tests/test_check_version_bump.sh
+++ b/tests/test_check_version_bump.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# test_check_version_bump.sh — self-test for the version-bump gate.
+#
+# The gate makes two assertions: a git-independent MIRROR invariant (plugin.json
+# version == its marketplace.json entry version) and a git-anchored TOUCH check
+# (pr mode: untouched vs the fork point / post-merge mode: strictly greater).
+# Cases:
+#   1. pr, plugin touched but version untouched -> clean, exit 0.
+#   2. pr, version touched -> version-touched, exit 1.
+#   3. pr, stale-below-main -> CLEAN. The branch never touched the version but
+#      main advanced past it after the fork. This is the merge-base-anchoring
+#      regression test: a base-TIP anchor would false-flag this, and since main's
+#      version now advances on every merge it would false-flag most real PRs.
+#   4. pr, ^bump/ branch -> exempt, clean.
+#   5. post-merge, incremented -> clean, exit 0.
+#   6. post-merge, not incremented -> version-not-incremented, exit 1.
+#   7. post-merge, regressed -> version-regressed, exit 1.
+#   8. mirror drift -> version-mirror-desync in BOTH modes.
+#   9. degraded (no origin/main) -> status degraded, exit 0 — and a mirror
+#      violation is STILL reported, proving the mirror half needs no git.
+#  10. Real tree -> clean (the repo is in sync today).
+#
+# bash 3.2 + stdlib python3 + git.
+
+set -eu
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+GATE="$REPO_ROOT/scripts/check-version-bump.py"
+
+red()   { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+
+FAILED=0
+check() {  # check <label> <condition-exit-code>
+  if [ "$2" -eq 0 ]; then
+    green "PASS: $1"
+  else
+    red "FAIL: $1"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+GIT="git -c user.email=t@test -c user.name=test -c commit.gpgsign=false"
+
+# run_gate <root> [args...] -> prints "<exit>|<status>|<comma-separated checks>"
+run_gate() {
+  local root="$1"; shift
+  local out rc
+  set +e
+  out="$(cd "$root" && python3 "$GATE" --root "$root" "$@" 2>/dev/null)"
+  rc=$?
+  set -e
+  printf '%s|%s' "$rc" "$(printf '%s' "$out" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)["data"]
+codes = ",".join(sorted({v["check"] for v in d["violations"]})) or "EMPTY"
+print("%s|%s" % (d["status"], codes))
+')"
+}
+
+# Two plugins; alpha is the one under test.
+make_repo() {
+  local root="$1"
+  mkdir -p "$root/.claude-plugin" "$root/alpha/.claude-plugin" "$root/beta/.claude-plugin"
+  cat > "$root/.claude-plugin/marketplace.json" <<'JSON'
+{
+  "name": "fixture",
+  "plugins": [
+    {
+      "name": "alpha",
+      "source": "./alpha",
+      "version": "1.0.70"
+    },
+    {
+      "name": "beta",
+      "source": "./beta",
+      "version": "0.0.9"
+    }
+  ]
+}
+JSON
+  printf '{\n  "name": "alpha",\n  "version": "1.0.70"\n}\n' \
+    > "$root/alpha/.claude-plugin/plugin.json"
+  printf '{\n  "name": "beta",\n  "version": "0.0.9"\n}\n' \
+    > "$root/beta/.claude-plugin/plugin.json"
+  : > "$root/alpha/file.md"
+  (cd "$root" && $GIT init -q -b main && $GIT add -A && $GIT commit -qm base \
+     && $GIT update-ref refs/remotes/origin/main HEAD)
+}
+
+set_version() {  # set_version <root> <plugin> <old> <new> [both|plugin-only]
+  python3 - "$1" "$2" "$3" "$4" "${5:-both}" <<'PY'
+import pathlib, sys
+root, plugin, old, new, scope = (sys.argv[1], sys.argv[2], sys.argv[3],
+                                 sys.argv[4], sys.argv[5])
+root = pathlib.Path(root)
+p = root / plugin / ".claude-plugin" / "plugin.json"
+p.write_text(p.read_text().replace('"version": "%s"' % old,
+                                   '"version": "%s"' % new, 1))
+if scope == "both":
+    m = root / ".claude-plugin" / "marketplace.json"
+    t = m.read_text()
+    i = t.index('"name": "%s"' % plugin)
+    j = t.find('"name": "', i + 10)
+    j = j if j != -1 else len(t)
+    m.write_text(t[:i] + t[i:j].replace('"version": "%s"' % old,
+                                        '"version": "%s"' % new, 1) + t[j:])
+PY
+}
+
+# --- case 1: touched, version untouched ------------------------------------
+R1="$WORK/r1"; make_repo "$R1"
+(cd "$R1" && echo x >> alpha/file.md && $GIT commit -aqm touch)
+check "case 1: pr, touched but version untouched -> clean" \
+  "$([ "$(run_gate "$R1")" = "0|ok|EMPTY" ] && echo 0 || echo 1)"
+
+# --- case 2: version touched ------------------------------------------------
+set_version "$R1" alpha 1.0.70 1.0.71 both
+(cd "$R1" && $GIT commit -aqm bump)
+check "case 2: pr, version touched -> version-touched, exit 1" \
+  "$([ "$(run_gate "$R1")" = "1|ok|version-touched" ] && echo 0 || echo 1)"
+
+# --- case 5/6/7: post-merge polarity ----------------------------------------
+check "case 5: post-merge, incremented -> clean" \
+  "$([ "$(run_gate "$R1" --mode post-merge)" = "0|ok|EMPTY" ] && echo 0 || echo 1)"
+set_version "$R1" alpha 1.0.71 1.0.70 both
+(cd "$R1" && $GIT commit -aqm revert)
+check "case 6: post-merge, not incremented -> version-not-incremented" \
+  "$([ "$(run_gate "$R1" --mode post-merge)" = "1|ok|version-not-incremented" ] && echo 0 || echo 1)"
+set_version "$R1" alpha 1.0.70 1.0.69 both
+(cd "$R1" && $GIT commit -aqm regress)
+check "case 7: post-merge, regressed -> version-regressed" \
+  "$([ "$(run_gate "$R1" --mode post-merge)" = "1|ok|version-regressed" ] && echo 0 || echo 1)"
+
+# --- case 3: stale-below-main (merge-base anchoring regression test) --------
+# The branch touches alpha but never its version. Meanwhile main advances past
+# it — exactly what the post-merge bump workflow now does on every merge. Head
+# == fork point, so this must be CLEAN. Anchoring on the base TIP would report
+# version-touched here and break nearly every honest PR.
+R3="$WORK/r3"; make_repo "$R3"
+BASE="$(cd "$R3" && $GIT rev-parse HEAD)"
+(cd "$R3" && $GIT checkout -q -b feature && echo x >> alpha/file.md \
+   && $GIT commit -aqm "feature: no version change")
+(cd "$R3" && $GIT checkout -q -b mainline "$BASE")
+set_version "$R3" alpha 1.0.70 1.0.71 both
+(cd "$R3" && $GIT commit -aqm "bump(alpha): v1.0.71" \
+   && $GIT update-ref refs/remotes/origin/main HEAD && $GIT checkout -q feature)
+check "case 3: pr, stale-below-main -> clean (merge-base anchored)" \
+  "$([ "$(run_gate "$R3")" = "0|ok|EMPTY" ] && echo 0 || echo 1)"
+
+# --- case 4: ^bump/ exemption ----------------------------------------------
+R4="$WORK/r4"; make_repo "$R4"
+(cd "$R4" && $GIT checkout -q -b bump/auto-abc123 && echo x >> alpha/file.md)
+set_version "$R4" alpha 1.0.70 1.0.71 both
+(cd "$R4" && $GIT commit -aqm "bump(alpha)")
+check "case 4: pr, ^bump/ branch -> exempt, clean" \
+  "$([ "$(run_gate "$R4")" = "0|ok|EMPTY" ] && echo 0 || echo 1)"
+
+# --- case 8/9: mirror drift, and drift surviving the degraded path ----------
+R8="$WORK/r8"; make_repo "$R8"
+set_version "$R8" alpha 1.0.70 1.0.71 plugin-only
+(cd "$R8" && $GIT commit -aqm desync)
+# Bumping only plugin.json trips BOTH halves: the touch check sees the version
+# move vs the fork point, and the mirror check sees the pair disagree. Both are
+# correct and both must be reported.
+check "case 8: pr, mirror drift -> desync AND touched" \
+  "$([ "$(run_gate "$R8")" = "1|ok|version-mirror-desync,version-touched" ] && echo 0 || echo 1)"
+check "case 8: post-merge, mirror drift also reported" \
+  "$(run_gate "$R8" --mode post-merge | grep -q 'version-mirror-desync' && echo 0 || echo 1)"
+check "case 9: degraded base ref -> status degraded, drift STILL reported" \
+  "$([ "$(run_gate "$R8" --base-ref origin/nope)" = "1|degraded|version-mirror-desync" ] && echo 0 || echo 1)"
+
+R9="$WORK/r9"; make_repo "$R9"
+check "case 9: degraded base ref, tree in sync -> clean, exit 0" \
+  "$([ "$(run_gate "$R9" --base-ref origin/nope)" = "0|degraded|EMPTY" ] && echo 0 || echo 1)"
+
+# --- case 10: the real tree -------------------------------------------------
+set +e
+python3 "$GATE" --root "$REPO_ROOT" > "$WORK/real.json" 2>/dev/null
+REAL_RC=$?
+set -e
+REAL_CLEAN="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['data']['clean'])" "$WORK/real.json")"
+check "case 10: real tree -> clean, exit 0" \
+  "$([ "$REAL_RC" -eq 0 ] && [ "$REAL_CLEAN" = "True" ] && echo 0 || echo 1)"
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+  green "All check-version-bump tests passed."
+else
+  red "$FAILED test(s) failed."
+  exit 1
+fi

--- a/wiki/wiki/pages/concept-plugin-maturity-model.md
+++ b/wiki/wiki/pages/concept-plugin-maturity-model.md
@@ -26,7 +26,7 @@ Full reference: `cogni-docs/references/maturity-model.md`.
 
 ## Bump discipline
 
-The patch version bumps after **any** change to skills, agents, or structure. Plugin versions live in `.claude-plugin/plugin.json` and **must** be mirrored to `.claude-plugin/marketplace.json` for Claude Desktop's update detection — bumping one without the other ships an invisible update.
+The patch version bumps **post-merge**, automatically, for each plugin a merge actually touched — feature branches never author a version line. Plugin versions live in `.claude-plugin/plugin.json` and **must** be mirrored to `.claude-plugin/marketplace.json` for Claude Desktop's update detection — bumping one without the other ships an invisible update, which is why the `Version bump` workflow always edits the pair together.
 
 Marketplace sync is driven by git commit hash, but Desktop reads the marketplace.json version field for its update prompt.
 

--- a/wiki/wiki/pages/ecosystem-overview.md
+++ b/wiki/wiki/pages/ecosystem-overview.md
@@ -36,7 +36,7 @@ Seven cross-plugin pipelines have dedicated wiki pages: [[workflow-consulting-en
 
 ## Versioning and maturity
 
-Plugin versions live in `.claude-plugin/plugin.json` and are mirrored to `.claude-plugin/marketplace.json` for Claude Desktop update detection. The patch version bumps after any change to skills, agents, or structure. Maturity is hard-derived from the version itself ([[concept-plugin-maturity-model]]) — `0.0.x` Incubating through `2.x.x+` Established — and READMEs carry an auto-generated maturity callout for pre-1.0 and archived plugins.
+Plugin versions live in `.claude-plugin/plugin.json` and are mirrored to `.claude-plugin/marketplace.json` for Claude Desktop update detection. The patch version bumps post-merge, automatically, for each plugin a merge touched — both files together, never in a feature branch. Maturity is hard-derived from the version itself ([[concept-plugin-maturity-model]]) — `0.0.x` Incubating through `2.x.x+` Established — and READMEs carry an auto-generated maturity callout for pre-1.0 and archived plugins.
 
 ## MCP servers
 


### PR DESCRIPTION
## Description

Moves the plugin version bump out of feature branches and into a post-merge workflow, so the PR-time version gate that `cogni-service` runs against this repo stops failing every correct PR.

**The deadlock this fixes.** `check-version-bump.sh` (installed from `managed-service`, run at `service-review` Step 1.5b) asserts managed-service's convention: feature branches never touch a version, a post-merge workflow owns the bump. insight-wave mandated the opposite — a paired in-PR bump of `plugin.json` and the `marketplace.json` mirror — so every correct PR here tripped the gate as a `major` finding.

That finding cannot be waived. `pr-verdict-synthesizer` applies its rules first-match-wins, and both Rule 3 (the synthetic pre-gate verdict is hardcoded `needs_revision`) and Rule 4 (any `major` finding) fire *before* the `opt_out`-aware Rules 5/5b/6. Author-drain handoff is PASS-gated, so no drain-authored PR could ever reach the merger. #1136 and #1137 are stuck on exactly this and no change inside them can fix it.

Rather than patch the gate or the synthesizer (both upstream in cogni-service), this makes the gate's premise true.

## Changes

- **`.github/workflows/cogni-version-bump.yml`** — patch-bumps each plugin a merge touched, on push to `main`. Adapted from `managed-service/.github/workflows/cogni-service-version-bump.yml`, with three deltas: it pushes with the built-in `GITHUB_TOKEN` raised to `contents: write` (main's `admin` ruleset carries only `deletion` and `non_fast_forward` — no PR requirement, so no PAT and no bypass allowlist); it edits **both** manifests; and it asserts its pre-push verification was not vacuous.
- **`scripts/apply-version-bump.py`** — the paired edit. `marketplace.json` is one file shared by all 14 plugins, so the replacement is scoped to a single entry's text span, and nothing is written until the rewritten JSON re-parses and differs *only* in the intended version values. A plugin whose pair is already out of sync, or whose version tail is non-numeric, is skipped rather than guessed at.
- **`scripts/check-version-bump.py`** — gates PRs (`version-touched`), verifies the workflow's own increment (`--mode post-merge`), and in both modes asserts the `plugin.json` ↔ `marketplace.json` mirror invariant, which the upstream gate has no equivalent of. Merge-base anchored, so a PR that forked before a bump is not false-flagged.
- **`.github/workflows/lint.yml`** — new `version-bump-gate` job with `fetch-depth: 0` and a vacuity assertion, so dropping the fetch depth fails the build instead of silently turning the gate into a no-op.
- **Docs** — `CLAUDE.md`, `CONTRIBUTING.md`, `docs/contributing/plugin-development.md`, and the two root wiki pages now state the new convention.

Patch-only increments structurally cannot cross a maturity boundary, so `maturity` and the maturity keyword in `keywords[]` are never touched. Boundary crossings stay human, on a `bump/…` branch the gate exempts.

## Testing

`tests/test_apply_version_bump.sh` (18 assertions) and `tests/test_check_version_bump.sh` (12 assertions), both passing, alongside the two existing guard suites.

Beyond the unit tests, the shipped YAML was rehearsed end to end against a throwaway worktree with `git push` stubbed — the run-blocks were extracted from the workflow file itself, not copied:

- **Real bump path** — a merge touching `cogni-projects` produced one `bump(cogni-projects): v0.0.10 — post-merge auto-increment` commit authored by `github-actions[bot]`, changing exactly 2 files and 2 lines, with the post-merge verification reporting `status: ok` (not degraded).
- **No-op path** — a merge touching only root-level paths logged "no touched plugin to bump" and made no commit. **This is what merging this PR will do**, since it touches no plugin directory.
- **Loop guard** — a tip commit already starting with `bump(` short-circuits.
- **Gate paths** — clean branch exits 0; a bumped version exits 1 with the revert instruction; a simulated shallow clone fails the vacuity assertion rather than passing vacuously.
- **Highest-risk case** — two plugins sharing a version string, with the root `metadata.version` also colliding: only the touched entry moves, `metadata.version` is untouched, non-ASCII descriptions and `keywords` survive byte-for-byte.

## Follow-ups

1. A second PR syncs the plugin-internal copies of the same convention text (`cogni-knowledge/CLAUDE.md`, the two `cogni-workspace/wiki/…` mirrors). That one *does* touch plugin directories, so its merge exercises the real bump path.
2. #1136 and #1137 then need their version lines reverted and a rebase, after which the gate returns clean and the drain can hand off.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md)
- [x] My changes follow the existing code style
- [x] I have updated documentation where applicable
- [x] I have tested my changes
