### PR TITLE
cogni-projects: non-string status warns instead of crashing the render

### DIFF
--- a/cogni-projects/scripts/render-dashboard.py
+++ b/cogni-projects/scripts/render-dashboard.py
@@ -240,6 +240,31 @@ def _is_closed(status):
     return str(status or "").strip().lower() == "closed"
 
 
+def _status_text(raw, label, warnings):
+    """Read an entity's `status` as text, warning when it was not text already.
+
+    The frontmatter parser this script borrows from validate-entities.py coerces
+    any all-digit scalar to an int before the schema enum is ever checked — and
+    the renderer never runs that validator. So a hand-edited `status: 2026`
+    arrives here as an int, and calling a str method on it straight raises
+    inside _compute, which no local handler catches: the module-level catch-all
+    then discards every warning collected so far and fails the whole render.
+    That inverts this script's contract, where one bad record costs a warning
+    and nothing else.
+
+    The guard keys on `raw is not None`, deliberately not on truthiness —
+    `status: 0` coerces to a falsy int, which a truthy check would silently
+    normalize to "unknown" with no warning at all.
+    """
+    if raw is None:
+        return ""
+    if not isinstance(raw, str):
+        warnings.append(
+            "%s has a non-string status %r — coerced to text; fix the record" % (label, raw)
+        )
+    return str(raw).strip()
+
+
 def _open_role_demand(projects):
     """Sum unfilled roles across the projects that still represent live demand.
 
@@ -279,13 +304,18 @@ def _compute(entities, warnings):
         # An undeclared open_roles is not an empty one — see _normalize_open_roles.
         declared_roles = _normalize_open_roles(proj)
         open_roles = declared_roles or []
-        status = (proj.get("status") or "").strip()
+        status = _status_text(proj.get("status"), label, warnings)
         if declared_roles is None and status != "closed":
             warnings.append("%s has no open_roles — staffing status unknown" % label)
 
         covered = set()
         for a in assignments:
-            if a.get("project") == slug and (a.get("status") or "").strip() in ACTIVE_ASSIGNMENT_STATES:
+            # Filter first — an assignment belonging to another project must not
+            # have its status read here, or it would warn once per project.
+            if a.get("project") != slug:
+                continue
+            a_label = "assignment %s" % (a.get("_file") or a.get("slug") or "(unknown)")
+            if _status_text(a.get("status"), a_label, warnings) in ACTIVE_ASSIGNMENT_STATES:
                 role = a.get("role")
                 if role:
                     covered.add(role)

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -111,9 +111,11 @@ A failure here is cosmetic — the dashboard is already written to `data.path`.
   `projects-entities` does, via `register-entity.py`) and never touches
   `.metadata/`. Re-running only rewrites `output/dashboard.html`.
 - **Partial snapshots are expected mid-authoring.** A project without a
-  `strategic_impact`, a project that omits `open_roles`, or an entity file
-  that cannot be read or decoded is reported in the warnings list, not
-  treated as an error. One bad record never costs the rest of the portfolio.
+  `strategic_impact`, a project that omits `open_roles`, an entity whose
+  `status` is not text (an all-digit value such as `status: 2026` is read as a
+  number, then coerced back to text), or an entity file that cannot be read or
+  decoded is reported in the warnings list, not treated as an error. One bad
+  record never costs the rest of the portfolio.
 - **Theming is optional.** The dashboard renders with a built-in palette;
   pass `--design-variables <path.json>` to override colors when a themed look is
   wanted.

--- a/cogni-projects/tests/test-render-dashboard.sh
+++ b/cogni-projects/tests/test-render-dashboard.sh
@@ -63,6 +63,17 @@ assert_html_lacks() {
   fi
 }
 
+# Every "the renderer degraded instead of crashing" fixture needs this, and the
+# crash signature belongs in one place — widening it later should be one edit.
+assert_no_traceback() {
+  local label="$1" file="$2"
+  if grep -qF 'Traceback' "$file"; then
+    fail "$label" "traceback present: $(head -3 "$file")"
+  else
+    pass "$label"
+  fi
+}
+
 seed_portfolio() {
   # $1 = portfolio dir. Seeds a manifest + entity subdirs.
   local pf="$1"
@@ -327,11 +338,7 @@ assert_json "6e warns on unknown staffing (both shapes)" \
   "sum('staffing status unknown' in w for w in d['data']['warnings']) == 2"
 assert_json "6f warns on undecodable file" \
   "any('cannot read' in w and 'latin1' in w for w in d['data']['warnings'])"
-if grep -qF 'Traceback' "$STDERR6"; then
-  fail "6g no traceback on stderr" "traceback present: $(head -3 "$STDERR6")"
-else
-  pass "6g no traceback on stderr"
-fi
+assert_no_traceback "6g no traceback on stderr" "$STDERR6"
 assert_html "6h unknown staffing flagged in HTML" \
   "staffing unknown" "$PF6/output/dashboard.html"
 
@@ -434,6 +441,92 @@ assert_html "9f tile agrees with the envelope" \
   '<div class="n">1</div><div class="l">Open roles</div>' "$HTML9"
 assert_html "9g closed project still listed" "Legacy Migration" "$HTML9"
 assert_html "9h closed health flag still rendered" ">closed</span>" "$HTML9"
+
+# ---------------------------------------------------------------------------
+# Fixture 10 — a status that is not text. The frontmatter parser coerces an
+# all-digit scalar to an int before any enum check runs, so `status: 2026`
+# reached a str method and raised, and the module-level catch-all then threw
+# away every warning collected so far — one hand-edited record cost the whole
+# dashboard. 10c and 10d are a pair: `2026` used to crash while `0` is *falsy*
+# and used to normalize silently to "unknown", so a guard keyed on truthiness
+# rather than on None would pass one and fail the other.
+# ---------------------------------------------------------------------------
+PF10="$TMPROOT/nonstring-status"
+seed_portfolio "$PF10"
+write_entity "$PF10/projects/numeric-status.md" <<'EOF'
+---
+type: project
+slug: numeric-status
+name: Numeric Status
+client: NumCo
+strategic_impact: 3
+status: 2026
+open_roles: [lead]
+---
+# Numeric Status
+EOF
+write_entity "$PF10/projects/zero-status.md" <<'EOF'
+---
+type: project
+slug: zero-status
+name: Zero Status
+client: ZeroCo
+strategic_impact: 2
+status: 0
+open_roles: [lead]
+---
+# Zero Status
+EOF
+write_entity "$PF10/projects/sound.md" <<'EOF'
+---
+type: project
+slug: sound
+name: Sound Delivery
+client: SoundCo
+strategic_impact: 4
+status: active
+open_roles: [architect]
+---
+# Sound Delivery
+EOF
+# `project: sound` must name a real project — _compute filters on the project
+# before it reads an assignment's status, so an orphan assignment would never
+# reach the coercion and the fixture would pass against the unfixed script.
+write_entity "$PF10/assignments/numeric-assignment.md" <<'EOF'
+---
+type: assignment
+slug: rena--sound
+consultant: rena
+project: sound
+role: architect
+start_date: 2026-02-01
+end_date: 2026-08-01
+status: 1
+---
+# assignment
+EOF
+
+# The shared run() helper discards stderr, so invoke directly the way Fixture 6
+# does — 10g asserts on the absence of a traceback.
+STDERR10="$TMPROOT/stderr10.txt"
+LAST_JSON="$(python3 "$SCRIPT" "$PF10" 2>"$STDERR10" | tail -n 1)"
+
+assert_json "10a non-string status still succeeds" "d['success'] is True"
+assert_json "10b marked partial"                   "d['data']['partial'] is True"
+assert_json "10c falsy int status still warns" \
+  "any('non-string status' in w and 'Zero Status' in w for w in d['data']['warnings'])"
+assert_json "10d project surfaced by name" \
+  "any('non-string status' in w and 'Numeric Status' in w for w in d['data']['warnings'])"
+# The assignment is named by its relative path — _read_entities sets _file on
+# every kept entity, while slug is optional frontmatter.
+assert_json "10e assignment surfaced by file" \
+  "any('non-string status' in w and 'numeric-assignment.md' in w for w in d['data']['warnings'])"
+assert_json "10f every project still counted"      "d['data']['projects'] == 3"
+assert_no_traceback "10g no traceback on stderr" "$STDERR10"
+# A needle without quote characters: warnings reach the HTML through _esc, which
+# rewrites the quotes %r puts around a value.
+assert_html "10h healthy project still rendered" \
+  "Sound Delivery" "$PF10/output/dashboard.html"
 
 echo
 if [ "$failures" -eq 0 ]; then


### PR DESCRIPTION
Closes #1155.

## Summary

`render-dashboard.py` called `.strip()` straight on a frontmatter `status` at two sites in `_compute` — the project status, and the assignment status inside the role-coverage loop. The frontmatter parser it borrows from `validate-entities.py` coerces any all-digit scalar to an `int` before the schema enum is ever checked, and the renderer never runs that validator, so a hand-edited `status: 2026` arrived as an `int`. The int is truthy, so the `or ""` fallback never fired and `.strip()` raised.

Nothing local catches that, so it reached the module-level catch-all, whose `_fail` hard-codes empty `data` — discarding every warning collected so far. One bad record cost the partner the whole dashboard, inverting the script's contract that a malformed entity becomes a per-entity warning and nothing else.

Both sites now read through `_status_text`, which coerces to text and appends a warning naming the record.

## Two things worth a reviewer's attention

**1. The guard keys on `raw is not None`, not on truthiness.** `status: 0` coerces to a *falsy* int. A truthiness guard (`str(raw or "")`) would silently normalize it to `"unknown"` and warn about nothing at all — a quieter version of the same defect. Fixture 10's `10c`/`10d` are a pair specifically to pin both halves: `2026` used to crash, `0` used to vanish, and a regression to either shape fails exactly one of them.

**2. The issue documents one crash site; there are two.** The assignment-status read at the same nesting level has the identical signature. Fixing only the documented one would leave the contract violation reachable, so both are covered. The loop's compound condition became an early-`continue` purely so the coercion can sit in statement position — the project filter already ran first via `and` short-circuit, so this is not a behavior change and there was never a duplicate-warning bug to fix.

## Scope decisions

- **No parse-boundary normalization.** The strongest argument against this change's shape is that defending at read sites is per-field and the field list is unbounded — see the known adjacent defect below. Normalizing known string fields once in `_read_entities` would close the class. It is deliberately not done here: it changes normalization for every field on every entity type, which is a materially wider blast radius than this issue's acceptance criteria and needs its own decision about which fields count as string-typed. Filed as #1162.
- **`validate-entities.py` is untouched.** Its int coercion is genuinely wanted for `strategic_impact` / `allocation_pct`, the file is shared with other scripts, and the validator already reports `status: 2026` correctly as an invalid enum value. The defect is entirely that the renderer reuses the parser but skips the validator.
- **Fixture 10 is a sibling of Fixture 6, not a case inside it.** Fixture 6 pins a hardcoded project count and shares one stderr capture; folding a fourth malformed shape in would rewrite passing assertions and conflate a decode failure with this crash. No existing fixture, count, or comment is touched.
- **The assignment loop was not hoisted into a pre-pass.** Two reviewers suggested it (fewer nesting levels, `O(A)` instead of `O(P×A)`). Declined: hoisting makes orphan assignments newly status-read and warned, which is a behavior change beyond the acceptance criteria and is tracked separately as #1161.

## Known adjacent defect — not fixed here

The same whole-render loss is still reachable through `role` rather than `status`. `sorted(covered)` raises `TypeError` on a mixed int/str role set:

```
{"success": false, "data": {}, "error": "unexpected failure: TypeError: '<' not supported between instances of 'str' and 'int'"}
```

Reproduced against this branch (one project with `open_roles: [lead]`, two active assignments on it, one `role: 2` and one `role: lead`). Filed as #1162 with the repro and an exposure audit of every other frontmatter field this script reads.

This is surfaced rather than fixed because it is a different field with a different failure mode and is outside this issue's acceptance criteria — but a reviewer who thinks the parse-boundary fix should land instead of this one has everything needed to make that call, and this PR should then be closed in favor of #1162.

## Test plan

- [x] `bash cogni-projects/tests/test-render-dashboard.sh` — all 10 fixtures pass (46 assertions).
- [x] **The test actually pins the bug.** Reverting only `render-dashboard.py` to `origin/main` and re-running fails 7 of Fixture 10's 8 assertions with exactly `AttributeError: 'int' object has no attribute 'strip'`. (`10g` passes in both states — the catch-all suppresses the traceback — so it guards the same shape `6g` does rather than being the discriminating assertion.)
- [x] Warning cardinality: a portfolio with 3 projects and 1 bad-status assignment emits exactly **one** assignment warning, not one per project.
- [x] `bash cogni-projects/tests/test_register_entity.sh` and `test_portfolio_init.sh` — unaffected siblings still pass.
- [x] `check-breadcrumbs.py` 0 findings · `check-version-bump.py` `[ok]` (14 plugins scanned, 0 touched, 0 violations) · `check-external-dispatch.py` 0 findings · `check-skill-names.sh` OK.
- [x] `git diff origin/main -- '*/.claude-plugin/*.json'` is empty — no version line in this branch; the post-merge workflow owns the bump.

## Follow-up issues

- #1160 — unify the three case-sensitivity treatments of project `status`
- #1161 — warn on an assignment whose `project` matches no project
- #1162 — a non-string assignment `role` still crashes the whole render
