### PR TITLE
cogni-workspace: identifier clause governs spelling, not surfacing

### DIFF
--- a/cogni-workspace/assets/claude-templates/CLAUDE.de.md
+++ b/cogni-workspace/assets/claude-templates/CLAUDE.de.md
@@ -5,4 +5,4 @@
 - Auf Deutsch antworten, es sei denn, der Benutzer wechselt die Sprache
 - Korrekte deutsche Rechtschreibung verwenden, einschließlich aller Umlaute (ä, ö, ü, Ä, Ö, Ü) und Eszett (ß)
 - Keine Umschreibungen wie "ae" für "ä", "oe" für "ö", "ue" für "ü" oder "ss" für "ß" verwenden
-- Fachbegriffe, Code-Bezeichner und Dateinamen bleiben auf Englisch
+- Fachbegriffe, Code-Bezeichner und Dateinamen bleiben in ihrer englischen Form, wenn sie genannt werden müssen

--- a/cogni-workspace/assets/claude-templates/CLAUDE.en.md
+++ b/cogni-workspace/assets/claude-templates/CLAUDE.en.md
@@ -4,4 +4,4 @@
 
 - Respond in English unless the user switches language
 - Use concise, professional language
-- Technical terms, code identifiers, and filenames remain in English
+- Technical terms, code identifiers, and filenames remain in their English form when they must be named

--- a/cogni-workspace/assets/output-styles/workspace-de.md
+++ b/cogni-workspace/assets/output-styles/workspace-de.md
@@ -8,7 +8,7 @@
 - Bei Workspace-Pfaden Umgebungsvariablen verwenden (z.B. `$COGNI_RESEARCH_ROOT`) statt absolute Pfade
 - Bei Dateioperationen relative Pfade vom Workspace-Root anzeigen
 - Bei Multi-Plugin-Operationen angeben, welches Plugin welches Artefakt besitzt
-- Fachbegriffe, Code-Bezeichner und Dateinamen bleiben auf Englisch
+- Fachbegriffe, Code-Bezeichner und Dateinamen bleiben in ihrer englischen Form, wenn sie genannt werden müssen
 
 ## Intent Router
 

--- a/cogni-workspace/skills/manage-workspace/SKILL.md
+++ b/cogni-workspace/skills/manage-workspace/SKILL.md
@@ -248,9 +248,20 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/install-workspace-deps.sh --force
 Same fail-soft contract as Init Mode Step 3.5: warn and continue if `python3` /
 the `venv` module / the network is unavailable — never block the update.
 
-### 4. Update Output Styles and Theme Template
+### 4. Update Output Styles, CLAUDE.md Templates, and Theme Template
 
 Copy latest output-style files from `${CLAUDE_PLUGIN_ROOT}/assets/output-styles/` to `.claude/output-styles/`, overwriting existing ones (these are plugin-managed, not user-customized).
+
+Refresh both language templates in `.claude/templates/`. Like the output styles these are plugin-managed — the Obsidian Terminal launcher copies from them to the workspace root on every per-session language switch, so a correction to a template only reaches an existing workspace if this step runs. Init Mode installs them; without the refresh here they stay at whatever version was current when the workspace was created:
+
+```bash
+mkdir -p "${WORKSPACE_DIR}/.claude/templates"
+cp "${CLAUDE_PLUGIN_ROOT}/assets/claude-templates/CLAUDE.en.md" \
+   "${CLAUDE_PLUGIN_ROOT}/assets/claude-templates/CLAUDE.de.md" \
+   "${WORKSPACE_DIR}/.claude/templates/"
+```
+
+Do **not** overwrite the workspace-root `CLAUDE.md` here. Nothing declares it plugin-managed the way the output styles are declared above, and it is the natural place for a user to add project-specific instructions on top of the language rules. Compare it against `.claude/templates/CLAUDE.${LANGUAGE}.md` instead; if they differ, show the difference and ask whether to adopt the updated template, keep the current file, or merge by hand — defaulting to keeping the current file.
 
 Refresh `_template/theme.md` from `${CLAUDE_PLUGIN_ROOT}/themes/_template/`. Preserve all user-created themes.
 


### PR DESCRIPTION
Closes #1148.

## Summary

- **`assets/claude-templates/CLAUDE.de.md:8`** — appended the qualifier: `- Fachbegriffe, Code-Bezeichner und Dateinamen bleiben in ihrer englischen Form, wenn sie genannt werden müssen`. The clause now governs orthography (do not translate an identifier) instead of reading as standing permission to print one.
- **`assets/claude-templates/CLAUDE.en.md:7`** — equivalent English narrowing: `- Technical terms, code identifiers, and filenames remain in their English form when they must be named`.
- **`assets/output-styles/workspace-de.md:11`** — carried the identical defective sentence verbatim; narrowed the same way.
- **`skills/manage-workspace/SKILL.md`** Update Mode Step 4 — added a CLAUDE-template refresh so existing workspaces actually receive the correction.

## Two corrections to the issue as filed

**1. Acceptance criterion 4 was false, and its anchor pointed at the wrong thing.** The criterion reads "a `manage-workspace` update propagates the corrected template, since `SKILL.md:251-253` overwrites it as plugin-managed". That anchor is Update Mode Step 4 "Update Output Styles and Theme Template" — the "plugin-managed, not user-customized" language governs **output styles**, and Update Mode referenced `CLAUDE.md` nowhere at all. Every claude-template reference lived in Init Mode (`SKILL.md:113-134`), which runs only when `.workspace-config.json` is **absent**. Any workspace old enough to need this fix already has that file, so it goes through Update Mode and would never have received the correction. A prose-only edit could not have satisfied the criterion, so this PR adds the missing step.

**2. The issue's proposed replacement sentence would have loosened the rule, not narrowed it.** It drops `Fachbegriffe`, narrows `Code-Bezeichner` to `Bezeichner`, and adds `CLI-Befehle`. Dropping `Fachbegriffe` removes technical terms from the rule's coverage — a change in what the rule governs, not in how tightly it governs it, and in tension with acceptance criterion 3 ("neither file's other behavioral anchors change"). The original three nouns are kept in both languages; only the qualifier is appended.

## Scope decisions

**Included a file the criteria do not name.** `assets/output-styles/workspace-de.md:11` is the same sentence character-for-character, in the same plugin — and it is the surface Update Mode *already* refreshed on every update. Fixing the template while leaving the output style teaching the opposite would have reproduced, at plugin scale, exactly the contradiction this issue is about. Its EN twin `workspace-en.md` has no identifier bullet at all, so there is nothing to narrow there; that pre-existing DE/EN asymmetry is left alone.

**The propagation step is deliberately non-destructive.** Update Mode now unconditionally refreshes `.claude/templates/CLAUDE.{en,de}.md` — an unambiguously plugin-managed cache nobody hand-edits, which `cogni-workspace/templates/obsidian/plugins/terminal/workspace-orchestrator.sh:84-95` copies to the workspace root on every per-session language switch. The workspace-root `CLAUDE.md` is compared rather than clobbered, defaulting to keep. See the open question.

## Test plan

- [x] `git diff --numstat` shows exactly **+1/-1** on each of the three asset files — no other bullet touched.
- [x] Real `ä/ö/ü/ß` throughout both DE files (`müssen` included); grep for `muessen` / `\uXXXX` escapes returns nothing.
- [x] `check-breadcrumbs.py` 0 violations · `check-version-bump.py` `[ok]` (14 plugins scanned, 0 touched, 0 violations) · `check-external-dispatch.py` 0 violations · `check-skill-names.sh` OK.
- [x] `git diff origin/main -- '*/.claude-plugin/*.json'` is empty — no version line; the post-merge workflow owns the bump.
- [x] `manage-workspace/SKILL.md` body is 294 lines against the 500-line soft cap after +11 net.
- [ ] **Manual, not run here:** against a scratch workspace with a stale `.claude/templates/CLAUDE.de.md` and a hand-edited root `CLAUDE.md`, run `manage-workspace` update and confirm the templates are refreshed while the root file stays byte-identical unless the user opts in.
- [ ] **Manual, not run here:** in that workspace, run the Obsidian launcher language switch and confirm the root `CLAUDE.md` picks up the corrected sentence.

## Open questions

**Is the workspace-root `CLAUDE.md` plugin-managed or user-owned?** Nothing in cogni-workspace states an ownership contract for it, and no checksum, version stamp, or drift detection covers it — all such machinery is theme-file-only. It is also the natural place for a user to add project instructions on top of the language rules. This PR therefore takes the safe path: refresh the plugin-managed template cache unconditionally, diff-and-ask before touching the root file, defaulting to keep.

Evidence pulling the other way, found while validating the plan: `copy_claude_template` in the Obsidian launcher (`workspace-orchestrator.sh:84-95`) **already** overwrites the workspace-root `CLAUDE.md` unconditionally on every language switch — no diff, no prompt. So the root file is arguably already treated as plugin-managed in practice, and this PR's prompt is *stricter* than shipped behavior. If that is the intent, the prompt collapses to an unconditional `cp` and acceptance criterion 4 holds with no user interaction.

This is a product-ownership go/no-go that cannot be answered from the repository, which is why this PR is a draft.