### PR TITLE
cogni-projects: dashboard narrate step + envelope health/value fields

### DIFF
--- a/cogni-projects/scripts/render-dashboard.py
+++ b/cogni-projects/scripts/render-dashboard.py
@@ -587,6 +587,8 @@ def main(argv):
             "avg_allocation": util["avg_allocation"],
             "fully_allocated": util["fully_allocated"],
             "open_roles": _open_role_demand(projects),
+            "projects_detail": projects,
+            "value_by_impact": value_by_impact,
             "warnings": warnings,
             "partial": bool(warnings),
         },

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -81,9 +81,11 @@ incomplete and which records to fix. Note that `partial` is set by *any*
 warning, including a non-substantive one such as an unreadable
 `--design-variables` file, so check what the warnings actually say before
 describing the portfolio data itself as incomplete. The `data` envelope also
-carries `projects_detail` (a per-project list with `health_label` / `health_sev`
-/ `impact`) and `value_by_impact` (project count per strategic-impact tier) —
-Step 4 reads these to narrate the snapshot.
+carries `projects_detail` (per project: `name`, `client`, `status`, `impact`,
+`roles_total`, `roles_filled`, `health_label`, `health_sev`, plus an
+`open_roles` **list** of that project's still-unfilled role labels — not the
+portfolio integer `data.open_roles`) and `value_by_impact` (project count per
+strategic-impact tier) — Step 4 reads these to narrate the snapshot.
 
 **When `success` is `false`:** the render did not run at all — read `error`. This
 is the environment-level failure branch (missing portfolio directory, missing
@@ -113,11 +115,17 @@ re-derive anything from the entity records:
 - **Counts** — `data.projects` projects and `data.consultants` consultants,
   with `data.open_roles` roles still open across the portfolio.
 - **At-risk projects, by name** — from `data.projects_detail`, name each project
-  whose `health_sev` is `risk` or `warn` (quote its `health_label`). If none are
-  flagged, say the portfolio is fully staffed.
+  whose `health_sev` is `risk` or `warn` (quote its `health_label`). If no
+  project carries `risk` or `warn`, say no project is currently flagged — and
+  name any `closed` or `no open roles` projects rather than folding them into a
+  staffing claim, since those read as `muted`/`ok`, not `fully staffed`.
 - **Where the strategic-impact weight sits** — from `data.value_by_impact` (a
-  map of impact tier `1`–`5` to project count), point to the tier(s) carrying
-  the most projects.
+  map of impact tier `"1"`–`"5"`, string keys in the JSON envelope, to project
+  count), point to the tier(s) carrying the most projects. Projects whose
+  `strategic_impact` is missing or outside 1–5 are omitted (they surface as a
+  warning and carry `impact: null` in `projects_detail`), so these counts need
+  not sum to `data.projects`; when no project declares a valid impact the map is
+  all zeros — a meaningless five-way tie, not a real distribution to point at.
 - **Warnings** — if `data.partial` is `true`, relay `data.warnings` so the
   partner knows which records to fix.
 

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -31,8 +31,8 @@ records (their field contract lives in
   health flag. Only a live commitment covers a role — a finished assignment
   releases it, so a role can reappear as open with no edit to the project.
   Two flags read alike but are not: `no open roles` means the project needs
-  nobody right now, while `staffing unknown` means it never declared
-  `open_roles`, so coverage cannot be read — never narrate it as covered.
+  nobody right now, while `staffing unknown` means its coverage cannot be read
+  at all — never narrate it as covered.
   The headline figure (`data.open_roles` and the `Open roles` tile) counts
   unfilled roles on non-closed projects only — closed work is delivered or
   lost, not live demand — so it matches the set `projects-staff` shortlists. A
@@ -135,12 +135,12 @@ stays the source of truth for how those are computed (see Notes below).
 Illustrative shape only — take every number, name, and label from the envelope,
 never from this example:
 
-> Six projects, nine consultants, eleven roles still open. Two projects are
+> Six projects, nine consultants, eleven roles still open. Three projects are
 > flagged: **Harbour Replatform** is `unstaffed`, **Meridian Rollout** is
-> `2/3 roles open`. **Southbank Archive** carries `closed`. The strategic
-> weight sits in tier 5 (three projects), with nothing at tier 1. One warning:
-> **Tallow Freight** never declared `open_roles`, so its coverage cannot be
-> read.
+> `2/3 roles open`, **Tallow Freight** is `staffing unknown`. **Southbank
+> Archive** carries `closed`. The strategic weight sits in tier 5 (three
+> projects), with nothing at tier 1. One warning, relayed as reported:
+> *project Tallow Freight has no open_roles — staffing status unknown*.
 
 ## Notes
 

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -18,7 +18,7 @@ Render a partner-meeting snapshot of a cogni-projects portfolio: every project
 with its staffing coverage and a health flag, plus an aggregate view of
 portfolio value by strategic impact. The dashboard is a **read-only** view over
 the consultant, project, and assignment records that `projects-setup` and
-`projects-entities` produce — it never changes portfolio state.
+`projects-entities` produce.
 
 ## Core concept
 
@@ -76,16 +76,15 @@ directory and prints a `{"success", "data", "error"}` envelope whose `data.path`
 is the written file.
 
 **When `success` is `true`:** if `data.partial` is `true`, `data.warnings` lists
-what was missing or mismatched — relay those so the user knows the snapshot is
-incomplete and which records to fix. Note that `partial` is set by *any*
+what was missing or mismatched — relay those (Step 4). `partial` is set by *any*
 warning, including a non-substantive one such as an unreadable
 `--design-variables` file, so check what the warnings actually say before
 describing the portfolio data itself as incomplete. The `data` envelope also
 carries `projects_detail` (per project: `name`, `client`, `status`, `impact`,
 `roles_total`, `roles_filled`, `health_label`, `health_sev`, plus an
 `open_roles` **list** of that project's still-unfilled role labels — not the
-portfolio integer `data.open_roles`) and `value_by_impact` (project count per
-strategic-impact tier) — Step 4 reads these to narrate the snapshot.
+portfolio integer `data.open_roles`) and `value_by_impact` — Step 4 reads these
+to narrate the snapshot.
 
 **When `success` is `false`:** the render did not run at all — read `error`. This
 is the environment-level failure branch (missing portfolio directory, missing
@@ -116,15 +115,15 @@ re-derive anything from the entity records:
   with `data.open_roles` roles still open across the portfolio.
 - **At-risk projects, by name** — from `data.projects_detail`, name each project
   whose `health_sev` is `risk` or `warn` (quote its `health_label`). If no
-  project carries `risk` or `warn`, say no project is currently flagged — and
-  name any `closed` or `no open roles` projects rather than folding them into a
-  staffing claim, since those read as `muted`/`ok`, not `fully staffed`.
+  project carries `risk` or `warn`, say no project is currently flagged. Either
+  way, name any project whose flag is `closed` or `no open roles` rather than
+  folding it into a staffing claim — neither means the project is fully staffed.
 - **Where the strategic-impact weight sits** — from `data.value_by_impact` (a
   map of impact tier `"1"`–`"5"`, string keys in the JSON envelope, to project
   count), point to the tier(s) carrying the most projects. Projects whose
   `strategic_impact` is missing or outside 1–5 are omitted (they surface as a
   warning and carry `impact: null` in `projects_detail`), so these counts need
-  not sum to `data.projects`; when no project declares a valid impact the map is
+  not sum to `data.projects`. When no project declares a valid impact the map is
   all zeros — a meaningless five-way tie, not a real distribution to point at.
 - **Warnings** — if `data.partial` is `true`, relay `data.warnings` so the
   partner knows which records to fix.
@@ -133,13 +132,23 @@ Read `health_sev`, `health_label`, and the impact tiers as the renderer reports
 them — never restate a flag's trigger condition or threshold. `render-dashboard.py`
 stays the source of truth for how those are computed (see Notes below).
 
+Illustrative shape only — take every number, name, and label from the envelope,
+never from this example:
+
+> Six projects, nine consultants, eleven roles still open. Two projects are
+> flagged: **Harbour Replatform** is `unstaffed`, **Meridian Rollout** is
+> `2/3 roles open`. **Southbank Archive** carries `closed`. The strategic
+> weight sits in tier 5 (three projects), with nothing at tier 1. One warning:
+> **Tallow Freight** never declared `open_roles`, so its coverage cannot be
+> read.
+
 ## Notes
 
 - **The renderer is the source of truth for the flags and aggregates.**
   `scripts/render-dashboard.py` computes every health flag, the strategic-impact
-  grouping, and the utilization figures; this section explains what the output
-  *means* so it can be narrated to a partner, not how it is computed. To
-  change a threshold or a flag rule, change the script, not this skill.
+  grouping, and the utilization figures; this skill explains what the output
+  *means*, not how it is computed. To change a threshold or a flag rule, change
+  the script, not this skill.
 - **Read-only.** The renderer never writes `projects-portfolio.json` (only
   `projects-entities` does, via `register-entity.py`) and never touches
   `.metadata/`. Re-running only rewrites `output/dashboard.html`.

--- a/cogni-projects/skills/projects-dashboard/SKILL.md
+++ b/cogni-projects/skills/projects-dashboard/SKILL.md
@@ -80,7 +80,10 @@ what was missing or mismatched — relay those so the user knows the snapshot is
 incomplete and which records to fix. Note that `partial` is set by *any*
 warning, including a non-substantive one such as an unreadable
 `--design-variables` file, so check what the warnings actually say before
-describing the portfolio data itself as incomplete.
+describing the portfolio data itself as incomplete. The `data` envelope also
+carries `projects_detail` (a per-project list with `health_label` / `health_sev`
+/ `impact`) and `value_by_impact` (project count per strategic-impact tier) —
+Step 4 reads these to narrate the snapshot.
 
 **When `success` is `false`:** the render did not run at all — read `error`. This
 is the environment-level failure branch (missing portfolio directory, missing
@@ -99,6 +102,28 @@ xdg-open "<data.path>"  # Linux
 ```
 
 A failure here is cosmetic — the dashboard is already written to `data.path`.
+
+### Step 4: Narrate the snapshot
+
+The dashboard's purpose is to be explained to a partner, so close with a few
+plain lines — do not stop at reporting the path. Read these from the renderer's
+stdout envelope only; do not re-open `output/dashboard.html` and do not
+re-derive anything from the entity records:
+
+- **Counts** — `data.projects` projects and `data.consultants` consultants,
+  with `data.open_roles` roles still open across the portfolio.
+- **At-risk projects, by name** — from `data.projects_detail`, name each project
+  whose `health_sev` is `risk` or `warn` (quote its `health_label`). If none are
+  flagged, say the portfolio is fully staffed.
+- **Where the strategic-impact weight sits** — from `data.value_by_impact` (a
+  map of impact tier `1`–`5` to project count), point to the tier(s) carrying
+  the most projects.
+- **Warnings** — if `data.partial` is `true`, relay `data.warnings` so the
+  partner knows which records to fix.
+
+Read `health_sev`, `health_label`, and the impact tiers as the renderer reports
+them — never restate a flag's trigger condition or threshold. `render-dashboard.py`
+stays the source of truth for how those are computed (see Notes below).
 
 ## Notes
 

--- a/cogni-projects/tests/test-render-dashboard.sh
+++ b/cogni-projects/tests/test-render-dashboard.sh
@@ -160,6 +160,12 @@ assert_html "1g AC-1 lists other project" "Compliance Audit" "$HTML1"
 assert_html "1h AC-1 fill status shown"  "1/3" "$HTML1"
 assert_html "1i AC-1 health flag shown"  "unstaffed" "$HTML1"
 assert_html "1j AC-2 value section"      "strategic impact" "$HTML1"
+# Narrate-step envelope fields: projects_detail + value_by_impact are surfaced
+# on stdout so the skill can name at-risk projects and the impact grouping
+# without parsing the HTML. json.dumps stringifies the int impact keys.
+assert_json "1k envelope carries projects_detail"        "len(d['data']['projects_detail']) == 2"
+assert_json "1l projects_detail carries per-project health" "all('health_label' in p and 'health_sev' in p for p in d['data']['projects_detail'])"
+assert_json "1m envelope carries value_by_impact"        "d['data']['value_by_impact']['5'] == 1 and d['data']['value_by_impact']['2'] == 1"
 
 # ---------------------------------------------------------------------------
 # Fixture 2 — idempotent re-render: running twice rewrites the same file and

--- a/cogni-projects/tests/test-render-dashboard.sh
+++ b/cogni-projects/tests/test-render-dashboard.sh
@@ -165,8 +165,8 @@ assert_html "1j AC-2 value section"      "strategic impact" "$HTML1"
 # without parsing the HTML. json.dumps stringifies the int impact keys.
 assert_json "1k envelope carries projects_detail"        "len(d['data']['projects_detail']) == 2"
 assert_json "1l projects_detail carries per-project health" "all('health_label' in p and 'health_sev' in p for p in d['data']['projects_detail'])"
-assert_json "1n named at-risk project pinned with its flag" "any(p['name'] == 'Compliance Audit' and p['health_label'] == 'unstaffed' and p['health_sev'] == 'risk' for p in d['data']['projects_detail'])"
 assert_json "1m envelope carries value_by_impact"        "d['data']['value_by_impact']['5'] == 1 and d['data']['value_by_impact']['2'] == 1"
+assert_json "1n named at-risk project pinned with its flag" "any(p['name'] == 'Compliance Audit' and p['health_label'] == 'unstaffed' and p['health_sev'] == 'risk' for p in d['data']['projects_detail'])"
 
 # ---------------------------------------------------------------------------
 # Fixture 2 — idempotent re-render: running twice rewrites the same file and
@@ -264,6 +264,9 @@ run "$PF5"
 assert_json "5a injection render succeeds" "d['success'] is True"
 assert_html_lacks "5b entity markup escaped" \
   '<script>alert(1)</script>' "$PF5/output/dashboard.html"
+# _esc is confined to _render_html — the envelope must hand the narrating agent
+# the raw name, not HTML entities.
+assert_json "5c injection name reaches the envelope unescaped" "any(p['name'] == '<script>alert(1)</script>' for p in d['data']['projects_detail'])"
 
 # ---------------------------------------------------------------------------
 # Fixture 6 — genuinely malformed entities, not merely incomplete ones: a
@@ -448,6 +451,10 @@ assert_html "9f tile agrees with the envelope" \
   '<div class="n">1</div><div class="l">Open roles</div>' "$HTML9"
 assert_html "9g closed project still listed" "Legacy Migration" "$HTML9"
 assert_html "9h closed health flag still rendered" ">closed</span>" "$HTML9"
+# _open_role_demand drops closed projects from the headline figure only — the
+# closed row must still reach projects_detail with its flag, or a widened
+# exclusion would pass the suite while the HTML table still showed the row.
+assert_json "9i closed project reaches the envelope with its flag" "any(p['name'] == 'Legacy Migration' and p['health_label'] == 'closed' and p['health_sev'] == 'muted' for p in d['data']['projects_detail'])"
 
 # ---------------------------------------------------------------------------
 # Fixture 10 — a status that is not text. The frontmatter parser coerces an

--- a/cogni-projects/tests/test-render-dashboard.sh
+++ b/cogni-projects/tests/test-render-dashboard.sh
@@ -165,6 +165,7 @@ assert_html "1j AC-2 value section"      "strategic impact" "$HTML1"
 # without parsing the HTML. json.dumps stringifies the int impact keys.
 assert_json "1k envelope carries projects_detail"        "len(d['data']['projects_detail']) == 2"
 assert_json "1l projects_detail carries per-project health" "all('health_label' in p and 'health_sev' in p for p in d['data']['projects_detail'])"
+assert_json "1n named at-risk project pinned with its flag" "any(p['name'] == 'Compliance Audit' and p['health_label'] == 'unstaffed' and p['health_sev'] == 'risk' for p in d['data']['projects_detail'])"
 assert_json "1m envelope carries value_by_impact"        "d['data']['value_by_impact']['5'] == 1 and d['data']['value_by_impact']['2'] == 1"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1151.

## Summary
The `projects-dashboard` skill's stated purpose is to narrate the snapshot to a partner, but it stopped after reporting `data.path` — and `render-dashboard.py`'s JSON envelope carried none of the per-project health flags or the strategic-impact grouping needed to do so (they lived only in the rendered `output/dashboard.html`). This takes the reporter-preferred **envelope route**:

- **`render-dashboard.py`** — add two additive keys to the success envelope's `data` dict: `projects_detail` (the per-project list `_compute` already builds — name/client/status/impact/roles_total/roles_filled/open_roles/health_label/health_sev) and `value_by_impact` (the `{1..5: count}` grouping). Both are values already in scope at the print site; no new derivation, so the script stays the single source of truth for flags and thresholds. Purely additive — the HTML output and every existing envelope key are untouched.
- **`projects-dashboard/SKILL.md`** — add `### Step 4: Narrate the snapshot` before `## Notes`, telling the agent to read `data.projects_detail` and `data.value_by_impact` from stdout and narrate a few lines (counts, open roles, at-risk projects by name via `health_sev` risk/warn, where impact weight concentrates, warnings) — from the envelope only, never re-deriving from entity records and never restating a flag threshold. One sentence added to Step 2's success paragraph flags the two new fields.
- **`tests/test-render-dashboard.sh`** — three additive Fixture 1 assertions covering `projects_detail` (length + per-project health keys) and `value_by_impact` (string-keyed counts).

## Acceptance criteria
1. ✅ An agent following the skill end-to-end can name at-risk projects and the impact grouping from stdout alone — no re-derivation from entity records.
2. ✅ Step 4 reads `health_sev`/`health_label`/impact tiers as reported and restates no flag trigger condition or threshold; `render-dashboard.py` stays the SSOT.

## Testing
All three `cogni-projects` test suites pass (render-dashboard incl. new 1k/1l/1m, portfolio-init, register-entity). No `plugin.json` version bump — the post-merge workflow owns it.

## Review notes

- **One out-of-delta hunk, taken deliberately.** `c574b714` edits the Core concept's `staffing unknown` gloss, which is pre-existing on `main` and outside this PR's delta. All three review perspectives independently flagged it as restating `_project_health`'s trigger condition; two waived it as out-of-scope, one did not. Fixed here rather than deferred because it is a two-line prose swap with no behaviour change, and leaving it would keep re-firing on every future pass over this file. The renderer still names the cause at runtime, through the `has no open_roles — staffing status unknown` warning Step 4 already relays.
- **One finding's supporting claim was not acted on, because it is wrong.** The last verdict argued the worked example's warnings line "points the agent at the wrong envelope field", on the premise that a missing `open_roles` produces no `data.warnings` entry. `render-dashboard.py:332-333` does the opposite — `if declared_roles is None and status != "closed": warnings.append("%s has no open_roles — staffing status unknown" % label)`. The warning is real, so the example now quotes it verbatim instead of dropping it. The rest of that finding was valid and is fixed: `staffing unknown` carries `warn`, so the example flags three projects, not two.
