### PR TITLE
cogni-projects: referential-integrity check for assignment refs

### DIFF
--- a/cogni-projects/references/data-model.md
+++ b/cogni-projects/references/data-model.md
@@ -275,7 +275,10 @@ values, kebab-case slug shape, ISO dates and their `start_date <= end_date` /
 repo-standard `{"success", "data", "error"}` envelope with `success: false` and
 a per-field `{entity, file, field, message}` list when an entity is malformed.
 
-It validates **frontmatter shape only**. An assignment's `consultant` and
-`project` values are not resolved to real entity files, so a passing run is not
-evidence those refs exist — read both referenced entities before authoring an
-assignment.
+A **single-file** run validates **frontmatter shape only** — an assignment's
+`consultant` and `project` values are not resolved, so a passing run is not
+evidence those refs exist; read both referenced entities before authoring an
+assignment. A **portfolio-directory** run additionally resolves each
+assignment's `consultant` / `project` slug against the collected consultant /
+project entities and reports a dangling reference as an error in the same
+`{entity, file, field, message}` shape.

--- a/cogni-projects/scripts/validate-entities.py
+++ b/cogni-projects/scripts/validate-entities.py
@@ -6,8 +6,11 @@ Checks the YAML frontmatter of consultant / project / assignment entity files
 enum values, kebab-case slug shape, ISO dates and their start <= end ordering,
 and numeric ranges.
 
-Frontmatter shape only: an assignment's consultant / project values are not
-resolved to real entity files.
+Frontmatter shape is always checked. When a path argument is a portfolio
+directory, an assignment's consultant / project values are additionally
+resolved against the collected consultant / project entity slugs, and a
+dangling reference is an error. A single-file argument stays shape-only:
+no portfolio-wide slug set is available to resolve against.
 
 Stdlib-only (no PyYAML): a small frontmatter-subset parser handles the flat
 scalar + simple-list frontmatter the data model uses.
@@ -217,6 +220,17 @@ def _entity_files(path):
     return files
 
 
+def _entity_type(fm, filepath):
+    """Resolve a file's entity type the same way validate_file does: the
+    declared `type` when it is a known type, else the type inferred from the
+    file's parent subdirectory. Returns None when neither resolves.
+    """
+    parent = os.path.basename(os.path.dirname(filepath))
+    inferred = SUBDIR_TO_TYPE.get(parent)
+    declared = fm.get("type") if fm else None
+    return declared if declared in SCHEMA else inferred
+
+
 def validate_file(filepath):
     """Validate one entity file. Returns (errors, warnings) as lists of dicts."""
     errors, warnings = [], []
@@ -337,6 +351,7 @@ def main(argv):
         return 2
 
     all_files = []
+    any_dir = False
     for path in argv:
         if not os.path.exists(path):
             print(json.dumps({
@@ -344,6 +359,8 @@ def main(argv):
                 "error": "path not found: %s" % path,
             }, ensure_ascii=False))
             return 2
+        if os.path.isdir(path):
+            any_dir = True
         found = _entity_files(path)
         # Fail closed on a mistargeted directory. A path that expands to no
         # entity files would otherwise report success, which a caller gating
@@ -383,6 +400,59 @@ def main(argv):
             }], []
         errors.extend(e)
         warnings.extend(w)
+
+    # Referential integrity — only when a portfolio directory was given, so a
+    # single-file invocation (which cannot see the sibling entities) keeps its
+    # shape-only contract. Resolve each assignment's consultant / project
+    # frontmatter value against the slugs collected from the portfolio's
+    # consultant / project entities; an unresolved reference is a dangling ref.
+    if any_dir:
+        # Files that already failed shape validation are excluded from both the
+        # slug sets and the ref check: their slug / consultant / project values
+        # are unreliable, and re-flagging them here would double-report one
+        # malformed record.
+        errored_files = {e["file"] for e in errors}
+        consultant_slugs, project_slugs = set(), set()
+        assignment_records = []
+        for f in all_files:
+            if f in errored_files:
+                continue
+            try:
+                with open(f, "r", encoding="utf-8") as fh:
+                    fm = parse_frontmatter(fh.read())
+            except (OSError, UnicodeDecodeError):
+                continue
+            if not fm:
+                continue
+            etype = _entity_type(fm, f)
+            if etype == "consultant":
+                slug = fm.get("slug")
+                if isinstance(slug, str) and slug:
+                    consultant_slugs.add(slug)
+            elif etype == "project":
+                slug = fm.get("slug")
+                if isinstance(slug, str) and slug:
+                    project_slugs.add(slug)
+            elif etype == "assignment":
+                assignment_records.append((f, fm))
+
+        for f, fm in assignment_records:
+            consultant = fm.get("consultant")
+            if (isinstance(consultant, str) and consultant
+                    and consultant not in consultant_slugs):
+                errors.append({
+                    "entity": "assignment", "file": f, "field": "consultant",
+                    "message": "consultant %r does not resolve to a consultant "
+                               "entity in the portfolio" % consultant,
+                })
+            project = fm.get("project")
+            if (isinstance(project, str) and project
+                    and project not in project_slugs):
+                errors.append({
+                    "entity": "assignment", "file": f, "field": "project",
+                    "message": "project %r does not resolve to a project entity "
+                               "in the portfolio" % project,
+                })
 
     success = len(errors) == 0
     print(json.dumps({

--- a/cogni-projects/skills/projects-entities/SKILL.md
+++ b/cogni-projects/skills/projects-entities/SKILL.md
@@ -106,11 +106,15 @@ Read `data.warnings[]` too. An `unknown field (ignored)` warning is usually a
 misspelled key — the value is being dropped, not stored — so correct it against
 the data model before registering.
 
-The validator checks **frontmatter shape only**: required keys, enums, slug
-casing, ISO dates and their ordering, numeric ranges. It does **not** resolve an
-assignment's `consultant` / `project` slugs to real entity files, so a passing
-run is not evidence the refs exist — reading both referenced entities in Step 2
-remains the guard against a dangling reference.
+The validator checks **frontmatter shape** — required keys, enums, slug casing,
+ISO dates and their ordering, numeric ranges — and, when given a **portfolio
+directory**, additionally resolves each assignment's `consultant` / `project`
+slug against the collected consultant / project entities and errors on a
+dangling reference. Step 4 above passes a **single file**, which stays
+shape-only (no portfolio-wide slug set is available to resolve against), so a
+passing single-file run is not evidence the refs exist — reading both
+referenced entities in Step 2 remains the guard against a dangling reference on
+the single-file authoring path.
 
 ### Step 5: Register in the manifest and log the transition
 

--- a/cogni-projects/tests/test_validate_entities.sh
+++ b/cogni-projects/tests/test_validate_entities.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Test validate-entities.py's referential-integrity check for assignment refs.
+#
+# Covers the portfolio-directory ref check (a dangling consultant / project ref
+# is an error in the {entity, file, field, message} shape), the single-file
+# exemption (a single-file run stays shape-only and never ref-checks), the
+# clean-portfolio path (resolvable refs report success), and the no-double-
+# report guarantee (an assignment that already fails shape validation is
+# excluded from the ref check rather than flagged twice).
+#
+# stdlib-only (bash + python3, no pytest/pip), matching the house convention.
+#
+# Usage: bash cogni-projects/tests/test_validate_entities.sh
+# Exits non-zero on any assertion failure.
+
+set -u
+
+SCRIPTS_DIR="$(cd "$(dirname "$0")/../scripts" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+SCRIPTS_DIR="$SCRIPTS_DIR" WORK="$WORK" python3 - <<'PY'
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+
+SCRIPTS_DIR = os.environ["SCRIPTS_DIR"]
+WORK = os.environ["WORK"]
+
+# validate-entities.py is not an importable module name (hyphen), so load it by
+# file location — the same idiom the script itself documents.
+_spec = importlib.util.spec_from_file_location(
+    "validate_entities", os.path.join(SCRIPTS_DIR, "validate-entities.py")
+)
+ve = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ve)
+
+failures = 0
+
+
+def check(tag, cond, detail=""):
+    global failures
+    if cond:
+        print("PASS: " + tag)
+    else:
+        failures += 1
+        print("FAIL: " + tag + (" — " + detail if detail else ""))
+
+
+def make_portfolio(name):
+    root = os.path.join(WORK, name)
+    for subdir in ("consultants", "projects", "assignments"):
+        os.makedirs(os.path.join(root, subdir))
+    return root
+
+
+def write_consultant(root, slug, name="A Consultant"):
+    path = os.path.join(root, "consultants", slug + ".md")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(
+            "---\n"
+            "type: consultant\n"
+            "slug: %s\n"
+            "name: %s\n"
+            "seniority: senior\n"
+            "skills: [cloud, data]\n"
+            "---\n\n# %s\n" % (slug, name, name)
+        )
+    return path
+
+
+def write_project(root, slug, name="A Project"):
+    path = os.path.join(root, "projects", slug + ".md")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(
+            "---\n"
+            "type: project\n"
+            "slug: %s\n"
+            "name: %s\n"
+            "client: Acme\n"
+            "strategic_impact: 3\n"
+            "---\n\n# %s\n" % (slug, name, name)
+        )
+    return path
+
+
+def write_assignment(root, consultant, project, role="Architect", omit=None):
+    """Write an assignment file. `omit` drops a required field to force a
+    shape error (used to test the no-double-report exclusion)."""
+    slug = "%s--%s" % (consultant, project)
+    fields = [
+        ("type", "assignment"),
+        ("slug", slug),
+        ("consultant", consultant),
+        ("project", project),
+        ("role", role),
+        ("start_date", "2026-01-01"),
+        ("end_date", "2026-06-01"),
+    ]
+    path = os.path.join(root, "assignments", slug + ".md")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("---\n")
+        for key, value in fields:
+            if key == omit:
+                continue
+            f.write("%s: %s\n" % (key, value))
+        f.write("---\n\n# %s\n" % slug)
+    return path
+
+
+def run(*paths):
+    """Run ve.main(paths) and return the parsed envelope."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ve.main(list(paths))
+    return json.loads(buf.getvalue().strip().splitlines()[-1])
+
+
+def ref_errors(env, field):
+    return [
+        e for e in env.get("data", {}).get("errors", [])
+        if e.get("field") == field and "does not resolve" in e.get("message", "")
+    ]
+
+
+# --- (a) Directory run flags a dangling consultant AND project ref -----------
+root = make_portfolio("dangling")
+write_consultant(root, "ana-silva")
+write_project(root, "apollo")
+write_assignment(root, "ghost", "apollo")          # dangling consultant
+write_assignment(root, "ana-silva", "phantom")     # dangling project
+resolvable = write_assignment(root, "ana-silva", "apollo")  # both resolve
+
+env = run(root)
+check("dangling: success is False", env.get("success") is False, str(env))
+c_errs = ref_errors(env, "consultant")
+p_errs = ref_errors(env, "project")
+check("dangling: consultant ref flagged", len(c_errs) == 1, str(c_errs))
+check("dangling: consultant message names the bad slug",
+      c_errs and "ghost" in c_errs[0]["message"], str(c_errs))
+check("dangling: consultant error entity is assignment",
+      c_errs and c_errs[0].get("entity") == "assignment", str(c_errs))
+check("dangling: project ref flagged", len(p_errs) == 1, str(p_errs))
+check("dangling: project message names the bad slug",
+      p_errs and "phantom" in p_errs[0]["message"], str(p_errs))
+# The fully-resolvable assignment produces no ref error of its own.
+resolvable_errs = [
+    e for e in env["data"]["errors"] if e.get("file") == resolvable
+]
+check("dangling: resolvable assignment has no error",
+      resolvable_errs == [], str(resolvable_errs))
+
+# --- (b) Directory run with all refs resolvable reports success --------------
+clean = make_portfolio("clean")
+write_consultant(clean, "bea-costa")
+write_project(clean, "borealis")
+write_assignment(clean, "bea-costa", "borealis")
+env = run(clean)
+check("clean: success is True", env.get("success") is True, str(env))
+check("clean: no errors at all", env["data"]["errors"] == [], str(env["data"]["errors"]))
+
+# --- (c) Single-file run stays shape-only: no ref check ----------------------
+# The same dangling assignment, validated as a single file, must NOT ref-check
+# (no portfolio-wide slug set is available) and is otherwise shape-valid.
+single = make_portfolio("single")
+write_consultant(single, "cid-vega")
+write_project(single, "cosmos")
+lone = write_assignment(single, "ghost", "cosmos")  # dangling consultant
+env = run(lone)
+check("single-file: success is True (no ref check)", env.get("success") is True, str(env))
+check("single-file: no consultant ref error", ref_errors(env, "consultant") == [], str(env))
+
+# --- (d) A shape-broken assignment is excluded from the ref check ------------
+# An assignment missing `role` (shape error) that ALSO has a dangling consultant
+# must be reported once (the missing field), never double-flagged with a ref
+# error — its frontmatter is unreliable, so it is excluded from the ref pass.
+mixed = make_portfolio("mixed")
+write_consultant(mixed, "dana-koch")
+write_project(mixed, "draco")
+broken = write_assignment(mixed, "ghost", "draco", omit="role")
+env = run(mixed)
+check("mixed: success is False", env.get("success") is False, str(env))
+role_errs = [
+    e for e in env["data"]["errors"]
+    if e.get("file") == broken and e.get("field") == "role"
+]
+check("mixed: missing-role shape error reported", len(role_errs) == 1, str(role_errs))
+broken_ref_errs = [
+    e for e in env["data"]["errors"]
+    if e.get("file") == broken and "does not resolve" in e.get("message", "")
+]
+check("mixed: shape-broken assignment not double-flagged as dangling",
+      broken_ref_errs == [], str(broken_ref_errs))
+
+print()
+if failures:
+    print("%d check(s) failed." % failures)
+    sys.exit(1)
+print("All checks passed.")
+PY


### PR DESCRIPTION
Closes #1122.

## Summary
- `validate-entities.py`: a **portfolio-directory** invocation now collects consultant and project slugs and ERRORs on any assignment whose `consultant` or `project` slug does not resolve, in the standard `{entity, file, field, message}` shape (AC1).
- **Single-file** invocation is unchanged (AC2) — `register-entity.py` calls `validate_file()` on a single file, so it is unaffected; the ref pass is gated on a directory argument (`any_dir`).
- Files that already fail shape validation are excluded from the slug sets and the ref check, so a malformed record is reported once, never double-flagged as "dangling".
- Doc anchors updated in lockstep: the module docstring, `projects-entities/SKILL.md` Step 4 scope statement (AC3), and `references/data-model.md` Validation section. The single-file authoring note (SKILL.md Step 2) stays true and is left as-is.
- New `tests/test_validate_entities.sh` covers the positive (directory flags a dangling ref), clean (resolvable refs → success), single-file-exemption, and no-double-report cases.

## Scope decisions
- In: AC1, AC2, AC3, and a dedicated test. All three doc claims moved together to prevent drift.
- Out: nothing deferred. AC4 (ordering before #1114) is moot — #1114 has shipped.
- README component-table label is auto-generated by cogni-docs, so it is not hand-edited here.
- No `plugin.json` / `marketplace.json` version bump — the post-merge workflow owns that.

## Test plan
- [x] `bash cogni-projects/tests/test_validate_entities.sh` passes (new — 14 checks).
- [x] `bash cogni-projects/tests/test_register_entity.sh` still passes (single-file contract unchanged).
- [ ] Manual: run the validator against a real portfolio dir with resolvable refs — `success:true`, no new errors.

---
🤖 Resolved by cogni-service (author instance). Draft, `svc:needs-review` — handed off to the merger instance for independent review.
