### PR TITLE
cogni-consult: collapse the WBS dashboard to five columns

### DIFF
--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -115,8 +115,8 @@ chosen here.
 
 Close the dashboard with the **next-deliverable recommendation**. Check for
 stale deliverables first: any deliverable carrying `lineage_status.status:
-"stale"` has been invalidated by an upstream change, and refreshing it outranks
-starting fresh pending work. When stale deliverables exist, run
+"stale"` was invalidated upstream, and refreshing it outranks fresh work,
+which a stale foundation would waste. When stale deliverables exist, run
 `deliverable-graph.py <engagement-dir> refresh-order` and recommend refreshing
 them in **topological order — upstream before dependents**: layer-0 first,
 deeper layers only once the layer above is refreshed. Route to
@@ -140,7 +140,7 @@ prompting by delegating to the `consult-dashboard-refresher` agent with
 
 **Milestone README refresh.** Whenever the WBS structure changed this session,
 also run `python3 $CLAUDE_PLUGIN_ROOT/scripts/generate-engagement-readme.py "<engagement-dir>"`
-to refresh the engagement-root README front door — unconditional and
+to refresh the engagement-root README front door — no theme gate, and
 non-fatal: on failure, warn and continue.
 
 ### 4. Plan a Field's Deliverable Set

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -98,14 +98,15 @@ proper-cased for display (`ideate` → `Ideate`). A `complete` deliverable
 renders no stage — a **render-time** suppression only, so `dt_stage` stays
 stored in `field.json`.
 
-`Route` is no longer a column: when a deliverable's `producing_route` differs
-from the default `consult-design-thinking`, append a note line under it —
-`Route: <deliverable> · <producing_route>`, e.g.
-`Route: market-sizing · cogni-visual`.
+`Route` is not a column: when a deliverable's `producing_route` differs from
+the default `consult-design-thinking`, note it beneath the table, never a
+sixth cell: `Route: <deliverable> · <producing_route>`, e.g.
+`Route: gtm-onepager · cogni-visual`.
 
-An English session renders the same table, seeded by example: header
+An English session renders the same table: header
 `| Action field | Deliverable | Status | Framework | Persona review |`, values
-`done` / `in progress · Ideate` / `open`, and the same `Route:` note line.
+`complete` / `in progress · Ideate` / `pending`, and the same `Route:` note
+line.
 
 `Framework` shows the stored `chosen_framework` read-only — a registry slug
 verbatim, a `combo:<slugA>+<slugB>` pairing rendered `<slugA> + <slugB>` (the
@@ -124,10 +125,10 @@ deeper layers only once the layer above is refreshed. Route to
 Only when nothing is stale, fall through to the first deliverable with
 `state: "pending"`, walking in that same order. When a field has an empty
 `deliverables[]`, recommend planning that field's set (step 4) instead — an
-empty container outranks a half-done one. Skip unreadable fields — surface their warning rather than a
-planning recommendation that would `Edit` a malformed `field.json`. When every
-deliverable is `complete` and current, say so — completion is derived, nothing
-is stored.
+empty container outranks a half-done one. Skip unreadable fields — surface
+their warning rather than a planning recommendation that would `Edit` a
+malformed `field.json`. When every deliverable is `complete` and current, say
+so — completion is derived, nothing is stored.
 
 **Offer the visual dashboard.** This text table is the quick check; for a
 themed, browsable view, offer `/cogni-consult:consult-dashboard`. When the

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -94,9 +94,9 @@ deliverables in manifest order:
 ```
 
 `Stand` merges the stored `state` and `dt_stage` into one value, the stage
-proper-cased for display (`ideate` → `Ideate`). A `complete` deliverable
-renders no stage — a **render-time** suppression only, so `dt_stage` stays
-stored in `field.json`.
+proper-cased for display (`ideate` → `Ideate`). A `complete` or `pending`
+deliverable renders no stage — a **render-time** suppression only, so
+`dt_stage` stays stored in `field.json`.
 
 `Route` is not a column: when a deliverable's `producing_route` differs from
 the default `consult-design-thinking`, note it beneath the table, never a

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -81,49 +81,57 @@ skill's to replace).
 
 ### 3. Render the WBS Dashboard
 
-Present one table, fields in `action_fields[]` order (that order is the WBS
-priority), deliverables in manifest order:
+Present one table, fields in `action_fields[]` order (the WBS priority),
+deliverables in manifest order:
 
 ```
-| Action field | Deliverable | State | DT stage | Framework | Route | Persona review |
-|---|---|---|---|---|---|---|
-| market-evidence | market-sizing | complete | test | pyramid-principle | consult-design-thinking | complete |
-| market-evidence | competitor-landscape | in-progress | ideate | — | consult-design-thinking | pending |
-| portfolio-fit | — (no deliverables planned) | | | | | |
-| go-to-market | ⚠ unreadable field.json (see warnings) | | | | | |
+| Handlungsfeld | Deliverable | Stand | Framework | Persona-Prüfung |
+|---|---|---|---|---|
+| market-evidence | market-sizing | fertig | pyramid-principle | fertig |
+| market-evidence | competitor-landscape | in Arbeit · Ideate | — | offen |
+| portfolio-fit | — (no deliverables planned) | | | |
+| go-to-market | ⚠ unreadable field.json (see warnings) | | | |
 ```
 
-`Framework` shows the deliverable's stored `chosen_framework` read-only — a
-registry slug verbatim, or for a `combo:<slugA>+<slugB>` pairing the two slugs
-joined as `<slugA> + <slugB>` (the stored `combo:` prefix dropped for display),
-or `—` when none is stored (legacy deliverables, or one created before a
-framework was chosen). The value is never inferred or chosen here.
+`Stand` merges the stored `state` and `dt_stage` into one value, the stage
+proper-cased for display (`ideate` → `Ideate`). A `complete` deliverable
+renders no stage — a **render-time** suppression only, so `dt_stage` stays
+stored in `field.json`.
+
+`Route` is no longer a column: when a deliverable's `producing_route` differs
+from the default `consult-design-thinking`, append a note line under it —
+`Route: <deliverable> · <producing_route>`, e.g.
+`Route: market-sizing · cogni-visual`.
+
+An English session renders the same table, seeded by example: header
+`| Action field | Deliverable | Status | Framework | Persona review |`, values
+`done` / `in progress · Ideate` / `open`, and the same `Route:` note line.
+
+`Framework` shows the stored `chosen_framework` read-only — a registry slug
+verbatim, a `combo:<slugA>+<slugB>` pairing rendered `<slugA> + <slugB>` (the
+stored `combo:` prefix dropped), or `—` when none is stored. Never inferred or
+chosen here.
 
 Close the dashboard with the **next-deliverable recommendation**. Check for
 stale deliverables first: any deliverable carrying `lineage_status.status:
 "stale"` has been invalidated by an upstream change, and refreshing it outranks
-starting fresh pending work (new work built on a stale foundation is wasted).
-When stale deliverables exist, run `deliverable-graph.py <engagement-dir>
-refresh-order` and recommend refreshing them in **topological order — upstream
-before dependents**: the layer-0 deliverable(s) first (nothing else stale
-depends on them, so they are safe to refresh now), deeper layers only once the
-layer above is refreshed. Route to `knowledge-refresh`, then
-`consult-design-thinking` to re-run the deliverable's loop.
+starting fresh pending work. When stale deliverables exist, run
+`deliverable-graph.py <engagement-dir> refresh-order` and recommend refreshing
+them in **topological order — upstream before dependents**: layer-0 first,
+deeper layers only once the layer above is refreshed. Route to
+`knowledge-refresh`, then `consult-design-thinking` to re-run the loop.
 
 Only when nothing is stale, fall through to the first deliverable with
-`state: "pending"`, walking fields in `action_fields[]` order and deliverables
-in manifest order. When a field has an empty `deliverables[]`, recommend
-planning that field's set (step 4) instead — an empty container outranks a
-half-done one. Skip unreadable fields in this walk — the rollup reports them
-with an empty `deliverables[]` too, but the right response is surfacing their
-warning, not a planning recommendation that would `Edit` a malformed
-`field.json`. When every deliverable is `complete` and current, say so: the
-engagement is complete by derivation, there is nothing to store.
+`state: "pending"`, walking in that same order. When a field has an empty
+`deliverables[]`, recommend planning that field's set (step 4) instead — an
+empty container outranks a half-done one. Skip unreadable fields — surface their warning rather than a
+planning recommendation that would `Edit` a malformed `field.json`. When every
+deliverable is `complete` and current, say so — completion is derived, nothing
+is stored.
 
 **Offer the visual dashboard.** This text table is the quick check; for a
-themed, browsable view of the same WBS — deliverable states, design-thinking
-stages, and persona-review coverage — offer `/cogni-consult:consult-dashboard`.
-When the engagement already has `output/design-variables.json` and the WBS
+themed, browsable view, offer `/cogni-consult:consult-dashboard`. When the
+engagement already has `output/design-variables.json` and the WBS
 structure changed this session (a field's deliverable set was planned in step 4,
 or a field was added/split/merged), regenerate the HTML snapshot without
 prompting by delegating to the `consult-dashboard-refresher` agent with
@@ -131,9 +139,8 @@ prompting by delegating to the `consult-dashboard-refresher` agent with
 
 **Milestone README refresh.** Whenever the WBS structure changed this session,
 also run `python3 $CLAUDE_PLUGIN_ROOT/scripts/generate-engagement-readme.py "<engagement-dir>"`
-to refresh the engagement-root README front door — unconditional (unlike the
-theme-gated dashboard, no `output/design-variables.json` needed) and non-fatal:
-on failure, warn and continue.
+to refresh the engagement-root README front door — unconditional and
+non-fatal: on failure, warn and continue.
 
 ### 4. Plan a Field's Deliverable Set
 


### PR DESCRIPTION
Closes #1157.

## Summary

- Collapse the Step 3 WBS dashboard example in `cogni-consult/skills/consult-action-fields/SKILL.md` from seven columns to five: `| Handlungsfeld | Deliverable | Stand | Framework | Persona-Prüfung |`. The two degenerate rows (`— (no deliverables planned)`, `⚠ unreadable field.json (see warnings)`) carry over verbatim, reshaped to five cells, and still tie to Step 2's `warnings[]` surfacing rule.
- Merge the stored `state` and `dt_stage` into one `Stand` value, seeded by the worked example `in Arbeit · Ideate`. A `complete` or `pending` deliverable renders **no stage** — stated as a **render-time** suppression that leaves `dt_stage` stored in `field.json` untouched, and seeded by example (`fertig`) so the rule need not be inferred from prose alone.
- Drop `Route` from the standing columns. Deviation surfaces as a note line rendered **under** the fence, emitted only when `producing_route` differs from the default `consult-design-thinking`, with an explicit literal format string plus a filled-in instance.
- Seed the English session verbatim by example (all five English labels plus the cell values), mirroring the precedent at `consult-resume/SKILL.md:99-106`.

## Scope decisions

**Exactly one file changes.** Only `consult-action-fields/SKILL.md`. The merge is render-time only and nulls nothing, so `references/data-model.md`, `scripts/generate-engagement-readme.py` (its unrelated 3-column `| Action field | Done | State |` rollup at `:365` and `STATE_LABEL` at `:288`), `skills/consult-dashboard/scripts/generate-dashboard.py` and `output-styles/strategy-advisor-de.md` appear in no hunk. Verified: `git diff origin/main -- <those four paths>` is empty.

**Deviation-note placement is decided, not left open.** Two acceptance criteria pull against each other: one requires every data row *inside* the fence to have exactly five pipe-delimited cells, the other requires the note to have a rendered shape. A pipe-less line inside the fence would make the first ambiguous to grade, so the note goes **under** the fence — which the second criterion's own wording ("inside/**under** the fenced block, **or** an explicit literal format string") permits. The fence holds exactly six lines: header, separator, four 5-cell rows.

**German vocabulary is reused, not invented.** `fertig` / `in Arbeit` / `offen`, the `Stand` header, the Capitalized stage and the `·` separator all come from the family's live table at `consult-resume/SKILL.md:135-139`. No raw `pending` / `in-progress` / `complete` appears as a German cell value, per `output-styles/strategy-advisor-de.md:61-68`. The English label is `Status`, not `State`, so nothing collides with the field-level rollup header.

**The `references/interaction-language.md` pointer is deliberately NOT added.** This is a conscious omission, not an oversight: the wiring is owned across the family by the sibling Step 0 language-gate child, and `consult-action-fields` is not the only skill lacking it (`consult-publish` lacks it too), so "every sibling has one" was never a safe reason to add it here by reflex.

**No version is touched.** The post-merge workflow owns the bump.

**No new automated test.** No repo test, eval, or lint asserts on this table's shape in base; the achievable bar is the code-shape greps plus the mutation check below. The acceptance criteria state explicitly that the absence of a new test is not a defect here.

## Review notes

**Pre-existing over-cap, annotated not fixed.** `consult-action-fields/SKILL.md` was already **819 chars over** its complexity-scaled cap on `origin/main` (`chars_body` 20319 vs `cap_chars` 19500). Per the net-growth budget, an over-cap unit that a diff does **not** grow is annotate-only — coupling an aggressive whole-file rewrite to a focused change is explicitly out of scope, and corpus-wide pre-existing over-cap is `service-simplify`'s standing sweep. This PR therefore does **not** attempt to get the file under cap; it guarantees only that the file leaves no larger than it entered.

Measured: base `chars_body` **20319** → head **20299** (**net −20**). The collapse itself returns only ~100 chars, so the ~700 chars of new mandated prose were paid for by tightening prose **inside Step 3 only** — compressing the `Framework` paragraph to a semantically equivalent form (all four invariants retained), deduplicating the unreadable-fields sentence against Step 2's rule at `:67-69`, deduplicating the restated walk-order against the section lead-in, and dropping three rationale parentheticals. No content outside Step 3 was trimmed.

The `skill-quality-reviewer` also flagged the over-cap body as a whole-skill structural issue, tagged `introduced_by_change: false` — same pre-existing condition, recorded here rather than re-planned.

**One reviewer finding was auto-fixed before commit.** The merged `Stand` cell renders the stage title-cased (`Ideate`) while the stored value is lowercase (`ideate`), and nothing stated that lift — an implicit transformation the merged cell newly introduces. The sibling dashboard states the rule explicitly (`consult-resume/SKILL.md:149`), so the convention existed but was unstated here. Fixed by naming it in the merge sentence: "the stage proper-cased for display (`ideate` → `Ideate`)".

## Test plan

Verified on the branch head:

- [x] `git diff --name-only origin/main` lists exactly one path.
- [x] Old 7-column header returns **0** grep matches; new German header returns exactly **1**, separator has five `---` cells.
- [x] All six lines inside the fence are pipe-delimited with exactly **5 cells**, including both carried-over degenerate rows.
- [x] `in Arbeit · Ideate` present with the middot; the `complete` row's `Stand` is `fertig` with no `· <stage>` segment; **0** German cells carry a raw engine enum.
- [x] Step 3 names both `state` and `dt_stage`, labels the suppression **render-time**, and states `dt_stage` stays stored.
- [x] Step 3 conditions the note on `producing_route` differing from `consult-design-thinking`; the literal `Route: <deliverable> · <producing_route>` is present.
- [x] All five English labels appear verbatim on one greppable line.
- [x] `interaction-language` returns **0** matches (the deliberate omission above).
- [x] `Framework` invariants intact (`combo:<slugA>+<slugB>` → `<slugA> + <slugB>`, prefix dropped, `—` when none, never inferred).
- [x] Guard files unchanged; `generate-engagement-readme.py:365` and `STATE_LABEL` at `:288` intact.
- [x] **cogni-consult test suite: 7/7 pass**, including `test_deliverable_graph.sh` (whose `:206` / `:578` fixtures assert `dt_stage == 'test'` on complete deliverables — proving no data-level null crept in).
- [x] Breadcrumb guard clean (0 violations); version-bump gate `status: ok`; frontmatter check `data.clean: true`.
- [x] Length: head 20299 ≤ base 20319.
- [x] **Mutation check:** restoring the old 7-column header flips the zero-grep to 1; reverting returns it to 0 — the grep genuinely binds.

## Known temporary inconsistencies (not introduced here)

- `output-styles/strategy-advisor-de.md:58` still whitelists "Action Field" as permissibly English — owned by the sibling lexicon child.
- `consult-resume/SKILL.md:135` still shows English headers in its German example — filed separately.
