### PR TITLE
cogni-consult: Step 0 interaction-language gate across all nine skills

### DIFF
--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -38,9 +38,10 @@ its producing route (a `consult-design-thinking` run by default).
 Before any user-facing output, resolve the **interaction language** — the
 workspace default, overridden by the user's message language — per
 `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
-resolution ladder; do not restate the ladder here. It is independent of the
-engagement's `language` field, which is the deliverable axis. This contract
-holds on the default path: it does not depend on an output style being active.
+resolution ladder. Conduct the entire conversation in the resolved language.
+It is independent of the engagement's `language` field, which is the
+deliverable axis. This contract holds on the default path: it does not depend
+on an output style being active.
 
 The `description` of a Bash tool call is rendered to the consultant, so it is
 user copy — write it in the interaction language, outcome-shaped, at most 6

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -33,6 +33,21 @@ its producing route (a `consult-design-thinking` run by default).
 
 ## Workflow
 
+### 0. Resolve the Interaction Language
+
+Before any user-facing output, resolve the **interaction language** — the
+workspace default, overridden by the user's message language — per
+`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
+resolution ladder; do not restate the ladder here. It is independent of the
+engagement's `language` field, which is the deliverable axis. This contract
+holds on the default path: it does not depend on an output style being active.
+
+The `description` of a Bash tool call is rendered to the consultant, so it is
+user copy — write it in the interaction language, outcome-shaped, at most 6
+words, with no script, file, or skill names, and never derived from the
+script's filename or header comment. Worked pair:
+`Discover cogni-consult engagements` → `Laufende Engagements holen`.
+
 ### 1. Prerequisite Gate
 
 When arriving via an in-session `consult-scope` handoff, the engagement

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -33,6 +33,24 @@ generator is **read-only** — it never modifies any engagement file.
 
 ## Workflow
 
+### 0. Resolve the Interaction Language
+
+Before any user-facing output, resolve the **interaction language** — the
+workspace default, overridden by the user's message language — per
+`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
+resolution ladder; do not restate the ladder here. It is independent of the
+engagement's `language` field, which is the deliverable axis. This contract
+holds on the default path: it does not depend on an output style being active.
+
+The `description` of a Bash tool call is rendered to the consultant, so it is
+user copy — write it in the interaction language, outcome-shaped, at most 6
+words, with no script, file, or skill names, and never derived from the
+script's filename or header comment. Worked pair:
+`Discover cogni-consult engagements` → `Laufende Engagements holen`.
+
+The dashboard document's own `<html lang>` attribute and language badge follow
+the engagement's deliverable `language`, not the interaction language.
+
 ### 1. Find the Active Engagement
 
 Discover engagements with `scripts/discover-projects.sh` (the registry wrapper), or scan
@@ -186,9 +204,3 @@ with "pending").
 - The HTML file is fully self-contained (inline CSS, no external dependencies beyond an optional
   Google Fonts import).
 - Re-running the script overwrites the previous dashboard at `output/dashboard.html`.
-- **Interaction language**: communicate with the user (status messages, instructions,
-  recommendations, questions) in the resolved interaction language — the workspace default,
-  overridden by the user's message language — not the engagement's `language` field, which is
-  the deliverable axis (it controls the dashboard document's `<html lang>` and the language
-  badge, not how you address the user). Technical terms, skill names, and CLI commands remain in
-  English. See `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`.

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -38,9 +38,10 @@ generator is **read-only** — it never modifies any engagement file.
 Before any user-facing output, resolve the **interaction language** — the
 workspace default, overridden by the user's message language — per
 `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
-resolution ladder; do not restate the ladder here. It is independent of the
-engagement's `language` field, which is the deliverable axis. This contract
-holds on the default path: it does not depend on an output style being active.
+resolution ladder. Conduct the entire conversation in the resolved language.
+It is independent of the engagement's `language` field, which is the
+deliverable axis. This contract holds on the default path: it does not depend
+on an output style being active.
 
 The `description` of a Bash tool call is rendered to the consultant, so it is
 user copy — write it in the interaction language, outcome-shaped, at most 6

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -54,6 +54,21 @@ only adds shape when present; it never blocks production when absent.
 
 ## Workflow
 
+### 0. Resolve the Interaction Language
+
+Before any user-facing output, resolve the **interaction language** — the
+workspace default, overridden by the user's message language — per
+`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
+resolution ladder; do not restate the ladder here. It is independent of the
+engagement's `language` field, which is the deliverable axis. This contract
+holds on the default path: it does not depend on an output style being active.
+
+The `description` of a Bash tool call is rendered to the consultant, so it is
+user copy — write it in the interaction language, outcome-shaped, at most 6
+words, with no script, file, or skill names, and never derived from the
+script's filename or header comment. Worked pair:
+`Discover cogni-consult engagements` → `Laufende Engagements holen`.
+
 ### Interaction mode
 
 By default this loop runs as an **auto-walk**: it writes each stage's artifact
@@ -143,11 +158,6 @@ Dispatch `Skill("cogni-consult:consult-action-fields")` to plan the field's
 deliverable set (it writes the full planned-entry shape, including
 `producing_route` and `persona_review`), then resume here with the planned
 entry.
-
-Conduct the conversation in the resolved **interaction language** (workspace
-default, overridden by the user's message language) — independent of the
-engagement's `language` field, which is the deliverable axis. See
-`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`.
 
 **Personas gate (fresh starts only).** Before opening the loop for a deliverable
 whose `state` is `pending` (a fresh start — not a resume or rework), the

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -59,9 +59,10 @@ only adds shape when present; it never blocks production when absent.
 Before any user-facing output, resolve the **interaction language** — the
 workspace default, overridden by the user's message language — per
 `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
-resolution ladder; do not restate the ladder here. It is independent of the
-engagement's `language` field, which is the deliverable axis. This contract
-holds on the default path: it does not depend on an output style being active.
+resolution ladder. Conduct the entire conversation in the resolved language.
+It is independent of the engagement's `language` field, which is the
+deliverable axis. This contract holds on the default path: it does not depend
+on an output style being active.
 
 The `description` of a Bash tool call is rendered to the consultant, so it is
 user copy — write it in the interaction language, outcome-shaped, at most 6

--- a/cogni-consult/skills/consult-personas/SKILL.md
+++ b/cogni-consult/skills/consult-personas/SKILL.md
@@ -34,9 +34,10 @@ Modes: define (step 3), waive (step 3a), enrich (step 4), challenge (step 5).
 Before any user-facing output, resolve the **interaction language** — the
 workspace default, overridden by the user's message language — per
 `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
-resolution ladder; do not restate the ladder here. It is independent of the
-engagement's `language` field, which is the deliverable axis. This contract
-holds on the default path: it does not depend on an output style being active.
+resolution ladder. Conduct the entire conversation in the resolved language.
+It is independent of the engagement's `language` field, which is the
+deliverable axis. This contract holds on the default path: it does not depend
+on an output style being active.
 
 The `description` of a Bash tool call is rendered to the consultant, so it is
 user copy — write it in the interaction language, outcome-shaped, at most 6

--- a/cogni-consult/skills/consult-personas/SKILL.md
+++ b/cogni-consult/skills/consult-personas/SKILL.md
@@ -29,6 +29,21 @@ templates live in `$CLAUDE_PLUGIN_ROOT/references/personas/`.
 
 Modes: define (step 3), waive (step 3a), enrich (step 4), challenge (step 5).
 
+### 0. Resolve the Interaction Language
+
+Before any user-facing output, resolve the **interaction language** — the
+workspace default, overridden by the user's message language — per
+`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
+resolution ladder; do not restate the ladder here. It is independent of the
+engagement's `language` field, which is the deliverable axis. This contract
+holds on the default path: it does not depend on an output style being active.
+
+The `description` of a Bash tool call is rendered to the consultant, so it is
+user copy — write it in the interaction language, outcome-shaped, at most 6
+words, with no script, file, or skill names, and never derived from the
+script's filename or header comment. Worked pair:
+`Discover cogni-consult engagements` → `Laufende Engagements holen`.
+
 ### 1. Prerequisite Gate
 
 When arriving via an in-session handoff (e.g. a design-thinking test stage
@@ -45,11 +60,6 @@ registered. Read `<engagement-dir>/consult-project.json`. If it is missing
 `Skill("cogni-consult:consult-setup")` and stop — write nothing. Scoping is
 NOT a prerequisite — the two default advisors are useful from day one; only
 scope-seeding (step 3) needs a completed scope.
-
-Conduct the conversation in the resolved **interaction language** (workspace
-default, overridden by the user's message language) — independent of the
-engagement's `language` field, which is the deliverable axis. See
-`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`.
 
 ### 2. Ensure the Default Advisors Exist
 
@@ -95,7 +105,7 @@ waiver is that escape, and it is a deliberate, confirmed decision — never a
 silent default.
 
 Only take this path when the consultant explicitly confirms it. Ask, in the
-resolved interaction language (see step 1), whether the engagement genuinely
+resolved interaction language (see step 0), whether the engagement genuinely
 has no external stakeholders to model beyond the shipped advisors. Do **not**
 write the marker on silence, on ambiguity, or as a fallback when scope-seeding
 merely hasn't happened yet — a *pending* gate and a *waived* gate are
@@ -145,7 +155,7 @@ its writes:
 1. **Fan out the objections (read-only).** For each relevant persona, dispatch
    the read-only `consult-persona-challenger` agent (inputs `engagement_dir`,
    `field_slug`, `deliverable_slug`, `persona_slug`, `plugin_root`,
-   `interaction_language` — the language resolved in step 1, as an ISO 639-1
+   `interaction_language` — the language resolved in step 0, as an ISO 639-1
    code); it adopts
    that persona's `voice` bounded by its `capabilities`/`wants`/`needs`/
    `core_tension` and returns the standard `{success, data, error}` envelope

--- a/cogni-consult/skills/consult-project-plan/SKILL.md
+++ b/cogni-consult/skills/consult-project-plan/SKILL.md
@@ -49,9 +49,10 @@ schedule. Populating the scheduling fields is the job of `consult-action-fields`
 Before any user-facing output, resolve the **interaction language** — the
 workspace default, overridden by the user's message language — per
 `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
-resolution ladder; do not restate the ladder here. It is independent of the
-engagement's `language` field, which is the deliverable axis. This contract
-holds on the default path: it does not depend on an output style being active.
+resolution ladder. Conduct the entire conversation in the resolved language.
+It is independent of the engagement's `language` field, which is the
+deliverable axis. This contract holds on the default path: it does not depend
+on an output style being active.
 
 The `description` of a Bash tool call is rendered to the consultant, so it is
 user copy — write it in the interaction language, outcome-shaped, at most 6

--- a/cogni-consult/skills/consult-project-plan/SKILL.md
+++ b/cogni-consult/skills/consult-project-plan/SKILL.md
@@ -44,6 +44,24 @@ schedule. Populating the scheduling fields is the job of `consult-action-fields`
 
 ## Workflow
 
+### 0. Resolve the Interaction Language
+
+Before any user-facing output, resolve the **interaction language** — the
+workspace default, overridden by the user's message language — per
+`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
+resolution ladder; do not restate the ladder here. It is independent of the
+engagement's `language` field, which is the deliverable axis. This contract
+holds on the default path: it does not depend on an output style being active.
+
+The `description` of a Bash tool call is rendered to the consultant, so it is
+user copy — write it in the interaction language, outcome-shaped, at most 6
+words, with no script, file, or skill names, and never derived from the
+script's filename or header comment. Worked pair:
+`Discover cogni-consult engagements` → `Laufende Engagements holen`.
+
+The engagement's `language` field controls the artifact's `lang` frontmatter,
+not how you address the user.
+
 ### 1. Prerequisite Gate
 
 When arriving via an in-session handoff that already resolved the engagement
@@ -156,8 +174,8 @@ unscheduled_count: <len(data.unscheduled)>
 ---
 ```
 
-**Body** — a short lead-in sentence (in the interaction language; see Important
-Notes), then one `## Phase N` heading per layer, each with a table:
+**Body** — a short lead-in sentence (in the interaction language; see Step 0),
+then one `## Phase N` heading per layer, each with a table:
 
 | Deliverable | Action field | Owner | Start | Due | Duration (d) | Milestone | Critical path |
 |-------------|--------------|-------|-------|-----|--------------|-----------|---------------|
@@ -220,10 +238,3 @@ artifact is markdown for Obsidian.
   Step 2 stops and surfaces it rather than writing a misleading partial plan.
 - The roadmap **phases** are topological layers of the deliverable graph, not
   engagement stages (cogni-consult engagements have no phases).
-- **Interaction language**: communicate with the user (status messages,
-  instructions, recommendations, questions) in the resolved interaction language —
-  the workspace default, overridden by the user's message language — not the
-  engagement's `language` field, which is the deliverable axis (it controls the
-  artifact's `lang` frontmatter, not how you address the user). Technical terms,
-  skill names, and CLI commands remain in English. See
-  `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`.

--- a/cogni-consult/skills/consult-publish/SKILL.md
+++ b/cogni-consult/skills/consult-publish/SKILL.md
@@ -49,9 +49,10 @@ not automatic**:
 Before any user-facing output, resolve the **interaction language** — the
 workspace default, overridden by the user's message language — per
 `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
-resolution ladder; do not restate the ladder here. It is independent of the
-engagement's `language` field, which is the deliverable axis. This contract
-holds on the default path: it does not depend on an output style being active.
+resolution ladder. Conduct the entire conversation in the resolved language.
+It is independent of the engagement's `language` field, which is the
+deliverable axis. This contract holds on the default path: it does not depend
+on an output style being active.
 
 The `description` of a Bash tool call is rendered to the consultant, so it is
 user copy — write it in the interaction language, outcome-shaped, at most 6

--- a/cogni-consult/skills/consult-publish/SKILL.md
+++ b/cogni-consult/skills/consult-publish/SKILL.md
@@ -44,6 +44,21 @@ not automatic**:
 
 ## Workflow
 
+### 0. Resolve the Interaction Language
+
+Before any user-facing output, resolve the **interaction language** — the
+workspace default, overridden by the user's message language — per
+`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
+resolution ladder; do not restate the ladder here. It is independent of the
+engagement's `language` field, which is the deliverable axis. This contract
+holds on the default path: it does not depend on an output style being active.
+
+The `description` of a Bash tool call is rendered to the consultant, so it is
+user copy — write it in the interaction language, outcome-shaped, at most 6
+words, with no script, file, or skill names, and never derived from the
+script's filename or header comment. Worked pair:
+`Discover cogni-consult engagements` → `Laufende Engagements holen`.
+
 ### 1. Locate the engagement and the deliverable
 
 Resolve the engagement root (the directory holding `consult-project.json`) and

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -25,6 +25,21 @@ other write belongs to the skill it routes to.
 
 ## Workflow
 
+### 0. Resolve the Interaction Language
+
+Before any user-facing output, resolve the **interaction language** — the
+workspace default, overridden by the user's message language — per
+`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
+resolution ladder; do not restate the ladder here. It is independent of the
+engagement's `language` field, which is the deliverable axis. This contract
+holds on the default path: it does not depend on an output style being active.
+
+The `description` of a Bash tool call is rendered to the consultant, so it is
+user copy — write it in the interaction language, outcome-shaped, at most 6
+words, with no script, file, or skill names, and never derived from the
+script's filename or header comment. Worked pair:
+`Discover cogni-consult engagements` → `Laufende Engagements holen`.
+
 ### 1. Discover Engagements
 
 ```bash
@@ -105,11 +120,6 @@ and one next step.` Dates keep the same day-first shape, so a date reads the
 same way in either session. The columns, sort, cap, and the list-and-stop
 obligation are identical in both languages.
 
-Conduct the conversation in the resolved **interaction language** (workspace
-default, overridden by the user's message language) — independent of the
-engagement's `language` field, which is the deliverable axis. See
-`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`.
-
 ### 3. Read the Engagement Status
 
 ```bash
@@ -166,7 +176,7 @@ passes through with each deliverable. Fall back to the slug only when no title
 is stored — slugs are storage keys, not display names, and titles are rendered
 as stored, never translated.
 `zuletzt bearbeitet` resolves exactly as in step 2; compute it for the selected
-engagement here when step 2's branch did not already. Step 2's language rule
+engagement here when step 2's branch did not already. Step 2's rendering rule
 covers this table too — its column headers, status cells, preamble labels and
 the date shape.
 

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -30,9 +30,10 @@ other write belongs to the skill it routes to.
 Before any user-facing output, resolve the **interaction language** — the
 workspace default, overridden by the user's message language — per
 `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
-resolution ladder; do not restate the ladder here. It is independent of the
-engagement's `language` field, which is the deliverable axis. This contract
-holds on the default path: it does not depend on an output style being active.
+resolution ladder. Conduct the entire conversation in the resolved language.
+It is independent of the engagement's `language` field, which is the
+deliverable axis. This contract holds on the default path: it does not depend
+on an output style being active.
 
 The `description` of a Bash tool call is rendered to the consultant, so it is
 user copy — write it in the interaction language, outcome-shaped, at most 6

--- a/cogni-consult/skills/consult-scope/SKILL.md
+++ b/cogni-consult/skills/consult-scope/SKILL.md
@@ -19,6 +19,21 @@ Produce the keystone deliverable of a cogni-consult engagement: one SMART key qu
 
 ## Workflow
 
+### 0. Resolve the Interaction Language
+
+Before any user-facing output, resolve the **interaction language** — the
+workspace default, overridden by the user's message language — per
+`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
+resolution ladder; do not restate the ladder here. It is independent of the
+engagement's `language` field, which is the deliverable axis. This contract
+holds on the default path: it does not depend on an output style being active.
+
+The `description` of a Bash tool call is rendered to the consultant, so it is
+user copy — write it in the interaction language, outcome-shaped, at most 6
+words, with no script, file, or skill names, and never derived from the
+script's filename or header comment. Worked pair:
+`Discover cogni-consult engagements` → `Laufende Engagements holen`.
+
 ### 1. Prerequisite Gate
 
 When arriving via an in-session `consult-setup` handoff, the engagement directory is already known — skip discovery. Otherwise locate the engagement:
@@ -36,8 +51,6 @@ When `workflow_state.scope` is already `complete`, this is a re-scope (pivot): c
 ### 2. Open the Scoping Conversation
 
 Read `$CLAUDE_PLUGIN_ROOT/references/methods/scope-dimensions.md`, then set `workflow_state.scope` to `"in-progress"` and `updated` to today's ISO date in one `Edit` — never rewrite `consult-project.json` (the `created` timestamp and `plugin_refs` set by setup must survive; `updated` covers scope edits per the data model, so an interrupted session still shows fresh modification).
-
-Conduct the conversation in the resolved **interaction language** (workspace default, overridden by the user's message language) — independent of the engagement's `language` field, which is the deliverable axis. See `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`.
 
 ### 3. Key Question, Then the Five Dimensions
 

--- a/cogni-consult/skills/consult-scope/SKILL.md
+++ b/cogni-consult/skills/consult-scope/SKILL.md
@@ -24,9 +24,10 @@ Produce the keystone deliverable of a cogni-consult engagement: one SMART key qu
 Before any user-facing output, resolve the **interaction language** — the
 workspace default, overridden by the user's message language — per
 `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
-resolution ladder; do not restate the ladder here. It is independent of the
-engagement's `language` field, which is the deliverable axis. This contract
-holds on the default path: it does not depend on an output style being active.
+resolution ladder. Conduct the entire conversation in the resolved language.
+It is independent of the engagement's `language` field, which is the
+deliverable axis. This contract holds on the default path: it does not depend
+on an output style being active.
 
 The `description` of a Bash tool call is rendered to the consultant, so it is
 user copy — write it in the interaction language, outcome-shaped, at most 6

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -22,6 +22,21 @@ Setup deliberately stays light: it captures the outcome and the research spine, 
 
 ## Workflow
 
+### 0. Resolve the Interaction Language
+
+Before any user-facing output, resolve the **interaction language** — the
+workspace default, overridden by the user's message language — per
+`$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
+resolution ladder; do not restate the ladder here. It is independent of the
+engagement's `language` field, which is the deliverable axis. This contract
+holds on the default path: it does not depend on an output style being active.
+
+The `description` of a Bash tool call is rendered to the consultant, so it is
+user copy — write it in the interaction language, outcome-shaped, at most 6
+words, with no script, file, or skill names, and never derived from the
+script's filename or header comment. Worked pair:
+`Discover cogni-consult engagements` → `Laufende Engagements holen`.
+
 ### 1. Gather Engagement Context
 
 Collect these fields, extracting whatever the user already provided and asking only for what is missing:
@@ -100,5 +115,4 @@ Close by confirming what exists (engagement directory, bound knowledge base, reg
 
 - **State ownership**: `consult-project.json` holds only the `scope` workflow state. Deliverable state lives exclusively in each field's `field.json` — setup never touches it (no fields exist yet). See `$CLAUDE_PLUGIN_ROOT/references/data-model.md`.
 - **One base per engagement**: never bind a second knowledge base; re-runs reuse `plugin_refs.knowledge_base`.
-- **Interaction language**: conduct the conversation in the resolved interaction language (workspace default, overridden by the user's message language), independent of the engagement's deliverable-axis `language` field; technical terms, skill names, and CLI commands stay English. See `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`.
 - **Legacy boundary**: legacy Double Diamond engagement directories are never shared with or migrated into cogni-consult structures; they remain where they are.

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -27,9 +27,10 @@ Setup deliberately stays light: it captures the outcome and the research spine, 
 Before any user-facing output, resolve the **interaction language** — the
 workspace default, overridden by the user's message language — per
 `$CLAUDE_PLUGIN_ROOT/references/interaction-language.md`, which owns the
-resolution ladder; do not restate the ladder here. It is independent of the
-engagement's `language` field, which is the deliverable axis. This contract
-holds on the default path: it does not depend on an output style being active.
+resolution ladder. Conduct the entire conversation in the resolved language.
+It is independent of the engagement's `language` field, which is the
+deliverable axis. This contract holds on the default path: it does not depend
+on an output style being active.
 
 The `description` of a Bash tool call is rendered to the consultant, so it is
 user copy — write it in the interaction language, outcome-shaped, at most 6


### PR DESCRIPTION
Closes #1141.

## Summary

The interaction-language rule fired too late to govern the output it was meant to govern. In `consult-resume` it sat inside `### 2. Select the Engagement` — after Step 1 had already run `discover-projects.sh` and emitted user-facing text — and in `consult-dashboard`, `consult-project-plan` and `consult-setup` it lived in end-of-file `## Important Notes`, after every step. A rule placed after the first output cannot decide the language of that output. That is an ordering defect, not a register defect, which is why this is a prose *move* rather than new prose.

- All nine `cogni-consult/skills/consult-*/SKILL.md` now open their `## Workflow` with a byte-identical `### 0. Resolve the Interaction Language`, ahead of Step 1 and ahead of any user-facing output.
- The seven pre-existing rules **move** rather than duplicate; each file ends with exactly one interaction-language rule.
- `consult-action-fields` and `consult-publish`, which carried no rule at all, gain the same Step 0.
- Step 0 delegates the resolution ladder to `references/interaction-language.md` instead of restating it — `.workspace-config.json` still appears zero times across the nine files.
- Every Step 0 adds the Bash-`description`-is-user-copy rule with the verbatim worked pair `Discover cogni-consult engagements` → `Laufende Engagements holen`, and states the contract holds on the default path with no output style active.
- Stale back-references re-pointed: `consult-personas` ×2 ("step 1" → "step 0"), `consult-project-plan` ("see Important Notes" → "see Step 0"), and `consult-resume` ("Step 2's language rule" → "Step 2's rendering rule", since Step 2 no longer holds the rule). `consult-design-thinking` already said "step 0" and becomes correct on its own.

The `description` leak traced to the script's own header comment (`scripts/discover-projects.sh:2`), not to any skill-authored string — so the rule forbids *deriving* the description from a filename or header comment. `discover-projects.sh` is deliberately untouched; its comment is legitimate operator documentation.

## Scope decisions

Two judgment calls the acceptance criteria left open, decided rather than escalated:

1. **All seven existing rules move, not just `consult-resume`'s.** The ACs only specify the move for `consult-resume`. Leaving the other six at Step-1/Step-2/Important-Notes depth would preserve exactly the unreachability the epic diagnoses, and two copies of a language contract drift.
2. **`consult-design-thinking`'s Step 0 goes immediately after `## Workflow`**, ahead of the two unnumbered policy subsections (`### Interaction mode`, `### Advancing the stage`), not immediately before `### 1.`. Both readings satisfy "ahead of any output"; the earlier slot keeps the heading in the same structural position in all nine. Neither unnumbered subsection emits user-facing output, so nothing is displaced.

Deliberately dropped, not lost: the "technical terms, skill names, and CLI commands stay English" tail on the `consult-setup` / `consult-dashboard` / `consult-project-plan` variants is not restated — `references/interaction-language.md` owns it verbatim and Step 0 delegates there. The file-specific artifact-axis sentences (`<html lang>` + badge; `lang` frontmatter) are preserved as a separate paragraph *after* the canonical block, so the canonical string stays byte-identical across all nine.

Not touched: `references/interaction-language.md` (the delegation target), and `references/user-facing-output.md`, which does not exist and belongs to phase-2 sibling #1142.

## Reviewer notes

- **Body-size budget.** `consult-resume`, `consult-design-thinking` and `consult-action-fields` were already over the body-size convention on base, and this diff grows them (+558, +558, +833 chars). Every added byte is AC-mandated block text and there is no in-section offset available, since the section is new. Annotated rather than paid down: reducing `consult-design-thinking` below the cap means relocating orchestration prose into `references/`, which is unrelated to an ordering fix. **Please do not request a whole-file dedup sweep on this PR.**
- **Wrap-width mismatch, accepted deliberately.** `consult-scope` and `consult-setup` are unwrapped-long-line files (p90 575 and 321 chars); the canonical block wraps at 71–78. Re-wrapping per file would break byte-identity across the nine, which is the stronger property here. Flagged rather than silently reconciled.
- **Heading case in `consult-publish`.** That file uses sentence case for its other numbered headings; the Step 0 heading is Title Case because AC1 greps the exact heading text across all nine.
- **`consult-publish` documents no Bash fences**, so its Bash paragraph reads speculative — but `allowed-tools` includes Bash and step 4.5 runs the assumption resolver, whose `description` reaches the consultant. Kept because AC4 mandates it in every Step 0.
- **Skipped auto-fix, recorded.** The skill-quality reviewer also suggested adding a step-0 pointer to `consult-resume`'s German/English seeding text. Declined: that text is inside the region the plan ringfenced, and it is less self-contained rather than wrong.
- **Quality-gate scope.** `skill-quality-reviewer` ran on the three highest-risk files (`consult-resume`, `consult-design-thinking`, `consult-publish`) rather than all nine — the remaining six take the same byte-identical insertion with no deletion inside a complex step. Verdicts: 2 pass, 1 needs_revision whose single low-severity finding is fixed in this branch.

## Test plan

- [x] `grep -l '^### 0\. Resolve the Interaction Language' cogni-consult/skills/consult-*/SKILL.md | wc -l` → **9**
- [x] `grep -c 'references/interaction-language.md' cogni-consult/skills/consult-resume/SKILL.md` → **1** (moved, not duplicated); the diff shows a deletion inside `### 2.` and an addition ahead of `### 1.`
- [x] worked pair present in all nine; the nine Step 0 blocks are byte-identical (single md5 across all nine)
- [x] default-path sentence present in all nine
- [x] `grep -rn 'workspace-config' cogni-consult/skills/` → **no hits**
- [x] no stale back-reference points the rule at "step 1" or "Important Notes"
- [x] cogni-consult test suite **7/7 pass**; `check-skill-names.sh` OK; `check-breadcrumbs.py` **0 violations**; version-bump gate `ok`, **0 plugins touched**
- [x] no `plugin.json` / `marketplace.json` change — the post-merge workflow owns the bump
- [ ] **Acceptance bar (manual, AC8):** run `/cogni-consult:consult-resume` in a German workspace with **no output style active** — German from the first word, no English preamble, and no leaked Bash `description` step title.

## Follow-up issues

- #1201 — the Bash-`description` rule this issue mandates inline in all nine Step 0 blocks has no owning entry in `references/interaction-language.md`, so the nine copies have no single source of truth and no drift guard. Not folded in here: this issue's ACs pin the inline constraints and leave the reference unedited.