### PR TITLE
docs: sync 9 plugins and root README with code reality

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -46,7 +46,9 @@
         "deliverables",
         "personas",
         "knowledge-base",
-        "orchestrator"
+        "orchestrator",
+        "agent",
+        "hooks"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 ### Knowledge Management
 
-[cogni-knowledge](cogni-knowledge/README.md) is the wiki-first research orchestrator — it binds its own vendored wiki knowledge base to any number of research projects so findings compound across runs instead of dying in chat history. Its zero-network inverted pipeline (plan → curate → fetch → ingest → compose → verify → finalize) deposits verified syntheses straight into the wiki, where future questions read them as prior framing. 12 skills.
+[cogni-knowledge](cogni-knowledge/README.md) is the wiki-first research orchestrator — it binds its own vendored wiki knowledge base to any number of research projects so findings compound across runs instead of dying in chat history. Its zero-network inverted pipeline (plan → curate → fetch → ingest → compose → verify → finalize) deposits verified syntheses straight into the wiki, where future questions read them as prior framing. 21 skills and 16 agents.
 
 > "Set up a knowledge base on the EU AI Act and deposit my first research synthesis"
 
@@ -23,15 +23,21 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 ### Consulting Orchestration
 
-[cogni-consult](cogni-consult/README.md) manages consulting engagements where action fields are the work-breakdown-structure containers for every deliverable. Scoping derives 3-6 action fields from one SMART key question; each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement compounds research across all deliverables. 6 skills.
+[cogni-consult](cogni-consult/README.md) manages consulting engagements where action fields are the work-breakdown-structure containers for every deliverable. Scoping derives 3-6 action fields from one SMART key question; each deliverable runs its own design-thinking loop (empathize→define→ideate→prototype→test), acting stakeholder personas challenge the work in their own voice, and one cogni-knowledge base per engagement compounds research across all deliverables. 9 skills and 4 agents.
 
 > "I need to evaluate strategic options for expanding our cloud services portfolio in the DACH mid-market"
 
 → [Plugin guide](docs/plugin-guide/cogni-consult.md) · [Consulting Engagement workflow](docs/workflows/consulting-engagement.md)
 
+[cogni-projects](cogni-projects/README.md) steers the other side of a consulting practice — the people, not the engagement. It holds one self-contained portfolio of consultants, projects, and assignments, then ranks candidates for every open role on availability, profile fit, and strategic impact, so staffing decisions are defensible rather than recalled. A read-only dashboard renders staffing coverage, at-risk projects, and portfolio value for partner meetings. 4 skills.
+
+> "Who should I put on the Nordics ERP rollout, and which projects are at risk?"
+
+→ [Plugin guide](docs/plugin-guide/cogni-projects.md)
+
 ### Trend Intelligence
 
-[cogni-trends](cogni-trends/README.md) scouts industry trends across four TIPS dimensions with bilingual DE/EN web research, producing 60 scored trend candidates per run using multi-framework analysis (TIPS, Ansoff, Rogers, CRAAP). The value-modeler consolidates candidates into 3-7 investment themes with solution blueprints. Reusable industry catalogs accumulate knowledge across engagements. European-first with curated institutional sources per market — German-rooted (VDMA, BITKOM, Fraunhofer) and extending across FR/IT/ES/NL/PL plus UK/US. 6 skills and 9 agents.
+[cogni-trends](cogni-trends/README.md) scouts industry trends across four TIPS dimensions with bilingual DE/EN web research, producing 60 scored trend candidates per run using multi-framework analysis (TIPS, Ansoff, Rogers, CRAAP). The value-modeler consolidates candidates into 3-7 investment themes with solution blueprints. Reusable industry catalogs accumulate knowledge across engagements. European-first with curated institutional sources per market — German-rooted (VDMA, BITKOM, Fraunhofer) and extending across FR/IT/ES/NL/PL plus UK/US. 9 skills and 12 agents.
 
 > "Scout trends for the automotive industry, then model investment themes from the results"
 
@@ -39,7 +45,7 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 ### Portfolio Messaging
 
-[cogni-portfolio](cogni-portfolio/README.md) structures products, features, and target markets into market-specific value propositions using IS/DOES/MEANS messaging. 19 skills handle the full positioning lifecycle — from TAM/SAM/SOM market sizing and competitive analysis through three-layer quality assessment to export-ready proposals and workbooks. Eight industry taxonomies (ICT, SaaS, FinTech, HealthTech, MarTech, Industrial Tech, Professional Services, Open Source) classify your portfolio automatically. 19 skills and 20 agents.
+[cogni-portfolio](cogni-portfolio/README.md) structures products, features, and target markets into market-specific value propositions using IS/DOES/MEANS messaging. 21 skills handle the full positioning lifecycle — from TAM/SAM/SOM market sizing and competitive analysis through three-layer quality assessment to export-ready proposals and workbooks. Eight industry taxonomies (ICT, SaaS, FinTech, HealthTech, MarTech, Industrial Tech, Professional Services, Open Source) classify your portfolio automatically. 21 skills and 20 agents.
 
 > "Set up a portfolio for our cloud monitoring product targeting mid-market SaaS companies in DACH"
 
@@ -47,7 +53,7 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 ### Content Production
 
-[cogni-marketing](cogni-marketing/README.md) bridges portfolio propositions and trend themes into channel-ready content across 16 formats — blogs, LinkedIn articles, whitepapers, battle cards, email nurtures, video scripts, and more. A 3D content matrix (market x GTM path x content type) tracks coverage gaps. [cogni-copywriting](cogni-copywriting/README.md) polishes any document for executive readability using 7 messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid) and runs 5 parallel stakeholder personas to catch blind spots. [cogni-narrative](cogni-narrative/README.md) transforms structured content into executive narratives using 10 story arc frameworks with quality scoring (0-100, A-F grades). Together: 18 skills and 8 agents.
+[cogni-marketing](cogni-marketing/README.md) bridges portfolio propositions and trend themes into channel-ready content across 16 formats — blogs, LinkedIn articles, whitepapers, battle cards, email nurtures, video scripts, and more. A 3D content matrix (market x GTM path x content type) tracks coverage gaps. [cogni-copywriting](cogni-copywriting/README.md) polishes any document for executive readability using 7 messaging frameworks (BLUF, Pyramid, SCQA, STAR, PSB, FAB, Inverted Pyramid) and runs 5 parallel stakeholder personas to catch blind spots. [cogni-narrative](cogni-narrative/README.md) transforms structured content into executive narratives using 11 story arc frameworks with quality scoring (0-100, A-F grades). Together: 18 skills and 8 agents.
 
 > "Generate thought leadership content for the AI automation theme across LinkedIn and blog formats"
 
@@ -81,7 +87,7 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 #### Workspace Foundation
 
-[cogni-workspace](cogni-workspace/README.md) manages the shared foundation — environment variables, MCP server installation, theme management, plugin discovery, and workspace health. Runs dependency checks, discovers installed plugins, and generates shared settings. Includes Obsidian vault integration for browsable knowledge management. 5 skills.
+[cogni-workspace](cogni-workspace/README.md) manages the shared foundation — environment variables, MCP server installation, theme management, plugin discovery, and workspace health. Runs dependency checks, discovers installed plugins, and generates shared settings. Includes Obsidian vault integration for browsable knowledge management. 9 skills.
 
 > "Initialize my insight-wave workspace and check plugin health"
 
@@ -97,7 +103,7 @@ Each plugin implements an established framework (Corporate Visions, Double Diamo
 
 #### Help & Learning
 
-[cogni-help](cogni-help/README.md) provides a 12-course interactive curriculum, 6 cross-plugin workflow templates, and troubleshooting diagnostics. Routes tasks to the right plugin, chains multi-plugin workflows, and generates cheatsheets for any plugin. 7 skills and 1 agent.
+[cogni-help](cogni-help/README.md) provides a 7-tour interactive curriculum, 7 cross-plugin workflow templates, and troubleshooting diagnostics. Routes tasks to the right plugin, chains multi-plugin workflows, and generates cheatsheets for any plugin. 7 skills and 1 agent.
 
 > "Which plugin should I use to verify claims in my research report?"
 
@@ -227,21 +233,22 @@ Plugins follow the [Claude Code plugin standard](https://code.claude.com/docs/en
 
 | Plugin | Capability | Skills | Agents | What it does |
 |--------|-----------|--------|--------|--------------|
-| [cogni-knowledge](cogni-knowledge/README.md) | Platform | 12 | 7 | Wiki-first research orchestrator — binds its own vendored wiki base to N research projects so findings compound across runs via a zero-network inverted pipeline |
-| [cogni-consult](cogni-consult/README.md) | Consulting | 6 | 0 | Action-fields-WBS consulting orchestrator with per-deliverable design thinking and acting stakeholder personas |
+| [cogni-knowledge](cogni-knowledge/README.md) | Platform | 21 | 16 | Wiki-first research orchestrator — binds its own vendored wiki base to N research projects so findings compound across runs via a zero-network inverted pipeline |
+| [cogni-consult](cogni-consult/README.md) | Consulting | 9 | 4 | Action-fields-WBS consulting orchestrator with per-deliverable design thinking and acting stakeholder personas |
+| [cogni-projects](cogni-projects/README.md) | Consulting | 4 | 0 | Partner project-portfolio steering — consultants, projects, and a deterministic staffing match engine with a partner-meeting dashboard |
 | [cogni-trends](cogni-trends/README.md) | Trend Intelligence | 9 | 12 | TIPS trend scouting with bilingual DE/EN research, investment theme modeling, and reusable industry catalogs |
 | [cogni-portfolio](cogni-portfolio/README.md) | Portfolio | 21 | 20 | IS/DOES/MEANS portfolio positioning with eight industry taxonomies, competitive analysis, and market sizing |
 | [cogni-marketing](cogni-marketing/README.md) | Content | 11 | 3 | B2B marketing content engine — 16 formats across thought leadership, demand gen, lead gen, sales enablement, ABM |
 | [cogni-copywriting](cogni-copywriting/README.md) | Content | 4 | 2 | Professional copywriting with 7 messaging frameworks, 5 stakeholder personas, and arc-aware polishing |
 | [cogni-narrative](cogni-narrative/README.md) | Content | 3 | 3 | Story arc narrative transformation using 11 frameworks with quality scoring and derivative format adaptation |
 | [cogni-sales](cogni-sales/README.md) | Sales | 1 | 4 | Corporate Visions Why Change pitch generation for named customers or market segments |
-| [cogni-visual](cogni-visual/README.md) | Visual | 8 | 19 | Slide decks, infographics, web narratives, poster storyboards, and report enrichment from narratives |
+| [cogni-visual](cogni-visual/README.md) | Visual | 7 | 19 | Slide decks, infographics, web narratives, poster storyboards, and report enrichment from narratives |
 | [cogni-website](cogni-website/README.md) | Website | 6 | 3 | Multi-page customer websites from portfolio, marketing, and research content with shared navigation and theming |
 | [cogni-claims](cogni-claims/README.md) | Quality | 2 | 2 | Source verification — catches misquotations, unsupported conclusions, and stale data in sourced claims |
-| [cogni-help](cogni-help/README.md) | Platform | 7 | 1 | 12-course curriculum, plugin discovery, workflow templates, troubleshooting, and cheatsheets |
+| [cogni-help](cogni-help/README.md) | Platform | 7 | 1 | 7-tour curriculum, plugin discovery, workflow templates, troubleshooting, and cheatsheets |
 | [cogni-workspace](cogni-workspace/README.md) | Platform | 9 | 0 | Shared foundation — env vars, MCP installation, theme management, plugin discovery, workspace health, Obsidian integration, bundled wiki |
 
-**99 skills, 76 agents** across the 14 active plugins.
+**114 skills, 89 agents** across the 14 active plugins.
 
 See [Cross-Plugin Data Flow](docs/er-diagram.md) for how data flows between plugins, or browse the [full documentation](docs/ecosystem-overview.md).
 

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -17,6 +17,6 @@
     "knowledge-base",
     "orchestrator",
     "agent",
-    "hook"
+    "hooks"
   ]
 }

--- a/cogni-consult/.claude-plugin/plugin.json
+++ b/cogni-consult/.claude-plugin/plugin.json
@@ -15,6 +15,8 @@
     "deliverables",
     "personas",
     "knowledge-base",
-    "orchestrator"
+    "orchestrator",
+    "agent",
+    "hook"
   ]
 }

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -220,6 +220,8 @@ cogni-consult/
 | cogni-knowledge | Yes | Bound once at setup (`plugin_refs.knowledge_base`) — the research spine every deliverable's evidence routes through |
 | cogni-workspace | No | Cross-session engagement discovery (`discover-projects.sh` delegates to its helper); `pick-theme` themes the `consult-dashboard` HTML (falls back to a built-in theme) |
 | cogni-visual / document-skills | No | Deliverable export (slides, documents) when a deliverable names an export route |
+| cogni-claims | No | consult-design-thinking routes the claims-correction cascade; `submit-assumption-claim.py` submits assumption claims for verification |
+| cogni-copywriting | No | consult-publish runs an optional `copywriter` polish pass before brief handoff |
 
 cogni-consult is standalone as an orchestrator — it structures the engagement, the WBS, and the design-thinking loops on its own. cogni-knowledge is the one required integration: without it, deliverable research has no compounding base.
 

--- a/cogni-consult/README.md
+++ b/cogni-consult/README.md
@@ -162,6 +162,8 @@ Publishing is **consultant-elected and never automatic** — it does not fire at
 | `schedule-edit.py` | Script | Read/write one deliverable's optional scheduling fields (`start_date`, `due_date`, `duration`, `owner`, `milestone`) in `field.json` — the write surface backing the `consult-project-plan` roadmap |
 | `resolve-assumptions.py` | Script | Render-time resolver replacing `{{asm:id}}` placeholders with values from the engagement-root `assumptions.json` registry — fail-loud on unresolvable placeholders, wired into `consult-publish`; opt-in `--mode link` emits `[[assumptions#slug\|value]]` wikilinks into the register |
 | `register-generator.py` | Script | Generate the browsable `assumptions.md` register (summary table + anchored `## <slug>` sections with value, provenance, source lineage, and `used_by[]` backlinks) from `assumptions.json`; overwrite-guarded |
+| `submit-assumption-claim.py` | Script | Adapter for the assumption ↔ cogni-claims verify round-trip: `submit` appends an `unverified` ClaimRecord under a lock (idempotent — one assumption, one record), `propagate` writes `status: verified` + `citation.claim_id` back onto the assumption record, `resolve-propagate` completes the deviated→resolved leg for the three value-affecting resolution actions |
+| `assumption-change-frequency.sh` | Script | Read-only retrospective spike over a deliverable corpus's git history: reports how often bare numeric literals changed (`edits_per_literal`), sizing the payoff of propagation automation independently of `assumptions.json` |
 | `discover-projects.sh` | Script | Engagement discovery (delegates to the cogni-workspace helper) |
 | `consult-dashboard/scripts/generate-dashboard.py` | Script | Render the engagement HTML dashboard from `consult-project.json` + `field.json` files (read-only) |
 
@@ -182,8 +184,10 @@ cogni-consult/
 │   │                              Prototype framework lens
 │   ├── interaction-language.md    Interaction language vs. deliverable language rule
 │   ├── persona-schema.md          Acting-persona schema + acting contract
+│   ├── project-plan-model.md      Scheduling-field schema + roadmap read-model
 │   ├── publish-routing.md         Canonical publish format→route contract
 │   ├── research-routing.md        Canonical cogni-knowledge research rule
+│   ├── subagent-output-contract.md  Register rules the SubagentStart hook emits
 │   ├── personas/                  Packaged default advisors (partner, PM)
 │   ├── methods/                   Stage methods (scope dimensions, empathy mapping,
 │   │                              HMW synthesis, guided ideation)
@@ -231,7 +235,7 @@ Need a tailored deliverable type, a custom acting persona, or this orchestrator 
 
 ## License
 
-[Apache-2.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution terms.
+[Apache-2.0](../LICENSE) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for contribution terms.
 
 ---
 

--- a/cogni-help/README.md
+++ b/cogni-help/README.md
@@ -4,13 +4,13 @@
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-The onboarding and navigation layer for the [insight-wave](https://github.com/cogni-work/insight-wave) ecosystem — the single entry point that makes 12 plugins with 70+ skills behave like one coherent system.
+The onboarding and navigation layer for the [insight-wave](https://github.com/cogni-work/insight-wave) ecosystem — the single entry point that makes 14 plugins with 110+ skills behave like one coherent system.
 
 ## Why this exists
 
 | Problem | What happens | Impact |
 |---------|-------------|--------|
-| 12 plugins, no map | New users don't know which plugin handles their task | Trial-and-error onboarding — first productive use takes hours |
+| 14 plugins, no map | New users don't know which plugin handles their task | Trial-and-error onboarding — first productive use takes hours |
 | Disconnected workflows | Research, narrative, visual, and sales plugins work together but no guide shows how | Users run one plugin well, miss the multi-plugin pipelines that deliver 10x value |
 | Silent failures | A missing dependency or stale workspace breaks skills at runtime | Cryptic errors with no diagnostic path — users blame the plugin, not the config |
 | No structured learning | Users learn by stumbling into slash commands | Shallow usage — power features go undiscovered |
@@ -19,12 +19,12 @@ A capable ecosystem nobody can navigate is a capability nobody uses — the cost
 
 ## What it is
 
-A meta-plugin for the insight-wave ecosystem, built on a workflow-tour curriculum keyed 1:1 to the canonical cross-plugin pipelines. While the other plugins produce content — research, narratives, portfolios, visuals — cogni-help is the layer that teaches you how to use them together and routes you to the right one. It owns no domain data; it indexes the ecosystem so the other twelve plugins read as a single system.
+A meta-plugin for the insight-wave ecosystem, built on a workflow-tour curriculum keyed 1:1 to the canonical cross-plugin pipelines. While the other plugins produce content — research, narratives, portfolios, visuals — cogni-help is the layer that teaches you how to use them together and routes you to the right one. It owns no domain data; it indexes the ecosystem so the other thirteen plugins read as a single system.
 
 ## What it does
 
 1. **Teach** through 7 interactive workflow tours — adaptive pacing, hands-on exercises, quizzes, and progress tracking across the canonical end-to-end pipelines
-2. **Guide** users to the right plugin — match natural-language task descriptions to capabilities across 12 plugins and 70+ skills
+2. **Guide** users to the right plugin — match natural-language task descriptions to capabilities across 14 plugins and 110+ skills
 3. **Chain** plugins into pipelines — 7 cross-plugin workflow templates from install-to-infographic through full consulting engagements
 4. **Diagnose** plugin problems — check integrity, dependencies, workspace health, and known issues before they surface as runtime failures
 5. **Summarize** any plugin — generate one-screen quick-reference cheatsheets with commands, capabilities, and tips
@@ -33,7 +33,7 @@ A meta-plugin for the insight-wave ecosystem, built on a workflow-tour curriculu
 
 ## What it means for you
 
-- **Skip the memorization.** Describe your task in plain language and the guide skill routes it to the exact plugin and skill across 12 plugins and 70+ skills — first productive result in under 5 minutes.
+- **Skip the memorization.** Describe your task in plain language and the guide skill routes it to the exact plugin and skill across 14 plugins and 110+ skills — first productive result in under 5 minutes.
 - **Build real skills in 5–6 hours.** Complete all 7 workflow tours (~45–60 minutes each) with hands-on exercises that produce real output. Resume any tour mid-module — progress is tracked to the lesson.
 - **Collapse multi-plugin work into 3–4 steps.** Run any of 7 workflow templates to chain plugins into repeatable pipelines — research-to-report in 3 steps, portfolio-to-pitch in 4.
 - **Catch failures before they surface.** Run the 5-tier health check to surface missing dependencies, stale configs, and integrity issues before they become cryptic runtime errors.
@@ -73,7 +73,7 @@ Don't know which plugin handles your task? Describe it in plain language:
 
 > Run `/guide "I need to turn research into a slide deck"`
 
-The guide skill matches your description against all 12 plugins and 70+ skills and routes you to the pipeline, e.g.:
+The guide skill matches your description against all 14 plugins and 110+ skills and routes you to the pipeline, e.g.:
 
 ```
 research-to-report pipeline:
@@ -157,7 +157,7 @@ The remaining skills support that core loop. `troubleshoot` runs ahead of failur
 
 ```
 cogni-help/
-├── .claude-plugin/plugin.json    Plugin manifest (v0.0.10)
+├── .claude-plugin/plugin.json    Plugin manifest (v0.0.12)
 ├── agents/                       1 delegation agent
 │   └── course-deck-generator.md
 ├── skills/                       7 skills

--- a/cogni-knowledge/README.md
+++ b/cogni-knowledge/README.md
@@ -212,9 +212,9 @@ cogni-knowledge/
 ├── LICENSE                       Apache-2.0
 ├── _archive/                     Archived research+report chain (see _archive/README.md)
 ├── agents/                       16 forked + new pipeline agents
-├── references/                   21 framework + design docs
-├── scripts/                      27 utility scripts (binding, synthesis-impact, cycle-guard, fetch-cache, candidate-store, citation-store, verify-store, wiki-grounding, wiki-coverage, wiki-source-manifest, concept-store, question-store, ingest-integrity, contradiction-ingest-store, pipeline-summary, build_open_questions_payload; vendored wiki-engine: control-path, root_index, sub_index, concepts_index, perspectives_index, overview_update, pdf-extract; one-shot migrators: migrate-layout, migrate-question-index, reclassify-person-entities, backfill_concepts_index) + _knowledge_lib helper
-├── skills/                       20 knowledge-* skills
+├── references/                   28 framework + design docs
+├── scripts/                      34 utility scripts (binding, synthesis-impact, cycle-guard, fetch-cache, candidate-store, citation-store, verify-store, wiki-grounding, wiki-coverage, wiki-source-manifest, concept-store, question-store, ingest-integrity, contradiction-ingest-store, pipeline-summary, build_open_questions_payload; vendored wiki-engine: control-path, root_index, sub_index, concepts_index, perspectives_index, overview_update, pdf-extract; one-shot migrators: migrate-layout, migrate-question-index, reclassify-person-entities, backfill_concepts_index) + _knowledge_lib helper
+├── skills/                       21 knowledge-* skills
 └── tests/                        Contract tests (one per phase)
 ```
 

--- a/cogni-narrative/README.md
+++ b/cogni-narrative/README.md
@@ -96,6 +96,7 @@ The adapter writes `executive-brief.md` alongside the source, condensing proport
 | `strategic-foresight` | Signals → Scenarios → Strategies → Decisions | Long-range planning, scenario analysis, strategic options |
 | `industry-transformation` | Forces → Friction → Evolution → Leadership | Industry analysis, regulatory impact, transformation roadmaps |
 | `trend-panorama` | Forces → Impact → Horizons → Foundations | Trend-scout output, TIPS trend reports, multi-horizon landscapes |
+| `smarter-service` | Forces → Impact → Horizons → Foundations | TIPS reports with investment themes (theme-aware sibling of trend-panorama) |
 | `theme-thesis` | Why Change → Why Now → Why You → Why Pay | Investment theme narratives within TIPS reports |
 | `jtbd-portfolio` | Jobs → Friction → Portfolio → Invitation | Portfolio introductions, capability overviews, pre-sales |
 | `company-credo` | Mission → Conviction → Credibility → Promise | Website About-Us pages, company introductions |

--- a/cogni-portfolio/README.md
+++ b/cogni-portfolio/README.md
@@ -222,6 +222,7 @@ cogni-portfolio/
 | cogni-knowledge | No | Pitch arcs (technology-futures, strategic-foresight, trend-panorama, theme-thesis) in portfolio-communicate draw on cogni-knowledge research syntheses for evidence |
 | cogni-workspace | No | Theme selection for portfolio-dashboard via pick-theme |
 | cogni-sales | No | Downstream consumer — why-change pitch builds on portfolio features and propositions |
+| cogni-copywriting | No | portfolio-communicate pitch templates tune acronym-expansion depth via the `copywriter` audience field |
 | document-skills | No | Document ingestion (docx, pptx, xlsx, pdf) via portfolio-ingest; XLSX export via portfolio-communicate |
 
 cogni-portfolio is standalone for core messaging workflows. All integrations are optional and activate when the respective plugin is installed.

--- a/cogni-projects/README.md
+++ b/cogni-projects/README.md
@@ -2,6 +2,8 @@
 
 > **Incubating** (v0.0.x) — skills, data formats, and workflows may change at any time.
 
+> **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
+
 Partner project-portfolio steering for consulting firms on Claude Code. cogni-projects gives partners one place to model consultants, projects, and staffing — so they can match the right people to the right work by availability, profile fit, and strategic impact. The portfolio scaffold, entity authoring, the staffing match engine, and a read-only partner-meeting dashboard have shipped; the backfilling recommender arrives in a later release.
 
 ## Why this exists
@@ -90,6 +92,26 @@ The manifest holds portfolio identity (`slug`, `name`, `language`, timestamps) p
 | Script | `render-dashboard.py` | Render the portfolio dashboard HTML from entity data |
 
 ## Architecture
+
+```
+cogni-projects/
+├── .claude-plugin/plugin.json          Plugin manifest
+├── skills/                             4 portfolio skills
+│   ├── projects-setup/                 Initialize a portfolio directory (entry point)
+│   ├── projects-entities/              Author + register one consultant/project/assignment
+│   ├── projects-staff/                 Rank candidate consultants per open project role
+│   └── projects-dashboard/             Render a partner-meeting portfolio dashboard (read-only)
+├── scripts/                            6 stdlib-only utilities
+│   ├── _projects_lib.py                Shared loader for the hyphen-named validate-entities.py
+│   ├── portfolio-init.sh               Idempotent portfolio scaffolder
+│   ├── validate-entities.py            Entity validator: frontmatter + assignment refs
+│   ├── register-entity.py              Slug-keyed manifest upsert + execution-log append
+│   ├── staffing-score.py               Deterministic staffing scorer (availability/fit/impact)
+│   └── render-dashboard.py             Portfolio health + value HTML render
+├── tests/                              5 bash regression suites
+│   └── fixtures/                       Shared assertion harness + exit-code-safe runner
+└── references/                         Consultant / project / assignment entity schemas
+```
 
 cogni-projects is standalone at this stage. Its portfolio directory is the shared substrate for its skills (entity authoring, staffing match, dashboard) and for later ones (backfilling), and for planned cross-plugin bridges to cogni-consult and cogni-portfolio.
 

--- a/cogni-sales/README.md
+++ b/cogni-sales/README.md
@@ -128,7 +128,7 @@ The four research phases each dispatch the `why-change-researcher` agent. The re
 
 ```
 cogni-sales/
-├── .claude-plugin/               Plugin manifest (v0.4.2)
+├── .claude-plugin/               Plugin manifest (v0.4.3)
 ├── skills/                       1 pitch skill
 │   └── why-change/
 │       ├── SKILL.md

--- a/cogni-visual/README.md
+++ b/cogni-visual/README.md
@@ -143,7 +143,7 @@ In the second phase, a rendering agent consumes the brief and produces the outpu
 
 ```
 cogni-visual/                              # 7 skills · 19 agents · 6 commands · 1 hook
-├── .claude-plugin/                        Plugin manifest (v0.16.24)
+├── .claude-plugin/                        Plugin manifest (v0.16.26)
 ├── skills/                               7 visual skills (4 brief generators · 1 renderer · 1 enricher · 1 reviewer)
 │   ├── story-to-slides/
 │   ├── story-to-web/

--- a/cogni-website/README.md
+++ b/cogni-website/README.md
@@ -137,13 +137,15 @@ Open `index.html` over a local HTTP server with `/cogni-website:website-preview`
 
 ```
 cogni-website/
-├── .claude-plugin/               Plugin manifest (v0.0.4)
+├── .claude-plugin/               Plugin manifest (v0.0.6)
 │   └── plugin.json
 ├── skills/                       6 workflow skills
 │   ├── website-setup/
 │   │   └── SKILL.md              Source discovery, theme selection, project scaffolding, legal foundation
 │   ├── website-plan/
-│   │   └── SKILL.md              Deep content scan, page proposal, navigation design
+│   │   ├── SKILL.md              Deep content scan, page proposal, navigation design
+│   │   └── references/
+│   │       └── page-type-registry.md     Page-type definitions consumed by the planner
 │   ├── website-legal/
 │   │   ├── SKILL.md              Jurisdiction-driven legal page generation
 │   │   └── references/
@@ -155,7 +157,9 @@ cogni-website/
 │   │           ├── ch/           Impressum, Datenschutz, Cookies (revDSG)
 │   │           └── eu/           Legal Notice, Privacy Policy, Cookies (GDPR/ePrivacy)
 │   ├── website-build/
-│   │   └── SKILL.md              Build orchestration, parallel page generation
+│   │   ├── SKILL.md              Build orchestration, parallel page generation
+│   │   └── scripts/
+│   │       └── generate-css.py           Theme-driven stylesheet generation
 │   ├── website-preview/
 │   │   └── SKILL.md              Link validation, browser preview
 │   └── website-resume/

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -137,6 +137,7 @@ State lives in two layers that other plugins consume. Configuration (env vars, t
 | `audit-region-sources` | skill | Read-only sibling of manage-markets — audit per-plugin region-source overlays against the canonical registry for orphans and drift |
 | `workspace-dashboard` | skill | Interactive HTML dashboard of workspace foundation, env vars, plugin registry, themes, and dependencies |
 | `on-session-start.sh` | hook (SessionStart) | Sources workspace environment and validates plugin availability at session start |
+| `on-session-start-language.sh` | hook (SessionStart) | Injects the language rules the built-in "# Language" system-prompt section does not carry |
 | `check-dependencies.sh` | script | Returns JSON with availability/version of required and optional dependencies |
 | `check-skill-names.sh` | script | Validates skill directory names against plugin.json manifest for consistency |
 | `check-workspace-python-deps.sh` | script | Fail-soft health check for optional Python packages in the workspace venv; reports per-package importability (`success` stays true) |
@@ -166,8 +167,7 @@ cogni-workspace/
 │   └── workspace-status/
 ├── wiki/                         Bundled vendor-curated insight-wave reference wiki (read by ask)
 │   ├── .cogni-wiki/              Wiki config + lockfile
-│   ├── raw/                      Immutable source snapshots (plugin READMEs, curation notes)
-│   ├── assets/                   Attachments (SVG, images) referenced by wiki pages
+│   ├── SCHEMA.md                 Wiki page schema
 │   └── wiki/                     LLM-maintained pages, index, log, overview
 ├── templates/                    Shared templates
 │   ├── obsidian/                 Obsidian vault config templates
@@ -188,7 +188,8 @@ cogni-workspace/
 │   ├── install-workspace-deps.sh Provision optional Python deps into an isolated venv
 │   ├── patch-desktop-config.py   Merge MCP entries into Claude Desktop config
 │   ├── setup-obsidian.sh
-│   └── update-obsidian.sh
+│   ├── update-obsidian.sh
+│   └── baselines/                Tier-0 output baselines for script contract checks
 ├── bash/                         Cross-platform utilities
 │   └── portability-utils.sh
 ├── contracts/                    Script interface definitions
@@ -200,6 +201,7 @@ cogni-workspace/
 ├── schemas/                      JSON schemas
 │   └── examples/                 Schema usage examples
 ├── references/                   Reference documentation
+├── tests/                        Script unit tests (check-skill-names, sanitize-theme)
 ├── docs/                         Developer notes (e.g. theme-system v2 migration)
 └── assets/
     └── output-styles/            Language-specific behavioral anchors (EN/DE)
@@ -216,6 +218,8 @@ cogni-workspace has no required plugin dependencies — it is the foundation lay
 | cogni-help | No | Referenced inline in workspace skills for issue filing and guided help |
 | cogni-portfolio | No | install-mcp references cogni-portfolio as a consumer of excalidraw MCP in the installation plan |
 | cogni-claims | No | workspace-status references cogni-claims as a provider plugin for the claude-in-chrome MCP server check |
+| cogni-trends | No | audit-region-sources and manage-markets read the trends region-authority overlay when auditing market coverage |
+| cogni-knowledge | No | ask, workspace-status, and manage-workspace route knowledge-base questions to knowledge-setup / knowledge-query |
 
 ## Contributing
 

--- a/docs/plugin-guide/cogni-consult.md
+++ b/docs/plugin-guide/cogni-consult.md
@@ -82,6 +82,24 @@ Defines personas from the scope's Stakeholder dimension (or enriches the shipped
 
 Discovers engagements (registry-backed, works from any directory), renders the action-fields × deliverables × status dashboard, surfaces manifest warnings, and recommends exactly one next action keyed on derived state — scope not done → `consult-scope`; unplanned field → `consult-action-fields`; deliverable mid-loop → `consult-design-thinking`; challenge pass open → `consult-personas`. Read-only: it never writes engagement state.
 
+### `consult-dashboard` — the engagement in a browser
+
+Generates an interactive HTML dashboard of the engagement: action fields, their deliverables, each deliverable's design-thinking stage, and persona-review progress. Where `consult-resume` answers "what do I do next?" in the terminal, `consult-dashboard` answers "what does the whole engagement look like?" in a browser — the view you open before a status call rather than between work sessions.
+
+> Show me the engagement dashboard
+
+### `consult-project-plan` — sequenced roadmap of the WBS
+
+Turns the engagement's own deliverables into a phased roadmap, sequenced from the dependency graph and per-deliverable durations, and writes it as an Obsidian-browsable markdown artifact. This is an *internal* engagement-management view — a read-mostly sibling of `consult-dashboard` and `consult-resume` — not a client-facing deliverable. Reach for it when the question is "when does this engagement finish?" rather than "what should the client see?".
+
+> Show the roadmap — when does the engagement finish?
+
+### `consult-publish` — deliverable to render-ready brief
+
+Turns a completed deliverable into presentation-ready documentation: a brief handed off to the rendering layer for slides, a poster, a web page, a report, or an infographic. Two properties matter. It runs only when the named deliverable's `state` is `complete`, so half-finished work cannot be published by accident. And it is consultant-elected — you invoke it explicitly; the design-thinking loop never auto-fires it, because deciding that a deliverable is ready to leave the engagement is a judgment call, not a pipeline step.
+
+> Turn the operating-model deliverable into slides
+
 ---
 
 ## Integration Points

--- a/docs/plugin-guide/cogni-help.md
+++ b/docs/plugin-guide/cogni-help.md
@@ -50,13 +50,13 @@ Start with `tour-install-to-infographic` — it is the first-run capstone and as
 
 ## Getting Started
 
-If you are new to insight-wave, start with Course 1:
+If you are new to insight-wave, start with the first-run capstone tour:
 
 ```
-/teach 1
+/teach tour-install-to-infographic
 ```
 
-The teach skill introduces you to the Cowork environment, the plugin model, and how to navigate the ecosystem. From there you can continue through the curriculum at your own pace.
+It walks you from a fresh workspace through theme selection to a rendered infographic, so you finish with a working artifact rather than notes. From there, pick whichever tour matches the pipeline you need — the rest are independent.
 
 If you already know what you need to do but not which plugin handles it:
 
@@ -77,16 +77,12 @@ The teach skill delivers any of the 7 workflow tours interactively. It tracks yo
 Start or resume a tour by ID:
 
 ```
-/teach 1
+/teach tour-research-to-report
 ```
 
-Continue where you left off:
+Progress is tracked to the lesson, so re-running the same tour ID resumes where you left off.
 
-```
-/teach continue
-```
-
-Check which courses you have completed:
+Check which tours you have completed:
 
 ```
 /courses
@@ -239,7 +235,7 @@ cogni-help references every other plugin — it is the only plugin with no funct
 
 ### Downstream — cogni-workspace
 
-Before running any course involving plugin-specific work, ensure the workspace is initialized. If `workspace-status` reports issues, resolve them before starting Course 2 and beyond. See [cogni-workspace](../plugin-guide/cogni-workspace.md).
+Before running any tour involving plugin-specific work, ensure the workspace is initialized. If `workspace-status` reports issues, resolve them before starting. See [cogni-workspace](../plugin-guide/cogni-workspace.md).
 
 ---
 
@@ -250,10 +246,9 @@ Before running any course involving plugin-specific work, ensure the workspace i
 Walk a new user through the full ecosystem:
 
 1. Run `manage-workspace` from cogni-workspace to prepare the environment
-2. Start `/teach 1` — Cowork Fundamentals covers the mental model and navigation
-3. Continue through `/teach 2` — Workspace and Obsidian for environment setup
-4. Use `/guide` to match their first real task to the right plugin
-5. Run the relevant course for that plugin
+2. Start `/teach tour-install-to-infographic` — the first-run capstone, from install to a rendered artifact
+3. Use `/guide` to match their first real task to the right plugin
+4. Run the tour matching that plugin's pipeline
 
 For a structured onboarding plan covering the full curriculum, use `/workflow full-onboarding`.
 
@@ -295,7 +290,7 @@ For automated pipeline orchestration, see [cogni-consult](../plugin-guide/cogni-
 
 **Chrome native messaging host conflict (KI-001):** When both Claude Desktop (Cowork) and Claude Code are installed, the `cogni-issues` skill — which files GitHub issues via browser automation — may not have access to browser tools. The Chrome extension connects to one native host and ignores the other, so 16 of 19 browser automation tools can silently vanish.
 
-**Workaround:** Toggle native messaging host configs by renaming the `.json` file for the unused product in `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/` and restarting Chrome. Alternatively, file issues using the `gh` CLI or manually on github.com. See the [Known Issues Registry](../../cogni-docs/references/known-issues.md) for detailed steps.
+**Workaround:** Toggle native messaging host configs by renaming the `.json` file for the unused product in `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/` and restarting Chrome. Alternatively, file issues using the `gh` CLI or manually on github.com. See the [Known Issues Registry](../known-issues.md#ki-001) for detailed steps.
 
 ---
 
@@ -303,8 +298,8 @@ For automated pipeline orchestration, see [cogni-consult](../plugin-guide/cogni-
 
 The highest-value contributions to cogni-help are:
 
-- **New courses** — if a plugin exists in the ecosystem but has no dedicated course, adding one follows the Theory → Demo → Exercise → Quiz → Recap structure used by existing courses
-- **New workflow templates** — if you have developed a repeatable multi-plugin pipeline not in the current six templates, document it as a new workflow definition in `workflow/references/workflows/`
+- **New tours** — if a canonical pipeline exists but has no dedicated tour, adding one follows the Theory → Demo → Exercise → Quiz → Recap structure used by existing tours
+- **New workflow templates** — if you have developed a repeatable multi-plugin pipeline not in the current seven user-facing templates, document it as a new workflow definition in `workflow/references/workflows/`
 - **Diagnostic checks** — the troubleshoot skill's known-issues catalog grows best when users report problems and someone encodes the resolution pattern
 - **Plugin catalog updates** — whenever a new plugin or significant new skill lands in the ecosystem, `guide/references/plugin-catalog.md` needs updating
 

--- a/docs/plugin-guide/cogni-help.md
+++ b/docs/plugin-guide/cogni-help.md
@@ -6,11 +6,11 @@
 
 ## Overview
 
-cogni-help is the navigation and learning layer for the insight-wave ecosystem. With 12 plugins and 70+ skills available in the marketplace, it is easy to know something exists but not know which specific skill handles a given task. cogni-help addresses this in four ways:
+cogni-help is the navigation and learning layer for the insight-wave ecosystem. With 14 plugins and 110+ skills available in the marketplace, it is easy to know something exists but not know which specific skill handles a given task. cogni-help addresses this in four ways:
 
 1. **Plugin discovery** — describe what you need, and the guide skill matches it to the right plugin and skill
-2. **Structured learning** — a 12-course curriculum covers every plugin from fundamentals through advanced workflows, each course running about 45 minutes
-3. **Workflow templates** — six cross-plugin pipeline playbooks show how to chain plugins into end-to-end workflows (research to slides, trends to marketing, portfolio to pitch)
+2. **Structured learning** — a 7-tour curriculum keyed 1:1 to the canonical cross-plugin pipelines, each tour running about 45–60 minutes
+3. **Workflow templates** — seven cross-plugin pipeline playbooks show how to chain plugins into end-to-end workflows (install to infographic, research to report, portfolio to pitch)
 4. **Diagnostics** — the troubleshoot skill checks plugin integrity, workspace health, and dependency state before problems surface as cryptic errors at runtime
 
 cogni-help produces no content of its own — it teaches, routes, templates, and diagnoses. Think of it as the layer that makes the rest of the ecosystem learnable and navigable.
@@ -22,32 +22,29 @@ cogni-help produces no content of its own — it teaches, routes, templates, and
 | Term | What it means |
 |------|--------------|
 | **Guide** | Task-to-plugin matching — describe what you want, get the right skill recommendation |
-| **Course** | A ~45-minute interactive module: Theory → Demo → Exercise → Quiz → Recap |
-| **Curriculum** | The 12-course sequence covering the full ecosystem, ordered by dependency |
+| **Tour** | A ~45–60-minute interactive walkthrough of one pipeline: Theory → Demo → Exercise → Quiz → Recap |
+| **Curriculum** | The 7-tour sequence, one tour per canonical cross-plugin pipeline |
 | **Workflow template** | A step-by-step playbook for chaining 3–5 plugins into an end-to-end pipeline |
 | **Cheatsheet** | A one-screen quick-reference card for a specific plugin's commands and concepts |
 | **Troubleshoot** | Plugin-level diagnostics: integrity checks, dependency validation, known issue matching |
-| **Course progress** | Per-user progress stored in `.claude/cogni-help.local.md` — persists across sessions |
+| **Tour progress** | Per-user progress stored in `.claude/cogni-help.local.md` — tracked to the lesson, persists across sessions |
 | **Plugin catalog** | The index in `guide/references/plugin-catalog.md` that maps capabilities to plugins |
 
-### The 12-course curriculum
+### The 7-tour curriculum
 
-| # | Course | Plugins covered |
-|---|--------|-----------------|
-| 1 | Cowork Fundamentals | cogni-help (meta) |
-| 2 | Workspace and Obsidian | cogni-workspace, cogni-help:cogni-issues |
-| 3 | Basic Tools | cogni-copywriting, cogni-narrative, cogni-claims |
-| 4 | Trend Scouting | cogni-trends (part 1) |
-| 5 | Trend Reporting | cogni-trends (part 2) |
-| 6 | Portfolio Messaging | cogni-consult, cogni-portfolio |
-| 7 | Visual Deliverables | cogni-visual |
-| 8 | Research Reports | cogni-knowledge |
-| 9 | B2B Marketing | cogni-marketing |
-| 10 | Sales Pitches | cogni-sales |
-| 11 | Consulting Orchestration | cogni-consult |
-| 12 | Documentation Pipeline | cogni-docs |
+| Tour ID | Title | Pipeline |
+|---------|-------|----------|
+| `tour-install-to-infographic` | Install-to-Infographic | cogni-workspace → themes → cogni-visual |
+| `tour-research-to-report` | Research-to-Report | cogni-knowledge → cogni-narrative → cogni-visual |
+| `tour-trends-to-solutions` | Trends-to-Solutions | cogni-trends → cogni-portfolio → cogni-marketing |
+| `tour-content-pipeline` | Content-Pipeline | cogni-marketing → cogni-narrative → cogni-copywriting → cogni-visual |
+| `tour-portfolio-to-pitch` | Portfolio-to-Pitch | cogni-portfolio → cogni-narrative → cogni-sales → cogni-visual |
+| `tour-portfolio-to-website` | Portfolio-to-Website | cogni-portfolio → cogni-workspace → cogni-website |
+| `tour-consulting-engagement` | Consulting-Engagement | cogni-consult (setup → scope → action fields → design-thinking → personas) |
 
-Courses are designed to be completed in order — later courses assume familiarity with earlier ones. You can jump in at any course if you know the prerequisites.
+Tour IDs are 1:1 with the canonical workflow IDs in `docs/workflows/`, so the tour that teaches a pipeline and the guide that documents it always carry the same name.
+
+Start with `tour-install-to-infographic` — it is the first-run capstone and assumes nothing. The rest are independent: pick the pipeline you need rather than working through them in order.
 
 ---
 
@@ -75,9 +72,9 @@ The guide skill reads your task description, consults the plugin catalog, and re
 
 ### `teach` — Interactive course delivery
 
-The teach skill delivers any of the 12 courses interactively. It tracks your progress per course and adapts pacing based on your responses.
+The teach skill delivers any of the 7 workflow tours interactively. It tracks your progress to the lesson and adapts pacing based on your responses.
 
-Start or resume a course by number:
+Start or resume a tour by ID:
 
 ```
 /teach 1
@@ -133,24 +130,27 @@ Available templates:
 
 | Workflow | Pipeline |
 |----------|---------|
-| `research-to-slides` | cogni-knowledge → cogni-narrative → cogni-visual |
-| `trend-to-marketing` | cogni-trends → cogni-portfolio → cogni-marketing |
+| `install-to-infographic` | cogni-workspace → cogni-workspace (themes) → cogni-visual |
+| `research-to-report` | cogni-knowledge → cogni-narrative → cogni-visual |
+| `trends-to-solutions` | cogni-trends → cogni-portfolio → cogni-marketing |
 | `portfolio-to-pitch` | cogni-portfolio → cogni-narrative → cogni-sales → cogni-visual |
-| `new-engagement` | cogni-consult: action fields + a design-thinking loop per deliverable |
-| `docs-pipeline` | cogni-knowledge → cogni-docs → cogni-narrative |
-| `full-onboarding` | cogni-workspace → cogni-help courses 1–12 |
+| `portfolio-to-website` | cogni-portfolio → cogni-workspace → cogni-website |
+| `content-pipeline` | cogni-marketing → cogni-narrative → cogni-copywriting → cogni-visual |
+| `consulting-engagement` | cogni-consult (setup → scope → action fields → design-thinking → personas) |
+
+Two further templates are internal maintainer pipelines with no `docs/workflows/` companion: `docs-pipeline` (the cogni-docs sweep) and `full-onboarding` (cogni-workspace → the workflow tours).
 
 Open a specific workflow:
 
 ```
-/workflow research-to-slides
+/workflow research-to-report
 ```
 
 ```
 How do I go from trend analysis to a marketing campaign?
 ```
 
-Workflow definitions live in `cogni-help/skills/workflow/references/workflows/`.
+User-facing workflow definitions live in `cogni-help/skills/workflow/references/workflows/`; the internal ones live in `references/internal-workflows/`.
 
 ---
 
@@ -208,8 +208,8 @@ Issue state is tracked locally in `cogni-issues/issues.json` in your project dir
 
 The course-deck skill generates PPTX slide decks for training sessions. Two modes:
 
-1. **Curriculum overview** — all 12 courses at a glance, for introducing the program to a group
-2. **Course introduction** — learning objectives, module breakdown, and prerequisites for a specific course
+1. **Curriculum overview** — all 7 tours at a glance, for introducing the program to a group
+2. **Tour introduction** — learning objectives, module breakdown, and prerequisites for a specific tour
 
 ```
 /course-deck curriculum

--- a/docs/plugin-guide/cogni-knowledge.md
+++ b/docs/plugin-guide/cogni-knowledge.md
@@ -103,6 +103,14 @@ Status skill and session entry point. Reads `binding.json` and computes the wiki
 
 Bootstraps a knowledge base. Dispatches `cogni-wiki:wiki-setup` to create the wiki if it does not exist, then writes `binding.json`. The only setup work this skill does beyond wiki creation is initializing the binding manifest; all wiki structure is owned by cogni-wiki.
 
+### knowledge-run
+
+The ordered-phase driver — the fresh-topic entry point. Runs the whole seven-phase chain (`knowledge-plan` → `curate` → `fetch` → `ingest` → `distill` → `compose` → `verify` → `finalize`) in one invocation, threading a single resolved project path between phases, so researching a new topic no longer means hand-dispatching seven skills and re-reading each SKILL.md. Takes one explicit `--topic` and ends with a deposited, claim-verified `type: synthesis` page in the bound wiki.
+
+Distinguish it from its two siblings: `knowledge-refresh` lints the wiki and re-researches whatever is stale (no explicit topic), and `knowledge-refresh-synthesis` extends one *existing* synthesis from a freshly-landed source. `knowledge-run` researches a brand-new topic from scratch.
+
+> Run the knowledge pipeline on the EU AI Act's GPAI obligations into my eu-ai-act base
+
 ### knowledge-plan
 
 Phase 1 of the inverted pipeline. Decomposes a topic into 3–7 sub-questions with per-sub-question `candidate_domains[]`, using no web access. Writes `<project>/.metadata/plan.json`. When a market is configured, reads `cogni-workspace/scripts/get-market-config.py` to seed bilingual domain candidates for localized search in Phase 2.
@@ -168,6 +176,14 @@ Seeds the base with curated foundation concept pages (Porter's Five Forces, JTBD
 ### knowledge-lint
 
 Semantic lint — surfaces stale pages/drafts, claim drift, and broken reverse links. `--fix` repairs the mechanical classes (reverse-link backfill, drift reconciliation). Runs on the vendored lint engine.
+
+### knowledge-index
+
+Rebuilds the curated root index and per-type sub-indexes of a base on demand, delegating to the locked renderers (`sub_index.py`, `root_index.py`) so index-shaping logic stays in one place. It also owns two repair paths: migrating a pre-0.0.8 wiki to the curated layout (control files into `wiki/meta/`, overview folded into the index intro, flat root split into root-map plus sub-indexes), and repairing drifted machine-owned regions such as theme-scoped ROOT-LINKS or a lagging schema version on a base already at 0.0.8+.
+
+Reach for it when `knowledge-resume` or `knowledge-health` surfaces a migration nudge or a structural-drift verdict.
+
+> Rebuild the knowledge index
 
 ### knowledge-health
 

--- a/docs/plugin-guide/cogni-narrative.md
+++ b/docs/plugin-guide/cogni-narrative.md
@@ -10,7 +10,7 @@ Story arc-driven narrative transformation for the insight-wave ecosystem.
 
 cogni-narrative sits in the composition layer of the insight-wave pipeline: after research is collected and before content is polished or visualised. Its job is to impose narrative structure on unstructured input — research syntheses, analyses, TIPS trend reports, competitive landscapes — so the output reads as a deliberate argument rather than an information dump.
 
-The plugin provides ten story arc frameworks. Each framework is a sequence of named elements (for example: Why Change → Why Now → Why You → Why Pay) with defined rhetorical intent, evidence requirements, and transition patterns between elements. When you run `/narrative`, the skill reads your source files, proposes the best-fit arc, and writes a ~1,675-word insight summary structured around it. The output file (`insight-summary.md`) carries YAML frontmatter with an `arc_id` field that downstream plugins (cogni-copywriting, cogni-visual) use to apply arc-aware processing.
+The plugin provides eleven story arc frameworks. Each framework is a sequence of named elements (for example: Why Change → Why Now → Why You → Why Pay) with defined rhetorical intent, evidence requirements, and transition patterns between elements. When you run `/narrative`, the skill reads your source files, proposes the best-fit arc, and writes a ~1,675-word insight summary structured around it. The output file (`insight-summary.md`) carries YAML frontmatter with an `arc_id` field that downstream plugins (cogni-copywriting, cogni-visual) use to apply arc-aware processing.
 
 ### When to reach for this plugin
 
@@ -35,6 +35,7 @@ An arc framework defines the shape of an argument. Rather than writing a narrati
 | `strategic-foresight` | Signals → Scenarios → Strategies → Decisions | Long-range planning; scenario analysis; strategic options |
 | `industry-transformation` | Forces → Friction → Evolution → Leadership | Industry analysis; regulatory impact; transformation roadmaps |
 | `trend-panorama` | Forces → Impact → Horizons → Foundations | TIPS trend-scout output; Trendradar-native reports |
+| `smarter-service` | Forces → Impact → Horizons → Foundations | TIPS reports with investment themes (theme-aware sibling of trend-panorama) |
 | `theme-thesis` | Why Change → Why Now → Why You → Why Pay | Investment theme narratives within TIPS reports |
 | `jtbd-portfolio` | Jobs → Friction → Portfolio → Invitation | Portfolio introductions; capability overviews; pre-sales |
 | `company-credo` | Mission → Conviction → Credibility → Promise | Website About-Us pages; company introductions |
@@ -174,8 +175,6 @@ This is the most common sequence: research output exists, an executive needs a c
 2. Run `/narrative-review ./insight-summary.md` — check the quality scorecard; address any warn/fail gates
 3. Run `/narrative-adapt ./insight-summary.md --format executive-brief` — produce the 300-500 word email-ready version
 4. Optional: run `/copywrite executive-brief.md` (cogni-copywriting) for final polish
-
-See [../workflows/research-to-narrative.md](../workflows/research-to-narrative.md) for the full pipeline.
 
 ### Trend report with German output
 

--- a/docs/plugin-guide/cogni-projects.md
+++ b/docs/plugin-guide/cogni-projects.md
@@ -1,0 +1,218 @@
+# cogni-projects
+
+**Plugin guide** — for canonical positioning see the [cogni-projects README](../../cogni-projects/README.md).
+
+> **Incubating** (v0.0.x) — skills, data formats, and workflows may change at any time.
+
+---
+
+## Overview
+
+cogni-projects is the partner-facing steering layer for a consulting firm's project portfolio. It holds one self-contained directory of consultants, projects, and assignments, and answers the three questions partners otherwise carry in their heads: who is rolling off next month, who fits this mandate, and which assignment actually moves the firm's strategy forward.
+
+The plugin is deliberately narrow. It does not run engagements — that is cogni-consult's job — and it does not model your service offering — that is cogni-portfolio. cogni-projects models *people against work*: availability, profile fit, and strategic impact, scored deterministically so a staffing decision can be defended in a partner meeting rather than justified from memory.
+
+Four skills have shipped: portfolio scaffolding, entity authoring, the staffing match engine, and a read-only partner-meeting dashboard. The backfilling recommender arrives in a later release.
+
+---
+
+## Key Concepts
+
+| Term | What it means in practice |
+|------|--------------------------|
+| **Portfolio** | One `cogni-projects/<portfolio-slug>/` directory rooted by a `projects-portfolio.json` manifest — the unit everything else writes into |
+| **Consultant** | A person record: seniority, skills, availability windows, and the profile the matcher scores against |
+| **Project** | A mandate record with open roles, each role naming the skills and seniority it needs |
+| **Assignment** | A consultant staffed to a project role for a date range — the link between the two entity types |
+| **Open role** | A project role with no active assignment covering it; the unit the staffing engine ranks candidates for |
+| **Strategic impact** | A per-project weight that lets staffing optimize for firm strategy rather than raw utilization |
+| **Staffing recommendation** | The last-run scorer output — a ranked candidate list per open role, overwritten each run |
+
+### Why the manifest is written last
+
+`portfolio-init.sh` creates the directory skeleton first and writes `projects-portfolio.json` last, so the manifest's existence is a reliable "fully initialized" marker. An interrupted scaffold (directories made, manifest never written) is repairable by simply re-running; a completed portfolio returns a clean "already initialized" no-op and overwrites nothing.
+
+---
+
+## Getting Started
+
+Scaffold a portfolio:
+
+```
+/cogni-projects:projects-setup
+```
+
+You will be asked for a portfolio name and a slug. Name it "Demo Advisory", accept the derived slug `demo-advisory`, and confirm. You get:
+
+```
+cogni-projects/demo-advisory/
+├── projects-portfolio.json    Root manifest (identity + entity lists)
+├── consultants/
+├── projects/
+├── assignments/
+└── .metadata/                 Append-only logs
+```
+
+The manifest starts with portfolio identity and three empty entity lists:
+
+```json
+{
+  "slug": "demo-advisory",
+  "name": "Demo Advisory",
+  "language": "en",
+  "consultants": [],
+  "projects": [],
+  "assignments": [],
+  "workflow_state": { ... }
+}
+```
+
+Run the command a second time — it reports the portfolio is already initialized and changes nothing. That idempotency is the point: setup is safe to re-run at any time.
+
+From there the normal sequence is authoring entities, then staffing, then rendering the dashboard.
+
+---
+
+## Capabilities
+
+### `projects-setup` — Initialize a portfolio
+
+Scaffolds the portfolio directory and writes the root manifest. This is the entry point for all portfolio work — every other skill expects a manifest to exist and will point you here if one does not.
+
+Trigger it with any request to begin structured consultant/project/staffing work, even without the word "setup":
+
+> Set up a projects portfolio for my advisory practice
+
+### `projects-entities` — Author and register records
+
+Authors one consultant, project, or assignment record and registers it in the manifest. Each write runs structural validation — frontmatter fields against the entity schema, and for assignments, referential integrity against the consultant and project the assignment names.
+
+Registration is a slug-keyed upsert, so re-authoring the same consultant updates the existing record rather than duplicating it, and every write appends to `.metadata/execution-log.json`.
+
+> Add a consultant: Maria Lang, senior manager, available from March, strong in supply-chain and SAP
+
+Author consultants and projects before assignments — an assignment that names a consultant or project slug that does not exist yet fails validation on the reference check.
+
+### `projects-staff` — Rank candidates per open role
+
+The staffing match engine. It reads every project's open roles and scores each available consultant on three axes — availability against the role's date range, profile fit against the role's required skills and seniority, and the project's strategic impact — then writes a ranked shortlist per role to `.metadata/staffing-recommendations.json`.
+
+Scoring is deterministic (`staffing-score.py`), which is what makes the output defensible: the same portfolio produces the same ranking, and the per-axis contributions are visible rather than buried in a single opaque number.
+
+> Who should I put on the Nordics ERP rollout?
+
+Note that `staffing-recommendations.json` is a snapshot, not a log — each run overwrites it. The append-only history lives in `.metadata/staffing-log.json`, whose `matches[]` array gains one record per run.
+
+### `projects-dashboard` — Partner-meeting snapshot
+
+Renders a read-only HTML snapshot of the portfolio: staffing coverage per project, at-risk projects (open roles with no strong candidate or imminent start), and portfolio value grouped by strategic impact.
+
+The skill is strictly read-only — it holds no write tools and never mutates entity data, so it is safe to run mid-meeting.
+
+> Show me the project portfolio — which projects are at risk?
+
+---
+
+## Data Model
+
+A portfolio is one directory. The manifest holds identity plus the three entity lists; per-entity records live in their own directories; `.metadata/` holds append-only logs plus the staffing snapshot.
+
+```
+cogni-projects/<portfolio-slug>/
+├── projects-portfolio.json    slug, name, language, timestamps, entity lists, workflow_state
+├── consultants/               one record per consultant
+├── projects/                  one record per project (with open roles)
+├── assignments/               consultant → project role, with date range
+└── .metadata/
+    ├── execution-log.json     append-only: every entity write
+    ├── staffing-log.json      append-only: {"matches": [...]} one entry per staffing run
+    ├── decision-log.json      append-only: staffing decisions
+    └── staffing-recommendations.json   last-run scorer output (overwritten each run)
+```
+
+Full entity schemas — consultant, project, assignment, plus naming and validation rules — live in [`cogni-projects/references/data-model.md`](../../cogni-projects/references/data-model.md).
+
+---
+
+## Integration Points
+
+### Upstream — nothing feeds cogni-projects yet
+
+cogni-projects is standalone at this stage. Consultant and project data is authored directly through `projects-entities` rather than imported from another plugin.
+
+### Downstream — nothing consumes it yet
+
+The portfolio directory is the shared substrate for the plugin's own skills and for the backfilling recommender that lands later.
+
+### Planned bridges
+
+Two cross-plugin bridges are on the roadmap but not yet built:
+
+- **cogni-consult** — an engagement in cogni-consult and a project in cogni-projects describe the same client work from two angles (delivery structure vs. staffing). A bridge would let a scoped engagement seed a project record.
+- **cogni-portfolio** — cogni-portfolio models what the firm sells; cogni-projects models who delivers it. Linking a project to the propositions it delivers would let staffing weight strategic impact against portfolio strategy rather than a hand-set number.
+
+Until those land, treat cogni-projects as a self-contained tool.
+
+---
+
+## Common Workflows
+
+### Workflow 1: Stand up a portfolio from scratch
+
+1. `/cogni-projects:projects-setup` — scaffold the directory
+2. Author consultants: "Add a consultant: …" (repeat per person)
+3. Author projects with their open roles: "Add a project: …"
+4. Author any existing assignments so the matcher knows who is already committed
+5. `/cogni-projects:projects-dashboard` — confirm the portfolio reads correctly
+
+Author consultants and projects before assignments, so the reference check passes.
+
+### Workflow 2: Staff an open role
+
+1. Confirm the project's open roles are current (re-author the project if a role changed)
+2. Run the match engine: "Who should I put on the Nordics ERP rollout?"
+3. Read the ranked shortlist — per-axis scores show *why* each candidate ranked where they did
+4. Author the assignment for the chosen consultant
+5. Re-run the dashboard — staffing coverage for that project should now reflect the new assignment
+
+### Workflow 3: Prepare for a partner meeting
+
+1. `/cogni-projects:projects-dashboard`
+2. Review at-risk projects — open roles with no strong candidate are the agenda
+3. For each, run the match engine to bring a shortlist into the room rather than a question
+
+---
+
+## Troubleshooting
+
+**"Portfolio already initialized"** — this is the expected no-op from re-running `projects-setup`. Nothing was overwritten. If you genuinely want a second portfolio, run setup with a different slug.
+
+**An assignment fails validation** — the assignment names a consultant or project slug that is not registered in the manifest. Author the referenced entity first, then re-author the assignment.
+
+**A consultant never appears in a shortlist** — check their availability window against the role's date range. The availability axis gates the other two; a consultant with no overlap will not surface regardless of profile fit.
+
+**Scripts fail with a JSON parse error** — every script returns `{"success", "data", "error"}`. Read the `error` field; the scripts are stdlib-only bash + python3, so a failure is usually a malformed entity file rather than a missing dependency.
+
+Run the regression suites directly if you suspect a script-level problem:
+
+```bash
+bash cogni-projects/tests/test_portfolio_init.sh
+bash cogni-projects/tests/test_register_entity.sh
+bash cogni-projects/tests/test_validate_entities_refs.sh
+bash cogni-projects/tests/test_staffing_score.sh
+bash cogni-projects/tests/test-render-dashboard.sh
+```
+
+---
+
+## Extending This Plugin
+
+cogni-projects is open-source under Apache-2.0 and early enough that structural contributions are still cheap. The most useful areas:
+
+- **Scoring axes** — availability, profile fit, and strategic impact cover the common case. Firms that staff against utilization targets, travel constraints, or client-continuity rules would benefit from additional axes in `staffing-score.py`.
+- **Entity schema extensions** — the consultant schema is deliberately minimal. Certifications, language proficiency, and industry history are natural additions; see `references/data-model.md`.
+- **The planned cross-plugin bridges** — a cogni-consult or cogni-portfolio bridge is the highest-leverage contribution, since it turns three separate models of the same client work into one.
+
+Conventions to follow: scripts return `{"success", "data", "error"}` JSON and stay stdlib-only (bash + python3, no pip); skill names carry the `projects-` domain prefix; the portfolio manifest is the source of truth.
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) and the [plugin development guide](../contributing/plugin-development.md) for guidelines.


### PR DESCRIPTION
## Summary

- Regenerate structural README sections (architecture trees, dependency tables, component tables) for 9 plugins whose docs drifted from code reality: cogni-consult, cogni-help, cogni-knowledge, cogni-portfolio, cogni-projects, cogni-sales, cogni-visual, cogni-website, cogni-workspace.
- Refresh 3 stale `docs/plugin-guide` pages and create the missing cogni-projects guide.
- Regenerate the root README, which was missing cogni-projects entirely and carried stale skill/agent totals.
- Defer all WEAK-messaging and narrative-conformance findings to humans; no `doc-power` is dispatched and no plugin version is touched.

Branch: `docs/sync-drift-2026-08-04` (base `main`, from `aebdd8d5`).

## Plugins fixed

- **cogni-consult** — dependencies (undocumented `cogni-claims` + `cogni-copywriting`), plugin.json keywords (missing `agent`, `hook`), stale plugin guide 6 → 9 skills. Narrative word-band drift deferred.
- **cogni-help** — architecture tree version annotation (README said v0.0.10, plugin.json is v0.0.12), "12 plugins"/"70+ skills" → "14 plugins"/"110+ skills" across 5 sections, stale plugin guide (12-course → 7-tour curriculum, 6 → 7 workflow templates).
- **cogni-knowledge** — architecture tree counts (skills 20 → 21, references 21 → 28, scripts 27 → 34), plugin guide 19 → 21 skills (`knowledge-run`, `knowledge-index` added).
- **cogni-portfolio** — dependencies (undocumented `cogni-copywriting`). Messaging WEAK deferred.
- **cogni-projects** — architecture section had no directory tree at all, missing readiness callout, missing `docs/plugin-guide/cogni-projects.md`. Messaging WEAK and narrative drift deferred.
- **cogni-sales** — architecture tree version annotation v0.4.2 → v0.4.3.
- **cogni-visual** — architecture tree version annotation v0.16.24 → v0.16.26.
- **cogni-website** — architecture tree version annotation v0.0.4 → v0.0.6 plus two missing directories (`skills/website-build/scripts/`, `skills/website-plan/references/`).
- **cogni-workspace** — components table missing the `on-session-start-language.sh` hook row, architecture tree missing `tests/` and `scripts/baselines/` while still showing the deleted `wiki/raw/` and `wiki/assets/`, dependencies missing `cogni-trends` and `cogni-knowledge`.
- **Root README** — cogni-projects absent from "Plugins at a glance" (13 rows vs 14 plugins) and from the capability sections; totals line "99 skills, 76 agents" → **114 skills, 89 agents**; per-row counts corrected (cogni-knowledge 12/7 → 21/16, cogni-consult 6/0 → 9/4, cogni-visual 8 → 7); prose counts corrected across 8 capability paragraphs.

**Version-bump policy:** only README prose annotations that *cite* a version are corrected. No `plugin.json` or `marketplace.json` `version` field is edited, per `CLAUDE.md` and `scripts/check-version-bump.py`. The only manifest write is cogni-consult's `keywords[]`. Both CI gates verified green locally before commit: `check-version-bump.py` (0 violations, 14 scanned) and `check-breadcrumbs.py` (0 violations).

## Plugins deferred

- **cogni-copywriting** — Check 7 WEAK messaging is its only finding; "What it means for you" needs a human voice call, and `doc-power` is never auto-dispatched.
- **cogni-marketing** — Check 18 narrative drift is its only finding; `## Data model` is prose where the guide wants an entity table, a hand-written section no doc-* skill may rewrite.

*(cogni-narrative was originally listed here as deferred. Commit `d3112b0f` brought it into scope — see Review notes.)*

## Test plan

- [x] `check-version-bump.py` — 0 violations, no `version` line changed
- [x] `check-breadcrumbs.py` — 0 violations
- [x] Post-fix audit re-run on all 9 changed plugins — every targeted drift cell verified resolved
- [x] `git diff` confirms cogni-claims, cogni-trends, cogni-copywriting, cogni-marketing are untouched (cogni-narrative *is* touched as of `d3112b0f`)
- [x] Root README "Plugins at a glance" is 14/14 rows against marketplace.json, no dead plugin links
- [x] Render-check each fixed plugin README on github.com — architecture code fences intact, tables not broken
- [x] Both gates re-run green on `27bfeb9d` — version-bump 0 violations / 10 plugins touched, breadcrumbs 0 violations; both manifests still parse and neither `version` line is in the diff

## Review notes (post-fix audit)

**Verdict: `pass`** as of the gatekeeper run on `d3112b0f` (the original `needs_revision` was cleared by the `d3112b0f` revision). No regressions; residual findings are deferred-by-design plus pre-existing drift newly surfaced.

**Regression check: clean.** Every finding present in the post-audit but absent from the pre-audit sits on a surface this branch never touched (verified by `git diff aebdd8d5..HEAD` per file). Zero regressions introduced.

**One incomplete fix, caught and corrected in `a080cb32`.** The first pass rewrote the cogni-help guide's curriculum and workflow *tables* but left the body prose on the retired 12-course numbering (`/teach 1`, "Course 1", `/teach continue`), a stale "six templates" count, and a Known Issues link resolving outside the repo (`../../cogni-docs/…`). The post-audit caught all four; the follow-up commit fixes them.

**Newly surfaced pre-existing drift — not addressed here, needs its own pass:**

| Plugin | Check | Finding |
|---|---|---|
| cogni-knowledge | dependencies | `knowledge-refresh/SKILL.md` dispatches `cogni-claims:claims` under `--resweep` and documents the requirement, but `cogni-claims` is not in the Dependencies table |
| cogni-portfolio | doc_logic | `portfolio-dashboard` has `final_hint: "interactive dashboard"` in pipeline-registry.json but the "What it does" item renders no `(…)` suffix |
| cogni-portfolio | markets | callout enumerates 25 markets by tier with no authority names, instead of the registry's `primary_regions_shown_in_callout` shape with 2–3 authorities each |
| cogni-visual | architecture | tree omits `scripts/load-theme-component.py` and `references/theme-component-loader.md` (filed as #1209) |

*(Two "has `hooks/` but no `hooks` keyword" rows for cogni-portfolio and cogni-visual were dropped from this table — re-reading both manifests shows the keyword is already present, so that drift does not exist. The cogni-knowledge dependencies row is filed as #1207 and is in flight on #1213; the cogni-portfolio markets row is #1208.)*

## Open questions

- ~~**cogni-narrative was dropped by the planner.**~~ **Resolved in `d3112b0f`.** The guide's arc count is corrected to eleven, the missing `smarter-service` row is appended to both the guide's and the README's arc tables, and the dangling `docs/workflows/research-to-narrative.md` link is removed (no existing workflow doc covers research→narrative, so the sentence went rather than being retargeted). The same stale claims surviving *outside* the guide are tracked as #1211.
- **cogni-workspace reads an archived plugin.** `skills/audit-region-sources/SKILL.md` and `skills/manage-markets/SKILL.md` read `cogni-research/references/market-sources.json` — a path owned by an archived plugin with no current owner. This sweep deliberately did **not** add `cogni-research` to the Dependencies table, because documenting a dependency on a dead plugin is worse than the gap. Decide whether to repoint those skills at `cogni-workspace/references/supported-markets-registry.json` before documenting anything.
- **Deploy data is 110 days stale** (researched 2026-04-16, threshold 90). Run `/cogni-docs:doc-deploy refresh`. The cogni-projects readiness callout this PR injects derives from that stale data and should be re-verified after the refresh.
- **known-issues.json is 105 days stale** (threshold 60) — run `/cogni-docs:doc-issues list` to audit the 2 registered issues against current upstream state.
- **pipeline-registry.json is missing 12 skills** that exist on disk (`consult-dashboard`, `consult-project-plan`, `consult-publish`, `knowledge-run`, `projects-{dashboard,entities,setup,staff}`, `service-{conformance,gatekeeper,groom,simplify}`). Added-only, no removals — advisory. Run `/doc-meta --apply --file pipeline-registry` to scaffold.
- **Check 17 archived-plugin references: 103 hits across 22 files** (102 after this branch). Roughly 72 are genuine (`cogni-wiki` 37, `cogni-consulting` 20, `cogni-research` 15) and ~31 are false positives — `cogni-docs`/`cogni-service`/`cogni-issues` are live in the `managed-service` ecosystem, and `cogni-x`/`cogni-work`/`cogni-example`/`cogni-plugin` are placeholders and brand tokens. The false-positive rate is a tooling gap: on the home repo the `known-ecosystem-plugins.json` supplement is deliberately not consulted. Prose correction, not a `doc-generate` pass — needs its own scoped PR.
- **Deferred messaging/narrative** — cogni-copywriting ("Trust the claims."-style unquantified MEANS bullets), cogni-portfolio, cogni-website, cogni-projects (2-column problem table, no MEANS bullets), cogni-consult (158/366-word sections), cogni-marketing (`## Data model` as prose). All need `/doc-power`, which is never auto-dispatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

