### PR TITLE
cogni-consult: user-facing-output.md as the register's single source of truth

### DIFF
--- a/cogni-consult/CLAUDE.md
+++ b/cogni-consult/CLAUDE.md
@@ -29,6 +29,8 @@ cogni-consult/
 │   │                              pipeline rungs, depth framing, storage contract)
 │   ├── subagent-output-contract.md  Register rules the SubagentStart hook emits
 │   │                              verbatim into every dispatched agent
+│   ├── user-facing-output.md      Main-loop register contract (surface scope,
+│   │                              state lexicon, table rules, step announcements)
 │   ├── personas/                  Packaged default advisors (consulting-partner,
 │   │                              project-manager)
 │   ├── methods/
@@ -138,7 +140,7 @@ cogni-consult/
 
   **Both files declare `keep-coding-instructions: true`, and it is load-bearing.** Without it, activating a style drops Claude Code's `# Doing tasks` block — prefer-editing-existing-files, the OWASP warning, the over-engineering rules — which matters for skills that run `deliverable-graph.py` and do idempotent `Edit` round-trips on `field.json`. The plugin output-style loader reads the field (`keepCodingInstructions` travels with `forceForPlugin` from the frontmatter through the merged style map into the prompt assembler), so declaring it keeps those instructions in place. `# Executing actions with care` is unconditional and survives either way. Treat the declaration as behaviour, not decoration: if either file loses it, activating that register silently costs the engineering defaults
 
-- **Language reaches subagents only through the hook** — a subagent's system prompt is its own body plus a notes block and the environment info: no settings `language` key, no `CLAUDE.md`, no active output style. `hooks/hooks.json` registers a `SubagentStart` hook matched on the four `consult-*` agent types; `hooks/on-subagent-start.sh` resolves the workspace default language and emits it together with `references/subagent-output-contract.md`, read verbatim. Because a hook cannot see the user's message, rung 2 of `references/interaction-language.md` (message-detection override) travels as the `interaction_language` dispatch input, which wins over the hook's default. Keep the doctrine in the reference, not in the hook script and not in the four agent bodies — the script is a delivery mechanism, and the agent bodies hold only the input declaration. When `references/user-facing-output.md` lands, reconcile the two: one contract, two delivery paths (that file loads in the main loop, this one is injected into agents)
+- **Language reaches subagents only through the hook** — a subagent's system prompt is its own body plus a notes block and the environment info: no settings `language` key, no `CLAUDE.md`, no active output style. `hooks/hooks.json` registers a `SubagentStart` hook matched on the four `consult-*` agent types; `hooks/on-subagent-start.sh` resolves the workspace default language and emits it together with `references/subagent-output-contract.md`, read verbatim. Because a hook cannot see the user's message, rung 2 of `references/interaction-language.md` (message-detection override) travels as the `interaction_language` dispatch input, which wins over the hook's default. Keep the doctrine in the reference, not in the hook script and not in the four agent bodies — the script is a delivery mechanism, and the agent bodies hold only the input declaration. `references/user-facing-output.md` is the other half: one contract, two delivery paths (that file loads in the main loop, this one is injected into agents), so a rule changed in either is checked against the other
 
 ## Data Model
 

--- a/cogni-consult/references/user-facing-output.md
+++ b/cogni-consult/references/user-facing-output.md
@@ -1,0 +1,111 @@
+# User-facing output
+
+The register every cogni-consult skill follows when it writes for the
+consultant: which language, which surfaces the rules cover, which words stand in
+for a stored value, how a table reads, and how a step is announced.
+
+**This file governs the main loop only.** A dispatched agent never sees it — a
+subagent's prompt carries no `CLAUDE.md`, no settings language, no output style
+and no skill body. Agents receive the same doctrine through
+`references/subagent-output-contract.md`, injected by the `SubagentStart` hook,
+plus an `interaction_language` dispatch input. The two are one contract with two
+delivery paths, not two contracts: check a rule changed here against that file.
+
+## (a) Language
+
+Resolve the **interaction language** per `references/interaction-language.md`,
+which owns the resolution ladder and the separation from the engagement's
+deliverable `language`. Do not restate the ladder — read it there. Everything
+below applies in whatever language that resolves to.
+
+## (b) Scope — every surface, not only prose
+
+These rules govern **every** user-facing surface, not only prose: table cells,
+column headers, list items, headings, count lines, step announcements,
+offer lines, and the `description` of a tool call.
+
+A table is not an exemption from the register — it is where register failures are
+most visible, because a column header reads as a label the system endorses.
+
+## (c) State lexicon
+
+An engine value is **never** displayed raw. A value missing from this table is a
+gap in the table, not a licence to pass the raw value through — add the row.
+
+| Engine value | German | English |
+|---|---|---|
+| `pending` | offen | pending |
+| `in-progress` | in Arbeit | in progress |
+| `complete` | fertig | complete |
+| `lineage_status.status: "stale"` | überholt | outdated |
+| `unreadable` | nicht lesbar | unreadable |
+| `personas_gate: "satisfied"` | erfüllt | satisfied |
+| `personas_gate: "pending"` | offen | pending |
+| adherence `strong` / `partial` / `drifted` | stark / teilweise / abgewichen | strong / partial / drifted |
+| outcome `promoted` / `declined` / `none-found` | übernommen / abgelehnt / nichts gefunden | promoted / declined / none found |
+| disposition `accepted` / `revised` / `rejected` | übernommen / überarbeitet / begründet verworfen | accepted / revised / rejected with reason |
+
+Four notes travel with the table:
+
+- The `pending` / `in-progress` / `complete` triple is shared by a deliverable's
+  `state`, `workflow_state.scope`, and `persona_review`. One triple, one mapping.
+- `unreadable` is a **field-rollup** state, written alongside a `warnings[]`
+  entry — never conflated with `pending`, which means not started. Surface the
+  warning's substance; do not pass the token through.
+- The disposition triple is **prose vocabulary**, not a stored field. It names
+  how the consultant answered a persona challenge; no JSON key carries it.
+- Design-thinking stage names (`empathize` → `define` → `ideate` → `prototype` →
+  `test`) are method terms: proper-case them for display (`ideate` → `Ideate`),
+  do not translate them.
+
+Where an English display string happens to equal the engine token, that is a
+coincidence of vocabulary, not an exemption — the value still passes through the
+lexicon rather than being printed because it "already looks like English".
+
+## (d) Table contract
+
+1. A fixed, named column set — never derived at runtime from whatever keys the
+   data happens to carry.
+2. Natural-language headers. A field identifier as a column header is a defect.
+3. An explicit sort, stated once, not left to the order the data arrived in.
+4. A row cap, plus one overflow line naming what was not shown.
+5. Drop degenerate columns — a column carrying an identical value in every row
+   informs no one.
+6. No table under four rows. Below that, prose or a list reads better.
+7. A slug appears only where the reader needs it to *act*, in code form. Never
+   as a header, and never as a deliverable's name.
+
+## (e) Step announcements and brevity budgets
+
+Two tiers, split by irreversibility rather than by skill:
+
+- **Orientierungsschritt** (read-only): one sentence, at most 25 words.
+- **Arbeitsschritt** (writes state, or fans out over engagement entities): two
+  sentences, at most 45 words, naming what comes back and what changes on disk.
+
+One announcement per perceptible wait, never one per tool call.
+
+Three rules keep the announcement cheap:
+
+- **Announce before *or* report after — never both.** Saying it twice costs the
+  reader a second pass and adds nothing.
+- **Name the actors when they are engagement entities, never the dispatch.**
+  "Partner, Projektleitung, CFO und Betriebsrat, jeder in seiner eigenen Logik",
+  not "vier Agenten" — the consultant knows the stakeholders, not the machinery.
+- **No wall-clock estimates.** A wrong estimate is a trust withdrawal, which
+  inverts what the announcement is for.
+
+## What binds here but lives elsewhere
+
+These rules are not restated in this file; they hold on every surface named in
+(b) all the same:
+
+- Audience framing, executive register and compression discipline, the
+  engine-vocabulary-stays-internal rule, and the no-slug-in-prose rule —
+  `references/subagent-output-contract.md` (`## Register`) and
+  `output-styles/strategy-advisor.md` / `strategy-advisor-de.md`.
+- German orthography (ß/ss, Umlaute) — `output-styles/strategy-advisor-de.md`.
+
+One boundary: the generated HTML dashboard document follows the engagement's
+deliverable `language` axis, not the interaction language, and is therefore
+outside this contract.

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -49,6 +49,10 @@ words, with no script, file, or skill names, and never derived from the
 script's filename or header comment. Worked pair:
 `Discover cogni-consult engagements` → `Laufende Engagements holen`.
 
+The register that output follows — scope, state lexicon, table rules, step
+announcements — is `$CLAUDE_PLUGIN_ROOT/references/user-facing-output.md`;
+table cells and headers are user copy too, not an exemption.
+
 ### 1. Prerequisite Gate
 
 When arriving via an in-session `consult-scope` handoff, the engagement
@@ -106,7 +110,7 @@ deliverables in manifest order:
 | market-evidence | market-sizing | fertig | pyramid-principle | fertig |
 | market-evidence | competitor-landscape | in Arbeit · Ideate | — | offen |
 | portfolio-fit | — (no deliverables planned) | | | |
-| go-to-market | ⚠ unreadable field.json (see warnings) | | | |
+| go-to-market | ⚠ field.json nicht lesbar (siehe Warnungen) | | | |
 ```
 
 `Stand` merges the stored `state` and `dt_stage` into one value, the stage
@@ -121,8 +125,8 @@ sixth cell: `Route: <deliverable> · <producing_route>`, e.g.
 
 An English session renders the same table: header
 `| Action field | Deliverable | Status | Framework | Persona review |`, values
-`complete` / `in progress · Ideate` / `pending`, and the same `Route:` note
-line.
+`complete` / `in progress · Ideate` / `pending`, the unreadable-field row
+`⚠ field.json not readable (see warnings)`, and the same `Route:` note line.
 
 `Framework` shows the stored `chosen_framework` read-only — a registry slug
 verbatim, a `combo:<slugA>+<slugB>` pairing rendered `<slugA> + <slugB>` (the

--- a/cogni-consult/skills/consult-action-fields/SKILL.md
+++ b/cogni-consult/skills/consult-action-fields/SKILL.md
@@ -109,7 +109,7 @@ deliverables in manifest order:
 |---|---|---|---|---|
 | market-evidence | market-sizing | fertig | pyramid-principle | fertig |
 | market-evidence | competitor-landscape | in Arbeit · Ideate | — | offen |
-| portfolio-fit | — (no deliverables planned) | | | |
+| portfolio-fit | — (keine Deliverables geplant) | | | |
 | go-to-market | ⚠ field.json nicht lesbar (siehe Warnungen) | | | |
 ```
 
@@ -125,7 +125,8 @@ sixth cell: `Route: <deliverable> · <producing_route>`, e.g.
 
 An English session renders the same table: header
 `| Action field | Deliverable | Status | Framework | Persona review |`, values
-`complete` / `in progress · Ideate` / `pending`, the unreadable-field row
+`complete` / `in progress · Ideate` / `pending`, the no-deliverables row
+`— (no deliverables planned)`, the unreadable-field row
 `⚠ field.json not readable (see warnings)`, and the same `Route:` note line.
 
 `Framework` shows the stored `chosen_framework` read-only — a registry slug

--- a/cogni-consult/skills/consult-dashboard/SKILL.md
+++ b/cogni-consult/skills/consult-dashboard/SKILL.md
@@ -52,6 +52,10 @@ script's filename or header comment. Worked pair:
 The dashboard document's own `<html lang>` attribute and language badge follow
 the engagement's deliverable `language`, not the interaction language.
 
+The register that output follows — scope, state lexicon, table rules, step
+announcements — is `$CLAUDE_PLUGIN_ROOT/references/user-facing-output.md`;
+table cells and headers are user copy too, not an exemption.
+
 ### 1. Find the Active Engagement
 
 Discover engagements with `scripts/discover-projects.sh` (the registry wrapper), or scan

--- a/cogni-consult/skills/consult-design-thinking/SKILL.md
+++ b/cogni-consult/skills/consult-design-thinking/SKILL.md
@@ -70,6 +70,10 @@ words, with no script, file, or skill names, and never derived from the
 script's filename or header comment. Worked pair:
 `Discover cogni-consult engagements` → `Laufende Engagements holen`.
 
+The register that output follows — scope, state lexicon, table rules, step
+announcements — is `$CLAUDE_PLUGIN_ROOT/references/user-facing-output.md`;
+table cells and headers are user copy too, not an exemption.
+
 ### Interaction mode
 
 By default this loop runs as an **auto-walk**: it writes each stage's artifact

--- a/cogni-consult/skills/consult-personas/SKILL.md
+++ b/cogni-consult/skills/consult-personas/SKILL.md
@@ -45,6 +45,10 @@ words, with no script, file, or skill names, and never derived from the
 script's filename or header comment. Worked pair:
 `Discover cogni-consult engagements` → `Laufende Engagements holen`.
 
+The register that output follows — scope, state lexicon, table rules, step
+announcements — is `$CLAUDE_PLUGIN_ROOT/references/user-facing-output.md`;
+table cells and headers are user copy too, not an exemption.
+
 ### 1. Prerequisite Gate
 
 When arriving via an in-session handoff (e.g. a design-thinking test stage
@@ -179,11 +183,15 @@ its writes:
    idempotent: skip a persona already carrying a `challenged` entry for these
    `(action_field, deliverable)` coordinates; append (or update) a consolidated
    `## Persona Challenges` section in the deliverable artifact summarizing each
-   persona's challenge and the consultant's disposition (accepted / revised /
-   rejected with reason); when the field's manifest entry carries a
+   persona's challenge and the consultant's disposition. The disposition triple
+   is prose, not a stored field, and renders per `references/user-facing-output.md`
+   — übernommen / überarbeitet / begründet verworfen, or accepted / revised /
+   rejected with reason; when the field's manifest entry carries a
    `persona_review` field, advance it (`pending` → `in-progress` when
    challenges start, → `complete` only once the consultant has dispositioned
-   every challenge) — never create the field on an entry that lacks it.
+   every challenge) — never create the field on an entry that lacks it. Those
+   are the stored values; report them to the consultant as offen / in Arbeit /
+   fertig, or pending / in progress / complete in an English session.
 4. **Zero personas on disk.** When no persona files exist at all (step 2's
    seeding normally prevents this), run the challenge against the consultant
    directly ("what would your engagement partner push back on?") and note the

--- a/cogni-consult/skills/consult-project-plan/SKILL.md
+++ b/cogni-consult/skills/consult-project-plan/SKILL.md
@@ -63,6 +63,10 @@ script's filename or header comment. Worked pair:
 The engagement's `language` field controls the artifact's `lang` frontmatter,
 not how you address the user.
 
+The register that output follows — scope, state lexicon, table rules, step
+announcements — is `$CLAUDE_PLUGIN_ROOT/references/user-facing-output.md`;
+table cells and headers are user copy too, not an exemption.
+
 ### 1. Prerequisite Gate
 
 When arriving via an in-session handoff that already resolved the engagement

--- a/cogni-consult/skills/consult-publish/SKILL.md
+++ b/cogni-consult/skills/consult-publish/SKILL.md
@@ -60,6 +60,10 @@ words, with no script, file, or skill names, and never derived from the
 script's filename or header comment. Worked pair:
 `Discover cogni-consult engagements` → `Laufende Engagements holen`.
 
+The register that output follows — scope, state lexicon, table rules, step
+announcements — is `$CLAUDE_PLUGIN_ROOT/references/user-facing-output.md`;
+table cells and headers are user copy too, not an exemption.
+
 ### 1. Locate the engagement and the deliverable
 
 Resolve the engagement root (the directory holding `consult-project.json`) and

--- a/cogni-consult/skills/consult-resume/SKILL.md
+++ b/cogni-consult/skills/consult-resume/SKILL.md
@@ -41,6 +41,10 @@ words, with no script, file, or skill names, and never derived from the
 script's filename or header comment. Worked pair:
 `Discover cogni-consult engagements` → `Laufende Engagements holen`.
 
+The register that output follows — scope, state lexicon, table rules, step
+announcements — is `$CLAUDE_PLUGIN_ROOT/references/user-facing-output.md`;
+table cells and headers are user copy too, not an exemption.
+
 ### 1. Discover Engagements
 
 ```bash
@@ -132,8 +136,9 @@ the rollups at read time: `scope_state`, an engagement-level `personas_gate`
 (`satisfied` once a scope-seeded persona or a `.gate-waiver` marker exists,
 else `pending`), and per field its `state` plus each deliverable's `state`,
 `dt_stage`, `producing_route`, and `persona_review`.
-Surface any `warnings[]` verbatim (an `unreadable` field manifest is a
-problem for the consultant to see, not to paper over).
+Never suppress `warnings[]` (an unreadable field manifest is a problem for
+the consultant to see, not to paper over), but render its state as its
+display string, not the raw value.
 
 ### 4. Present the Dashboard
 

--- a/cogni-consult/skills/consult-scope/SKILL.md
+++ b/cogni-consult/skills/consult-scope/SKILL.md
@@ -35,6 +35,10 @@ words, with no script, file, or skill names, and never derived from the
 script's filename or header comment. Worked pair:
 `Discover cogni-consult engagements` → `Laufende Engagements holen`.
 
+The register that output follows — scope, state lexicon, table rules, step
+announcements — is `$CLAUDE_PLUGIN_ROOT/references/user-facing-output.md`;
+table cells and headers are user copy too, not an exemption.
+
 ### 1. Prerequisite Gate
 
 When arriving via an in-session `consult-setup` handoff, the engagement directory is already known — skip discovery. Otherwise locate the engagement:

--- a/cogni-consult/skills/consult-setup/SKILL.md
+++ b/cogni-consult/skills/consult-setup/SKILL.md
@@ -38,6 +38,10 @@ words, with no script, file, or skill names, and never derived from the
 script's filename or header comment. Worked pair:
 `Discover cogni-consult engagements` → `Laufende Engagements holen`.
 
+The register that output follows — scope, state lexicon, table rules, step
+announcements — is `$CLAUDE_PLUGIN_ROOT/references/user-facing-output.md`;
+table cells and headers are user copy too, not an exemption.
+
 ### 1. Gather Engagement Context
 
 Collect these fields, extracting whatever the user already provided and asking only for what is missing:


### PR DESCRIPTION
Closes #1142. Phase 2 (the governance layer) of epic #1147.

## Summary

- New `cogni-consult/references/user-facing-output.md` (**111 lines**, cap 120) — the main-loop register contract, five sections: (a) language delegation, (b) the every-surface scope clause, (c) the engine-value → display-string lexicon, (d) the table contract, (e) Schrittansage tiers with brevity budgets.
- A **byte-identical** pointer paragraph in all nine `consult-*/SKILL.md`, appended *after* the frozen Step 0 canonical block, above every step that emits user-facing output.
- Three raw-value leaks fixed at their point of emission.
- `CLAUDE.md`: architecture-map entry, and the deferred "when it lands, reconcile the two" promise moved to the present tense.

## Why the file delegates instead of restating

The issue's diagnosis is that register doctrine is scattered and prose-scoped. A new file that restated the existing rules would have become the *n*th copy — the disease, not the cure. So this file carries only what nothing else generalizes: the scope clause, the state lexicon, the table contract, and the step-announcement stance (which today lives **only** inside the two output styles and is abstracted nowhere).

Audience framing, executive register/compression, engine-vocabulary-stays-internal, no-slug-in-prose and German orthography are deliberately **absent**: they already exist in `output-styles/strategy-advisor{,-de}.md` and `references/subagent-output-contract.md` `## Register`. The new file names them as binding and points at their owners. That is also what makes the 120-line cap reachable.

## Pointer placement was constrained

The Step 0 canonical block is byte-identical across all nine skills, and a prior PR's merge ruling made that uniformity a contract item. The pointer is therefore **appended after** the block — and after the file-specific paragraph in `consult-dashboard` and `consult-project-plan`, exactly as those two already extend Step 0. No line inside the block is touched.

Reproduce both invariants:

```bash
for f in cogni-consult/skills/consult-*/SKILL.md; do awk '/^### 0\. Resolve the Interaction Language/,/Laufende Engagements holen/' "$f" | md5 -q; done | sort -u | wc -l   # -> 1
for f in cogni-consult/skills/consult-*/SKILL.md; do grep -A2 '^The register that output follows' "$f" | md5 -q; done | sort -u | wc -l                                      # -> 1
```

## The issue's two AC line anchors were stale — re-anchored

Both were filed before the Step 0 gate landed across the nine skills, which shifted them:

| AC cites | Actually at | What is there now |
|---|---|---|
| `consult-action-fields:88-93` | **`:103-125`** | 88–93 is gap-repair prose. The real site is the WBS table + its display rules. |
| `consult-personas:169` | **`:182-186`** | 169 is envelope-merge prose. The disposition triple and `persona_review` are at 182–186. |

This changed the work in **opposite directions**. `consult-action-fields` was largely already correct (a prior issue collapsed it to five columns with German display strings and an English variant), so its residual gap was a single leaked token. `consult-personas` was the real leak — bare `accepted / revised / rejected` and `pending → in-progress → complete` with no display strings anywhere.

## Engine values verified against source, not the issue text

Three of the issue's listed values were wrong and are corrected in the lexicon:

- `lineage_status` is an **object** (`{status:"stale", …}`, null when current) — the lexicon maps the nested `.status`, not a bare field.
- `unreadable` is a **field-rollup** state written alongside a `warnings[]` entry, explicitly *never conflated with `pending`* — not a deliverable state.
- `accepted / revised / rejected` is **prose vocabulary, not a stored field**. Labelled as such so no implementer invents a JSON key.

## Body-size budget — declared, not traded

| Skill | base | now | note |
|---|---|---|---|
| `consult-action-fields` | 21173 / 21000 (**+173**) | 21459 (**+459**) | pointer + row substitution + EN mirror row |
| `consult-resume` | 21211 / 18000 (**+3211**) | 21478 (**+3478**) | pointer + `warnings[]` rewrite |
| `consult-design-thinking` | 32332 / 27000 (**+5332**) | 32544 (**+5544**) | pointer only |
| other six | all far under cap | +212 each | absorbed |

All three were **already over cap on base**. A dedicated prose-simplifier pass ran and returned a justified no-op with a stronger argument than expected: the touched Step 0 section is *entirely byte-locked* — header, plus two paragraphs inside the md5 uniformity range, plus the pointer paragraph — so an in-section trade is structurally impossible, not merely unsafe. The only unlocked bytes are blank separators, and removing one would desync that file's hash from the other eight.

The base overages are pre-existing debt owned by **#1205** (`introduced_by_change: false`). **Reviewers: annotate, do not refactor.** Removing the Bash-`description` constraints to make room was considered and rejected — a merged issue's ACs mandate them and **#1201** owns re-homing that rule.

## Review notes (annotated, not fixed)

The skill-quality gate returned `needs_revision` with two `auto_fixable` findings, **both applied** — each had seeded display strings in one language only, which would have reintroduced the raw-token fallback in the other:

1. `consult-personas` seeded `persona_review` German-only; now seeds both.
2. `consult-action-fields`' English mirror did not cover the new unreadable row; now does.

Two `structural_issues`, both `introduced_by_change: false`, left for a human:

- **The worked example in `consult-action-fields` step 3 renders action-field and deliverable slugs as display names** (`market-evidence`, `market-sizing`, …), which table rule 7 in the new contract classifies as a defect. Pre-existing, and adjacent to the raw-value sweep owned by #1143–#1146. Worth noting the exemplars now disagree: `consult-resume`'s equivalent table already renders stored titles.
- The body-size debt above (#1205). The simplifier additionally identified ~2.5k chars in `consult-design-thinking` (Step 2 rework-intent logic, Test-stage copywriter rung) as genuine `references/orchestration/` relocation candidates — concrete evidence for #1205 rather than new work.

## Scope boundary

The remaining raw-value sites — `consult-project-plan:121-123`/`:181-182`, `consult-publish:69-72`, `consult-dashboard:199-200`, `consult-personas:91-93`/`:134`, `consult-design-thinking:179-183`/`:426-427` — are the per-skill application work already filed as **#1143–#1146**, which depend on this issue. They are governed by the pointer and section (c) as of this PR. **Nothing new is deferred; no follow-up issue was filed.**

A root-cause alternative that swept all nine sites now was considered and rejected: it duplicates those open issues, collides with the epic's phase structure, and grows the over-cap files substantially further.

Also observed, deliberately not fixed: `CLAUDE.md`'s skills tree omits `consult-project-plan` entirely. Unrelated to register doctrine.

## Verification

- [x] `wc -l` = 111 (≤ 120); `grep -c workspace-config` = **0**
- [x] Five sections; eight surfaces named; both travelling rules; seven table rules; both tiers with budgets
- [x] Nine pointers present and **byte-identical** (1 unique hash over 9 files)
- [x] Step 0 canonical block still uniform (1 unique hash over 9 files)
- [x] Each pointer above its file's first emission — scope 39<42, setup 42<45, resume 45<48, personas 49<52, action-fields 53<56, dashboard 56<59, project-plan 67<70, publish 64<67, design-thinking 74<135
- [x] cogni-consult tests **7/7**; `check-breadcrumbs.py` 0 violations; version-bump gate `ok` (14 scanned, **0 touched**); `check-skill-names.sh` OK
- [ ] **AC 10 — manual bar, cannot be run by a branch.** Re-run both transcripts with no output style active and confirm no raw engine value appears in any table cell or column header. Graded *documented/claimed*, per the precedent set on the phase-1 PR; it remains the real acceptance bar after merge.

No `plugin.json` / `marketplace.json` version touched — the post-merge workflow owns the bump.