### PR TITLE
cogni-portfolio: register Lean-Canvas Solutions-block entries as solution candidates

### DIFF
--- a/cogni-portfolio/references/data-model.md
+++ b/cogni-portfolio/references/data-model.md
@@ -34,6 +34,7 @@ cogni-portfolio/{project-slug}/
 └── research/                               # Portfolio scan artifacts (when scan is used)
     ├── research-report.md                  # Scan findings per taxonomy dimension
     ├── scan-solutions-draft.json           # Per-stack delivery seeds for solutions/ (category-aggregation mode only; persistent across sessions)
+    ├── solution-candidates.json            # Solution candidates pre-registered from a canvas/offer Solutions block (seed for solutions/, never counted as finished)
     ├── .logs/                              # Raw scan data (offerings, sources)
     ├── .metadata/
     │   └── scan-output.json                # Scan-run metadata (consolidation_mode, dedupe_summary, provider_units)
@@ -77,6 +78,40 @@ Fields:
   - `delivery_stack` — inferred from link host + USP text (e.g. `open-telekom-cloud`, `aws-frankfurt`, `gcp-frankfurt`, `on-prem`, `unknown`). Refinement rules are owned by the consuming `solutions/` entry point, not by scan.
 
 **Lifecycle:** scan writes the file during Phase 7.6 Branch F and does **not** remove it in the post-write sweep — `research/scan-solutions-draft.json` persists across scan sessions so `solutions/` can consume it whenever the user next runs the seed-from-scan-draft entry point. After that entry point has processed a draft, the consuming skill is responsible for deleting or archiving it. Until the `solutions/` seed-from-scan-draft entry point lands, the file is purely diagnostic — inspect it manually with `cat` to see what per-stack seeds the scan proposes.
+
+### Solution Candidate Register
+
+**`research/solution-candidates.json`** *(persistent)* — pre-registered solution **candidates** carried forward from a canvas or offer document's **Solutions block**. A Lean Canvas holds offerings the founder has already decided on; without this register that content is dropped at ingest, the `solutions/` layer starts empty, and the `solutions` skill falls back to generating one solution per proposition (the 1:1 default). `portfolio-canvas` (Step 6.5) and `portfolio-ingest` (Step 7b) write this register via `scripts/register-solution-candidates.py`, and `portfolio-setup` defers to that path for canvas bootstraps.
+
+It lives under `research/`, **not** `solutions/`, on purpose: `project-status.sh` counts `solutions/*.json` as finished solutions and `validate-entities.sh` validates them against the full solution schema, so a draft placed there would be miscounted and rejected. A candidate is a *seed*, distinguished from a finished solution by its `status` field — finished solutions carry `solution_type` / `shared_solution_ref`, never `status: "candidate"`.
+
+Schema:
+
+```json
+{
+  "version": 1,
+  "candidates": [
+    {
+      "slug": "cloud-monitoring",
+      "name": "Cloud Monitoring",
+      "status": "candidate",
+      "product_ref": "cloud-monitoring",
+      "source": "lean-canvas.json",
+      "created": "2026-01-16T10:00:00+00:00"
+    }
+  ]
+}
+```
+
+Fields:
+- `slug` — deterministic kebab-case slug derived from `name`; the **idempotency key**. Re-running the register upserts by slug (updates a matching record in place, appends only genuinely new slugs), so a canvas re-ingest never duplicates a candidate.
+- `name` — the offering text from the Solutions block.
+- `status` — `candidate` (or `draft`); the marker that keeps a candidate out of the finished-solution count.
+- `product_ref` — the `products/{slug}.json` this candidate resolves to, or `null` when no product matches. Candidates key on **products** (present at canvas/ingest time), not propositions or markets, which frequently do not exist yet.
+- `source` — the canvas/offer filename the candidate came from.
+- `created` — ISO-8601 timestamp; preserved across upserts.
+
+**Lifecycle:** written whenever a Solutions block is ingested; an **absent or empty** Solutions block is a no-op (the register is neither created nor mutated). The `solutions` skill reads it as a seed so its work begins from the decided offering structure instead of the 1:1 fallback.
 
 ## Entity Schemas
 

--- a/cogni-portfolio/scripts/mutation-check.sh
+++ b/cogni-portfolio/scripts/mutation-check.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-# Mutation harness for the #1230 commercial-consolidation gate (AC: scripts/mutation-check.sh).
+# Mutation harness for cogni-portfolio (AC: scripts/mutation-check.sh).
 #
-# Reverts the "commercial structure shared?" check in project-status.sh to a
-# constant false, then asserts test_hybrid_consolidates goes RED against the
-# mutant — proving the detection gate actually has teeth. Exit 0 iff the mutation
-# is caught (the test failed); non-zero if the mutation survived.
+# Runs each feature's mutation falsifier in turn and asserts the targeted test
+# goes RED against the mutant — proving the detection actually has teeth. Exit 0
+# iff EVERY mutation is caught; non-zero if any mutation survives.
+#
+#   1. commercial-consolidation gate (#1230): flip the "commercial structure
+#      shared?" check in project-status.sh to a constant false; expect
+#      test_hybrid_consolidates to go RED.
+#   2. solution-candidate register: remove the Solutions-block mapping in
+#      register-solution-candidates.py; expect test_ingest_registers_candidates
+#      to go RED.
 #
 # Kept under scripts/ (NOT tests/) deliberately: run-plugin-tests.py auto-discovers
 # tests/*.sh and would run this as a normal suite; this is a manual meta-check that
-# deliberately drives a failing sub-run.
+# deliberately drives failing sub-runs.
 #
 # Usage: bash cogni-portfolio/scripts/mutation-check.sh   (no args, no network)
 
@@ -16,21 +22,25 @@ set -u
 
 SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
-TEST="$PLUGIN_DIR/tests/test-commercial-consolidation.sh"
 
-for f in "$SCRIPTS_DIR/project-status.sh" "$TEST"; do
-  [ -f "$f" ] || { echo "FAIL: missing $f" >&2; exit 1; }
-done
+overall=0
 
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+# --- Mutation 1: commercial-consolidation gate -----------------------------
+# Reverts the "commercial structure shared?" check in project-status.sh to a
+# constant false, then asserts test_hybrid_consolidates goes RED against the
+# mutant. Returns 0 when the mutation is caught, non-zero otherwise.
+mutation_commercial_consolidation() {
+  local test="$PLUGIN_DIR/tests/test-commercial-consolidation.sh"
+  for f in "$SCRIPTS_DIR/project-status.sh" "$test"; do
+    [ -f "$f" ] || { echo "FAIL: missing $f" >&2; return 1; }
+  done
 
-# Copy the whole scripts/ dir so the mutant still finds its sibling scripts.
-cp -R "$SCRIPTS_DIR" "$TMP/scripts"
-MUTATED="$TMP/scripts/project-status.sh"
+  local tmp; tmp="$(mktemp -d)"
+  # Copy the whole scripts/ dir so the mutant still finds its sibling scripts.
+  cp -R "$SCRIPTS_DIR" "$tmp/scripts"
+  local mutated="$tmp/scripts/project-status.sh"
 
-# Flip the single commercial-structure detection line to a constant false.
-if ! python3 - "$MUTATED" <<'PY'
+  if ! python3 - "$mutated" <<'PY'
 import re, sys
 path = sys.argv[1]
 src = open(path).read()
@@ -43,16 +53,82 @@ if n != 1:
     sys.exit(3)
 open(path, 'w').write(new)
 PY
-then
-  echo "FAIL: mutation could not be applied" >&2
-  exit 1
-fi
+  then
+    echo "FAIL: commercial-consolidation mutation could not be applied" >&2
+    rm -rf "$tmp"; return 1
+  fi
 
-# Run only the hybrid consolidation assertion against the mutant.
-if PROJECT_STATUS_SCRIPT="$MUTATED" bash "$TEST" test_hybrid_consolidates >/dev/null 2>&1; then
-  echo "FAIL: mutation survived — test_hybrid_consolidates still passed with the shared check disabled" >&2
-  exit 1
-fi
+  local rc=0
+  if PROJECT_STATUS_SCRIPT="$mutated" bash "$test" test_hybrid_consolidates >/dev/null 2>&1; then
+    echo "FALSIFIER: mutation survived — test_hybrid_consolidates still passed with the shared check disabled" >&2
+    rc=1
+  else
+    echo "OK: mutation caught — test_hybrid_consolidates went red with the shared check disabled"
+  fi
+  rm -rf "$tmp"
+  return "$rc"
+}
 
-echo "OK: mutation caught — test_hybrid_consolidates went red with the shared check disabled"
-exit 0
+# --- Mutation 2: solution-candidate register -------------------------------
+# Excises the Solutions-block mapping (between the AC6-MUTATION-TARGET markers)
+# in register-solution-candidates.py, then asserts test_ingest_registers_candidates
+# goes RED. The source is always restored. Returns 0 when caught, non-zero otherwise.
+mutation_solution_candidates() {
+  local target="$SCRIPTS_DIR/register-solution-candidates.py"
+  local suite="$PLUGIN_DIR/tests/test-solution-candidates.sh"
+  local test_name="test_ingest_registers_candidates"
+  for f in "$target" "$suite"; do
+    [ -f "$f" ] || { echo "FAIL: missing $f" >&2; return 1; }
+  done
+
+  # Baseline: the target test must be GREEN before we mutate, or a later red
+  # tells us nothing.
+  if ! bash "$suite" "$test_name" >/dev/null 2>&1; then
+    echo "FAIL: baseline $test_name is already red before mutation" >&2
+    return 1
+  fi
+
+  local backup; backup="$(mktemp)"
+  cp "$target" "$backup"
+
+  if ! python3 - "$target" <<'PY'
+import re, sys
+path = sys.argv[1]
+src = open(path, encoding="utf-8").read()
+mutated, n = re.subn(
+    r"^[ \t]*# >>> AC6-MUTATION-TARGET:.*?^[ \t]*# <<< AC6-MUTATION-TARGET[ \t]*\n",
+    "",
+    src,
+    count=1,
+    flags=re.DOTALL | re.MULTILINE,
+)
+if n != 1:
+    sys.stderr.write("AC6-MUTATION-TARGET markers not found — cannot mutate.\n")
+    sys.exit(4)
+open(path, "w", encoding="utf-8").write(mutated)
+PY
+  then
+    echo "FAIL: solution-candidate mutation could not be applied" >&2
+    cp "$backup" "$target"; rm -f "$backup"; return 1
+  fi
+
+  local rc=0
+  if bash "$suite" "$test_name" >/dev/null 2>&1; then
+    echo "FALSIFIER: mutation survived — $test_name stayed GREEN with the Solutions-block mapping removed" >&2
+    rc=1
+  else
+    echo "OK: mutation caught — $test_name goes red when the Solutions-block mapping is removed"
+  fi
+  cp "$backup" "$target"; rm -f "$backup"   # always restore
+  return "$rc"
+}
+
+mutation_commercial_consolidation || overall=1
+mutation_solution_candidates || overall=1
+
+if [ "$overall" -eq 0 ]; then
+  echo "All mutations caught."
+else
+  echo "One or more mutations survived." >&2
+fi
+exit "$overall"

--- a/cogni-portfolio/scripts/register-solution-candidates.py
+++ b/cogni-portfolio/scripts/register-solution-candidates.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Pre-register a Lean-Canvas Solutions block as solution CANDIDATES.
+
+A Lean Canvas (or any offer document) has a "Solution"/"Solutions" block holding
+already-decided offerings. Portfolio ingest historically dropped that content, so
+the solutions layer started empty and the `solutions` skill fell back to 1:1
+generation from propositions. This script carries those offerings forward as
+marked candidates into a register that lives OUTSIDE the solutions/ directory —
+so `project-status.sh` (which counts solutions/*.json) never mistakes a candidate
+for a finished, sellable solution.
+
+Design (option a — a candidate register): candidates are written to
+`<project>/research/solution-candidates.json`, mirroring the existing
+`research/scan-solutions-draft.json` seed-file precedent. Each candidate carries a
+`status` of "candidate", a deterministic `slug` (idempotency key), and a
+`product_ref` resolved against the project's products/ when a match exists.
+
+Contract: stdlib-only, emits a single `{"success", "data", "error"}` JSON object
+on stdout. An absent or empty Solutions block is a no-op with exit 0 (no register
+mutation). Re-running on the same canvas is idempotent: candidates are UPSERTed by
+slug (matching records are updated in place, only genuinely new slugs are
+appended), never duplicated.
+
+Usage:
+  register-solution-candidates.py --project <project-dir> --canvas <canvas-file>
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+STATUS_CANDIDATE = "candidate"
+REGISTER_RELPATH = os.path.join("research", "solution-candidates.json")
+REGISTER_VERSION = 1
+
+
+def _out(success, data=None, error=None, code=0):
+    """Emit the canonical envelope and exit."""
+    print(json.dumps({"success": success, "data": data, "error": error}))
+    sys.exit(code)
+
+
+def slugify(text):
+    """Deterministic kebab-case slug — the register's idempotency key."""
+    s = re.sub(r"[^a-z0-9]+", "-", (text or "").strip().lower())
+    return s.strip("-")
+
+
+def _entry_name(entry):
+    """Coerce one Solutions-block entry (str or dict) to a display name."""
+    if isinstance(entry, str):
+        return entry.strip()
+    if isinstance(entry, dict):
+        for key in ("name", "title", "text", "label", "value", "solution"):
+            v = entry.get(key)
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+    return ""
+
+
+def _norm_key(k):
+    return re.sub(r"[^a-z]", "", (k or "").lower())
+
+
+def _find_solutions_in_obj(obj):
+    """Locate a Solutions block inside a parsed JSON canvas.
+
+    Accepts a value keyed (case-insensitively, ignoring punctuation) as
+    `solution` or `solutions` at the top level or nested one level under a
+    container such as `sections`, `blocks`, or `canvas`. This mapping is the
+    single load-bearing line the AC6 mutation check removes.
+    """
+    if not isinstance(obj, dict):
+        return None
+    # >>> AC6-MUTATION-TARGET: Solutions-block mapping (mutation-check.sh excises
+    # the lines between these two markers to prove the candidate path has teeth).
+    for k, v in obj.items():
+        if _norm_key(k) in ("solution", "solutions"):
+            return v
+    # <<< AC6-MUTATION-TARGET
+    for container in ("sections", "blocks", "canvas", "lean_canvas", "leancanvas"):
+        inner = obj.get(container)
+        if isinstance(inner, dict):
+            found = _find_solutions_in_obj(inner)
+            if found is not None:
+                return found
+    return None
+
+
+def _coerce_entries(block):
+    """Turn a Solutions block value into a list of entry names."""
+    names = []
+    if block is None:
+        return names
+    if isinstance(block, list):
+        for item in block:
+            n = _entry_name(item)
+            if n:
+                names.append(n)
+    elif isinstance(block, dict):
+        for item in block.values():
+            n = _entry_name(item)
+            if n:
+                names.append(n)
+    elif isinstance(block, str):
+        for line in re.split(r"[\n;]+", block):
+            n = re.sub(r"^[\s\-\*•\d\.\)]+", "", line).strip()
+            if n:
+                names.append(n)
+    return names
+
+
+def _parse_markdown_solutions(text):
+    """Extract Solutions-block entries from a markdown canvas.
+
+    Finds a heading matching Solution/Solutions (numbered prefixes like
+    "## 4. Solution" allowed) and collects the following list items until the
+    next heading.
+    """
+    names = []
+    heading_re = re.compile(r"^#{1,6}\s*(?:\d+[\.\)]\s*)?solutions?\b", re.IGNORECASE)
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        if heading_re.match(lines[i].strip()):
+            i += 1
+            while i < len(lines):
+                stripped = lines[i].strip()
+                if stripped.startswith("#"):
+                    break  # next heading ends the block
+                if stripped:
+                    # Strip a leading bullet / numbered-list marker, keep the text.
+                    item = re.sub(r"^[\-\*•]\s+", "", stripped)
+                    item = re.sub(r"^\d+[\.\)]\s+", "", item).strip()
+                    if item:
+                        names.append(item)
+                i += 1
+            break
+        i += 1
+    return names
+
+
+def extract_solutions(canvas_path):
+    """Read a canvas file and return its Solutions-block entry names.
+
+    Returns [] for a missing file, an absent block, or an empty block — the
+    caller treats all three as the same no-op.
+    """
+    if not canvas_path or not os.path.isfile(canvas_path):
+        return []
+    with open(canvas_path, "r", encoding="utf-8") as fh:
+        raw = fh.read()
+    if canvas_path.lower().endswith(".json"):
+        try:
+            obj = json.loads(raw)
+        except (ValueError, json.JSONDecodeError):
+            return []
+        return _coerce_entries(_find_solutions_in_obj(obj))
+    # Markdown / plain text canvas.
+    return _parse_markdown_solutions(raw)
+
+
+def load_products(project_dir):
+    """Map product slug/name -> product slug, for candidate resolution."""
+    products = {}
+    pdir = os.path.join(project_dir, "products")
+    if not os.path.isdir(pdir):
+        return products
+    for fn in sorted(os.listdir(pdir)):
+        if not fn.endswith(".json"):
+            continue
+        try:
+            with open(os.path.join(pdir, fn), "r", encoding="utf-8") as fh:
+                p = json.load(fh)
+        except (ValueError, OSError):
+            continue
+        slug = p.get("slug") or os.path.splitext(fn)[0]
+        products[slug] = {"slug": slug, "name": (p.get("name") or "").strip()}
+    return products
+
+
+def resolve_product(entry_name, entry_slug, products):
+    """Best-effort resolve a candidate to an existing product slug, else None."""
+    if entry_slug in products:
+        return entry_slug
+    el = entry_name.lower()
+    for slug, p in products.items():
+        name = p["name"].lower()
+        if name and (name in el or el in name):
+            return slug
+        if slug and slug in entry_slug:
+            return slug
+    return None
+
+
+def load_register(path):
+    if not os.path.isfile(path):
+        return {"version": REGISTER_VERSION, "candidates": []}
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict) and isinstance(data.get("candidates"), list):
+            data.setdefault("version", REGISTER_VERSION)
+            return data
+    except (ValueError, OSError):
+        pass
+    return {"version": REGISTER_VERSION, "candidates": []}
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Register Lean-Canvas Solutions-block entries as solution candidates.")
+    ap.add_argument("--project", required=True, help="Portfolio project directory (holds portfolio.json, research/, products/).")
+    ap.add_argument("--canvas", required=True, help="Path to the canvas / offer document (markdown or JSON).")
+    ap.add_argument("--status", default=STATUS_CANDIDATE, choices=["candidate", "draft"], help="Candidate status marker.")
+    args = ap.parse_args()
+
+    project_dir = args.project
+    if not os.path.isdir(project_dir):
+        _out(False, error="Project directory not found: %s" % project_dir, code=2)
+
+    names = extract_solutions(args.canvas)
+    register_path = os.path.join(project_dir, REGISTER_RELPATH)
+
+    # No-op: absent/empty Solutions block. Never create or mutate the register.
+    if not names:
+        _out(True, data={
+            "registered": 0,
+            "new": 0,
+            "updated": 0,
+            "register_path": register_path,
+            "candidates": [],
+            "noop": True,
+        }, code=0)
+
+    products = load_products(project_dir)
+    register = load_register(register_path)
+    by_slug = {c.get("slug"): c for c in register["candidates"] if isinstance(c, dict) and c.get("slug")}
+
+    source = os.path.basename(args.canvas)
+    now = datetime.now(timezone.utc).isoformat()
+    new_count = 0
+    updated_count = 0
+    touched = []
+
+    seen = set()
+    for name in names:
+        slug = slugify(name)
+        if not slug or slug in seen:
+            continue  # de-dupe within a single canvas by slug
+        seen.add(slug)
+        product_ref = resolve_product(name, slug, products)
+        if slug in by_slug:
+            rec = by_slug[slug]
+            rec["name"] = name
+            rec["status"] = args.status
+            rec["product_ref"] = product_ref
+            rec["source"] = source
+            rec.setdefault("created", now)  # preserve original creation time
+            updated_count += 1
+        else:
+            rec = {
+                "slug": slug,
+                "name": name,
+                "status": args.status,
+                "product_ref": product_ref,
+                "source": source,
+                "created": now,
+            }
+            register["candidates"].append(rec)
+            by_slug[slug] = rec
+            new_count += 1
+        touched.append(slug)
+
+    os.makedirs(os.path.dirname(register_path), exist_ok=True)
+    with open(register_path, "w", encoding="utf-8") as fh:
+        json.dump(register, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+
+    _out(True, data={
+        "registered": len(touched),
+        "new": new_count,
+        "updated": updated_count,
+        "register_path": register_path,
+        "candidates": touched,
+        "noop": False,
+    }, code=0)
+
+
+if __name__ == "__main__":
+    main()

--- a/cogni-portfolio/skills/portfolio-canvas/SKILL.md
+++ b/cogni-portfolio/skills/portfolio-canvas/SKILL.md
@@ -34,6 +34,7 @@ The key insight: a canvas already contains products, markets, and pricing buried
 | **Customer Segments** | Markets | Each segment becomes a market. Primary → `priority: "beachhead"`, Secondary → `"expansion"`, Tertiary → `"aspirational"`. Pain points feed downstream proposition DOES/MEANS. |
 | **Solution** (layers/components) | Products | Each distinct solution layer or component becomes a product with `maturity: "concept"` and inferred `revenue_model`. |
 | **Solution** (capabilities within layers) | Features | Specific capabilities mentioned within solution layers become features with `readiness: "planned"`. |
+| **Solution** (decided offerings) | Solution **candidates** | Each already-decided offering in the Solutions block is pre-registered as a marked candidate in `research/solution-candidates.json` (Step 6.5), so the `solutions` skill starts from the decided structure instead of generating 1:1 from propositions. Candidates carry `status: "candidate"` and live outside `solutions/`, so they are never counted as finished solutions. |
 | **Revenue Streams** | Solution pricing templates | Pricing assumptions seed solution `pricing` or `subscription` fields. The revenue type (license, subscription, consulting, maintenance) determines `solution_type`. |
 | **Problem** | *Context* | Pain points inform proposition DOES statements downstream — stored as `canvas_context.problems` in `portfolio.json` for reference. |
 | **UVP** | *Context* | The overarching value proposition informs product `positioning` — stored as `canvas_context.uvp` in `portfolio.json`. |
@@ -162,6 +163,18 @@ For each confirmed entity, write JSON following the schemas in `$CLAUDE_PLUGIN_R
 - Include pain points from the canvas in `description`
 - Leave `tam`/`sam`/`som` empty with a note — founding-stage businesses typically have hypotheses, not validated sizing. The `markets` skill can add sizing later.
 - Set `segmentation` fields where the canvas provides enough detail (employee range, vertical, etc.)
+
+### 6.5 Pre-register Solutions-block Candidates
+
+A Lean Canvas Solutions block holds offerings the founder has *already decided on*. If that content is dropped at ingest, the `solutions` skill later starts from an empty layer and falls back to generating one solution per proposition (the 1:1 default). Carry those offerings forward as marked **candidates** so solutions work begins from the decided structure.
+
+Run this **after** the products are written in Step 6 — a candidate resolves to a product, so the products must exist first:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/insight-wave/cogni-portfolio/*/ | head -1)}/scripts/register-solution-candidates.py" --project <project-dir> --canvas <canvas-file>
+```
+
+The script parses the canvas Solutions block and writes each offering to `research/solution-candidates.json` with `status: "candidate"`, a deterministic slug, and a `product_ref` resolved against `products/` when a match exists. It is a **no-op (exit 0)** when the Solutions block is absent or empty, and **idempotent** — re-running upserts by slug rather than duplicating, so a canvas re-ingest is safe. Candidates live outside `solutions/`, so `project-status.sh` never counts them as finished solutions; the `solutions` skill reads the register as its seed.
 
 ### 7. Write Canvas Context to portfolio.json
 

--- a/cogni-portfolio/skills/portfolio-ingest/SKILL.md
+++ b/cogni-portfolio/skills/portfolio-ingest/SKILL.md
@@ -176,6 +176,18 @@ After writing all context entries, rebuild `context/context-index.json` by scann
 
 Include `version`, `entry_count`, and `updated` fields. See `$CLAUDE_PLUGIN_ROOT/references/data-model.md` for the full index schema.
 
+### 7b. Pre-register Solutions-block Candidates
+
+When the ingested document carries a **Solution / Solutions block** (a Lean Canvas, an offer catalog, a pitch deck's offering slide), its entries are offerings the company has already decided on. Historically that content was dropped — the solutions layer stayed empty and the `solutions` skill fell back to generating one solution per proposition (the 1:1 default). Carry those offerings forward as marked **candidates** instead.
+
+Run this **after** Step 6 wrote the products (a candidate resolves to a product):
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT:-$(ls -td "$HOME"/.claude/plugins/cache/insight-wave/cogni-portfolio/*/ | head -1)}/scripts/register-solution-candidates.py" --project <project-dir> --canvas <ingested-file>
+```
+
+The script writes each offering to `research/solution-candidates.json` with `status: "candidate"`, a deterministic slug, and a `product_ref` resolved against `products/`. It is a **no-op (exit 0)** when the document has no Solutions block, so it is safe to run on any ingested file, and **idempotent** — re-ingesting upserts by slug rather than duplicating. Candidates live outside `solutions/`, so `project-status.sh` never counts them as finished; the `solutions` skill reads the register as its seed. Skip this step for documents that plainly carry no offering block (e.g. a pure pricing sheet or win/loss report) — the no-op makes running it harmless either way.
+
 ### 8. Move Processed Files
 
 After all confirmed items are written, move processed files to `uploads/processed/`. Create the directory if it doesn't exist. Only move files that were successfully processed. If a file yielded no usable entities or context (user skipped everything), still move it to avoid re-processing on the next run.

--- a/cogni-portfolio/skills/portfolio-setup/SKILL.md
+++ b/cogni-portfolio/skills/portfolio-setup/SKILL.md
@@ -46,7 +46,7 @@ If the user already provided a URL or company name in their initial message, ski
 
 - **URL provided →** delegate to a subagent (Agent tool) immediately to extract company name, description, industry sector, and broad service areas from the company's public pages. Store the company domain for use in Step 5.5. Do NOT attempt detailed product discovery or feature-level analysis — that is the job of the full portfolio scan in Step 5.5.
 - **Documents in uploads/ →** scan them for company context (name, description, industry, products). A strategy deck or lean canvas often contains all four fields.
-- **Canvas file →** extract via canvas mapping (the `portfolio-canvas` skill handles this, but you can extract company-level context directly).
+- **Canvas file →** extract via canvas mapping (the `portfolio-canvas` skill handles this, but you can extract company-level context directly). A canvas Solutions block is pre-registered as solution **candidates** (`research/solution-candidates.json`) by `portfolio-canvas` Step 6.5 — defer to it rather than re-implementing here. If setup writes products directly from a canvas without running `portfolio-canvas`, run `scripts/register-solution-candidates.py --project <project-dir> --canvas <canvas-file>` after the products are written so the decided offerings still seed the `solutions` skill (the script is an idempotent no-op-on-empty, so a later `portfolio-canvas` run does not double-register).
 - **Just a name (no URL, no documents) →** fall back to asking for description, industry, and products individually. This is the last resort, not the default path.
 
 #### Step 1d: State what you found

--- a/cogni-portfolio/tests/test-solution-candidates.sh
+++ b/cogni-portfolio/tests/test-solution-candidates.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Regression suite for cogni-portfolio/scripts/register-solution-candidates.py —
+# the Lean-Canvas Solutions-block -> solution-candidate register.
+#
+# Fixtures are heredoc'd inline — no committed JSON blobs to maintain. Each test
+# builds a minimal portfolio project in a temp directory, runs the register
+# script, and asserts on the register file / script envelope.
+#
+# Named acceptance tests (each is one shell function):
+#   test_ingest_registers_candidates       filled Solutions block -> >=2 candidates
+#   test_candidate_status_marker           every candidate status in {candidate,draft}, none finished
+#   test_empty_solutions_block_noop        absent/empty block -> 0 candidates, exit 0, no register
+#   test_reingest_idempotent               double ingest -> same count, no duplicates
+#   test_candidates_resolvable_by_solutions each candidate resolves to a seeded product
+#
+# Usage:
+#   bash cogni-portfolio/tests/test-solution-candidates.sh              # run all
+#   bash cogni-portfolio/tests/test-solution-candidates.sh <test_name>  # run one
+# Exits non-zero on any assertion failure (so scripts/run-plugin-tests.py and
+# scripts/mutation-check.sh can read the exit status).
+
+# `set -u` only — `set -e` would abort on the first failing assertion and defeat
+# the per-test failure counter.
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+SCRIPT="$PLUGIN_DIR/scripts/register-solution-candidates.py"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: register-solution-candidates.py not found at $SCRIPT" >&2
+  exit 1
+fi
+
+failures=0
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+_mk() { local d="$TMPROOT/$1"; rm -rf "$d"; mkdir -p "$d"; echo "$d"; }
+
+fail() { echo "  FAIL: $1" >&2; failures=$((failures + 1)); }
+pass() { echo "  ok: $1"; }
+
+# candidate_count <register-file> — prints the number of candidates, 0 if absent.
+candidate_count() {
+  local f="$1"
+  [ -f "$f" ] || { echo 0; return; }
+  python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(len(d.get("candidates",[])))' "$f" 2>/dev/null || echo 0
+}
+
+# ---- fixtures --------------------------------------------------------------
+
+# seed_project <dir> — a minimal project with two products the candidates resolve to.
+seed_project() {
+  local dir="$1"
+  mkdir -p "$dir/products" "$dir/research"
+  printf '{"slug":"cloud-monitoring","name":"Cloud Monitoring"}\n' > "$dir/products/cloud-monitoring.json"
+  printf '{"slug":"managed-onboarding","name":"Managed Onboarding"}\n' > "$dir/products/managed-onboarding.json"
+}
+
+# filled canvas (JSON) — a top-level solutions block with two entries whose names
+# match the seeded products. JSON is used deliberately so test_ingest exercises
+# the AC6-MUTATION-TARGET mapping in _find_solutions_in_obj.
+write_filled_canvas() {
+  cat > "$1" <<'CANVAS'
+{"problem": "manual ops", "solutions": ["Cloud Monitoring", "Managed Onboarding"]}
+CANVAS
+}
+
+# ---- tests -----------------------------------------------------------------
+
+test_ingest_registers_candidates() {
+  local tmp; tmp="$(_mk "${FUNCNAME[0]}")"
+  seed_project "$tmp"
+  write_filled_canvas "$tmp/canvas.json"
+  python3 "$SCRIPT" --project "$tmp" --canvas "$tmp/canvas.json" >/dev/null 2>&1
+  local reg="$tmp/research/solution-candidates.json"
+  local n; n="$(candidate_count "$reg")"
+  # RED when the Solutions block yields 0 candidates and the layer stays empty.
+  if [ "$n" -ge 2 ]; then pass "registers >=2 candidates (got $n)"; else
+    fail "expected >=2 candidates from a filled Solutions block, got $n"; fi
+}
+
+test_candidate_status_marker() {
+  local tmp; tmp="$(_mk "${FUNCNAME[0]}")"
+  seed_project "$tmp"
+  write_filled_canvas "$tmp/canvas.json"
+  python3 "$SCRIPT" --project "$tmp" --canvas "$tmp/canvas.json" >/dev/null 2>&1
+  local reg="$tmp/research/solution-candidates.json"
+  # Every candidate must carry status in {candidate,draft} and no finished-solution
+  # marker (e.g. shared_solution_ref / solution_type).
+  local bad
+  bad="$(python3 - "$reg" <<'PY'
+import json,sys
+d=json.load(open(sys.argv[1]))
+bad=0
+for c in d.get("candidates",[]):
+    if c.get("status") not in ("candidate","draft"): bad+=1
+    if "shared_solution_ref" in c or "solution_type" in c: bad+=1
+print(bad)
+PY
+)"
+  if [ "$bad" = "0" ]; then pass "all candidates carry a draft/candidate status, none finished"; else
+    fail "$bad candidate(s) missing a {candidate,draft} status or carrying a finished marker"; fi
+}
+
+test_empty_solutions_block_noop() {
+  local tmp; tmp="$(_mk "${FUNCNAME[0]}")"
+  seed_project "$tmp"
+  # A canvas whose Solutions block is empty.
+  cat > "$tmp/canvas.json" <<'CANVAS'
+{"problem": "manual ops", "solutions": []}
+CANVAS
+  python3 "$SCRIPT" --project "$tmp" --canvas "$tmp/canvas.json" >/dev/null 2>&1
+  local rc=$?
+  local reg="$tmp/research/solution-candidates.json"
+  local n; n="$(candidate_count "$reg")"
+  if [ "$rc" -eq 0 ] && [ "$n" -eq 0 ]; then pass "empty block is a no-op (exit 0, 0 candidates)"; else
+    fail "empty block expected exit 0 + 0 candidates, got exit=$rc candidates=$n"; fi
+  # A missing canvas file must also be a clean no-op.
+  python3 "$SCRIPT" --project "$tmp" --canvas "$tmp/does-not-exist.json" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then pass "missing canvas file is a no-op (exit 0)"; else
+    fail "missing canvas file expected exit 0"; fi
+}
+
+test_reingest_idempotent() {
+  local tmp; tmp="$(_mk "${FUNCNAME[0]}")"
+  seed_project "$tmp"
+  write_filled_canvas "$tmp/canvas.json"
+  python3 "$SCRIPT" --project "$tmp" --canvas "$tmp/canvas.json" >/dev/null 2>&1
+  local reg="$tmp/research/solution-candidates.json"
+  local first; first="$(candidate_count "$reg")"
+  python3 "$SCRIPT" --project "$tmp" --canvas "$tmp/canvas.json" >/dev/null 2>&1
+  local second; second="$(candidate_count "$reg")"
+  if [ "$first" = "$second" ] && [ "$first" -ge 2 ]; then pass "re-ingest is idempotent ($first == $second)"; else
+    fail "re-ingest changed the candidate count: first=$first second=$second (expected equal, >=2)"; fi
+}
+
+test_candidates_resolvable_by_solutions() {
+  local tmp; tmp="$(_mk "${FUNCNAME[0]}")"
+  seed_project "$tmp"   # pre-seeds the products the candidates resolve against
+  write_filled_canvas "$tmp/canvas.json"
+  python3 "$SCRIPT" --project "$tmp" --canvas "$tmp/canvas.json" >/dev/null 2>&1
+  local reg="$tmp/research/solution-candidates.json"
+  # Every candidate must resolve to a seeded product slug (non-null product_ref
+  # pointing at a real products/*.json).
+  local unresolved
+  unresolved="$(python3 - "$reg" "$tmp" <<'PY'
+import json,os,sys
+reg,proj=sys.argv[1],sys.argv[2]
+d=json.load(open(reg))
+bad=0
+for c in d.get("candidates",[]):
+    ref=c.get("product_ref")
+    if not ref or not os.path.isfile(os.path.join(proj,"products",ref+".json")):
+        bad+=1
+print(bad)
+PY
+)"
+  if [ "$unresolved" = "0" ]; then pass "every candidate resolves to a seeded product"; else
+    fail "$unresolved candidate(s) did not resolve to a seeded product"; fi
+}
+
+ALL_TESTS="test_ingest_registers_candidates test_candidate_status_marker test_empty_solutions_block_noop test_reingest_idempotent test_candidates_resolvable_by_solutions"
+
+run_one() {
+  echo "== $1 =="
+  "$1"
+}
+
+if [ "$#" -ge 1 ]; then
+  # Run a single named test (used by mutation-check.sh).
+  case " $ALL_TESTS " in
+    *" $1 "*) run_one "$1" ;;
+    *) echo "FAIL: unknown test '$1'" >&2; exit 2 ;;
+  esac
+else
+  for t in $ALL_TESTS; do run_one "$t"; done
+fi
+
+if [ "$failures" -eq 0 ]; then
+  echo "All solution-candidate tests passed."
+  exit 0
+else
+  echo "$failures assertion(s) failed." >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #1231.

## Summary
Lean-Canvas ingest dropped the **Solutions block** — the offerings a founder has already decided on — so the solutions layer started empty and the `solutions` skill fell back to generating one solution per proposition (the 1:1 default). This carries those offerings forward as marked **candidates** so solutions work begins from the decided structure.

- **`scripts/register-solution-candidates.py`** (new, stdlib bash+python3, `{success,data,error}` JSON) parses a canvas/offer Solutions block (JSON canvas or markdown `## Solution(s)` section) and writes each offering to a new register **`research/solution-candidates.json`**. Each candidate carries `status: "candidate"`, a deterministic slug, and a `product_ref` resolved against `products/`. It is a **no-op (exit 0)** on an absent/empty block and **idempotent** — upserts by slug, never duplicates.
- **`references/data-model.md`** documents the register schema and the `candidate`/`draft` status, beside the existing `research/scan-solutions-draft.json` seed-file precedent.
- **`skills/portfolio-canvas`** (new Step 6.5), **`skills/portfolio-ingest`** (new Step 7b), and **`skills/portfolio-setup`** (Step 1c defer note) invoke / reference the register after products are written.
- **`tests/test-solution-candidates.sh`** (new, CI-discovered) implements the five named acceptance tests; **`scripts/mutation-check.sh`** gains the AC6 falsifier.

## Scope decision — option (a), a candidate register
Chose a **register file** over (b) draft entities under `solutions/` or (c) context entries. `solutions/*.json` is counted as finished by `project-status.sh` and validated by `validate-entities.sh`, so a draft placed there would be miscounted and rejected; context entries are silently ignored by the solutions skill. `research/scan-solutions-draft.json` is the established precedent for a solutions-seed file living outside `solutions/`, and only a script-backed register can satisfy the mutation-catchable, test-red-flippable acceptance criteria. Candidates resolve to a **product** (present at canvas/ingest time), not propositions/markets (often absent yet).

## Note for the reviewer — shared `scripts/mutation-check.sh`
`main` advanced during this work and now already carries a `scripts/mutation-check.sh` from the sibling **#1230** commercial-consolidation gate (whose AC also names that exact path). Rather than clobber it, this PR turns `mutation-check.sh` into a **combined harness** that runs *both* mutation falsifiers and exits non-zero if either survives — the #1230 commercial-consolidation mutation (preserved verbatim) and this feature's Solutions-block mutation. `test-commercial-consolidation.sh` still passes unchanged.

## Test plan
- [x] `bash cogni-portfolio/tests/test-solution-candidates.sh` — all five named tests green.
- [x] `bash cogni-portfolio/scripts/mutation-check.sh` — both mutations caught (exit 0): removing the Solutions-block mapping turns `test_ingest_registers_candidates` RED; the #1230 mutation still turns `test_hybrid_consolidates` RED.
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-portfolio` — 3/3 suites pass (commercial-consolidation, solution-candidates, validate-entities).
- [x] Breadcrumb guard clean; no `plugin.json`/`marketplace.json` version bump (post-merge workflow owns it).

Plan record: https://github.com/cogni-work/insight-wave/issues/1231#issuecomment-5200320338