### PR TITLE
cogni-visual: map the smarter-service arc to journey in arc-taxonomy

### DIFF
--- a/cogni-visual/CLAUDE.md
+++ b/cogni-visual/CLAUDE.md
@@ -125,7 +125,7 @@ cogni-trends/cogni-knowledge → enrich-report → browser / PDF / DOCX
 ## Key Conventions
 
 - **Briefs are YAML frontmatter + Markdown.** Frontmatter holds metadata (type, version, theme, arc_type, arc_id, confidence_score). Body holds the content specification.
-- **Unified arc taxonomy.** All narrative skills read `arc_id` from narrative frontmatter, map to visual `arc_type` via `libraries/arc-taxonomy.md` (10 narrative arcs → 5 visual arc types), and optionally load arc element names for labeling (section labels, arc labels, methodology phases).
+- **Unified arc taxonomy.** All narrative skills read `arc_id` from narrative frontmatter, map to visual `arc_type` via `libraries/arc-taxonomy.md` (11 narrative arcs → 5 visual arc types), and optionally load arc element names for labeling (section labels, arc labels, methodology phases).
 - **Agent responses are JSON-only.** Agents return structured JSON; no prose.
 - **Assertion headlines.** Every slide title, section headline, and poster headline must be an assertion (contains a verb), not a topic label.
 - **Number plays.** Statistics are reframed for visual impact (ratio framing, hero number isolation, before/after contrast).

--- a/cogni-visual/libraries/arc-taxonomy.md
+++ b/cogni-visual/libraries/arc-taxonomy.md
@@ -20,7 +20,7 @@ Map narrative arc IDs from cogni-narrative to visual arc types used by cogni-vis
 
 ## Arc ID to Visual Arc Type Mapping
 
-When the source narrative carries an `arc_id` from cogni-narrative (in YAML frontmatter or passed as parameter), map it to the visual arc type used for decomposition. This bridges the rich narrative taxonomy (6 arc types with 4-element structures) to the visual taxonomy (5 visual arc types optimized for layout selection).
+When the source narrative carries an `arc_id` from cogni-narrative (in YAML frontmatter or passed as parameter), map it to the visual arc type used for decomposition. This bridges the rich narrative taxonomy (11 arc types with 4-element structures) to the visual taxonomy (5 visual arc types optimized for layout selection).
 
 | cogni-narrative `arc_id` | Visual `arc_type` | Display Name | Reasoning |
 |--------------------------|-------------------|--------------|-----------|
@@ -34,6 +34,7 @@ When the source narrative carries an `arc_id` from cogni-narrative (in YAML fron
 | `jtbd-portfolio` | `argument` | JTBD Portfolio | Elements (Job Landscape/Friction Map/Portfolio Map/Invitation) build an analytical case from buyer jobs through friction to solutions |
 | `company-credo` | `argument` | Company Credo | Elements (Mission/Conviction/Credibility/Promise) build a belief-driven argument: the company states what it believes, backs it with receipts, and closes with a forward commitment |
 | `engagement-model` | `journey` | Engagement Model | Elements (Principles/Process/Partnership/Outcomes) describe a chronological progression through an engagement — Process is the longest element and reads as a phase sequence with artifacts and time bands |
+| `smarter-service` | `journey` | Smarter Service | Elements (Forces/Impact/Horizons/Foundations) describe the same progression from external pressures to capability requirements as Trend Panorama — the theme-aware sibling arc shares the identical TIPS dimension mapping, so it takes the same visual arc type |
 
 **Fallback:** If `arc_id` is not in this table, fall back to auto-detection from narrative content (same behavior as when no `arc_id` is present).
 
@@ -132,6 +133,17 @@ Each arc has 4 ordered elements that represent the phases of the narrative struc
 | 2 | Process | Prozess | Canonical 4–6 phases with artifacts and time bands |
 | 3 | Partnership | Partnerschaft | Reciprocal — what the buyer must bring for the engagement to work |
 | 4 | Outcomes | Ergebnisse | Cross-cutting results the buyer can observe |
+
+### smarter-service
+
+| # | Element (EN) | Element (DE) | Narrative Function |
+|---|-------------|-------------|-------------------|
+| 1 | Forces | Kräfte | External pressures and market signals (TIPS T-dimension) |
+| 2 | Impact | Wirkung | Value chain disruption and digital value drivers (TIPS I-dimension) |
+| 3 | Horizons | Horizonte | Strategic possibilities and new opportunities (TIPS P-dimension) |
+| 4 | Foundations | Fundamente | Capability requirements and digital foundations (TIPS S-dimension) |
+
+Same four elements as Trend Panorama — `smarter-service` is its theme-aware sibling. Element labels are identical; only the narrative wrapper differs (investment themes nest under each element).
 
 ---
 


### PR DESCRIPTION
Closes #1228.

## Summary

- Add the missing `smarter-service` row to the `arc_id` → `arc_type` mapping table in `cogni-visual/libraries/arc-taxonomy.md`. The table now carries 11 data rows — one per arc directory under `cogni-narrative/skills/narrative/references/story-arc/`. The arc previously fell through to the auto-detection fallback, silently.
- Add the matching `### smarter-service` subsection under `## Arc Element Names`, so all 11 mapped arcs carry element names.
- Correct two stale counts: `arc-taxonomy.md:23` (`6 arc types` → `11 arc types`) and `cogni-visual/CLAUDE.md:128` (`10 narrative arcs` → `11 narrative arcs`). The `5 visual arc types` half of each sentence is untouched — there really are still five visual arc types, and conflating the two taxonomies is the easy mistake here.

## The design call, and why it did not need an owner

The issue flagged the `arc_type` choice as needing cogni-visual owner sign-off. It turned out to be settled by the arc's own definition rather than open. `cogni-narrative/skills/narrative/references/story-arc/smarter-service/arc-definition.md` states verbatim:

> `smarter-service` and `trend-panorama` share the same four elements and the same TIPS dimension mapping.

Verified against both files: identical ordered elements (Forces / Impact / Horizons / Foundations), identical German labels (Kräfte / Wirkung / Horizonte / Fundamente), identical TIPS letters (T/I/P/S), and a horizon cascade the definition marks "Same as trend-panorama". The two arcs differ only in **theme-awareness** — `smarter-service` nests investment-theme cases as H3 under each macro element — which is a content-nesting property, not a layout-decomposition one, and `arc_type` governs decomposition.

`trend-panorama` is already mapped to `journey`, on the stated reasoning that its elements "describe a progression from external pressures to capability requirements". That reasoning transfers verbatim to an arc with byte-identical elements, so `journey` is the mapping the table's own logic entails — any other value would contradict the Reasoning cell of the row directly above it.

**A reviewer who disagrees should say so.** This is the one judgment call in the diff, and it is the reason the PR is worth reading rather than rubber-stamping.

## Why the element subsection is in scope

Not cosmetic. `story-to-slides`, `story-to-web` and `story-to-storyboard` each read element **names** in addition to `arc_type` — for the methodology slide, section labels, and poster labels respectively. Adding the mapping row without the element block would leave the arc half-wired: `arc_type` would resolve while labels still fell back to generic.

## Scope decisions

**In scope:** exactly two files.

**Deliberately untouched:**

- **`cogni-narrative/skills/narrative-adapt/SKILL.md:68`** carries the fourth stale arc count in the repo. It belongs to a separate in-flight issue whose own committed contract fails its PR on any `cogni-visual/` or `docs/` path. The two scopes are cleanly disjoint by construction; neither branch touches the other's files.
- **`docs/plugin-guide/cogni-visual.md:37`** ("Six narrative arcs map to five visual arc types") is stale on the first half. **Recording it explicitly as out of scope** rather than silently skipping it: `docs/plugin-guide/` is cogni-docs-generated, so a hand edit would be overwritten on the next `doc-generate` run and would widen this PR across a plugin boundary. Filed as its own follow-up.
- **The frontmatter `consumers:` list** (lines 5-8) is genuinely stale — it names three skills, but `story-to-infographic` is a real fourth consumer (`skills/story-to-infographic/SKILL.md:176`), and the file's own body at line 205 says "Reusable across all four visual skills", contradicting its own frontmatter. `cogni-website/skills/website-plan/SKILL.md:188` reads the table as well. Left byte-identical here and filed as its own follow-up.
- **Fallback semantics.** The `**Fallback:**` sentence and the entire Arc Resolution Pseudocode block (including its `WARN: Unknown arc_id` branch) are byte-identical to base. The pseudocode does a table lookup on the `arc_id` variable and never enumerates ids, so adding a row is sufficient and the fallback stays correct for any genuinely unknown id.
- **The 10 pre-existing mapping rows** are byte-identical; the new row is appended inside the table block.
- **No version bump** — the post-merge workflow owns the patch increment.
- **No wiki edit and no `release-bundle-wiki.sh` run** — no wiki mirror contains any of the corrected sentences (verified repo-wide). That script is an `rsync --delete` across two trees that have drifted, so running it for a two-file prose fix would sweep unrelated drift into this PR.

## Alternative considered

A second plan proposed the same fix plus the `docs/plugin-guide` correction **and** a new `cogni-visual/tests/test-arc-taxonomy-coverage.sh` CI guard asserting that the mapping table's `arc_id` set equals the arc-directory set — so a fourth recurrence of this drift would fail CI instead of shipping. Rejected here on blast radius: it introduces the plugin's first `tests/` directory and a new cross-plugin CI coupling, where a future cogni-narrative PR adding a 12th arc would turn cogni-visual's suite red until the mirror is updated in that same PR.

That is a real design decision with real upside, and it was rejected for scope, not merit. **If a reviewer wants the guard, say so and it can be added** — the drift has now been filed three times, which is decent evidence that prose fixes alone do not hold.

## Verification — results, not intentions

Every check below was executed against the branch at `0a30b0b6`:

| Check | Result |
|---|---|
| Mapping-table data rows between separator and `**Fallback:**` | 11 |
| Table `arc_id` set vs. the 11 arc directories | set-equal, no duplicates |
| Every `arc_type` in the table is one of the five valid values | true |
| `smarter-service` row cells | 4/4 populated — `` `journey` `` / Smarter Service / non-empty reasoning |
| `### <arc_id>` element sections | 11, superset of the table's ids |
| German labels | Kräfte / Wirkung / Horizonte / Fundamente; 0 ASCII substitutes |
| `grep -c '6 arc types'` in arc-taxonomy.md | 0 (`11 arc types` = 1) |
| `grep -c '5 visual arc types'` in arc-taxonomy.md | 1 — unchanged |
| `grep -rn '10 narrative arcs' cogni-visual/` | 0 hits |
| `11 narrative arcs → 5 visual arc types` in CLAUDE.md | 1 hit, U+2192 arrow preserved |
| Fallback / pseudocode lines appearing in the diff | 0 |
| `consumers:` frontmatter lines in the diff | 0 |
| Files changed | exactly 2 |
| `python3 scripts/check-breadcrumbs.py` | rc=0 |
| `python3 scripts/check-version-bump.py` | rc=0 — 14 plugins scanned, 0 touched, 0 violations |
| `bash cogni-workspace/scripts/check-skill-names.sh` | rc=0 |

**No behavioral test, and its absence is not a defect.** The mechanism is prose in a markdown library that skill prompts read at runtime; no script anywhere in the repo parses `arc-taxonomy.md`, and `cogni-visual` ships no `tests/` directory — so `run-plugin-tests.py --filter cogni-visual` fails on untouched `main` for lack of suites and must not be cited as evidence either way. The assertions above are the achievable bar.