### PR TITLE
cogni-portfolio: allowlist nineteen breadcrumb-guard false positives

### DIFF
--- a/cogni-portfolio/scripts/breadcrumb-allowlist.txt
+++ b/cogni-portfolio/scripts/breadcrumb-allowlist.txt
@@ -8,8 +8,9 @@
 # Every entry below is a FALSE POSITIVE, not a silenced breadcrumb. A genuine
 # maintainer breadcrumb — a citation of the issue/PR/version that motivated an
 # edit — must never be added here; scrub the prose instead. The two real ones
-# this plugin carried (`v0.9.23` and `#103`, both in portfolio-consolidate)
-# were removed at source under #1283 rather than exempted here.
+# this plugin carries (`v0.9.23` and `#103`, both in portfolio-consolidate) are
+# being removed at source under #1283 rather than exempted here — until that
+# lands the guard correctly still reports them as 2 offenders.
 #
 # Two distinct misclassifications are covered.
 #
@@ -35,9 +36,18 @@
 # `#334155`) while issue numbers are four digits today, so a genuine issue
 # reference cannot collide with them. Keep citing issues in full (`#1295`).
 #
-# RETIRE THIS FILE when cogni-work/managed-service#880 lands — that issue fixes
-# the pattern upstream so it stops matching hex colours, at which point the
-# class-1 entries become dead weight. Re-measure the class-2 entries then too.
+# The class-2 tokens carry the larger and nearer-term collision surface, because
+# they are plugin-version-SHAPED: `v1.0.0`–`v1.4.0` are exempted anywhere in
+# those two files. cogni-portfolio is at 0.9.x today, so once it crosses v1.0.0
+# a genuine release breadcrumb written in portfolio-scan or portfolio-dashboard
+# would be silently swallowed — exactly the vacuous-guard failure this file
+# exists to fence off. RE-MEASURE THESE ENTRIES BEFORE THE PLUGIN CROSSES v1.0.0.
+#
+# RETIRE THE CLASS-1 ENTRIES when cogni-work/managed-service#880 lands — that
+# issue fixes the pattern upstream so it stops matching hex colours, at which
+# point those four become dead weight. The class-2 entries SURVIVE #880 (it does
+# not touch the version-tag pattern) and need the separate re-measurement above,
+# so do not delete this file wholesale on that issue landing.
 #
 # Tracked by cogni-work/insight-wave#1295.
 

--- a/cogni-portfolio/scripts/breadcrumb-allowlist.txt
+++ b/cogni-portfolio/scripts/breadcrumb-allowlist.txt
@@ -1,0 +1,57 @@
+# Breadcrumb-guard allowlist for cogni-portfolio.
+#
+# Format: <relative-path>|<token> — one entry per line, matched on file plus
+# EXACT token (deliberately not file:line, so entries survive edits that shift
+# line numbers). Read by check-breadcrumbs.sh, which check-preflight.sh points
+# at via BREADCRUMB_ALLOWLIST.
+#
+# Every entry below is a FALSE POSITIVE, not a silenced breadcrumb. A genuine
+# maintainer breadcrumb — a citation of the issue/PR/version that motivated an
+# edit — must never be added here; scrub the prose instead. The two real ones
+# this plugin carried (`v0.9.23` and `#103`, both in portfolio-consolidate)
+# were removed at source under #1283 rather than exempted here.
+#
+# Two distinct misclassifications are covered.
+#
+# 1. HEX COLOURS. The guard's issue-ref pattern is `#[0-9]{2,}`, which matches
+#    the leading digits of a six-digit hex colour literal. portfolio-architecture
+#    is a diagram skill, so its readiness palette is load-bearing output — the
+#    renderer emits these values. Note the token is the pattern's match, not the
+#    full colour: `#92400e` is exempted as `#92400`, `#64748b` as `#64748`.
+#    Colours whose first two characters after `#` are not both digits
+#    (`#bbf7d0`, `#fef08a`, `#e5e7eb`, `#6b7280`, `#f8fafc`) never matched and
+#    need no entry.
+#
+# 2. CONTENT-MODEL SCHEMA GENERATIONS. `v1.0.0`–`v1.4.0` in portfolio-scan and
+#    portfolio-dashboard are `scan-output.json` schema versions, not plugin
+#    versions. The surrounding prose is compatibility documentation consumers
+#    depend on ("Consumers reading v1.2.0 or earlier must treat absent
+#    consolidation_mode as consolidate"), and the deprecation mappings are
+#    load-bearing on the tokens. Removing them would break real content.
+#
+# COLLISION SURFACE, because exemption is by exact token and not by line: an
+# entry swallows any occurrence of that literal token anywhere in that file. The
+# truncated colour tokens are five and six digits (`#92400`, `#64748`, `#166534`,
+# `#334155`) while issue numbers are four digits today, so a genuine issue
+# reference cannot collide with them. Keep citing issues in full (`#1295`).
+#
+# RETIRE THIS FILE when cogni-work/managed-service#880 lands — that issue fixes
+# the pattern upstream so it stops matching hex colours, at which point the
+# class-1 entries become dead weight. Re-measure the class-2 entries then too.
+#
+# Tracked by cogni-work/insight-wave#1295.
+
+# Excalidraw readiness palette — ga / beta stroke, product stroke, metadata text.
+skills/portfolio-architecture/SKILL.md|#166534
+skills/portfolio-architecture/SKILL.md|#92400
+skills/portfolio-architecture/SKILL.md|#334155
+skills/portfolio-architecture/SKILL.md|#64748
+
+# scan-output.json schema generations cited in consumer-compatibility prose.
+skills/portfolio-dashboard/SKILL.md|v1.2.0
+skills/portfolio-dashboard/SKILL.md|v1.3.0
+skills/portfolio-scan/SKILL.md|v1.0.0
+skills/portfolio-scan/SKILL.md|v1.1.0
+skills/portfolio-scan/SKILL.md|v1.2.0
+skills/portfolio-scan/SKILL.md|v1.3.0
+skills/portfolio-scan/SKILL.md|v1.4.0


### PR DESCRIPTION
Closes #1295.

Sibling of #1283 under the cogni-portfolio handoff block. **Adds exactly one file and edits nothing else.**

## Summary

`check-preflight.sh`'s `breadcrumbs` instrument runs `check-breadcrumbs.sh` **plugin-wide and unbaselined**, and blocks on any non-zero count. It reported **21 offenders** in cogni-portfolio, so every PR touching a `SKILL.md` or an `agents/*.md` was unable to complete the author→merger handoff regardless of its own diff — PR #1280 is the live casualty.

Nineteen of the twenty-one are false positives. This adds `cogni-portfolio/scripts/breadcrumb-allowlist.txt` covering exactly those nineteen.

| Class | Hits | Files | Why it is a false positive |
|---|---|---|---|
| Hex colours | 5 | `portfolio-architecture` | The guard's issue-ref pattern is `#[0-9]{2,}`, which matches the leading digits of a six-digit hex colour. This is a diagram skill; the readiness palette is load-bearing renderer output. |
| Schema generations | 14 | `portfolio-scan` (9), `portfolio-dashboard` (5) | `v1.0.0`–`v1.4.0` are `scan-output.json` **content-model versions**, not plugin versions, cited in consumer-compatibility prose the deprecation mappings depend on. |

Eleven entries cover all nineteen hits, because an entry exempts every occurrence of its token in that file.

## Measurements

| Gate | Base `main` | This branch |
|---|---|---|
| `check-breadcrumbs.sh cogni-portfolio` | `clean: false`, `count: 21`, `allowlisted: 0` | `count: 2`, **`allowlisted: 19`** |
| `check-breadcrumbs.py` (CI, 45-entry baseline) | exit 0 | exit 0, baseline byte-unchanged |
| `run-plugin-tests.py --filter cogni-portfolio` | exit 0 | exit 0 |
| `check-frontmatter.sh cogni-portfolio` | `count: 15` | `count: 15` — **identical**, see below |

The two offenders still standing are precisely #1283's:

```
skills/portfolio-consolidate/SKILL.md 32 'v0.9.23'
skills/portfolio-consolidate/SKILL.md 88 '#103'
```

## Reproducing this — the invocation matters

`check-breadcrumbs.sh` resolves its allowlist as `${BREADCRUMB_ALLOWLIST:-$SCRIPT_DIR/breadcrumb-allowlist.txt}`, and `$SCRIPT_DIR` is **cogni-service's own** scripts directory, not the target plugin's. A bare `check-breadcrumbs.sh <plugin>` therefore reads the wrong allowlist and reports `allowlisted: 0`, making this file look inert.

`check-preflight.sh` passes it explicitly (`{allow_env: repo_root / p / "scripts" / allow_file}`), which is the path that matters. To reproduce by hand, do the same:

```bash
BREADCRUMB_ALLOWLIST="$PWD/cogni-portfolio/scripts/breadcrumb-allowlist.txt" \
  bash "$CLAUDE_PLUGIN_ROOT/scripts/check-breadcrumbs.sh" "$PWD/cogni-portfolio"
```

**Verified on a tree with this PR and #1297 both applied: `clean: true`, `count: 0`, `allowlisted: 19`.**

## The token is the pattern's match, not the literal

`#92400e` is exempted as `#92400` and `#64748b` as `#64748`, because that is what the regex captures. Colours whose first two characters after `#` are not both digits (`#bbf7d0`, `#fef08a`, `#e5e7eb`, `#6b7280`, `#f8fafc`) never matched and get no entry.

Collision surface, documented in the file header: exemption is by exact token and not by line. The truncated colour tokens are five and six digits while issue numbers are four, so a genuine issue reference cannot be swallowed by them.

## Scope decisions

- **Nothing genuine is suppressed.** `v0.9.23` and `#103` in `portfolio-consolidate` are real maintainer breadcrumbs and are deliberately absent from the allowlist — #1283 scrubs them at source. Adding them here is exactly what the file header forbids.
- **Neither PR alone clears the block.** #1283 alone leaves 19; this alone leaves 2. Both merged → **0**, and #1280's preflight goes green. The two touch disjoint files, so order does not matter.
- **No authoring file is touched.** The diff is one new `scripts/` file. `check-breadcrumbs.sh`'s own scan surface is `SKILL.md` + `agents/*.md`, and CI's `check-breadcrumbs.py` uses `DEFAULT_GLOBS = ["*/skills/*/SKILL.md", "*/agents/*.md"]`, so the allowlist cannot perturb either gate or the ratcheted baseline.
- **Self-retiring.** The header names `cogni-work/managed-service#880` as the retire condition — that fixes the pattern upstream, at which point the class-1 entries become dead weight.
- **No version touched** — the post-merge workflow owns the bump.

## Precedent

This mirrors #1284 → #1288, which cleared cogni-visual's identical wall one hour before #1280 was blocked. `cogni-visual/scripts/breadcrumb-allowlist.txt` is on `main` today with CI green, and was the template for this file's header and entry format.

## Note on the frontmatter gate

`check-frontmatter.sh cogni-portfolio` reports `count: 15` on this branch. That is **byte-identical to base `origin/main`** — those fifteen are the offenders PR #1280 repairs, and #1280 has not merged yet. This diff neither introduces nor touches them; it edits no frontmatter at all. #1295's acceptance criterion is written against that base measurement, so the 15 is not a violation introduced here.
