### PR TITLE
cogni-portfolio: remove two maintainer breadcrumbs from portfolio-consolidate

### DIFF
--- a/cogni-portfolio/skills/portfolio-consolidate/SKILL.md
+++ b/cogni-portfolio/skills/portfolio-consolidate/SKILL.md
@@ -29,7 +29,7 @@ If the user is asking "who offers what", use this skill. If they are asking "how
 
 ## Scope (Phase 1)
 
-The v0.9.23 cut ships the minimum useful slice:
+Phase 1 ships the minimum useful slice:
 
 - Two cell states — `✓` (Confirmed; includes Emerging and Extended) and `—` (Not Offered or not reported).
 - Per-category coverage rate (count of `✓` cells over the provider set).
@@ -85,7 +85,7 @@ Typical follow-ons from a fresh coverage matrix:
 
 - **Extend the scope**: run `portfolio-scan --mode=research-only` against one or two more peers and re-run consolidation.
 - **Deep-dive a category**: if one category is covered by everyone except the portfolio's own company, that's the strongest candidate for a `compete`-driven response or a new feature investment.
-- **Wait for Phase 2**: whitespace analysis and per-dimension exec summary are follow-up issues; if the user wants those immediately, point them at issue #103's deferred section.
+- **Wait for Phase 2**: whitespace analysis and per-dimension exec summary are follow-up issues; if the user wants those immediately, point them at the deferred items listed under Scope (Phase 1) above.
 
 ## Inputs and outputs
 

--- a/cogni-portfolio/skills/portfolio-consolidate/SKILL.md
+++ b/cogni-portfolio/skills/portfolio-consolidate/SKILL.md
@@ -85,7 +85,7 @@ Typical follow-ons from a fresh coverage matrix:
 
 - **Extend the scope**: run `portfolio-scan --mode=research-only` against one or two more peers and re-run consolidation.
 - **Deep-dive a category**: if one category is covered by everyone except the portfolio's own company, that's the strongest candidate for a `compete`-driven response or a new feature investment.
-- **Wait for Phase 2**: whitespace analysis and per-dimension exec summary are follow-up issues; if the user wants those immediately, point them at the deferred items listed under Scope (Phase 1) above.
+- **Wait for Phase 2**: whitespace analysis and per-dimension exec summary are deferred to a follow-up phase; if the user wants those immediately, point them at the deferred items listed under Scope (Phase 1) above.
 
 ## Inputs and outputs
 

--- a/scripts/baselines/breadcrumb-baseline.json
+++ b/scripts/baselines/breadcrumb-baseline.json
@@ -72,16 +72,6 @@
       "line_sha": "e1a88e90082a6d561a22ce668be53f0d76857b63"
     },
     {
-      "file": "cogni-portfolio/skills/portfolio-consolidate/SKILL.md",
-      "match": "#103",
-      "line_sha": "dbec4d286ae03f8004926ad4fa381b7b12f4c9c2"
-    },
-    {
-      "file": "cogni-portfolio/skills/portfolio-consolidate/SKILL.md",
-      "match": "v0.9.23",
-      "line_sha": "ffaa3e048f33cb2a669df27987bddb891c17e7b2"
-    },
-    {
       "file": "cogni-portfolio/skills/portfolio-dashboard/SKILL.md",
       "match": "v1.2.0",
       "line_sha": "56c19444cde76c15ef1437e517004c1c2ebcdf5f"


### PR DESCRIPTION
Closes #1283.

Sibling of #1296 under the cogni-portfolio handoff block. **Two prose lines in one file.**

## Summary

Two genuine maintainer breadcrumbs in `cogni-portfolio/skills/portfolio-consolidate/SKILL.md` are removed at source. Per repo convention, provenance belongs in git history, CHANGELOG and `references/` — not in `SKILL.md` prose.

| Line | Before | After |
|---|---|---|
| 32 | `The v0.9.23 cut ships the minimum useful slice:` | `Phase 1 ships the minimum useful slice:` |
| 88 | `…point them at issue #103's deferred section.` | `…point them at the deferred items listed under Scope (Phase 1) above.` |

**Both rationales are restated semantically, not deleted:**

- The section heading is already `## Scope (Phase 1)`, so naming Phase 1 keeps the sentence's meaning while dropping the plugin-version citation. Nothing about which slice ships changes.
- The deferred content the second line pointed at is already enumerated in-document, four lines under that same Scope heading (*"separate `Emerging` / `Extended` cell states, per-dimension executive summary, whitespace / gap analysis by category, leaders / laggards callouts, and portfolio-dashboard integration"*). The pointer now resolves in-document instead of by issue number — same destination, no breadcrumb.

**Neither is suppressed via an allowlist.** Both are fixed at source, per AC 3.

## Verification

| Check | Result |
|---|---|
| `check-breadcrumbs.sh cogni-portfolio` | `count: 21` → **`19`**; zero offenders remain in `portfolio-consolidate` |
| `check-breadcrumbs.py` (CI, 45-entry baseline) | exit 0, baseline **byte-unchanged** (never grown) |
| `run-plugin-tests.py --filter cogni-portfolio` | exit 0 |
| `v1.x.x` tokens in `portfolio-scan` / `portfolio-dashboard` | untouched — they are content, not breadcrumbs (AC 6) |
| Version manifests | untouched |

## This does not clear the block on its own

Stated up front in #1283's own scope boundary, and repeated here so the sequencing is unambiguous:

| Landing | Resulting count |
|---|---|
| This PR alone | 21 − 2 = **19**, still red |
| #1296 alone | 21 − 19 = **2**, still red |
| **Both** | **0** — preflight green, #1280 unblocks |

The remaining 19 are false positives — five CSS hex colours matched by the guard's `#[0-9]{2,}` pattern, and fourteen `scan-output.json` schema generations — and are owned by #1295 / #1296, which allowlists them. They are deliberately **not** touched here: they are load-bearing content, and removing them would break real behaviour.

The two PRs touch disjoint files (this one edits prose; #1296 adds a `scripts/` file), so they can merge in either order.