### PR TITLE
chore: ignore local Codex mirror (.codex/, AGENTS.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ __pycache__/
 .claude/worktrees/
 .claude/cogni-docs-state.json
 
+# Codex local mirror (per-user; AGENTS.md mirrors CLAUDE.md for the Codex CLI)
+/.codex/
+/AGENTS.md
+
 # macOS
 .DS_Store
 


### PR DESCRIPTION
## Problem

`.codex/config.toml` and `AGENTS.md` (a local Codex mirror of `CLAUDE.md`) sit untracked in the repo root with **no `.gitignore` coverage**. Any broad staging command — `git add -A`, `git add .` — silently sweeps them into whatever commit is being built. This happened during #1336 and had to be corrected by amending the commit.

## Change

Four lines in the root `.gitignore`, placed next to the existing "Claude Code local settings" group (same class of per-user agent-tool config):

```
# Codex local mirror (per-user; AGENTS.md mirrors CLAUDE.md for the Codex CLI)
/.codex/
/AGENTS.md
```

Root-anchored with a leading `/` to match the file's existing convention for root-scoped entries (`/cogni-issues/`, `/.alpha/`), so a plugin-level `AGENTS.md` would not be caught by accident.

## Verification

Probe files created at both paths on this branch:

```
$ git check-ignore -v .codex/config.toml AGENTS.md
.gitignore:15:/.codex/      .codex/config.toml
.gitignore:16:/AGENTS.md    AGENTS.md

$ git status --porcelain
 M .gitignore
```

Neither probe appears as untracked — the failure mode is closed. `git ls-files` confirms **neither path has ever been tracked**, so nothing is removed from the index and both files stay on disk as the maintainer's local mirror.

## Scope notes

- No plugin version fields touched — the post-merge workflow owns those.
- Epic #1331 lists `AGENTS.md` as out of scope for the carve-out children because it is untracked and cannot be fixed by a PR. This PR does not edit its content; it only stops broad staging from sweeping it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)