### PR TITLE
Purge residual cogni-projects pointers and stale plugin/skill counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # insight-wave
 
-14-plugin monorepo for consulting, sales, and marketing on Claude Code. Apache-2.0. All plugins follow the Claude Code plugin standard.
+13-plugin monorepo for consulting, sales, and marketing on Claude Code. Apache-2.0. All plugins follow the Claude Code plugin standard.
 
 ## Repo Structure
 
 ```
 insight-wave/
-├── .claude-plugin/marketplace.json    Marketplace manifest (14 plugins)
+├── .claude-plugin/marketplace.json    Marketplace manifest (13 plugins)
 ├── cogni-{name}/                      Each plugin directory
 │   ├── .claude-plugin/plugin.json     Plugin manifest (name, version, description)
 │   ├── README.md                      Plugin documentation (IS/DOES/MEANS messaging)
@@ -120,7 +120,7 @@ Key integration patterns:
 
 - Plugin version lives in `.claude-plugin/plugin.json` `version` field (semver), mirrored on the plugin's entry in the repo-root `.claude-plugin/marketplace.json` — Claude Desktop reads the marketplace copy for update detection, so the two must always agree
 - `.github/workflows/cogni-version-bump.yml` owns the bump. On every push to `main` it patch-increments each plugin the merge touched, editing **both** manifests in one `bump(...)` commit. `scripts/apply-version-bump.py` does the edit; nothing is written unless the rewritten JSON re-parses and differs *only* in the intended version values
-- A feature branch that still touches a version reintroduces the merge-conflict class the post-merge move eliminated: when every PR bumped at authoring time, the instant one PR merged, every other open PR's version lines became a textual conflict. insight-wave had it worse than a one-manifest-per-plugin repo, because marketplace.json is a single file all 14 plugins share — so the conflict was repo-wide, not per-plugin
+- A feature branch that still touches a version reintroduces the merge-conflict class the post-merge move eliminated: when every PR bumped at authoring time, the instant one PR merged, every other open PR's version lines became a textual conflict. insight-wave had it worse than a one-manifest-per-plugin repo, because marketplace.json is a single file all 13 plugins share — so the conflict was repo-wide, not per-plugin
 - `scripts/check-version-bump.py` enforces this at PR time (CI: "Version-bump gate" in `.github/workflows/lint.yml`). It flags `version-touched` on any version change vs the fork point, and `version-mirror-desync` whenever plugin.json and marketplace.json disagree. Fix a `version-touched` finding by reverting the version line in **both** files
 - The auto-bump is patch-only and structurally cannot cross a maturity boundary, so `maturity` and the maturity keyword in `keywords[]` are never touched by it. **Boundary crossings stay human** — make them on a `bump/…` branch, which the PR-time gate exempts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ python3 scripts/check-breadcrumbs.py --update-baseline
 
 **Do not bump a plugin version in your branch.** Every plugin's version lives in two places — `<plugin>/.claude-plugin/plugin.json` and the plugin's entry in the repo-root `.claude-plugin/marketplace.json` — and the `Version bump` workflow advances both, automatically, on merge to `main`, for each plugin your PR actually touched.
 
-The bump moved post-merge because that version line was the canonical merge-conflict class: when every PR bumped at authoring time, the instant one PR merged, every other open PR's version lines conflicted. Since `marketplace.json` is a single file shared by all 14 plugins, that conflict was repo-wide rather than per-plugin.
+The bump moved post-merge because that version line was the canonical merge-conflict class: when every PR bumped at authoring time, the instant one PR merged, every other open PR's version lines conflicted. Since `marketplace.json` is a single file shared by all 13 plugins, that conflict was repo-wide rather than per-plugin.
 
 The CI `Lint` workflow runs `scripts/check-version-bump.py` on every PR and fails on:
 

--- a/cogni-help/README.md
+++ b/cogni-help/README.md
@@ -4,13 +4,13 @@
 
 > **insight-wave readiness (Claude Code desktop recommended)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-The onboarding and navigation layer for the [insight-wave](https://github.com/cogni-work/insight-wave) ecosystem — the single entry point that makes 14 plugins with 110+ skills behave like one coherent system.
+The onboarding and navigation layer for the [insight-wave](https://github.com/cogni-work/insight-wave) ecosystem — the single entry point that makes 13 plugins with 110 skills behave like one coherent system.
 
 ## Why this exists
 
 | Problem | What happens | Impact |
 |---------|-------------|--------|
-| 14 plugins, no map | New users don't know which plugin handles their task | Trial-and-error onboarding — first productive use takes hours |
+| 13 plugins, no map | New users don't know which plugin handles their task | Trial-and-error onboarding — first productive use takes hours |
 | Disconnected workflows | Research, narrative, visual, and sales plugins work together but no guide shows how | Users run one plugin well, miss the multi-plugin pipelines that deliver 10x value |
 | Silent failures | A missing dependency or stale workspace breaks skills at runtime | Cryptic errors with no diagnostic path — users blame the plugin, not the config |
 | No structured learning | Users learn by stumbling into slash commands | Shallow usage — power features go undiscovered |
@@ -24,7 +24,7 @@ A meta-plugin for the insight-wave ecosystem, built on a workflow-tour curriculu
 ## What it does
 
 1. **Teach** through 7 interactive workflow tours — adaptive pacing, hands-on exercises, quizzes, and progress tracking across the canonical end-to-end pipelines
-2. **Guide** users to the right plugin — match natural-language task descriptions to capabilities across 14 plugins and 110+ skills
+2. **Guide** users to the right plugin — match natural-language task descriptions to capabilities across 13 plugins and 110 skills
 3. **Chain** plugins into pipelines — 7 cross-plugin workflow templates from install-to-infographic through full consulting engagements
 4. **Diagnose** plugin problems — check integrity, dependencies, workspace health, and known issues before they surface as runtime failures
 5. **Summarize** any plugin — generate one-screen quick-reference cheatsheets with commands, capabilities, and tips
@@ -33,7 +33,7 @@ A meta-plugin for the insight-wave ecosystem, built on a workflow-tour curriculu
 
 ## What it means for you
 
-- **Skip the memorization.** Describe your task in plain language and the guide skill routes it to the exact plugin and skill across 14 plugins and 110+ skills — first productive result in under 5 minutes.
+- **Skip the memorization.** Describe your task in plain language and the guide skill routes it to the exact plugin and skill across 13 plugins and 110 skills — first productive result in under 5 minutes.
 - **Build real skills in 5–6 hours.** Complete all 7 workflow tours (~45–60 minutes each) with hands-on exercises that produce real output. Resume any tour mid-module — progress is tracked to the lesson.
 - **Collapse multi-plugin work into 3–4 steps.** Run any of 7 workflow templates to chain plugins into repeatable pipelines — research-to-report in 3 steps, portfolio-to-pitch in 4.
 - **Catch failures before they surface.** Run the 5-tier health check to surface missing dependencies, stale configs, and integrity issues before they become cryptic runtime errors.
@@ -73,7 +73,7 @@ Don't know which plugin handles your task? Describe it in plain language:
 
 > Run `/guide "I need to turn research into a slide deck"`
 
-The guide skill matches your description against all 14 plugins and 110+ skills and routes you to the pipeline, e.g.:
+The guide skill matches your description against all 13 plugins and 110 skills and routes you to the pipeline, e.g.:
 
 ```
 research-to-report pipeline:

--- a/cogni-workspace/tests/test-sanitize-theme.sh
+++ b/cogni-workspace/tests/test-sanitize-theme.sh
@@ -7,8 +7,8 @@
 # must be rejected before it reaches the generated <style> block, with the
 # renderer falling back to its built-in palette for that key.
 #
-# stdlib-only: bash + python3, no pip deps. Mirrors the cogni conventions in
-# cogni-projects/tests/test-render-dashboard.sh.
+# stdlib-only: bash + python3, no pip deps, per the repo-wide script
+# convention — no file pointer here, so this comment cannot dangle.
 
 set -u
 HERE="$(cd "$(dirname "$0")" && pwd)"

--- a/docs/plugin-guide/cogni-help.md
+++ b/docs/plugin-guide/cogni-help.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-cogni-help is the navigation and learning layer for the insight-wave ecosystem. With 14 plugins and 110+ skills available in the marketplace, it is easy to know something exists but not know which specific skill handles a given task. cogni-help addresses this in four ways:
+cogni-help is the navigation and learning layer for the insight-wave ecosystem. With 13 plugins and 110 skills available in the marketplace, it is easy to know something exists but not know which specific skill handles a given task. cogni-help addresses this in four ways:
 
 1. **Plugin discovery** — describe what you need, and the guide skill matches it to the right plugin and skill
 2. **Structured learning** — a 7-tour curriculum keyed 1:1 to the canonical cross-plugin pipelines, each tour running about 45–60 minutes

--- a/scripts/apply-version-bump.py
+++ b/scripts/apply-version-bump.py
@@ -53,7 +53,7 @@ Usage:
     python3 scripts/apply-version-bump.py --changed-file changed-files.txt
 
     # testing — supply the changed paths directly
-    python3 scripts/apply-version-bump.py --changed cogni-projects/README.md
+    python3 scripts/apply-version-bump.py --changed cogni-help/README.md
     python3 scripts/apply-version-bump.py --changed ... --dry-run
 
 Output: {"success": bool, "data": {"bumped": [...], "skipped": [...]}, "error": ""}


### PR DESCRIPTION
Closes #1329. Phase 3 of the cogni-projects carve-out epic #1331.

**Stacked on #1336** (base `remove-cogni-projects-plugin`, not `main`). The repo-wide criterion — `git ls-files -z | xargs -0 grep -lI cogni-projects` returns nothing — is only evaluable once the directory is gone, so this branch sits on #1336's head. GitHub retargets it to `main` automatically when #1336 merges. The file sets remain disjoint: this PR touches none of #1336's files and vice versa.

## Counts were recounted, not subtracted

**13 plugins and 110 skills**, verified as tracked `<plugin>/skills/<name>/SKILL.md` across exactly the 13 plugins the marketplace enumerates — no skill on disk belongs to a non-marketplace directory.

The old claim was `110+ skills`. The true figure is now precisely 110, so a `+` floor would carry zero headroom while implying there are more. It is now an exact count. The four `*-workspace` directories are skill-creator eval scratch and two archived skills sit under `_archive/`; neither is a skill, and both are excluded.

The issue's warning was well placed: the root README credited cogni-projects with 4 skills when it shipped 5, so a subtraction would have produced 111 and quietly perpetuated the drift.

## Changes

| File | Change |
|---|---|
| `CLAUDE.md` | three sites, 14 → 13 plugins |
| `CONTRIBUTING.md` | one site, 14 → 13 |
| `cogni-help/README.md` | five claims — the pitch, problem table, capability list, MEANS bullet, Try-it line |
| `docs/plugin-guide/cogni-help.md` | the same claim |
| `scripts/apply-version-bump.py` | docstring example retargeted to `cogni-help/README.md`, so it is executable as written |
| `cogni-workspace/tests/test-sanitize-theme.sh` | states the convention with **no file pointer**, so the comment cannot dangle again |

## Verification

| Criterion | Result |
|---|---|
| No tracked file mentions the removed plugin | 0 files |
| Plugin-count claims equal the marketplace enumeration | 0 stale `14 plugins` / `14-plugin` remain |
| Skill-count claims are true | exact 110, recount 110 |
| Counts survive regeneration | no count string exists in any SKILL.md, plugin.json or catalog, so no generator can reintroduce one; all five cogni-help edits are in hand-written sections |
| Docstring example executable as written | every path in the usage block is tracked |
| Theme-sanitisation suite | passes, cites nothing deleted |
| Full CI-discovered sweep | **105 suites, 105 pass** |
| Out-of-scope files untouched | nothing under `wiki/`, `*/wiki/` or any slide/theme HTML in the diff |

## One pre-existing drift noted, not fixed

`cogni-help/README.md`'s "What it does" is a hand-written numbered list, though repo convention marks that section as generated from SKILL.md. Its content carries no count after this PR, so nothing here is at risk — but the section will be rewritten wholesale the next time `doc-generate` runs over it. That is doc-audit's territory, not the carve-out's.