### PR TITLE
Add a plugin-inventory guard and certify zero cogni-projects residue

### DIFF
--- a/scripts/check-plugin-inventory.py
+++ b/scripts/check-plugin-inventory.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""check-plugin-inventory.py — deterministic plugin-inventory guard.
+
+Asserts a **bijection** between the plugins the marketplace enumerates and the
+plugin directories that actually exist at the repo root:
+
+  1. every `plugins[].source` in `.claude-plugin/marketplace.json` resolves to a
+     directory containing `.claude-plugin/plugin.json`;
+  2. every top-level directory containing `.claude-plugin/plugin.json` appears
+     in `plugins[]`.
+
+Direction 1 restates what `check-version-bump.py` already enforces, so this
+guard reads standalone. Direction 2 is the gap this guard exists to close:
+`check-version-bump.py` enumerates plugins **only** from the marketplace and
+deliberately never globs the tree, so a plugin directory with **no** marketplace
+entry is invisible to every other guard in the repo. That is precisely the
+residue a half-finished plugin removal leaves behind — the directory survives, no
+manifest names it, and nothing anywhere raises.
+
+Enumeration is a single **non-recursive** scan of the repo root, and dot-prefixed
+entries are skipped. Both properties are load-bearing: stale plugin manifests
+live under `.claude/worktrees/**` and inside plugin caches, and a recursive glob
+would report them as unlisted plugins on a perfectly clean tree. This mirrors the
+reasoning in `run-plugin-tests.py`'s discovery docstring and the explicit
+no-globbing note in `check-version-bump.py`.
+
+Why a bijection rather than a banned-string grep: a one-off "never mention
+<retired-plugin>" guard encodes a single historical event, needs a
+hand-maintained list of retired names, and says nothing about the next plugin
+removed. The bijection is a durable invariant — it catches this failure class and
+every future carve-out, in both directions, without being told any names.
+
+stdlib only; runs under any python3. Exit 0 = clean, 1 = violations,
+2 = script error.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+MANIFEST = os.path.join(".claude-plugin", "plugin.json")
+MARKETPLACE = os.path.join(".claude-plugin", "marketplace.json")
+
+
+def read_marketplace(root):
+    """Return plugins[] from the repo marketplace manifest."""
+    path = os.path.join(root, MARKETPLACE)
+    if not os.path.isfile(path):
+        raise RuntimeError("marketplace manifest not found: {}".format(MARKETPLACE))
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except ValueError as exc:
+        raise RuntimeError("marketplace manifest is not valid JSON: {}".format(exc))
+    plugins = data.get("plugins")
+    if not isinstance(plugins, list):
+        raise RuntimeError("marketplace manifest has no plugins[] array")
+    return plugins
+
+
+def discover_plugin_dirs(root):
+    """Top-level directories holding a plugin manifest.
+
+    Non-recursive by design, and dot-prefixed entries are skipped, so stale
+    manifests under `.claude/worktrees/**` or a plugin cache never register.
+    """
+    found = []
+    for name in sorted(os.listdir(root)):
+        if name.startswith("."):
+            continue
+        if os.path.isfile(os.path.join(root, name, MANIFEST)):
+            found.append(name)
+    return found
+
+
+def source_to_dirname(source):
+    """Normalise a plugins[].source value to a top-level directory name.
+
+    Returns None when the source is not a plain relative path into this repo
+    (an absolute path or a remote reference), which the bijection cannot judge.
+    """
+    if not isinstance(source, str) or not source:
+        return None
+    cleaned = source.strip()
+    if cleaned.startswith("./"):
+        cleaned = cleaned[2:]
+    cleaned = cleaned.rstrip("/")
+    if not cleaned or cleaned.startswith("/") or ":" in cleaned or ".." in cleaned:
+        return None
+    return cleaned
+
+
+def collect(root):
+    """Return the violation list for the inventory bijection."""
+    plugins = read_marketplace(root)
+    dirs_on_disk = discover_plugin_dirs(root)
+    violations = []
+    enumerated = set()
+
+    for entry in plugins:
+        name = entry.get("name") if isinstance(entry, dict) else None
+        source = entry.get("source") if isinstance(entry, dict) else None
+        dirname = source_to_dirname(source)
+        if dirname is None:
+            violations.append({
+                "code": "source-unresolvable",
+                "plugin": name,
+                "source": source,
+                "detail": "plugins[].source is not a relative path into this repo",
+            })
+            continue
+        enumerated.add(dirname)
+        if not os.path.isfile(os.path.join(root, dirname, MANIFEST)):
+            violations.append({
+                "code": "source-missing",
+                "plugin": name,
+                "source": source,
+                "detail": "marketplace enumerates a plugin whose directory has no "
+                          "{}".format(MANIFEST),
+            })
+
+    for dirname in dirs_on_disk:
+        if dirname not in enumerated:
+            violations.append({
+                "code": "plugin-unlisted",
+                "plugin": dirname,
+                "source": "./{}".format(dirname),
+                "detail": "plugin directory exists but no plugins[] entry names it",
+            })
+
+    return violations, plugins, dirs_on_disk
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--root", help="repo root to check (default: this script's parent)")
+    args = ap.parse_args(argv)
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.abspath(args.root) if args.root else os.path.dirname(script_dir)
+
+    try:
+        violations, plugins, dirs_on_disk = collect(root)
+    except (RuntimeError, OSError) as exc:
+        print(json.dumps({"success": False, "data": {}, "error": str(exc)}))
+        return 2
+
+    by_code = {}
+    for v in violations:
+        by_code[v["code"]] = by_code.get(v["code"], 0) + 1
+
+    result = {
+        "success": not violations,
+        "data": {
+            "marketplace_plugins": len(plugins),
+            "plugin_directories": len(dirs_on_disk),
+            "violations": violations,
+            "summary": {"total": len(violations), "by_code": by_code},
+        },
+        "error": "",
+    }
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+    if violations:
+        print("\nFAIL: {} plugin-inventory violation(s):".format(len(violations)),
+              file=sys.stderr)
+        for v in violations:
+            print("  [{}] {}  ({})".format(v["code"], v["plugin"], v["detail"]),
+                  file=sys.stderr)
+        print("\nFix: for `source-missing`, the marketplace entry outlived its "
+              "directory — remove the entry in the same PR that deleted the "
+              "directory. For `plugin-unlisted`, a plugin directory has no "
+              "marketplace entry — either add the entry or, if the plugin was "
+              "removed, delete the leftover directory. The two halves of a "
+              "plugin removal must land together, or one guard or the other "
+              "trips.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_check_plugin_inventory.sh
+++ b/tests/test_check_plugin_inventory.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# test_check_plugin_inventory.sh — self-test for the plugin-inventory guard.
+#
+# The guard asserts a bijection between marketplace plugins[] and the top-level
+# directories holding .claude-plugin/plugin.json. Cases:
+#   1. Consistent fixture (2 entries, 2 directories) -> exit 0.
+#   2. Entry whose source points nowhere -> exit 1, code source-missing.
+#   3. Directory with a manifest and no entry -> exit 1, code plugin-unlisted.
+#      This is the direction no other guard in the repo covers; a suite that
+#      passes without asserting it has no teeth.
+#   4. Enumeration safety: a stale manifest under .claude/worktrees/** must NOT
+#      register, or the guard would fail every clean tree that has a worktree.
+#   5. Malformed marketplace -> exit 2 (script error), distinct from violations.
+#   6. Real repo at branch head -> exit 0.
+#
+# bash 3.2 + stdlib python3 only. No arguments, no network.
+
+set -eu
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+GUARD="$REPO_ROOT/scripts/check-plugin-inventory.py"
+
+red()   { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+
+FAILED=0
+check() {  # check <label> <condition-exit-code>
+  if [ "$2" -eq 0 ]; then
+    green "PASS: $1"
+  else
+    red "FAIL: $1"
+    FAILED=1
+  fi
+}
+
+assert_json() {  # assert_json <label> <json> <python-asserts>
+  set +e
+  printf '%s' "$2" | python3 -c "$3"
+  local _code=$?
+  set -e
+  check "$1" "$_code"
+}
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# make_plugin <fixture-root> <name>
+make_plugin() {
+  mkdir -p "$1/$2/.claude-plugin"
+  printf '{\n  "name": "%s",\n  "version": "0.0.1"\n}\n' "$2" > "$1/$2/.claude-plugin/plugin.json"
+}
+
+# make_marketplace <fixture-root> <name>...
+make_marketplace() {
+  local root="$1"; shift
+  mkdir -p "$root/.claude-plugin"
+  {
+    printf '{\n  "name": "fixture",\n  "plugins": [\n'
+    local first=1
+    for n in "$@"; do
+      [ $first -eq 1 ] || printf ',\n'
+      first=0
+      printf '    {"name": "%s", "source": "./%s", "version": "0.0.1"}' "$n" "$n"
+    done
+    printf '\n  ]\n}\n'
+  } > "$root/.claude-plugin/marketplace.json"
+}
+
+run_guard() {  # run_guard <root> -> sets OUT, CODE
+  set +e
+  OUT=$("$GUARD" --root "$1" 2>/dev/null)
+  CODE=$?
+  set -e
+}
+
+# ---------------------------------------------------------------- case 1
+CONSISTENT="$WORK/consistent"
+make_plugin "$CONSISTENT" cogni-alpha
+make_plugin "$CONSISTENT" cogni-beta
+make_marketplace "$CONSISTENT" cogni-alpha cogni-beta
+run_guard "$CONSISTENT"
+check "consistent inventory exits 0" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "consistent inventory reports zero violations" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is True, d
+assert d['data']['summary']['total']==0, d['data']['summary']
+assert d['data']['marketplace_plugins']==2, d['data']
+assert d['data']['plugin_directories']==2, d['data']
+"
+
+# ---------------------------------------------------------------- case 2
+NODIR="$WORK/entry-without-dir"
+make_plugin "$NODIR" cogni-alpha
+make_marketplace "$NODIR" cogni-alpha cogni-ghost
+run_guard "$NODIR"
+check "marketplace entry with no directory exits non-zero" "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
+assert_json "entry with no directory reports source-missing naming the plugin" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is False, d
+v=[x for x in d['data']['violations'] if x['code']=='source-missing']
+assert len(v)==1, d['data']['violations']
+assert v[0]['plugin']=='cogni-ghost', v
+"
+
+# ---------------------------------------------------------------- case 3
+# The uncovered direction: a plugin directory no marketplace entry names.
+UNLISTED="$WORK/dir-without-entry"
+make_plugin "$UNLISTED" cogni-alpha
+make_plugin "$UNLISTED" cogni-orphan
+make_marketplace "$UNLISTED" cogni-alpha
+run_guard "$UNLISTED"
+check "unlisted plugin directory exits non-zero" "$([ "$CODE" -eq 1 ] && echo 0 || echo 1)"
+assert_json "unlisted directory reports plugin-unlisted naming the directory" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is False, d
+v=[x for x in d['data']['violations'] if x['code']=='plugin-unlisted']
+assert len(v)==1, d['data']['violations']
+assert v[0]['plugin']=='cogni-orphan', v
+"
+
+# ---------------------------------------------------------------- case 4
+# A stale manifest inside .claude/worktrees/** is not a top-level plugin.
+NESTED="$WORK/nested-manifest"
+make_plugin "$NESTED" cogni-alpha
+make_marketplace "$NESTED" cogni-alpha
+mkdir -p "$NESTED/.claude/worktrees/wt-1/cogni-stale/.claude-plugin"
+printf '{"name":"cogni-stale","version":"9.9.9"}\n' \
+  > "$NESTED/.claude/worktrees/wt-1/cogni-stale/.claude-plugin/plugin.json"
+run_guard "$NESTED"
+check "stale manifest under .claude/worktrees is ignored" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "nested manifest does not register as a plugin directory" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is True, d
+assert d['data']['plugin_directories']==1, d['data']
+"
+
+# ---------------------------------------------------------------- case 5
+BROKEN="$WORK/broken-marketplace"
+make_plugin "$BROKEN" cogni-alpha
+mkdir -p "$BROKEN/.claude-plugin"
+printf '{ not json\n' > "$BROKEN/.claude-plugin/marketplace.json"
+run_guard "$BROKEN"
+check "malformed marketplace exits 2, not 1" "$([ "$CODE" -eq 2 ] && echo 0 || echo 1)"
+assert_json "malformed marketplace reports the error in the envelope" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is False, d
+assert d['error'], d
+"
+
+# ---------------------------------------------------------------- case 6
+run_guard "$REPO_ROOT"
+check "real repo inventory is consistent" "$([ "$CODE" -eq 0 ] && echo 0 || echo 1)"
+assert_json "real repo: marketplace count equals directory count" "$OUT" "
+import json,sys
+d=json.load(sys.stdin)
+assert d['success'] is True, d
+assert d['data']['marketplace_plugins']==d['data']['plugin_directories'], d['data']
+"
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+  green "All plugin-inventory guard tests passed."
+else
+  red "Some plugin-inventory guard tests FAILED."
+fi
+exit "$FAILED"


### PR DESCRIPTION
Closes #1330. Phase 4 — the last child of the cogni-projects carve-out epic #1331.

**Stacked on #1338** (base `purge-cogni-projects-residue`), which is stacked on #1336. The zero-residue certification is only meaningful on top of both, and GitHub retargets each PR as its base merges. Merge order: #1336 → #1338 → this.

## The gap being closed

`check-version-bump.py` enumerates plugins **only** from `marketplace.json` `plugins[].source` and deliberately never globs the tree — its docstring explains why (stale `plugin.json` copies live under `.claude/worktrees/**`). The coverage is therefore asymmetric:

| Inconsistency | Caught today? |
|---|---|
| Marketplace entry whose directory is missing | yes — `manifest-missing` |
| **Plugin directory with no marketplace entry** | **no guard in the repo sees it** |

The second row is precisely what a half-finished carve-out leaves behind: the directory survives, no manifest names it, every guard stays green, and nothing anywhere raises. This PR asserts the bijection in both directions.

## Why a bijection, not a banned-string grep

A "never mention cogni-projects" guard encodes one historical event, needs a hand-maintained list of retired names, and says nothing about the next plugin removed. The bijection is a durable invariant that catches this failure class and every future carve-out without being told any names.

## Enumeration safety

A single **non-recursive** scan of the repo root, skipping dot-prefixed entries. Both properties are load-bearing — a recursive glob would find stale manifests under `.claude/worktrees/**` and report them as unlisted plugins on a perfectly clean tree. The suite pins this with a fixture that plants a manifest at `.claude/worktrees/wt-1/cogni-stale/` and asserts the guard still exits 0.

## Verification

| Criterion | Result |
|---|---|
| Fails on a marketplace entry with no directory | `source-missing`, exit 1 |
| Fails on a plugin directory absent from the marketplace | `plugin-unlisted`, exit 1 |
| **Mutation check** | neutering the bijection assertion fails 2 assertions; restored suite green |
| Passes on the real repo | 13 marketplace plugins = 13 plugin directories, 0 violations |
| Enumeration-safe | nested `.claude/worktrees/**` manifest ignored |
| CI-discovered and self-contained | discovered as `tests/test_check_plugin_inventory.sh`; sweep now **106 suites, 106 pass** |
| Envelope and exit codes match siblings | pure `{success, data, error}` on stdout; 0 clean / 1 violations / 2 script error, fix hints on stderr |

## Zero-residue certification at branch head

| Check | Result |
|---|---|
| `git ls-files -z \| xargs -0 grep -lI cogni-projects` | **0 files** |
| `git ls-files \| grep '^cogni-projects/'` | **0 paths** |
| `plugins[]` length vs top-level plugin directories | **13 = 13** |
| Hand-maintained count claims differing from that number | **0** |
| Full CI-discovered sweep | 106 suites, 106 pass |

With this merged, the epic's close gate is no longer a prose assertion — it is a check anyone can re-run, and it will catch the next carve-out before a human has to.