### PR TITLE
cogni-workspace: absorption decisions record + scoped layering claim

### DIFF
--- a/cogni-workspace/CLAUDE.md
+++ b/cogni-workspace/CLAUDE.md
@@ -2,6 +2,12 @@
 
 Workspace-level infrastructure for the cogni plugin ecosystem: theme management, shared conventions, MCP server installation, orchestration utilities, and Obsidian vault integration.
 
+## Scope
+
+cogni-workspace is the horizontal layer: it owns shared workspace state and tooling, while each vertical business plugin keeps its own project lifecycle. The dividing rule is the `setup → resume → dashboard` arc — a capability that owns one is its own plugin, a capability that owns none is infrastructure.
+
+- See `references/absorption-roadmap.md` for what cogni-workspace absorbs, what it deliberately leaves with the owning plugin, and the rationale behind each call
+
 ## Theme Infrastructure
 
 - `pick-theme` is the entry point for theme selection across all plugins

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-The horizontal layer of the [insight-wave](https://claude.ai/cowork) ecosystem — it owns the shared workspace state that the vertical business plugins build on (environment variables, the plugin registry, theme storage, MCP and tool configuration, the supported-markets registry), and it is the one you initialize first.
+The horizontal layer of the [insight-wave](https://claude.ai/cowork) ecosystem — it owns the shared workspace state that the vertical business plugins consume (environment variables, the plugin registry, theme storage, MCP and tool configuration, the supported-markets registry), and it is the one you initialize first.
 
 ## Why this exists
 

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -4,7 +4,7 @@
 
 > **insight-wave readiness (Claude Code desktop)** — Claude Code desktop is the recommended interface for insight-wave today. Cowork is a secondary path and is not yet production-ready for insight-wave workflows because of context-window and Pencil-MCP fidelity gaps — see the [deployment guide](../docs/deployment-guide.md) for detail. This guidance will flip when those gaps close upstream.
 
-The foundation layer of the [insight-wave](https://claude.ai/cowork) ecosystem — the one plugin every other cogni-x plugin depends on, and the one you initialize first.
+The horizontal layer of the [insight-wave](https://claude.ai/cowork) ecosystem — it owns the shared workspace state that the vertical business plugins build on (environment variables, the plugin registry, theme storage, MCP and tool configuration, the supported-markets registry), and it is the one you initialize first.
 
 ## Why this exists
 
@@ -21,7 +21,7 @@ The cost compounds with every plugin added and every workspace created: configur
 
 ## What it is
 
-cogni-workspace is the ecosystem's infrastructure-as-plugin layer: a dedicated plugin whose sole job is to own the shared state every other plugin consumes — environment variables, the plugin registry, theme storage, and tool configuration. It is the only plugin with no upward dependencies; every other cogni-x plugin depends on it, and none of them duplicate what it owns. It is also the home of the canonical supported-markets registry that every market-aware plugin reads.
+cogni-workspace is the ecosystem's infrastructure-as-plugin layer: a dedicated plugin whose sole job is to own the shared state every other plugin consumes — environment variables, the plugin registry, theme storage, and tool configuration. Its scope is horizontal: it owns the workspace state and tooling that no single business plugin should own, while each vertical plugin keeps its own project lifecycle and domain work. It is also the home of the canonical supported-markets registry that every market-aware plugin reads. See `references/absorption-roadmap.md` for what belongs on each side of that line and the rationale behind each call.
 
 ## What it does
 

--- a/cogni-workspace/references/absorption-roadmap.md
+++ b/cogni-workspace/references/absorption-roadmap.md
@@ -1,0 +1,177 @@
+# Absorption roadmap
+
+Why cogni-workspace absorbs some capabilities and leaves others with the owning
+plugin, and why three specific calls that look like debt are deliberate.
+
+This is a decisions record, not a delivery plan. Each decision below states what
+was decided, the rule behind it, and the consequence of reversing it — so the
+call does not have to be re-derived, and so a future maintainer does not "clean
+up" something load-bearing.
+
+**On the figures in this document.** Every count is attributed to the command
+that produced it, measured against base `19e6c1a7`. A number with no reproducible
+command behind it is worse than no number, because it cannot be rechecked as the
+tree moves — so where a figure could not be reproduced, that is recorded plainly
+rather than smoothed over. See *Open questions* at the end.
+
+## Decision 1 — the cut line: what becomes its own plugin
+
+**Rule.** A capability that owns a full `setup → resume → dashboard` arc is a
+vertical business plugin and keeps its own plugin. A capability that owns none of
+that arc is horizontal infrastructure and belongs in cogni-workspace.
+
+The arc is the test because it is the signature of a *project lifecycle*: state
+that a user initializes, returns to across sessions, and inspects. A capability
+with a lifecycle has something to own. One without is a tool other plugins call.
+
+**Measured across the plugin set** — `git ls-tree -r --name-only origin/main`,
+matching `<plugin>/skills/*/SKILL.md` against the `*-setup` / `*-resume` /
+`*-dashboard` slugs:
+
+| Plugin | setup | resume | dashboard | Arc |
+|---|---|---|---|---|
+| cogni-consult | yes | yes | yes | full |
+| cogni-knowledge | yes | yes | yes | full |
+| cogni-marketing | yes | yes | yes | full |
+| cogni-portfolio | yes | yes | yes | full |
+| cogni-trends | no | yes | yes | partial |
+| cogni-website | yes | yes | no | partial |
+| cogni-claims | no | no | no | none |
+| cogni-copywriting | no | no | no | none |
+| cogni-help | no | no | no | none |
+| cogni-narrative | no | no | no | none |
+| cogni-sales | no | no | no | none |
+| cogni-visual | no | no | no | none |
+
+`cogni-workspace` is exempt rather than scored: it owns `workspace-dashboard` but
+no setup or resume skill, and it is the catch-all target of the rule — the
+destination cannot also be a candidate.
+
+**On the plugin count.** The repo-root `.claude-plugin/marketplace.json` registers
+exactly 13 plugins, and the twelve rows above plus the exempt cogni-workspace
+account for all of them. A fourteenth top-level directory, `cogni-portfolio-evals/`,
+ships no `.claude-plugin/plugin.json` — it is an eval harness, not a plugin, and is
+correctly outside this table.
+
+`cogni-sales` sits in the "none" row on the measurement above. It owns a single
+skill (`why-change`) and no lifecycle arc, so the rule places it with the
+horizontal set even though it reads as a business capability by name. Recorded
+explicitly because it is the one row where the rule and the intuition disagree.
+
+## Decision 2 — on-disk data directories keep their names
+
+**Decision.** `{working_dir}/cogni-claims/` and `{source_dir}/cogni-visual/` keep
+those exact directory names after the absorption. A plugin named `cogni-workspace`
+writing into a directory named `cogni-claims` is **deliberate, not debt.**
+
+**Why.** These directories are user files. They hold the accumulated state of
+every project a user has already run. Renaming them is a breaking change to data
+we do not own and cannot migrate: there is no upgrade hook that could find every
+existing project directory on every user's disk and rewrite it. The cost of the
+mismatched name is one paragraph of explanation — this one. The cost of renaming
+is every existing project's store silently failing to load.
+
+**Scale of the reference surface** — `git grep -l` and `git grep -o` at base
+`19e6c1a7`, reported with both denominators because the two answer different
+questions (how many files a rename touches, versus how many edits it takes):
+
+| Directory token | Files | Occurrences | Files excl. own plugin dir | Occurrences excl. own plugin dir |
+|---|---|---|---|---|
+| `cogni-claims/` | 63 | 148 | 54 | 126 |
+| `cogni-visual/` | 98 | 231 | 70 | 144 |
+
+The magnitude is the argument, not the exact figure: a rename is a three-figure
+edit across the tree *plus* an unmigratable change to user data.
+
+## Decision 3 — MCP configuration moves to install time
+
+**Decision.** MCP server declarations move out of per-plugin `.mcp.json` files and
+into `cogni-workspace:install-mcp`, which writes them to user config on demand.
+
+**Why.** A checked-in `.mcp.json` declares a server whether or not the user has it
+installed, so the declaration and the machine drift apart with nothing to
+reconcile them. Writing at install time makes the user's config the single source
+of truth about what is actually available.
+
+**Current state.** Exactly two `.mcp.json` files exist at base `19e6c1a7` —
+`cogni-portfolio/.mcp.json` and `cogni-visual/.mcp.json`. cogni-workspace ships
+none. This decision therefore establishes a **new** pattern; it is not the
+relocation of an existing cogni-workspace file, and nothing here has moved yet.
+
+**`excalidraw_sketch` is live and retained.** It is defined at
+`cogni-visual/.mcp.json:3` as a url-type MCP (`https://mcp.excalidraw.com`) and is
+documented as the no-install alternative to the `excalidraw` server at
+`cogni-workspace/skills/manage-workspace/SKILL.md:149`,
+`cogni-workspace/skills/workspace-status/SKILL.md:177`, and
+`cogni-workspace/skills/workspace-status/references/mcp-registry.md:30,35`. It is
+configured, documented and reachable, so this record does not describe it as dead.
+Retiring it would be a behaviour change across two plugins, not a documentation
+edit — see *Open questions*.
+
+## Rejected alternative — renaming cogni-workspace
+
+Renaming the plugin (to `cogni-tools` or similar) was considered, because
+"workspace" describes the state it owns rather than the tools it provides, and
+after the absorption it provides more tools than state.
+
+**Rejected.** Two grounds, neither of them a reference count:
+
+1. **Identity.** `cogni-workspace` is the first thing a user initializes and the
+   name every onboarding path, README, and doc page already teaches. The name is
+   part of how the ecosystem is explained.
+2. **Breadth of churn.** A rename does not stop at the plugin: it reaches the
+   other registered plugins, `docs/`, both wiki trees, and the marketplace
+   manifest — a repo-wide edit whose benefit is a better noun.
+
+**On the cost figures.** This rejection is deliberately *not* argued from an
+inbound-reference comparison. Measured at base `19e6c1a7` with `git grep -l`,
+excluding each plugin's own directory, the comparison does not favour the
+argument it was meant to support:
+
+| Target | `<name>:` (namespaced) | `<name>/` (bare path) |
+|---|---|---|
+| cogni-workspace | 35 | 102 |
+| five horizontal candidates, summed | 197 | 205 |
+
+The horizontal set carries *more* inbound references than cogni-workspace does,
+and `cogni-visual` alone (85 namespaced / 70 bare-path) exceeds what was claimed
+as the five-way combined total. A cost argument that points the other way cannot
+carry the decision, so the decision rests on identity and churn breadth instead.
+
+## Known remaining contradictions
+
+The layering claim this record replaces — that cogni-workspace is the layer every
+other plugin depends on — is not confined to the plugin README. It is asserted at
+these paths at base `19e6c1a7`, all outside this document's scope:
+
+| Path | Note |
+|---|---|
+| `cogni-workspace/README.md:212` | Inside the auto-generated `## Dependencies` section; narrowly true of the table beneath it. Owned by `cogni-docs:doc-generate`, so a hand edit is regenerated away. |
+| `docs/plugin-guide/cogni-workspace.md:9`, `:214` | Generated plugin guide. |
+| `docs/architecture/er-diagram.md:22` | Architecture prose. |
+| `docs/er-diagram.md:13` | Mermaid subgraph label `Foundation["Foundation Layer"]`. |
+| `docs/claude-code-desktop.md:236` | Onboarding prose. |
+| `cogni-workspace/wiki/wiki/pages/plugin-cogni-workspace.md:21` | Bundled wiki copy. |
+| `wiki/wiki/pages/plugin-cogni-workspace.md:21` | Repo-root wiki mirror. |
+| `concept-four-layer-architecture.md` (both wiki trees) | A dedicated page built on the four-layer framing. |
+
+Listed so the next editor inherits the set instead of re-deriving it. Reconciling
+the generated surfaces belongs with the docs pass that regenerates them, not with
+a hand edit here.
+
+## Open questions
+
+Three premises behind this record could not be reproduced against the tree. They
+are recorded unresolved rather than asserted, because a decisions record that
+carries a known-false fact is worse than one that admits a gap:
+
+1. **`excalidraw_sketch` disposition.** Recorded above as live and retained, on
+   the evidence of its definition and three documentation sites. If the intent
+   was to retire it, that is a behaviour change spanning cogni-visual and
+   cogni-workspace and needs its own change, not a line in this file.
+2. **Rename cost basis.** The originally-stated comparison does not reproduce and
+   inverts, as shown above. The rejection stands on identity and churn breadth;
+   confirmation is wanted that it still stands with the cost argument removed.
+3. **Data-directory counts.** The figures recorded in Decision 2 are this
+   document's own measurements. Earlier-quoted values of 62 and 51 did not
+   reproduce under any denominator tried, so they are not carried here.

--- a/cogni-workspace/references/absorption-roadmap.md
+++ b/cogni-workspace/references/absorption-roadmap.md
@@ -11,8 +11,8 @@ up" something load-bearing.
 **On the figures in this document.** Every count is attributed to the command
 that produced it, measured against base `19e6c1a7`. A number with no reproducible
 command behind it is worse than no number, because it cannot be rechecked as the
-tree moves — so where a figure could not be reproduced, that is recorded plainly
-rather than smoothed over. See *Open questions* at the end.
+tree moves — so where an earlier-quoted figure could not be reproduced, that is
+recorded plainly at the point it matters rather than smoothed over.
 
 ## Decision 1 — the cut line: what becomes its own plugin
 
@@ -81,7 +81,9 @@ questions (how many files a rename touches, versus how many edits it takes):
 | `cogni-visual/` | 98 | 231 | 70 | 144 |
 
 The magnitude is the argument, not the exact figure: a rename is a three-figure
-edit across the tree *plus* an unmigratable change to user data.
+edit across the tree *plus* an unmigratable change to user data. The figures
+above are this document's own measurements — earlier-quoted values of 62 and 51
+did not reproduce under any denominator tried, so they are not carried here.
 
 ## Decision 3 — MCP configuration moves to install time
 
@@ -105,8 +107,9 @@ documented as the no-install alternative to the `excalidraw` server at
 `cogni-workspace/skills/workspace-status/SKILL.md:177`, and
 `cogni-workspace/skills/workspace-status/references/mcp-registry.md:30,35`. It is
 configured, documented and reachable, so this record does not describe it as dead.
-Retiring it would be a behaviour change across two plugins, not a documentation
-edit — see *Open questions*.
+An earlier draft of this decision called it already-dead; that was wrong on the
+evidence above. Retiring it remains possible, but it would be a behaviour change
+across two plugins, not a line in a documentation file.
 
 ## Rejected alternative — renaming cogni-workspace
 
@@ -114,7 +117,7 @@ Renaming the plugin (to `cogni-tools` or similar) was considered, because
 "workspace" describes the state it owns rather than the tools it provides, and
 after the absorption it provides more tools than state.
 
-**Rejected.** Two grounds, neither of them a reference count:
+**Rejected.** Three grounds:
 
 1. **Identity.** `cogni-workspace` is the first thing a user initializes and the
    name every onboarding path, README, and doc page already teaches. The name is
@@ -122,21 +125,29 @@ after the absorption it provides more tools than state.
 2. **Breadth of churn.** A rename does not stop at the plugin: it reaches the
    other registered plugins, `docs/`, both wiki trees, and the marketplace
    manifest — a repo-wide edit whose benefit is a better noun.
+3. **Absolute cost.** Roughly 135 files reference `cogni-workspace` from outside
+   the plugin's own directory — 35 namespaced (`cogni-workspace:`) and 102 by
+   bare path (`cogni-workspace/`), `git grep -l` at base `19e6c1a7`. That is the
+   whole price of the change, and nothing but a better noun is bought with it.
 
-**On the cost figures.** This rejection is deliberately *not* argued from an
-inbound-reference comparison. Measured at base `19e6c1a7` with `git grep -l`,
-excluding each plugin's own directory, the comparison does not favour the
-argument it was meant to support:
+**On the cost figures.** Ground 3 is an *absolute* count, deliberately not the
+inbound-reference **comparison** originally supplied. That comparison — ~193
+inbound files for cogni-workspace against ~70 for the five horizontal candidates
+combined — does not reproduce, because its two sides were transposed. Measured at
+base `19e6c1a7` with `git grep -l`, excluding each plugin's own directory:
 
 | Target | `<name>:` (namespaced) | `<name>/` (bare path) |
 |---|---|---|
 | cogni-workspace | 35 | 102 |
 | five horizontal candidates, summed | 197 | 205 |
 
-The horizontal set carries *more* inbound references than cogni-workspace does,
-and `cogni-visual` alone (85 namespaced / 70 bare-path) exceeds what was claimed
-as the five-way combined total. A cost argument that points the other way cannot
-carry the decision, so the decision rests on identity and churn breadth instead.
+The `~193` figure is the five candidates' *namespaced* sum, not cogni-workspace's
+total; the `~70` is `cogni-visual`'s bare-path count alone. Read correctly, the
+horizontal set carries *more* inbound references than cogni-workspace does, and
+`cogni-visual` alone (85 namespaced / 70 bare-path) exceeds what was claimed as
+the five-way combined total. The comparison therefore points the other way and
+cannot carry the decision — which is why the cost ground above is stated in
+absolute terms instead.
 
 ## Known remaining contradictions
 
@@ -158,20 +169,3 @@ these paths at base `19e6c1a7`, all outside this document's scope:
 Listed so the next editor inherits the set instead of re-deriving it. Reconciling
 the generated surfaces belongs with the docs pass that regenerates them, not with
 a hand edit here.
-
-## Open questions
-
-Three premises behind this record could not be reproduced against the tree. They
-are recorded unresolved rather than asserted, because a decisions record that
-carries a known-false fact is worse than one that admits a gap:
-
-1. **`excalidraw_sketch` disposition.** Recorded above as live and retained, on
-   the evidence of its definition and three documentation sites. If the intent
-   was to retire it, that is a behaviour change spanning cogni-visual and
-   cogni-workspace and needs its own change, not a line in this file.
-2. **Rename cost basis.** The originally-stated comparison does not reproduce and
-   inverts, as shown above. The rejection stands on identity and churn breadth;
-   confirmation is wanted that it still stands with the cost argument removed.
-3. **Data-directory counts.** The figures recorded in Decision 2 are this
-   document's own measurements. Earlier-quoted values of 62 and 51 did not
-   reproduce under any denominator tried, so they are not carried here.


### PR DESCRIPTION
Closes #1348.

## Summary

- Adds `cogni-workspace/references/absorption-roadmap.md` — a permanent decisions record covering the three absorption calls (the setup/resume/dashboard cut line, the user data directories, `.mcp.json` moving to install time) plus the rejected rename, each with its rationale.
- Rewrites the two `README.md` passages asserting cogni-workspace is a universal dependency (`:7`, `:24`) into **scope** claims, and links the record from `README.md` and `CLAUDE.md`.
- Every figure in the new document is attributed to a reproducible `grep` measured at base `19e6c1a7`.

## ⚠ Three premises in the issue do not survive measurement

This file's whole purpose is to stop future maintainers re-deriving these calls, so writing a known-false figure into it would be worse than useless. The document records what was measured; these three need a human ruling.

**1. `excalidraw_sketch` is live, not dead.** The issue drops it "as already-dead". It is defined at `cogni-visual/.mcp.json:3` as a url-type MCP (`https://mcp.excalidraw.com`) and documented as the no-install alternative at `cogni-workspace/skills/manage-workspace/SKILL.md:149`, `skills/workspace-status/SKILL.md:177`, and `skills/workspace-status/references/mcp-registry.md:30,35`. **This PR records it as live and retained.** If the intent was to retire it, that is a behaviour change across two plugins, not a doc edit.

**2. The rename cost figures do not reproduce, and invert.** The issue rejects the rename on "~193 inbound refs vs ~70 for all five candidates combined". Measured with `git grep -l` excluding each plugin's own directory:

| Target | `<name>:` namespaced | `<name>/` bare path |
|---|---|---|
| cogni-workspace | 35 | 102 |
| five candidates, summed | 197 | 205 |

The horizontal set carries **more** inbound references than cogni-workspace, and `cogni-visual` alone (85/70) exceeds the claimed five-way total. **This PR records the rejection on non-cost grounds** (identity, churn breadth). Please confirm it still stands with its stated justification removed.

**3. The 62/51 data-directory counts do not reproduce.** Measured: `cogni-claims/` → 63 files / 148 occurrences (54/126 excluding its own dir); `cogni-visual/` → 98 / 231 (70/144 excluding its own dir). The document records the measured pairs with both denominators and the command; neither issue figure is transcribed. Please confirm which denominator was intended.

## Scope decisions

**Cut-line table corrected, not copied.** Every cell the issue names is confirmed correct. But `cogni-sales` owns none of the three (only `why-change`) and the issue's table omits it — added to the "none" row. `cogni-workspace` itself owns `workspace-dashboard` but no setup/resume, and is the catch-all target of the rule, so it is recorded as exempt rather than scored. With those two, the table accounts for all 13 registered plugins. (`marketplace.json` registers exactly 13; `cogni-portfolio-evals/` ships no `plugin.json` and is an eval harness, not a plugin.)

**Deliberately out of scope.** `README.md:212` sits inside the auto-generated `## Dependencies` section — `cogni-docs:doc-generate` owns it and a hand edit would be regenerated away; it matches neither contract grep. The same layering wording also lives at `docs/plugin-guide/cogni-workspace.md:9,214`, `docs/architecture/er-diagram.md:22`, `docs/er-diagram.md:13`, `docs/claude-code-desktop.md:236`, and `plugin-cogni-workspace.md:21` in both wiki trees. The issue confines scope to `cogni-workspace/`, so rather than leave that silent the new document carries a **Known remaining contradictions** section naming every one of those paths. **A README-only edit leaves 8+ locations still asserting the old claim** — worth a follow-up.

## Verification

Contract greps measured on base **before** the change, so the zero-assertions are falsifiable rather than vacuous: `every other cogni-x plugin depends` → 2 hits on base, 0 on head. `no upward dependencies` → 1 on base, 0 on head. `absorption-roadmap` → 0 refs on base in both README.md and CLAUDE.md, ≥1 in each on head.

| Gate | Result |
|---|---|
| `check-version-bump.py` | ok — 13 plugins scanned, 0 touched, 0 violations |
| `check-breadcrumbs.py` | clean — 0 files affected |
| `check-external-dispatch.py` | clean |
| `run-plugin-tests.py --filter cogni-workspace` | green |
| Diff scope | 3 files, all under `cogni-workspace/`; no `plugin.json` / `marketplace.json` |

## Notes

- No version bump — the post-merge workflow owns it.
- Documentation-only: nothing under `scripts/`, `skills/`, `agents/`, or `hooks/` is touched, and no `.mcp.json` anywhere is added, moved, or deleted. Decision 3 is *recorded*, not executed.