### PR TITLE
Reconcile layering claims to the horizontal-scope claim

### DIFF
--- a/cogni-help/skills/guide/references/plugin-catalog.md
+++ b/cogni-help/skills/guide/references/plugin-catalog.md
@@ -237,7 +237,7 @@ Excalidraw, Pencil MCP, and PPTX rendering.
 
 ## cogni-workspace
 
-**Purpose**: Lean workspace orchestrator. Manages shared foundation (env vars, settings),
+**Purpose**: Lean workspace orchestrator. Owns the shared workspace state (env vars, settings),
 theme management, plugin discovery, and workspace health diagnostics.
 
 **Key commands**: `/manage-workspace`, `/workspace-status`, `/pick-theme`, `/manage-themes`
@@ -245,6 +245,6 @@ theme management, plugin discovery, and workspace health diagnostics.
 **Use when**: User needs to initialize or maintain their insight-wave workspace, manage
 themes, or diagnose workspace configuration issues.
 
-**Foundation for**: All other plugins (provides shared env vars and settings)
+**Consumed by**: The vertical business plugins, which read the shared env vars, settings, and themes it owns
 
 **Related workflows**: portfolio-to-website, install-to-infographic

--- a/cogni-help/skills/teach/references/courses/tours/tour-install-to-infographic.md
+++ b/cogni-help/skills/teach/references/courses/tours/tour-install-to-infographic.md
@@ -77,7 +77,7 @@ workflows, do it now in the same step.
 
 ### Theory (6 min)
 
-`cogni-workspace` is the foundation every other plugin depends on — it owns
+`cogni-workspace` is the horizontal layer you initialize first — it owns
 shared state: themes, environment variables, MCP server configuration, and
 workspace health diagnostics.
 

--- a/cogni-help/skills/teach/references/courses/tours/tour-install-to-infographic.md
+++ b/cogni-help/skills/teach/references/courses/tours/tour-install-to-infographic.md
@@ -31,15 +31,19 @@ versions arrive without re-running install. Plugin versions live in
 `plugin.json` and are mirrored in the marketplace manifest — auto-update
 detects new versions via marketplace.json.
 
-The 13 plugins span four tiers:
-- Foundation: cogni-workspace, cogni-help, cogni-claims
-- Content production: cogni-knowledge, cogni-narrative, cogni-copywriting, cogni-visual
-- Domain pipelines: cogni-trends, cogni-portfolio, cogni-sales, cogni-marketing, cogni-website
-- Meta: cogni-consult (orchestrates the rest)
+The 13 plugins split along one line: cogni-workspace is **horizontal**
+infrastructure, and the business plugins are **vertical**, each keeping its own
+project lifecycle. The vertical grouping below is descriptive — it names the role
+each plugin plays, not an order in which they depend on each other:
+- Horizontal: cogni-workspace — owns the shared workspace state the others read
+- Data: cogni-portfolio, cogni-trends, cogni-knowledge, cogni-claims
+- Output: cogni-narrative, cogni-copywriting, cogni-visual, cogni-sales, cogni-marketing, cogni-website
+- Orchestration: cogni-consult (manages engagement state, produces no content itself)
+- Outside the groups: cogni-help — a cross-cutting utility that reads every plugin and is read by none
 
 ### Demo
 
-Install the foundation:
+Install the two plugins this workflow needs:
 1. Run `/plugin marketplace add cogni-work/insight-wave`.
 2. Install cogni-workspace: `/plugin install cogni-workspace@insight-wave`.
 3. Install cogni-visual: `/plugin install cogni-visual@insight-wave`.
@@ -48,8 +52,8 @@ Install the foundation:
 
 ### Exercise
 
-For the learner's actual setup, confirm the marketplace is added and the two
-foundation plugins are installed. If they want to install more for follow-on
+For the learner's actual setup, confirm the marketplace is added and both
+plugins are installed. If they want to install more for follow-on
 workflows, do it now in the same step.
 
 ### Quiz

--- a/cogni-help/skills/workflow/references/workflows/install-to-infographic.md
+++ b/cogni-help/skills/workflow/references/workflows/install-to-infographic.md
@@ -20,7 +20,7 @@ graph LR
 **Output**: insight-wave plugins available as slash commands
 
 **Tips**:
-- Start with `cogni-workspace` — it's the foundation every other plugin depends on
+- Start with `cogni-workspace` — it owns the shared workspace state (themes, env vars, MCP config) the other plugins read, so initialize it first
 - Enable auto-update inside `/plugin → Marketplaces → insight-wave` so new versions arrive without re-running this step
 - For this workflow you minimally need `cogni-workspace` and `cogni-visual`; install the rest when you reach a follow-on workflow that needs them
 

--- a/cogni-workspace/README.md
+++ b/cogni-workspace/README.md
@@ -209,8 +209,6 @@ cogni-workspace/
 
 ## Dependencies
 
-cogni-workspace has no required plugin dependencies — it is the foundation layer that other plugins depend on.
-
 | Plugin | Required | Purpose |
 |--------|----------|---------|
 | cogni-visual | No | manage-themes passes color variables to cogni-visual renderers (render-big-picture, render-big-block) |

--- a/cogni-workspace/references/absorption-roadmap.md
+++ b/cogni-workspace/references/absorption-roadmap.md
@@ -149,23 +149,86 @@ the five-way combined total. The comparison therefore points the other way and
 cannot carry the decision — which is why the cost ground above is stated in
 absolute terms instead.
 
-## Known remaining contradictions
+## Decision 5 — the four-layer concept page is retained in reduced form
+
+**Decision.** `concept-four-layer-architecture.md` keeps its descriptive
+Orchestration / Data / Output groupings and loses the dependency ordering built on
+top of them: the total-order claim ("plugins in higher layers depend on lower
+layers, but never the reverse") and the Foundation rung both go, and
+cogni-workspace is restated as the horizontal band alongside the vertical groups.
+The page's filename and frontmatter `id:` are **unchanged**.
+
+**Why.** Two things were tangled on that page. The dependency ordering is falsified
+by Decision 1 and had to go regardless of any taxonomy question. The role groupings
+are a separate, still-useful description of what each plugin does, and nothing in
+this record contradicts them. Deleting the page outright would have discarded the
+second to remove the first, and would have stranded 31 inbound references —
+20 of which are wikilink *aliases* on the per-plugin pages (`Data layer`,
+`Output layer`, `Foundation layer`) where the alias text is the assertion. Nothing
+in CI catches a dangling `[[...]]`: `test-wiki-namespace-sync.sh` checks only
+`plugin-*` / `skill-*` / `agent-*` filename stems against the marketplace roster and
+skips the `concept-*` family entirely.
+
+**What this leaves open.** Replacing the role taxonomy outright with an explicit
+horizontal/vertical vocabulary remains available, and costs no more later than it
+would have here: it would additionally rewrite the 18 surviving `Data layer` /
+`Output layer` aliases across 9 pages × 2 trees, and commit the ecosystem to a
+vocabulary this record does not ratify. That is an architecture-owner call. The
+reduced form is the reversible one, which is why it is the default taken here.
+
+**Reversing it** means re-deriving those 18 aliases and the page body together —
+the same work either way, so nothing is foreclosed.
+
+## Known remaining contradictions — reconciled
 
 The layering claim this record replaces — that cogni-workspace is the layer every
-other plugin depends on — is not confined to the plugin README. It is asserted at
-these paths at base `19e6c1a7`, all outside this document's scope:
+other plugin depends on — was not confined to the plugin README. It was asserted at
+the paths below, measured at base `19e6c1a7`. **All are now reconciled**; the table
+is kept as the historical inventory rather than deleted, so the set stays auditable.
+
+| Path | Note | State |
+|---|---|---|
+| `cogni-workspace/README.md:212` | Inside the auto-generated `## Dependencies` section. | Reconciled — sentence deleted. The `doc-generate` template for this section emits only a heading and a table and specifies no lead-in prose, so the deletion is regeneration-stable and needed no generator change. |
+| `docs/plugin-guide/cogni-workspace.md:9`, `:214` | Generated plugin guide. | Reconciled in the output only. The generator ships from another repository, so the fix could not be made at its source — see the caveat below. |
+| `docs/architecture/er-diagram.md:22` | Architecture prose. | Reconciled — `## Four Architectural Layers` is now `## Architectural Groups`. |
+| `docs/er-diagram.md:13` | Mermaid subgraph label `Foundation["Foundation Layer"]`. | Reconciled — display label only; the `Foundation` subgraph id is unchanged so every edge still resolves. |
+| `docs/claude-code-desktop.md:236` | Onboarding prose. | Reconciled. |
+| `cogni-workspace/wiki/wiki/pages/plugin-cogni-workspace.md:21` | Bundled wiki copy. | Reconciled — alias and the second occurrence at `:45`. |
+| `wiki/wiki/pages/plugin-cogni-workspace.md:21` | Repo-root wiki mirror. | Reconciled — same two edits, byte-identical. |
+| `concept-four-layer-architecture.md` (both wiki trees) | A dedicated page built on the four-layer framing. | Reconciled per Decision 5 above. |
+
+**The inventory above was incomplete.** These carried the same claim, were present
+at `19e6c1a7` too, and were missed when the table was first written:
 
 | Path | Note |
 |---|---|
-| `cogni-workspace/README.md:212` | Inside the auto-generated `## Dependencies` section; narrowly true of the table beneath it. Owned by `cogni-docs:doc-generate`, so a hand edit is regenerated away. |
-| `docs/plugin-guide/cogni-workspace.md:9`, `:214` | Generated plugin guide. |
-| `docs/architecture/er-diagram.md:22` | Architecture prose. |
-| `docs/er-diagram.md:13` | Mermaid subgraph label `Foundation["Foundation Layer"]`. |
-| `docs/claude-code-desktop.md:236` | Onboarding prose. |
-| `cogni-workspace/wiki/wiki/pages/plugin-cogni-workspace.md:21` | Bundled wiki copy. |
-| `wiki/wiki/pages/plugin-cogni-workspace.md:21` | Repo-root wiki mirror. |
-| `concept-four-layer-architecture.md` (both wiki trees) | A dedicated page built on the four-layer framing. |
+| `docs/ecosystem-overview.md:13`, `:17` | A `### Foundation` layer-group heading with cogni-workspace as its sole occupant, plus the table cell beneath it. Rewriting only the cell would have left the framing standing structurally. |
+| `docs/architecture/er-diagram.md:9` | The total-order sentence above the ASCII diagram — the table named only `:22`. |
+| `cogni-help/skills/guide/references/plugin-catalog.md:240`, `:248` | `**Foundation for**: All other plugins`. |
+| `cogni-help/skills/teach/.../tour-install-to-infographic.md:80` | Course prose. |
+| `cogni-help/skills/workflow/references/workflows/install-to-infographic.md:23` | Workflow prose. |
+| `arch-er-diagram.md:15-17` (both trees) | `## Four architectural layers` + the total-order sentence. |
+| `workflow-install-to-infographic.md:42` (both trees) | Wiki workflow prose. |
+| `plugin-cogni-workspace.md:45` (both trees) | `Foundation for all 13 other plugins.` — two paragraphs below the `:21` alias the table did name. |
+| `cogni-workspace/skills/ask/SKILL.md:72` | The worked example quoting the four-layer model. |
 
-Listed so the next editor inherits the set instead of re-deriving it. Reconciling
-the generated surfaces belongs with the docs pass that regenerates them, not with
-a hand edit here.
+**Deliberately left standing**, with reasons, so a future reader does not read them
+as misses: the ASCII-art fill labels in `cogni-visual/libraries/`
+(`excalidraw-patterns.md:165`, `svg-patterns.md:283`) are diagram legends unrelated
+to the claim; `wiki/log.md` and `wiki/pages/lint-2026-04-20.md` are dated historical
+artifacts, and rewriting history is not reconciliation; and
+`plugin-cogni-help.md:18-20` ("depends on every other plugin … is depended on by
+nothing") is an accurate statement *about cogni-help*, which stays true under the
+reduced form.
+
+**One caveat survives.** `docs/plugin-guide/cogni-workspace.md` is `cogni-docs`
+generator output, and `cogni-docs` ships from a separate repository — there is no
+`cogni-docs/` directory here to fix at source. The output is corrected so readers
+stop seeing a falsified claim, but a regeneration pass could reintroduce the wording
+in that one file until the generator is changed.
+
+`cogni-workspace/tests/test-layering-claim-reconciled.sh` guards the reconciled
+state: a forbidden-literal scan over the paths above, plus per-page byte-parity
+between the two wiki trees. Parity is asserted **per touched page**, never
+tree-wide — the trees legitimately differ by one page, so a tree-wide assertion
+would fail on arrival.

--- a/cogni-workspace/references/absorption-roadmap.md
+++ b/cogni-workspace/references/absorption-roadmap.md
@@ -212,6 +212,23 @@ at `19e6c1a7` too, and were missed when the table was first written:
 | `plugin-cogni-workspace.md:45` (both trees) | `Foundation for all 13 other plugins.` — two paragraphs below the `:21` alias the table did name. |
 | `cogni-workspace/skills/ask/SKILL.md:72` | The worked example quoting the four-layer model. |
 
+**A second pass found five more**, all of which the first two passes above also
+missed. They are recorded separately because the shape of each miss is the
+lesson, not the count:
+
+| Path | How it evaded the earlier passes |
+|---|---|
+| `docs/workflows/install-to-infographic.md:43`, `:65` | The narrative tutorial the `cogni-help` workflow template hands off to at its closing line, and which `docs/claude-code-desktop.md:236` recommends as the next step. Reconciling the template while leaving the page it links to meant a reader crossed from a reconciled sentence straight into an unreconciled one. Neither phrasing (`the foundation the others depend on`, `is the shared foundation`) matched any literal the guard then carried. |
+| `plugin-cogni-workspace.md:17` (both trees) | The hyphenated `Foundation-layer plugin`, four lines above the `:21` alias the first table did name — so the page asserted both framings about itself. The hyphen is why it evaded the `foundation layer` grep. |
+| `wiki/wiki/index.md:52` (both trees) | The index one-liner derived from that page's first line; correcting the page alone left the index contradicting it. |
+| `tour-install-to-infographic.md:34-38` (plus `:42`, `:52`) | The retired four-tier taxonomy, 46 lines above the `:80` line the first pass fixed and in the module a first-run learner reads first. It asserted a Foundation rung, and memberships for cogni-help and cogni-claims, that Decision 5 and the rewritten concept page deny. |
+| `.claude-plugin/plugin.json` + its `marketplace.json` mirror | The plugin description — the claim's highest-visibility surface and the upstream source of the wiki line above. **Not reconciled here:** the scope boundary confines this diff to markdown and `tests/*.sh`. The guard excludes `.claude-plugin/` explicitly rather than reporting clean over it; remove that exclusion when the manifests are corrected. |
+
+The recurring shape is worth naming: every miss but the last was **a second
+occurrence in a file the inventory had already listed**, or **a page derived from
+one**. A path-level inventory cannot catch either — only a re-grep of the whole
+tree after each edit can, which is what the guard now automates.
+
 **Deliberately left standing**, with reasons, so a future reader does not read them
 as misses: the ASCII-art fill labels in `cogni-visual/libraries/`
 (`excalidraw-patterns.md:165`, `svg-patterns.md:283`) are diagram legends unrelated

--- a/cogni-workspace/skills/ask/SKILL.md
+++ b/cogni-workspace/skills/ask/SKILL.md
@@ -69,7 +69,7 @@ Read each candidate page fully. Note:
 
 Write a plain-prose answer, inline-citing every factual claim with a `[[page-slug]]` link. Example:
 
-> The insight-wave ecosystem organizes into four layers — orchestration (cogni-consulting), foundation (cogni-workspace), data (cogni-portfolio, cogni-trends, cogni-research, cogni-claims), and output (cogni-narrative, cogni-copywriting, cogni-visual, cogni-sales, cogni-marketing) [[concept-four-layer-architecture]]. Plugins in higher layers depend on lower layers but never the reverse. Each plugin owns its data; cross-plugin reads happen through path references, bridge files, or YAML frontmatter contracts [[concept-data-isolation]].
+> The insight-wave ecosystem splits into a horizontal layer (cogni-workspace, which owns shared workspace state) and vertical business plugins grouped by role — orchestration (cogni-consult), data (cogni-portfolio, cogni-trends, cogni-knowledge, cogni-claims), and output (cogni-narrative, cogni-copywriting, cogni-visual, cogni-sales, cogni-marketing) [[concept-four-layer-architecture]]. Each vertical plugin keeps its own project lifecycle and owns its data; cross-plugin reads happen through path references, bridge files, or YAML frontmatter contracts [[concept-data-isolation]].
 
 Rules:
 - Every non-trivial claim links to at least one `[[page-slug]]`

--- a/cogni-workspace/tests/test-layering-claim-reconciled.sh
+++ b/cogni-workspace/tests/test-layering-claim-reconciled.sh
@@ -42,6 +42,27 @@
 # against editing a literal's wording; for a mutation that a change can actually
 # flip, target the parity checker (see L4).
 #
+# Phrase-level survivors. These lines keep foundation vocabulary on purpose and
+# must NOT be caught. Each says something about the workspace *state* other
+# plugins read, never about the plugin's position in a dependency order, so none
+# is falsified by the scope claim:
+#
+#   - manage-workspace/SKILL.md:23 — "An insight-wave workspace is the shared
+#     foundation that all marketplace plugins depend on" (subject is the
+#     workspace, not cogni-workspace)
+#   - workspace-dashboard/SKILL.md:24 — "the foundation that every other plugin
+#     reads from" (reads from, not depends on)
+#   - cogni-help full-onboarding.md:26 — "the workspace provides the foundation"
+#   - cogni-help tour-install-to-infographic.md — "builds on this foundation" /
+#     "the workspace + theme + MCP foundation" (bootstrap ordering among
+#     workflows, which the scope claim permits)
+#
+# This list is why the shared-foundation literal below is prefixed with the
+# plugin name: the bare "is the shared foundation" also matches the first entry,
+# so an unprefixed literal would make this suite red on arrival against a line
+# that is deliberately standing. Without this block a later editor cannot tell a
+# compatible survivor from a missed one.
+#
 # Path exclusions, each with a reason:
 #   - this file (it necessarily contains every literal it forbids)
 #   - references/absorption-roadmap.md — the decisions record quotes the retired
@@ -52,13 +73,16 @@
 #     editing it would also break the per-page parity assertion below
 #   - cogni-visual/libraries/ — "Foundation Layer" there is an ASCII-art fill
 #     label in a diagram legend, unrelated to the claim
-#   - .claude-plugin/ — the plugin.json description and its marketplace.json
-#     mirror still say "Foundation-layer plugin". They are the retired claim's
+#   - cogni-workspace/.claude-plugin/plugin.json and .claude-plugin/marketplace.json
+#     — these two say "Foundation-layer plugin". They are the retired claim's
 #     upstream source and DO need fixing, but the reconciliation's scope boundary
 #     confines its diff to markdown surfaces and tests/*.sh, so a manifest edit
 #     belongs to its own change. Excluded so the guard stays honest about what it
-#     covers rather than silently green; remove this exclusion when the manifests
-#     are corrected.
+#     covers rather than silently green; remove both entries when the manifests
+#     are corrected. Named as two exact paths, never as a `.claude-plugin/`
+#     fragment — that fragment would exempt all 15 files under every plugin's
+#     manifest directory, so any OTHER plugin could reintroduce the claim
+#     invisibly, and the gap would be far wider than the two files documented here.
 #   - .git/ and .claude/worktrees/ — nested checkouts of this same repo that
 #     local tooling leaves in the tree. Untracked, so `grep_hits` already skips
 #     them on the real repo; these entries only cover the filesystem fallback.
@@ -116,7 +140,8 @@ cogni-workspace/references/absorption-roadmap.md
 wiki/wiki/log.md
 wiki/wiki/pages/lint-2026-04-20.md
 cogni-visual/libraries/
-.claude-plugin/
+cogni-workspace/.claude-plugin/plugin.json
+.claude-plugin/marketplace.json
 .git/
 .claude/worktrees/'
 
@@ -256,9 +281,9 @@ assert_out_lacks(){ case "$LAST_OUT" in *"$1"*) echo "  expected output NOT to c
 # ---------------------------------------------------------------------------
 run_scan "$REPO_ROOT" "repo"
 if assert_rc 0; then
-  pass "L1 the real repo asserts no retired layering claim"
+  pass "L1 the real repo asserts no retired layering claim outside the excluded paths"
 else
-  fail "L1 the real repo asserts no retired layering claim"
+  fail "L1 the real repo asserts no retired layering claim outside the excluded paths"
 fi
 
 # ---------------------------------------------------------------------------
@@ -376,6 +401,51 @@ if assert_rc 0; then
   pass "L7 the real wiki trees agree on every page this change touched"
 else
   fail "L7 the real wiki trees agree on every page this change touched"
+fi
+
+# ---------------------------------------------------------------------------
+# L8 — the git-tracked arm of grep_hits is live, and its narrowing is deliberate.
+#
+# Without this case the arm is untested. Every "caught when planted" fixture
+# (L2, L3, L5) builds under mktemp, which is not a git work tree, so they all
+# exercise the recursive-grep fallback; the only cases reaching the git arm are
+# L1 and L7, and both assert CLEAN. Nothing would prove the arm can find
+# anything — so if it ever returned empty (an edit, a sparse checkout, a flag an
+# older git rejects) L1 would report PASS vacuously. That is the same half-dead
+# arm the `scanned -eq 0` floor and L6 exist to prevent, and the arms were one
+# code path until the scan was made git-aware.
+#
+# The second half pins the narrowing as intended rather than accidental: an
+# untracked file carrying a literal is deliberately skipped, because the claim is
+# an assertion about repo content and scanning ignored scratch made the verdict
+# depend on a developer's local state. If the arm is ever swapped back to a
+# filesystem walk, this half turns red and says so.
+# ---------------------------------------------------------------------------
+l8_ok=1
+G="$TMPROOT/l8"
+mkdir -p "$G/docs"
+if ! git init -q "$G" >/dev/null 2>&1; then
+  echo "  git init failed — cannot exercise the git-tracked arm"
+  l8_ok=0
+else
+  printf 'Some prose that says foundation layer in passing.\n' > "$G/docs/tracked.md"
+  git -C "$G" add docs/tracked.md >/dev/null 2>&1
+  git -C "$G" -c user.email=guard@example.invalid -c user.name=Guard \
+    commit -q -m "fixture" >/dev/null 2>&1 || l8_ok=0
+
+  # Tracked offender must be found, and named, by the git arm.
+  run_scan "$G" "git-tracked"
+  assert_rc 1 && assert_out_has "docs/tracked.md" || l8_ok=0
+
+  # Untracked offender must NOT be found — the deliberate narrowing.
+  printf 'Some prose that says foundation layer in passing.\n' > "$G/docs/untracked.md"
+  run_scan "$G" "git-untracked"
+  assert_rc 1 && assert_out_lacks "docs/untracked.md" || l8_ok=0
+fi
+if [ "$l8_ok" -eq 1 ]; then
+  pass "L8 the git-tracked scan arm is live and skips untracked files"
+else
+  fail "L8 the git-tracked scan arm is live and skips untracked files"
 fi
 
 # ---------------------------------------------------------------------------

--- a/cogni-workspace/tests/test-layering-claim-reconciled.sh
+++ b/cogni-workspace/tests/test-layering-claim-reconciled.sh
@@ -31,7 +31,16 @@
 # The first two literals measured ZERO on the base — an earlier PR had already
 # removed them, which is why the issue's own acceptance criterion citing them was
 # vacuous. They are retained here anyway, and case L2 plants each one in a
-# fixture, so they are a live regression guard rather than dead config.
+# fixture, so the scanner is proven to catch each phrase.
+#
+# What L2 does and does not prove. L2 reads the literals from FORBIDDEN, plants
+# each in a fixture, and scans with FORBIDDEN — so it proves the SCANNER catches
+# a planted phrase, but it cannot detect a literal being *reworded*: a
+# substitution changes the planted text and the needle together, leaving L2
+# green. The count floor below is what protects the set — dropping an entry takes
+# l2_n under the floor and turns L2 red. Do not read L2 as a regression guard
+# against editing a literal's wording; for a mutation that a change can actually
+# flip, target the parity checker (see L4).
 #
 # Path exclusions, each with a reason:
 #   - this file (it necessarily contains every literal it forbids)
@@ -43,6 +52,16 @@
 #     editing it would also break the per-page parity assertion below
 #   - cogni-visual/libraries/ — "Foundation Layer" there is an ASCII-art fill
 #     label in a diagram legend, unrelated to the claim
+#   - .claude-plugin/ — the plugin.json description and its marketplace.json
+#     mirror still say "Foundation-layer plugin". They are the retired claim's
+#     upstream source and DO need fixing, but the reconciliation's scope boundary
+#     confines its diff to markdown surfaces and tests/*.sh, so a manifest edit
+#     belongs to its own change. Excluded so the guard stays honest about what it
+#     covers rather than silently green; remove this exclusion when the manifests
+#     are corrected.
+#   - .git/ and .claude/worktrees/ — nested checkouts of this same repo that
+#     local tooling leaves in the tree. Untracked, so `grep_hits` already skips
+#     them on the real repo; these entries only cover the filesystem fallback.
 #
 # Parity is per-page, never tree-wide, and that is load-bearing. The two trees
 # legitimately differ (the root tree carries lint-2026-04-20.md and the bundled
@@ -83,7 +102,12 @@ higher layers depend
 depend on lower layers
 depends on lower layers
 depends on nothing
-foundation for all'
+foundation for all
+foundation-layer plugin
+the foundation the others depend on
+cogni-workspace is the shared foundation
+foundation: cogni-workspace
+span four tiers'
 
 # Repo-relative path fragments exempt from the scan. See the header for why each
 # one is here.
@@ -91,7 +115,10 @@ EXCLUDED='cogni-workspace/tests/test-layering-claim-reconciled.sh
 cogni-workspace/references/absorption-roadmap.md
 wiki/wiki/log.md
 wiki/wiki/pages/lint-2026-04-20.md
-cogni-visual/libraries/'
+cogni-visual/libraries/
+.claude-plugin/
+.git/
+.claude/worktrees/'
 
 # Pages that must stay byte-identical between the two wiki trees. Scoped to what
 # this reconciliation touched — see the header on why this is not tree-wide.
@@ -121,6 +148,31 @@ EOF
 
 # scan_literals <root> <label> -> 0 clean, 1 offenders found or root unusable.
 # Prints one "OFFENDER <path>: <literal>" line per hit.
+# Enumerate files under $1 containing the literal $2.
+#
+# Inside a git work tree, restrict the search to TRACKED files. The retired claim
+# is an assertion about repo content, and the filesystem under this root also
+# holds content git deliberately ignores — skill eval workspaces (`*-workspace/`)
+# and nested worktree checkouts of this same repo. Scanning those makes the
+# verdict depend on which branches and evals a developer happens to have on disk:
+# green in CI, where none of it exists, and red on a working machine for reasons
+# no reader can act on. `git grep` searches the working tree, so uncommitted edits
+# to tracked files are still scanned — which is what a pre-commit guard needs.
+#
+# Outside a git work tree (the synthetic fixtures below) fall back to a plain
+# recursive grep. The root must be the work tree's top level; `git grep` from a
+# subdirectory scopes itself to that subdirectory, which would silently narrow
+# the scan.
+grep_hits() {
+  local root="$1" lit="$2" top
+  top="$(git -C "$root" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [ -n "$top" ] && [ "$top" = "$(cd "$root" && pwd -P)" ]; then
+    git -C "$root" grep -IliF -- "$lit" 2>/dev/null || true
+  else
+    grep -RIliF -- "$lit" "$root" 2>/dev/null || true
+  fi
+}
+
 scan_literals() {
   local root="$1" label="$2"
   local offenders=0 scanned=0 lit hit path
@@ -141,7 +193,7 @@ scan_literals() {
       echo "OFFENDER $path: $lit"
       offenders=$((offenders + 1))
     done <<EOF
-$(grep -RIliF -- "$lit" "$root" 2>/dev/null || true)
+$(grep_hits "$root" "$lit")
 EOF
   done <<EOF
 $FORBIDDEN
@@ -210,8 +262,10 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# L2 — every forbidden literal is caught when planted. This is what keeps the
-# two zero-on-base literals from being dead config.
+# L2 — every forbidden literal is caught when planted, and the set has not
+# shrunk. The scan proves the two zero-on-base literals are wired to a working
+# scanner; the count floor below is what stops one being dropped unnoticed. See
+# the header on what this case cannot prove.
 # ---------------------------------------------------------------------------
 l2_ok=1
 l2_n=0
@@ -226,8 +280,8 @@ while IFS= read -r lit; do
 done <<EOF
 $FORBIDDEN
 EOF
-if [ "$l2_n" -lt 9 ]; then
-  echo "  expected at least 9 literals, found $l2_n"
+if [ "$l2_n" -lt 14 ]; then
+  echo "  expected at least 14 literals, found $l2_n"
   l2_ok=0
 fi
 if [ "$l2_ok" -eq 1 ]; then

--- a/cogni-workspace/tests/test-layering-claim-reconciled.sh
+++ b/cogni-workspace/tests/test-layering-claim-reconciled.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# Layering-claim guard: no surface may reassert that cogni-workspace is the
+# foundation layer every other plugin depends on.
+#
+# Why this exists. references/absorption-roadmap.md Decision 1 replaced the
+# LAYERING claim (cogni-workspace is the layer everything depends on) with a
+# SCOPE claim (it is the horizontal layer; each vertical business plugin keeps
+# its own project lifecycle). The claim was asserted in 19 places across docs/,
+# both wiki trees, cogni-help and cogni-workspace, and reconciling them by hand
+# is only durable if something notices when one comes back. Nothing did:
+# test-wiki-namespace-sync.sh checks filename stems against the marketplace
+# roster and never reads page prose, and no suite anywhere compares the two wiki
+# trees against each other. A regenerated doc or a re-imported wiki page could
+# reintroduce the claim silently.
+#
+# Contract under test:
+#   - none of the FORBIDDEN literals appears anywhere outside the excluded paths
+#   - every one of those literals is actually caught when present (no dead config)
+#   - a literal under an excluded path is NOT flagged
+#   - the four pages this reconciliation touched are byte-identical across the
+#     two wiki trees
+#   - a scan pointed at a missing or empty tree fails rather than reporting clean
+#
+# Literals, not a regex over "foundation". `foundation` alone has many legitimate
+# hits (cogni-portfolio prose, cogni-narrative, the theme-system migration guide),
+# and `four layers` collides with cogni-visual's four-layer validation gate and
+# cogni-trends' Foundations dimension. Each literal below is a phrase that was
+# measured present-and-wrong on the pre-reconciliation base, so each one is a
+# claim about this repo rather than a guess.
+#
+# The first two literals measured ZERO on the base — an earlier PR had already
+# removed them, which is why the issue's own acceptance criterion citing them was
+# vacuous. They are retained here anyway, and case L2 plants each one in a
+# fixture, so they are a live regression guard rather than dead config.
+#
+# Path exclusions, each with a reason:
+#   - this file (it necessarily contains every literal it forbids)
+#   - references/absorption-roadmap.md — the decisions record quotes the retired
+#     claim by design, as the historical inventory of what was reconciled
+#   - wiki/log.md and the bundled copy — a dated ingest log; rewriting history is
+#     not reconciliation
+#   - wiki/pages/lint-2026-04-20.md — a dated lint note, and root-tree-only, so
+#     editing it would also break the per-page parity assertion below
+#   - cogni-visual/libraries/ — "Foundation Layer" there is an ASCII-art fill
+#     label in a diagram legend, unrelated to the claim
+#
+# Parity is per-page, never tree-wide, and that is load-bearing. The two trees
+# legitimately differ (the root tree carries lint-2026-04-20.md and the bundled
+# one does not), and scripts/release-bundle-wiki.sh states that drift between
+# releases is acceptable. A tree-wide diff would be red on arrival and would
+# pressure someone into running that rsync --delete sync, which sweeps unrelated
+# drift. Naming the four pages this change touched keeps the assertion true and
+# useful at the same time.
+#
+# Case-label shape matches test-wiki-namespace-sync.sh on purpose: "PASS: <case>"
+# / "FAIL: <case>", because the cogni-service mutation harness classifies a case
+# GREEN only on ^[[:space:]]*(ok|PASS):[[:space:]]+<case> and RED on the matching
+# FAIL: form. Case ids are L-prefixed and never bare numerals, so the summary line
+# is not read as a case's RED line. Do not "fix" these back to the house
+# "OK   <label>" style.
+#
+# bash-3.2 portable (stock macOS /bin/bash is 3.2.57): no declare -A, no mapfile,
+# no ${var^^}. stdlib-only: bash + coreutils, no pip deps, no network.
+
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WS_ROOT="$(cd "$HERE/.." && pwd)"
+REPO_ROOT="$(cd "$WS_ROOT/.." && pwd)"
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+failures=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; failures=$((failures + 1)); }
+
+# Phrases that assert the retired layering claim. One per line; matched
+# case-insensitively as fixed strings, never as regexes.
+FORBIDDEN='every other plugin depends
+every other cogni-x plugin depends
+no upward dependencies
+foundation layer
+higher layers depend
+depend on lower layers
+depends on lower layers
+depends on nothing
+foundation for all'
+
+# Repo-relative path fragments exempt from the scan. See the header for why each
+# one is here.
+EXCLUDED='cogni-workspace/tests/test-layering-claim-reconciled.sh
+cogni-workspace/references/absorption-roadmap.md
+wiki/wiki/log.md
+wiki/wiki/pages/lint-2026-04-20.md
+cogni-visual/libraries/'
+
+# Pages that must stay byte-identical between the two wiki trees. Scoped to what
+# this reconciliation touched — see the header on why this is not tree-wide.
+PAGE_PARITY='plugin-cogni-workspace.md
+workflow-install-to-infographic.md
+arch-er-diagram.md
+concept-four-layer-architecture.md'
+
+# ---------------------------------------------------------------------------
+# The checkers. Fixture cases and the real-repo cases drive these same two
+# functions, so pointing a case at a broken checker turns that case red.
+# ---------------------------------------------------------------------------
+
+# is_excluded <repo-relative-path> -> 0 when the path is exempt.
+is_excluded() {
+  local path="$1" frag
+  while IFS= read -r frag; do
+    [ -n "$frag" ] || continue
+    case "$path" in
+      *"$frag"*) return 0 ;;
+    esac
+  done <<EOF
+$EXCLUDED
+EOF
+  return 1
+}
+
+# scan_literals <root> <label> -> 0 clean, 1 offenders found or root unusable.
+# Prints one "OFFENDER <path>: <literal>" line per hit.
+scan_literals() {
+  local root="$1" label="$2"
+  local offenders=0 scanned=0 lit hit path
+
+  if [ ! -d "$root" ]; then
+    echo "ERROR [$label] scan root not found: $root"
+    return 1
+  fi
+
+  while IFS= read -r lit; do
+    [ -n "$lit" ] || continue
+    scanned=$((scanned + 1))
+    # -R follows no symlinks by design; -I skips binaries; -l gives one path per file.
+    while IFS= read -r hit; do
+      [ -n "$hit" ] || continue
+      path="${hit#$root/}"
+      if is_excluded "$path"; then continue; fi
+      echo "OFFENDER $path: $lit"
+      offenders=$((offenders + 1))
+    done <<EOF
+$(grep -RIliF -- "$lit" "$root" 2>/dev/null || true)
+EOF
+  done <<EOF
+$FORBIDDEN
+EOF
+
+  # Liveness floor: a scan that examined no literals is not evidence of a clean
+  # tree, it is evidence of a broken constant. Same half-dead-arm failure
+  # test-wiki-namespace-sync.sh guards with its own empty-tree case.
+  if [ "$scanned" -eq 0 ]; then
+    echo "ERROR [$label] no literals scanned — FORBIDDEN is empty"
+    return 1
+  fi
+  [ "$offenders" -eq 0 ]
+}
+
+# check_parity <root> <label> -> 0 when every PAGE_PARITY page matches across trees.
+check_parity() {
+  local root="$1" label="$2"
+  local a="$root/wiki/wiki/pages" b="$root/cogni-workspace/wiki/wiki/pages"
+  local mismatches=0 compared=0 page
+
+  if [ ! -d "$a" ] || [ ! -d "$b" ]; then
+    echo "ERROR [$label] one or both wiki page trees not found"
+    return 1
+  fi
+
+  while IFS= read -r page; do
+    [ -n "$page" ] || continue
+    if [ ! -f "$a/$page" ] || [ ! -f "$b/$page" ]; then
+      echo "MISSING $page absent from one tree"
+      mismatches=$((mismatches + 1))
+      continue
+    fi
+    compared=$((compared + 1))
+    if ! cmp -s "$a/$page" "$b/$page"; then
+      echo "DRIFT $page differs between the two wiki trees"
+      mismatches=$((mismatches + 1))
+    fi
+  done <<EOF
+$PAGE_PARITY
+EOF
+
+  if [ "$compared" -eq 0 ] && [ "$mismatches" -eq 0 ]; then
+    echo "ERROR [$label] no pages compared — PAGE_PARITY is empty"
+    return 1
+  fi
+  [ "$mismatches" -eq 0 ]
+}
+
+# --- harness ---------------------------------------------------------------
+LAST_OUT=""; LAST_RC=0
+run_scan()   { LAST_OUT="$(scan_literals "$1" "$2" 2>&1)"; LAST_RC=$?; }
+run_parity() { LAST_OUT="$(check_parity  "$1" "$2" 2>&1)"; LAST_RC=$?; }
+assert_rc()      { [ "$LAST_RC" -eq "$1" ] || { echo "  expected rc=$1 got rc=$LAST_RC"; echo "$LAST_OUT" | sed 's/^/  | /'; return 1; }; }
+assert_out_has() { case "$LAST_OUT" in *"$1"*) return 0 ;; esac; echo "  expected output to contain: $1"; echo "$LAST_OUT" | sed 's/^/  | /'; return 1; }
+assert_out_lacks(){ case "$LAST_OUT" in *"$1"*) echo "  expected output NOT to contain: $1"; echo "$LAST_OUT" | sed 's/^/  | /'; return 1 ;; esac; return 0; }
+
+# ---------------------------------------------------------------------------
+# L1 — the real repo is clean.
+# ---------------------------------------------------------------------------
+run_scan "$REPO_ROOT" "repo"
+if assert_rc 0; then
+  pass "L1 the real repo asserts no retired layering claim"
+else
+  fail "L1 the real repo asserts no retired layering claim"
+fi
+
+# ---------------------------------------------------------------------------
+# L2 — every forbidden literal is caught when planted. This is what keeps the
+# two zero-on-base literals from being dead config.
+# ---------------------------------------------------------------------------
+l2_ok=1
+l2_n=0
+while IFS= read -r lit; do
+  [ -n "$lit" ] || continue
+  l2_n=$((l2_n + 1))
+  d="$TMPROOT/l2/$l2_n/docs"
+  mkdir -p "$d"
+  printf 'Some prose that says %s in passing.\n' "$lit" > "$d/page.md"
+  run_scan "$TMPROOT/l2/$l2_n" "planted"
+  assert_rc 1 && assert_out_has "docs/page.md" || l2_ok=0
+done <<EOF
+$FORBIDDEN
+EOF
+if [ "$l2_n" -lt 9 ]; then
+  echo "  expected at least 9 literals, found $l2_n"
+  l2_ok=0
+fi
+if [ "$l2_ok" -eq 1 ]; then
+  pass "L2 every forbidden literal is caught when planted"
+else
+  fail "L2 every forbidden literal is caught when planted"
+fi
+
+# ---------------------------------------------------------------------------
+# L3 — a literal under an excluded path is not flagged.
+# ---------------------------------------------------------------------------
+l3_ok=1
+mkdir -p "$TMPROOT/l3/cogni-visual/libraries" \
+         "$TMPROOT/l3/cogni-workspace/references" \
+         "$TMPROOT/l3/wiki/wiki/pages"
+printf '| Foundation Layer | fill |\n' > "$TMPROOT/l3/cogni-visual/libraries/svg-patterns.md"
+printf 'The claim was: every other plugin depends on it.\n' > "$TMPROOT/l3/cogni-workspace/references/absorption-roadmap.md"
+printf 'ingest: foundation layer\n' > "$TMPROOT/l3/wiki/wiki/log.md"
+printf 'quoted `no upward dependencies` in a lint note\n' > "$TMPROOT/l3/wiki/wiki/pages/lint-2026-04-20.md"
+run_scan "$TMPROOT/l3" "excluded"
+assert_rc 0 || l3_ok=0
+if [ "$l3_ok" -eq 1 ]; then
+  pass "L3 a forbidden literal under an excluded path is not flagged"
+else
+  fail "L3 a forbidden literal under an excluded path is not flagged"
+fi
+
+# ---------------------------------------------------------------------------
+# L4 — a PAGE_PARITY page that differs between the trees fails, and is named.
+# ---------------------------------------------------------------------------
+l4_ok=1
+A="$TMPROOT/l4/wiki/wiki/pages"; B="$TMPROOT/l4/cogni-workspace/wiki/wiki/pages"
+mkdir -p "$A" "$B"
+while IFS= read -r page; do
+  [ -n "$page" ] || continue
+  printf 'same\n' > "$A/$page"
+  printf 'same\n' > "$B/$page"
+done <<EOF
+$PAGE_PARITY
+EOF
+printf 'DIVERGED\n' > "$B/arch-er-diagram.md"
+run_parity "$TMPROOT/l4" "drift"
+assert_rc 1 && assert_out_has "arch-er-diagram.md" || l4_ok=0
+if [ "$l4_ok" -eq 1 ]; then
+  pass "L4 a touched page differing between the two trees fails and is named"
+else
+  fail "L4 a touched page differing between the two trees fails and is named"
+fi
+
+# ---------------------------------------------------------------------------
+# L5 — a page outside PAGE_PARITY may differ without failing. This is what keeps
+# the real trees' legitimate one-page delta from being red on arrival.
+# ---------------------------------------------------------------------------
+l5_ok=1
+A="$TMPROOT/l5/wiki/wiki/pages"; B="$TMPROOT/l5/cogni-workspace/wiki/wiki/pages"
+mkdir -p "$A" "$B"
+while IFS= read -r page; do
+  [ -n "$page" ] || continue
+  printf 'same\n' > "$A/$page"
+  printf 'same\n' > "$B/$page"
+done <<EOF
+$PAGE_PARITY
+EOF
+printf 'root-tree-only\n' > "$A/lint-2026-04-20.md"
+run_parity "$TMPROOT/l5" "unlisted"
+assert_rc 0 && assert_out_lacks "lint-2026-04-20" || l5_ok=0
+if [ "$l5_ok" -eq 1 ]; then
+  pass "L5 a page outside PAGE_PARITY may differ between the trees"
+else
+  fail "L5 a page outside PAGE_PARITY may differ between the trees"
+fi
+
+# ---------------------------------------------------------------------------
+# L6 — liveness floor: a missing tree fails rather than reporting clean.
+# ---------------------------------------------------------------------------
+l6_ok=1
+run_scan "$TMPROOT/l6/does-not-exist" "missing"
+assert_rc 1 && assert_out_has "scan root not found" || l6_ok=0
+run_parity "$TMPROOT/l6/does-not-exist" "missing"
+assert_rc 1 && assert_out_has "wiki page trees not found" || l6_ok=0
+if [ "$l6_ok" -eq 1 ]; then
+  pass "L6 a missing tree fails rather than reporting clean"
+else
+  fail "L6 a missing tree fails rather than reporting clean"
+fi
+
+# ---------------------------------------------------------------------------
+# L7 — the real repo's two wiki trees agree on every touched page.
+# ---------------------------------------------------------------------------
+run_parity "$REPO_ROOT" "repo"
+if assert_rc 0; then
+  pass "L7 the real wiki trees agree on every page this change touched"
+else
+  fail "L7 the real wiki trees agree on every page this change touched"
+fi
+
+# ---------------------------------------------------------------------------
+if [ "$failures" -gt 0 ]; then
+  echo ""
+  echo "FAIL: $failures layering-claim test(s) failed."
+  exit 1
+fi
+echo ""
+echo "All layering-claim tests passed."

--- a/cogni-workspace/tests/test-layering-claim-reconciled.sh
+++ b/cogni-workspace/tests/test-layering-claim-reconciled.sh
@@ -60,8 +60,17 @@
 # This list is why the shared-foundation literal below is prefixed with the
 # plugin name: the bare "is the shared foundation" also matches the first entry,
 # so an unprefixed literal would make this suite red on arrival against a line
-# that is deliberately standing. Without this block a later editor cannot tell a
-# compatible survivor from a missed one.
+# that is deliberately standing.
+#
+# The list is ILLUSTRATIVE, not exhaustive. It names the lines that shaped a
+# literal's wording, not every surviving use of "foundation". More exist — the
+# manage-workspace description propagates verbatim into its own frontmatter
+# (:4, :10), both wiki index.md:167, and both skill-cogni-workspace-manage-
+# workspace.md:16; cogni-help canonical-workflows.md:11 has its own. Those are
+# all the same compatible claim about workspace state, and no literal here
+# targets them. Grepping "foundation" will surface hits this block does not
+# account for; that is expected, and the test is whether the sentence asserts a
+# DEPENDENCY ORDER among plugins, not whether it uses the word.
 #
 # Path exclusions, each with a reason:
 #   - this file (it necessarily contains every literal it forbids)
@@ -430,7 +439,13 @@ if ! git init -q "$G" >/dev/null 2>&1; then
 else
   printf 'Some prose that says foundation layer in passing.\n' > "$G/docs/tracked.md"
   git -C "$G" add docs/tracked.md >/dev/null 2>&1
+  # commit.gpgsign is overridden too: it is a common personal global default, and
+  # a signing failure here would red this case for a reason with nothing to do
+  # with the arm under test — pointing a reader at the wrong code. CI is
+  # unaffected, so this only bites the local pre-PR run, which is where the
+  # suite's fastest signal is meant to come from.
   git -C "$G" -c user.email=guard@example.invalid -c user.name=Guard \
+    -c commit.gpgsign=false \
     commit -q -m "fixture" >/dev/null 2>&1 || l8_ok=0
 
   # Tracked offender must be found, and named, by the git arm.
@@ -446,6 +461,34 @@ if [ "$l8_ok" -eq 1 ]; then
   pass "L8 the git-tracked scan arm is live and skips untracked files"
 else
   fail "L8 the git-tracked scan arm is live and skips untracked files"
+fi
+
+# ---------------------------------------------------------------------------
+# L9 — the manifest exemption is scoped to two exact files, not to every
+# `.claude-plugin/` directory.
+#
+# Same lesson as L8: without a case, the narrowing is asserted only in a comment.
+# L1 is green whether EXCLUDED names the two paths or the old `.claude-plugin/`
+# fragment, because the two exempt manifests carry the literal either way and no
+# other manifest carries it today — so a revert to the fragment would silently
+# re-open a 15-file exemption with every case still passing. This case makes that
+# revert red by planting the literal in a DIFFERENT plugin's manifest, which must
+# be caught, while cogni-workspace's own stays exempt.
+# ---------------------------------------------------------------------------
+l9_ok=1
+X="$TMPROOT/l9"
+mkdir -p "$X/cogni-workspace/.claude-plugin" "$X/cogni-other/.claude-plugin"
+printf '{"description": "Foundation-layer plugin for insight-wave."}\n' \
+  > "$X/cogni-workspace/.claude-plugin/plugin.json"
+printf '{"description": "Foundation-layer plugin for insight-wave."}\n' \
+  > "$X/cogni-other/.claude-plugin/plugin.json"
+run_scan "$X" "manifest-scope"
+assert_rc 1 && assert_out_has "cogni-other/.claude-plugin/plugin.json" || l9_ok=0
+assert_out_lacks "cogni-workspace/.claude-plugin/plugin.json" || l9_ok=0
+if [ "$l9_ok" -eq 1 ]; then
+  pass "L9 the manifest exemption covers two exact files, not every .claude-plugin dir"
+else
+  fail "L9 the manifest exemption covers two exact files, not every .claude-plugin dir"
 fi
 
 # ---------------------------------------------------------------------------

--- a/cogni-workspace/wiki/wiki/index.md
+++ b/cogni-workspace/wiki/wiki/index.md
@@ -49,7 +49,7 @@ This is the content catalog for **insight-wave**. Every wiki page is listed here
 - [[plugin-cogni-trends]] — Strategic trend scouting and reporting pipeline.
 - [[plugin-cogni-visual]] — Transform polished narratives and structured data into visual deliverables — presentation briefs, slide decks, scrollable web narratives, poster storyboards, single-page infographics, and visual as....
 - [[plugin-cogni-website]] — Assembles multi-page customer websites from portfolio, marketing, trend, and research content produced by other insight-wave plugins.
-- [[plugin-cogni-workspace]] — Foundation-layer plugin for the insight-wave marketplace.
+- [[plugin-cogni-workspace]] — The horizontal layer of the insight-wave marketplace — it owns the shared workspace state the vertical business plugins consume.
 
 ### Workflows
 

--- a/cogni-workspace/wiki/wiki/pages/arch-er-diagram.md
+++ b/cogni-workspace/wiki/wiki/pages/arch-er-diagram.md
@@ -4,7 +4,7 @@ title: Entity relationships and cross-plugin data flow (architecture)
 type: summary
 tags: [architecture, entities, data-flow, bridge-files]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-08-13
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/docs/architecture/er-diagram.md
 status: stable
@@ -12,12 +12,12 @@ status: stable
 
 The cross-plugin entity model and how data flows between plugins. Every arrow is a read-only reference resolved at runtime — never a live connection or shared write path.
 
-## Four architectural layers
+## Architectural groups
 
-Plugins in higher layers depend on lower layers, not the reverse. See [[concept-four-layer-architecture]] for the full mapping.
+cogni-workspace is the horizontal layer owning shared workspace state; the business plugins are vertical, each keeping its own project lifecycle. The role groupings below are descriptive, not a dependency ordering. See [[concept-four-layer-architecture]] for the full mapping.
 
+- **Horizontal** — cogni-workspace (themes, env vars, vault config)
 - **Orchestration** — cogni-consulting (engagement state, phase dispatch)
-- **Foundation** — cogni-workspace (themes, env vars, vault config)
 - **Data** — cogni-portfolio, cogni-trends, cogni-research, cogni-claims (each owns a knowledge domain)
 - **Output** — cogni-narrative, cogni-copywriting, cogni-visual, cogni-sales, cogni-marketing (transform data-layer content into deliverables)
 

--- a/cogni-workspace/wiki/wiki/pages/concept-four-layer-architecture.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-four-layer-architecture.md
@@ -1,47 +1,46 @@
 ---
 id: concept-four-layer-architecture
-title: Four architectural layers (orchestration, foundation, data, output)
+title: Architectural groups (horizontal workspace, orchestration, data, output)
 type: concept
 tags: [architecture, layers, dependencies]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-08-13
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/docs/architecture/er-diagram.md
 status: stable
 ---
 
-The ecosystem (see [[ecosystem-overview]]) organizes into four layers. Plugins in higher layers depend on lower layers, but never the reverse.
+The ecosystem (see [[ecosystem-overview]]) splits along one line: cogni-workspace is **horizontal** infrastructure, and the business plugins are **vertical**, each keeping its own project lifecycle. A capability that owns a full `setup → resume → dashboard` arc is a vertical business plugin; a capability that owns none of that arc is horizontal infrastructure. The vertical plugins are grouped below by the role they play — that grouping is descriptive, not a dependency ordering.
 
 ```
-Orchestration   cogni-consulting
-                     |
-Foundation      cogni-workspace
-                     |
-Data            cogni-portfolio  cogni-trends  cogni-research  cogni-claims
-                     |
-Output          cogni-narrative  cogni-copywriting  cogni-visual
-                cogni-sales      cogni-marketing
+horizontal   cogni-workspace
+─────────────────────────────────────────────────────────────────
+vertical     Orchestration   cogni-consult
+             Data            cogni-portfolio  cogni-trends
+                             cogni-knowledge  cogni-claims
+             Output          cogni-narrative  cogni-copywriting
+                             cogni-visual     cogni-sales
+                             cogni-marketing
 ```
 
-## The layers
+## The groups
 
-- **Foundation** (cogni-workspace) — shared infrastructure: themes, environment variables, Obsidian vault configuration, MCP server installation. Every plugin that produces visual HTML output reads theme files from cogni-workspace. No plugin writes to cogni-workspace except through `pick-theme` and `manage-workspace`.
-- **Data** — each plugin owns a specialized knowledge domain. cogni-portfolio (products, markets, propositions, competitors). cogni-trends (TIPS paths, solution templates, catalogs). cogni-research (sub-questions, contexts, sources, claims). cogni-claims (verification state across all sourced assertions).
-- **Output** — transforms data-layer content into deliverables (narratives, polished docs, slides/HTML/infographics, sales pitches, marketing campaigns). Consumes but does not produce data-layer entities.
-- **Orchestration** (cogni-consulting) — manages engagement state. Dispatches to data and output layers at phase-appropriate moments without producing content itself. See [[concept-orchestrator-pattern]].
+- **Horizontal** (cogni-workspace) — shared infrastructure: themes, environment variables, Obsidian vault configuration, MCP server installation. Every plugin that produces visual HTML output reads theme files from cogni-workspace. No plugin writes to cogni-workspace except through `pick-theme` and `manage-workspace`.
+- **Data** — each plugin owns a specialized knowledge domain. cogni-portfolio (products, markets, propositions, competitors). cogni-trends (TIPS paths, solution templates, catalogs). cogni-knowledge (sub-questions, contexts, sources, claims). cogni-claims (verification state across all sourced assertions).
+- **Output** — transforms data-group content into deliverables (narratives, polished docs, slides/HTML/infographics, sales pitches, marketing campaigns). Consumes but does not produce data-group entities.
+- **Orchestration** (cogni-consult) — manages engagement state. Dispatches to data and output plugins at phase-appropriate moments without producing content itself. See [[concept-orchestrator-pattern]].
 
-## Why this layering
+## Why these groups
 
-The dependency direction is the contract: a data-layer plugin can be rebuilt without touching output plugins (they read entities; they don't depend on internal implementation). Output plugins can be added or replaced without touching data plugins. cogni-help and cogni-docs cut across layers as utility plugins (help, documentation) that depend on everything but are depended on by nothing.
+Substitutability is the point: a data-group plugin can be rebuilt without touching output plugins (they read entities; they don't depend on internal implementation), and output plugins can be added or replaced without touching data plugins. cogni-help and cogni-docs are cross-cutting utilities (help, documentation) that read from every plugin and are read by none.
 
-This layering combines with [[concept-data-isolation]] (each layer's plugins don't share writes) and [[concept-progressive-disclosure]] (each phase loads only its slice) to make the ecosystem horizontally extensible.
+The grouping combines with [[concept-data-isolation]] (plugins don't share writes) and [[concept-progressive-disclosure]] (each phase loads only its slice) to make the ecosystem horizontally extensible.
 
-## Plugins not in the four layers
+## Plugins outside the groups
 
-- **cogni-help** — utility, depends on everything via knowledge of skills/agents (read-only), is depended on by nothing.
+- **cogni-help** — utility, reads every plugin's skills/agents (read-only), is read by none.
 - **cogni-docs** — utility, generates documentation by reading every plugin's structure.
-- **cogni-wiki** — utility, ships this knowledge base.
 
-These don't violate the layering — they're tools that consume the four-layer model rather than participate in it.
+These are tools that consume the model rather than participate in it.
 
 **Source**: [docs/architecture/er-diagram.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/docs/architecture/er-diagram.md)

--- a/cogni-workspace/wiki/wiki/pages/concept-four-layer-architecture.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-four-layer-architecture.md
@@ -20,14 +20,14 @@ vertical     Orchestration   cogni-consult
                              cogni-knowledge  cogni-claims
              Output          cogni-narrative  cogni-copywriting
                              cogni-visual     cogni-sales
-                             cogni-marketing
+                             cogni-marketing  cogni-website
 ```
 
 ## The groups
 
 - **Horizontal** (cogni-workspace) — shared infrastructure: themes, environment variables, Obsidian vault configuration, MCP server installation. Every plugin that produces visual HTML output reads theme files from cogni-workspace. No plugin writes to cogni-workspace except through `pick-theme` and `manage-workspace`.
 - **Data** — each plugin owns a specialized knowledge domain. cogni-portfolio (products, markets, propositions, competitors). cogni-trends (TIPS paths, solution templates, catalogs). cogni-knowledge (sub-questions, contexts, sources, claims). cogni-claims (verification state across all sourced assertions).
-- **Output** — transforms data-group content into deliverables (narratives, polished docs, slides/HTML/infographics, sales pitches, marketing campaigns). Consumes but does not produce data-group entities.
+- **Output** — cogni-narrative, cogni-copywriting, cogni-visual, cogni-sales, cogni-marketing, cogni-website. Transforms data-group content into deliverables (narratives, polished docs, slides/HTML/infographics, sales pitches, marketing campaigns, customer websites). Consumes but does not produce data-group entities.
 - **Orchestration** (cogni-consult) — manages engagement state. Dispatches to data and output plugins at phase-appropriate moments without producing content itself. See [[concept-orchestrator-pattern]].
 
 ## Why these groups
@@ -39,7 +39,7 @@ The grouping combines with [[concept-data-isolation]] (plugins don't share write
 ## Plugins outside the groups
 
 - **cogni-help** — utility, reads every plugin's skills/agents (read-only), is read by none.
-- **cogni-docs** — utility, generates documentation by reading every plugin's structure.
+- **cogni-docs** — utility, generates documentation by reading every plugin's structure. Maintainer-side and not one of the 13 marketplace plugins; it ships separately.
 
 These are tools that consume the model rather than participate in it.
 

--- a/cogni-workspace/wiki/wiki/pages/plugin-cogni-workspace.md
+++ b/cogni-workspace/wiki/wiki/pages/plugin-cogni-workspace.md
@@ -14,7 +14,7 @@ related: [concept-theme-inheritance, concept-mcp-server-map]
 
 > **Preview** (v0.6.3) — core skills defined but may change.
 
-Foundation-layer plugin for the insight-wave marketplace. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, and Obsidian vault integration.
+The horizontal layer of the insight-wave marketplace — it owns the shared workspace state the vertical business plugins consume. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, and Obsidian vault integration.
 
 ## Layer
 

--- a/cogni-workspace/wiki/wiki/pages/plugin-cogni-workspace.md
+++ b/cogni-workspace/wiki/wiki/pages/plugin-cogni-workspace.md
@@ -42,6 +42,6 @@ The horizontal layer of the insight-wave marketplace — it owns the shared work
 
 ## Integration
 
-The horizontal layer the other 13 plugins consume. cogni-workspace is the first install — `manage-workspace` initializes the directory structure that every other plugin's project directories live inside. `pick-theme` is called by every visual plugin (cogni-visual, cogni-website, cogni-portfolio dashboards, cogni-trends dashboards).
+The horizontal layer the vertical business plugins consume. cogni-workspace is the first install — `manage-workspace` initializes the directory structure that every other plugin's project directories live inside. `pick-theme` is called by every visual plugin (cogni-visual, cogni-website, cogni-portfolio dashboards, cogni-trends dashboards).
 
 **Source**: [cogni-workspace README](https://github.com/cogni-work/insight-wave/blob/main/cogni-workspace/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-workspace.md)

--- a/cogni-workspace/wiki/wiki/pages/plugin-cogni-workspace.md
+++ b/cogni-workspace/wiki/wiki/pages/plugin-cogni-workspace.md
@@ -18,7 +18,7 @@ Foundation-layer plugin for the insight-wave marketplace. Manages shared infrast
 
 ## Layer
 
-[[concept-four-layer-architecture|Foundation layer]]. Every plugin that produces visual HTML output reads themes from cogni-workspace; every plugin needing an MCP server is installed via cogni-workspace.
+[[concept-four-layer-architecture|Horizontal layer]]. Every plugin that produces visual HTML output reads themes from cogni-workspace; every plugin needing an MCP server is installed via cogni-workspace.
 
 ## Skills
 
@@ -42,6 +42,6 @@ Foundation-layer plugin for the insight-wave marketplace. Manages shared infrast
 
 ## Integration
 
-Foundation for all 13 other plugins. cogni-workspace is the first install — `manage-workspace` initializes the directory structure that every other plugin's project directories live inside. `pick-theme` is called by every visual plugin (cogni-visual, cogni-website, cogni-portfolio dashboards, cogni-trends dashboards).
+The horizontal layer the other 13 plugins consume. cogni-workspace is the first install — `manage-workspace` initializes the directory structure that every other plugin's project directories live inside. `pick-theme` is called by every visual plugin (cogni-visual, cogni-website, cogni-portfolio dashboards, cogni-trends dashboards).
 
 **Source**: [cogni-workspace README](https://github.com/cogni-work/insight-wave/blob/main/cogni-workspace/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-workspace.md)

--- a/cogni-workspace/wiki/wiki/pages/workflow-install-to-infographic.md
+++ b/cogni-workspace/wiki/wiki/pages/workflow-install-to-infographic.md
@@ -39,7 +39,7 @@ A themed infographic rendered as SVG (Excalidraw) or `.pen` file (Pencil), align
 
 ## How it works
 
-The workflow is sequenced so you verify each layer before depending on it. [[plugin-cogni-workspace]] is installed first because every other plugin depends on it. `manage-workspace` initializes the directory structure, `install-mcp` brings up the MCP servers ([[concept-mcp-server-map]]), and `manage-themes` extracts your brand colors via `claude-in-chrome` browser automation.
+The workflow is sequenced so you verify each layer before depending on it. [[plugin-cogni-workspace]] is installed first because it owns the shared workspace state the later steps read. `manage-workspace` initializes the directory structure, `install-mcp` brings up the MCP servers ([[concept-mcp-server-map]]), and `manage-themes` extracts your brand colors via `claude-in-chrome` browser automation.
 
 [[plugin-cogni-visual]] then renders an infographic. `story-to-infographic` turns a narrative (e.g., a one-paragraph product positioning) into a structured `infographic-brief.md`. The matching render skill (Pencil for editorial, Excalidraw for sketchnote/whiteboard) then produces the visual. See [[concept-brief-based-rendering]].
 

--- a/docs/architecture/er-diagram.md
+++ b/docs/architecture/er-diagram.md
@@ -4,32 +4,30 @@ This document places the insight-wave entity model in context. The canonical dat
 
 ---
 
-## Four Architectural Layers
+## Architectural Groups
 
-The ecosystem organizes into four layers. Plugins in higher layers depend on plugins in lower layers, but not the reverse.
+The ecosystem splits along one line: cogni-workspace is **horizontal** infrastructure, and the business plugins are **vertical**, each keeping its own project lifecycle. The rule is the one recorded in [`absorption-roadmap.md`](../../cogni-workspace/references/absorption-roadmap.md) — a capability owning a full `setup → resume → dashboard` arc is a vertical business plugin; one owning none of that arc is horizontal infrastructure. The vertical plugins are grouped below by the role they play; that grouping is descriptive, not a dependency ordering.
 
 ```
-Orchestration   cogni-consult
-                     |
-Foundation      cogni-workspace
-                     |
-Data            cogni-portfolio  cogni-trends  cogni-knowledge  cogni-claims
-                     |
-Output          cogni-narrative  cogni-copywriting  cogni-visual
-                cogni-sales      cogni-marketing
+horizontal   cogni-workspace  (shared workspace state: themes, env vars, discovery)
+─────────────────────────────────────────────────────────────────────────────────
+vertical     Orchestration   cogni-consult
+             Data            cogni-portfolio  cogni-trends  cogni-knowledge  cogni-claims
+             Output          cogni-narrative  cogni-copywriting  cogni-visual
+                             cogni-sales      cogni-marketing
 ```
 
-**Foundation layer** (cogni-workspace) provides shared infrastructure: themes, environment variables, Obsidian vault configuration. Every plugin that produces visual HTML output reads theme files from cogni-workspace. No plugin writes to cogni-workspace except through the `pick-theme` and `manage-workspace` skills.
+**Shared workspace** (cogni-workspace) provides shared infrastructure: themes, environment variables, Obsidian vault configuration. Every plugin that produces visual HTML output reads theme files from cogni-workspace. No plugin writes to cogni-workspace except through the `pick-theme` and `manage-workspace` skills.
 
-**Data layer** plugins each own a specialized knowledge domain:
+**Data group** plugins each own a specialized knowledge domain:
 - cogni-portfolio owns product and market knowledge (features, propositions, competitors)
 - cogni-trends owns trend and value model knowledge (TIPS paths, solution templates, catalogs)
 - cogni-knowledge owns research artifacts in the bound wiki (sources, syntheses, distilled concepts, question nodes, claims)
 - cogni-claims owns the verification state for sourced assertions from any plugin
 
-**Output layer** plugins transform data-layer content into deliverables. They consume but do not produce data-layer entities.
+**Output group** plugins transform data-group content into deliverables. They consume but do not produce data-group entities.
 
-**Orchestration layer** (cogni-consult) manages engagement state. It dispatches research through the engagement's bound cogni-knowledge base and routes deliverable work to data and output layer plugins, but does not produce content itself. (It succeeds the archived cogni-consulting Double Diamond plugin.)
+**Orchestration group** (cogni-consult) manages engagement state. It dispatches research through the engagement's bound cogni-knowledge base and routes deliverable work to data and output group plugins, but does not produce content itself. (It succeeds the archived cogni-consulting Double Diamond plugin.)
 
 ---
 

--- a/docs/claude-code-desktop.md
+++ b/docs/claude-code-desktop.md
@@ -233,7 +233,7 @@ Your Claude Code is ready. The plugin ecosystem and MCP servers for insight-wave
 
 **Continue here:** [From Install to Infographic](workflows/install-to-infographic.md) — the 15-minute first-run workflow that adds the insight-wave marketplace, installs the plugins you need, runs `/install-mcp` for Pencil + Excalidraw + claude-in-chrome, and renders your first infographic.
 
-Why one walkthrough rather than separate plugin / MCP steps here? insight-wave ships `cogni-workspace` as the foundation layer (it sets up directories, themes, and MCP defaults), and `/install-mcp` handles all three MCP servers at once. Hand-running `claude mcp add` for each server works for generic Claude Code setups but conflicts with the insight-wave pattern. For enterprise-managed MCP configuration (MDM, allow-lists, managed settings), see [Deployment Guide](deployment-guide.md).
+Why one walkthrough rather than separate plugin / MCP steps here? insight-wave ships `cogni-workspace` as the shared workspace layer (it sets up directories, themes, and MCP defaults), and `/install-mcp` handles all three MCP servers at once. Hand-running `claude mcp add` for each server works for generic Claude Code setups but conflicts with the insight-wave pattern. For enterprise-managed MCP configuration (MDM, allow-lists, managed settings), see [Deployment Guide](deployment-guide.md).
 
 ---
 

--- a/docs/ecosystem-overview.md
+++ b/docs/ecosystem-overview.md
@@ -10,11 +10,11 @@ For the canonical plugin descriptions, see the individual README files. For step
 
 The 13 plugins are grouped by the role they play in a typical engagement — the same set the root [`marketplace.json`](../.claude-plugin/marketplace.json) enumerates.
 
-### Foundation
+### Workspace Infrastructure
 
 | Plugin | What it does |
 |--------|-------------|
-| [cogni-workspace](../cogni-workspace/README.md) | Initializes the shared workspace: environment variables, plugin discovery, theme management, and Obsidian vault integration. Every other plugin depends on it. |
+| [cogni-workspace](../cogni-workspace/README.md) | Initializes the shared workspace: environment variables, plugin discovery, theme management, and Obsidian vault integration. The vertical business plugins consume the shared state it owns; each keeps its own project lifecycle. |
 
 Run `/manage-workspace` once per project directory before using any other plugin.
 

--- a/docs/er-diagram.md
+++ b/docs/er-diagram.md
@@ -2,7 +2,7 @@
 
 How data flows between insight-wave plugins. No shared database — all cross-references are resolved at runtime via slug-based lookups, bridge files, and YAML frontmatter contracts.
 
-## Architecture Layers
+## Architectural Groups
 
 ```mermaid
 graph LR
@@ -10,7 +10,7 @@ graph LR
         DM[cogni-consult<br/>engagements, action fields<br/>deliverable state, personas]
     end
 
-    subgraph Foundation["Foundation Layer"]
+    subgraph Foundation["Shared Workspace (horizontal)"]
         WS[cogni-workspace<br/>themes, env vars, discovery<br/>obsidian, terminal, notes]
     end
 
@@ -36,7 +36,7 @@ graph LR
     DM -->|dispatches define/deliver| CL
     DM -->|dispatches export| VI
 
-    %% Foundation → All
+    %% Shared workspace → consumers
     WS -.->|themes| VI
     WS -.->|env vars| PF
     WS -.->|env vars| TI

--- a/docs/plugin-guide/cogni-workspace.md
+++ b/docs/plugin-guide/cogni-workspace.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-cogni-workspace is the foundation layer for the insight-wave ecosystem. Before any other cogni-x plugin can run reliably, it needs: a place to find the workspace root, environment variables pointing to shared resources, a theme directory, and knowledge of which other plugins are installed. cogni-workspace provides all of this through a single initialization command and a set of management skills.
+cogni-workspace is the horizontal layer of the insight-wave ecosystem — it owns the shared workspace state that the vertical business plugins consume. Before any other cogni-x plugin can run reliably, it needs: a place to find the workspace root, environment variables pointing to shared resources, a theme directory, and knowledge of which other plugins are installed. cogni-workspace provides all of this through a single initialization command and a set of management skills.
 
 In practice, most users interact with cogni-workspace twice: once when setting up a new workspace (`manage-workspace`), and occasionally when something drifts out of sync (`workspace-status`, `manage-workspace`). Theme management and Obsidian integration are optional — use them if you want visual consistency across plugin outputs or a terminal-integrated note-taking environment.
 
@@ -209,9 +209,9 @@ cogni-workspace owns the canonical market registry (`references/supported-market
 
 ## Integration Points
 
-### Upstream — cogni-workspace depends on nothing
+### Upstream — cogni-workspace requires no other plugin
 
-cogni-workspace is the foundation layer. It has no plugin dependencies. Every other plugin depends on it, not the other way around.
+cogni-workspace has no required plugin dependencies. Its scope is horizontal: the vertical business plugins consume the shared state it owns, while each keeps its own project lifecycle.
 
 ### Downstream — every visual and content plugin uses the workspace
 

--- a/docs/workflows/install-to-infographic.md
+++ b/docs/workflows/install-to-infographic.md
@@ -40,7 +40,7 @@ Pick **Marketplaces → insight-wave** and switch on the auto-update option. Cla
 /plugin marketplace update insight-wave
 ```
 
-Install the full insight-wave plugin set — any workflow you pick from Step 5 can then run without you coming back here. Start with `cogni-workspace` (the foundation the others depend on), then the rest:
+Install the full insight-wave plugin set — any workflow you pick from Step 5 can then run without you coming back here. Start with `cogni-workspace` (it owns the shared workspace state the others read), then the rest:
 
 ```
 /plugin install cogni-workspace@insight-wave
@@ -62,7 +62,7 @@ Or browse the **Discover** tab interactively inside `/plugin`.
 
 ## Step 2: Initialize Your Workspace
 
-cogni-workspace is the shared foundation — it sets up the directories, themes, and MCP servers that every other plugin relies on.
+cogni-workspace is the horizontal layer of the ecosystem — it owns the shared workspace state (directories, themes, MCP servers) that the vertical business plugins consume.
 
 ```
 /manage-workspace

--- a/wiki/wiki/index.md
+++ b/wiki/wiki/index.md
@@ -49,7 +49,7 @@ This is the content catalog for **insight-wave**. Every wiki page is listed here
 - [[plugin-cogni-trends]] — Strategic trend scouting and reporting pipeline.
 - [[plugin-cogni-visual]] — Transform polished narratives and structured data into visual deliverables — presentation briefs, slide decks, scrollable web narratives, poster storyboards, single-page infographics, and visual as....
 - [[plugin-cogni-website]] — Assembles multi-page customer websites from portfolio, marketing, trend, and research content produced by other insight-wave plugins.
-- [[plugin-cogni-workspace]] — Foundation-layer plugin for the insight-wave marketplace.
+- [[plugin-cogni-workspace]] — The horizontal layer of the insight-wave marketplace — it owns the shared workspace state the vertical business plugins consume.
 
 ### Workflows
 

--- a/wiki/wiki/pages/arch-er-diagram.md
+++ b/wiki/wiki/pages/arch-er-diagram.md
@@ -4,7 +4,7 @@ title: Entity relationships and cross-plugin data flow (architecture)
 type: summary
 tags: [architecture, entities, data-flow, bridge-files]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-08-13
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/docs/architecture/er-diagram.md
 status: stable
@@ -12,12 +12,12 @@ status: stable
 
 The cross-plugin entity model and how data flows between plugins. Every arrow is a read-only reference resolved at runtime — never a live connection or shared write path.
 
-## Four architectural layers
+## Architectural groups
 
-Plugins in higher layers depend on lower layers, not the reverse. See [[concept-four-layer-architecture]] for the full mapping.
+cogni-workspace is the horizontal layer owning shared workspace state; the business plugins are vertical, each keeping its own project lifecycle. The role groupings below are descriptive, not a dependency ordering. See [[concept-four-layer-architecture]] for the full mapping.
 
+- **Horizontal** — cogni-workspace (themes, env vars, vault config)
 - **Orchestration** — cogni-consulting (engagement state, phase dispatch)
-- **Foundation** — cogni-workspace (themes, env vars, vault config)
 - **Data** — cogni-portfolio, cogni-trends, cogni-research, cogni-claims (each owns a knowledge domain)
 - **Output** — cogni-narrative, cogni-copywriting, cogni-visual, cogni-sales, cogni-marketing (transform data-layer content into deliverables)
 

--- a/wiki/wiki/pages/concept-four-layer-architecture.md
+++ b/wiki/wiki/pages/concept-four-layer-architecture.md
@@ -1,47 +1,46 @@
 ---
 id: concept-four-layer-architecture
-title: Four architectural layers (orchestration, foundation, data, output)
+title: Architectural groups (horizontal workspace, orchestration, data, output)
 type: concept
 tags: [architecture, layers, dependencies]
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-08-13
 sources:
   - https://github.com/cogni-work/insight-wave/blob/main/docs/architecture/er-diagram.md
 status: stable
 ---
 
-The ecosystem (see [[ecosystem-overview]]) organizes into four layers. Plugins in higher layers depend on lower layers, but never the reverse.
+The ecosystem (see [[ecosystem-overview]]) splits along one line: cogni-workspace is **horizontal** infrastructure, and the business plugins are **vertical**, each keeping its own project lifecycle. A capability that owns a full `setup → resume → dashboard` arc is a vertical business plugin; a capability that owns none of that arc is horizontal infrastructure. The vertical plugins are grouped below by the role they play — that grouping is descriptive, not a dependency ordering.
 
 ```
-Orchestration   cogni-consulting
-                     |
-Foundation      cogni-workspace
-                     |
-Data            cogni-portfolio  cogni-trends  cogni-research  cogni-claims
-                     |
-Output          cogni-narrative  cogni-copywriting  cogni-visual
-                cogni-sales      cogni-marketing
+horizontal   cogni-workspace
+─────────────────────────────────────────────────────────────────
+vertical     Orchestration   cogni-consult
+             Data            cogni-portfolio  cogni-trends
+                             cogni-knowledge  cogni-claims
+             Output          cogni-narrative  cogni-copywriting
+                             cogni-visual     cogni-sales
+                             cogni-marketing
 ```
 
-## The layers
+## The groups
 
-- **Foundation** (cogni-workspace) — shared infrastructure: themes, environment variables, Obsidian vault configuration, MCP server installation. Every plugin that produces visual HTML output reads theme files from cogni-workspace. No plugin writes to cogni-workspace except through `pick-theme` and `manage-workspace`.
-- **Data** — each plugin owns a specialized knowledge domain. cogni-portfolio (products, markets, propositions, competitors). cogni-trends (TIPS paths, solution templates, catalogs). cogni-research (sub-questions, contexts, sources, claims). cogni-claims (verification state across all sourced assertions).
-- **Output** — transforms data-layer content into deliverables (narratives, polished docs, slides/HTML/infographics, sales pitches, marketing campaigns). Consumes but does not produce data-layer entities.
-- **Orchestration** (cogni-consulting) — manages engagement state. Dispatches to data and output layers at phase-appropriate moments without producing content itself. See [[concept-orchestrator-pattern]].
+- **Horizontal** (cogni-workspace) — shared infrastructure: themes, environment variables, Obsidian vault configuration, MCP server installation. Every plugin that produces visual HTML output reads theme files from cogni-workspace. No plugin writes to cogni-workspace except through `pick-theme` and `manage-workspace`.
+- **Data** — each plugin owns a specialized knowledge domain. cogni-portfolio (products, markets, propositions, competitors). cogni-trends (TIPS paths, solution templates, catalogs). cogni-knowledge (sub-questions, contexts, sources, claims). cogni-claims (verification state across all sourced assertions).
+- **Output** — transforms data-group content into deliverables (narratives, polished docs, slides/HTML/infographics, sales pitches, marketing campaigns). Consumes but does not produce data-group entities.
+- **Orchestration** (cogni-consult) — manages engagement state. Dispatches to data and output plugins at phase-appropriate moments without producing content itself. See [[concept-orchestrator-pattern]].
 
-## Why this layering
+## Why these groups
 
-The dependency direction is the contract: a data-layer plugin can be rebuilt without touching output plugins (they read entities; they don't depend on internal implementation). Output plugins can be added or replaced without touching data plugins. cogni-help and cogni-docs cut across layers as utility plugins (help, documentation) that depend on everything but are depended on by nothing.
+Substitutability is the point: a data-group plugin can be rebuilt without touching output plugins (they read entities; they don't depend on internal implementation), and output plugins can be added or replaced without touching data plugins. cogni-help and cogni-docs are cross-cutting utilities (help, documentation) that read from every plugin and are read by none.
 
-This layering combines with [[concept-data-isolation]] (each layer's plugins don't share writes) and [[concept-progressive-disclosure]] (each phase loads only its slice) to make the ecosystem horizontally extensible.
+The grouping combines with [[concept-data-isolation]] (plugins don't share writes) and [[concept-progressive-disclosure]] (each phase loads only its slice) to make the ecosystem horizontally extensible.
 
-## Plugins not in the four layers
+## Plugins outside the groups
 
-- **cogni-help** — utility, depends on everything via knowledge of skills/agents (read-only), is depended on by nothing.
+- **cogni-help** — utility, reads every plugin's skills/agents (read-only), is read by none.
 - **cogni-docs** — utility, generates documentation by reading every plugin's structure.
-- **cogni-wiki** — utility, ships this knowledge base.
 
-These don't violate the layering — they're tools that consume the four-layer model rather than participate in it.
+These are tools that consume the model rather than participate in it.
 
 **Source**: [docs/architecture/er-diagram.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/docs/architecture/er-diagram.md)

--- a/wiki/wiki/pages/concept-four-layer-architecture.md
+++ b/wiki/wiki/pages/concept-four-layer-architecture.md
@@ -20,14 +20,14 @@ vertical     Orchestration   cogni-consult
                              cogni-knowledge  cogni-claims
              Output          cogni-narrative  cogni-copywriting
                              cogni-visual     cogni-sales
-                             cogni-marketing
+                             cogni-marketing  cogni-website
 ```
 
 ## The groups
 
 - **Horizontal** (cogni-workspace) — shared infrastructure: themes, environment variables, Obsidian vault configuration, MCP server installation. Every plugin that produces visual HTML output reads theme files from cogni-workspace. No plugin writes to cogni-workspace except through `pick-theme` and `manage-workspace`.
 - **Data** — each plugin owns a specialized knowledge domain. cogni-portfolio (products, markets, propositions, competitors). cogni-trends (TIPS paths, solution templates, catalogs). cogni-knowledge (sub-questions, contexts, sources, claims). cogni-claims (verification state across all sourced assertions).
-- **Output** — transforms data-group content into deliverables (narratives, polished docs, slides/HTML/infographics, sales pitches, marketing campaigns). Consumes but does not produce data-group entities.
+- **Output** — cogni-narrative, cogni-copywriting, cogni-visual, cogni-sales, cogni-marketing, cogni-website. Transforms data-group content into deliverables (narratives, polished docs, slides/HTML/infographics, sales pitches, marketing campaigns, customer websites). Consumes but does not produce data-group entities.
 - **Orchestration** (cogni-consult) — manages engagement state. Dispatches to data and output plugins at phase-appropriate moments without producing content itself. See [[concept-orchestrator-pattern]].
 
 ## Why these groups
@@ -39,7 +39,7 @@ The grouping combines with [[concept-data-isolation]] (plugins don't share write
 ## Plugins outside the groups
 
 - **cogni-help** — utility, reads every plugin's skills/agents (read-only), is read by none.
-- **cogni-docs** — utility, generates documentation by reading every plugin's structure.
+- **cogni-docs** — utility, generates documentation by reading every plugin's structure. Maintainer-side and not one of the 13 marketplace plugins; it ships separately.
 
 These are tools that consume the model rather than participate in it.
 

--- a/wiki/wiki/pages/plugin-cogni-workspace.md
+++ b/wiki/wiki/pages/plugin-cogni-workspace.md
@@ -14,7 +14,7 @@ related: [concept-theme-inheritance, concept-mcp-server-map]
 
 > **Preview** (v0.6.3) — core skills defined but may change.
 
-Foundation-layer plugin for the insight-wave marketplace. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, and Obsidian vault integration.
+The horizontal layer of the insight-wave marketplace — it owns the shared workspace state the vertical business plugins consume. Manages shared infrastructure (env vars, settings), MCP server installation and Desktop config patching, theme management, theme picker, plugin discovery, workspace health, and Obsidian vault integration.
 
 ## Layer
 

--- a/wiki/wiki/pages/plugin-cogni-workspace.md
+++ b/wiki/wiki/pages/plugin-cogni-workspace.md
@@ -42,6 +42,6 @@ The horizontal layer of the insight-wave marketplace — it owns the shared work
 
 ## Integration
 
-The horizontal layer the other 13 plugins consume. cogni-workspace is the first install — `manage-workspace` initializes the directory structure that every other plugin's project directories live inside. `pick-theme` is called by every visual plugin (cogni-visual, cogni-website, cogni-portfolio dashboards, cogni-trends dashboards).
+The horizontal layer the vertical business plugins consume. cogni-workspace is the first install — `manage-workspace` initializes the directory structure that every other plugin's project directories live inside. `pick-theme` is called by every visual plugin (cogni-visual, cogni-website, cogni-portfolio dashboards, cogni-trends dashboards).
 
 **Source**: [cogni-workspace README](https://github.com/cogni-work/insight-wave/blob/main/cogni-workspace/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-workspace.md)

--- a/wiki/wiki/pages/plugin-cogni-workspace.md
+++ b/wiki/wiki/pages/plugin-cogni-workspace.md
@@ -18,7 +18,7 @@ Foundation-layer plugin for the insight-wave marketplace. Manages shared infrast
 
 ## Layer
 
-[[concept-four-layer-architecture|Foundation layer]]. Every plugin that produces visual HTML output reads themes from cogni-workspace; every plugin needing an MCP server is installed via cogni-workspace.
+[[concept-four-layer-architecture|Horizontal layer]]. Every plugin that produces visual HTML output reads themes from cogni-workspace; every plugin needing an MCP server is installed via cogni-workspace.
 
 ## Skills
 
@@ -42,6 +42,6 @@ Foundation-layer plugin for the insight-wave marketplace. Manages shared infrast
 
 ## Integration
 
-Foundation for all 13 other plugins. cogni-workspace is the first install — `manage-workspace` initializes the directory structure that every other plugin's project directories live inside. `pick-theme` is called by every visual plugin (cogni-visual, cogni-website, cogni-portfolio dashboards, cogni-trends dashboards).
+The horizontal layer the other 13 plugins consume. cogni-workspace is the first install — `manage-workspace` initializes the directory structure that every other plugin's project directories live inside. `pick-theme` is called by every visual plugin (cogni-visual, cogni-website, cogni-portfolio dashboards, cogni-trends dashboards).
 
 **Source**: [cogni-workspace README](https://github.com/cogni-work/insight-wave/blob/main/cogni-workspace/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-workspace.md)

--- a/wiki/wiki/pages/workflow-install-to-infographic.md
+++ b/wiki/wiki/pages/workflow-install-to-infographic.md
@@ -39,7 +39,7 @@ A themed infographic rendered as SVG (Excalidraw) or `.pen` file (Pencil), align
 
 ## How it works
 
-The workflow is sequenced so you verify each layer before depending on it. [[plugin-cogni-workspace]] is installed first because every other plugin depends on it. `manage-workspace` initializes the directory structure, `install-mcp` brings up the MCP servers ([[concept-mcp-server-map]]), and `manage-themes` extracts your brand colors via `claude-in-chrome` browser automation.
+The workflow is sequenced so you verify each layer before depending on it. [[plugin-cogni-workspace]] is installed first because it owns the shared workspace state the later steps read. `manage-workspace` initializes the directory structure, `install-mcp` brings up the MCP servers ([[concept-mcp-server-map]]), and `manage-themes` extracts your brand colors via `claude-in-chrome` browser automation.
 
 [[plugin-cogni-visual]] then renders an infographic. `story-to-infographic` turns a narrative (e.g., a one-paragraph product positioning) into a structured `infographic-brief.md`. The matching render skill (Pencil for editorial, Excalidraw for sketchnote/whiteboard) then produces the visual. See [[concept-brief-based-rendering]].
 


### PR DESCRIPTION
Closes #1368.

## Summary

Replaces the retired **layering** claim — cogni-workspace is the foundation layer every other plugin depends on — with the committed **scope** claim from `cogni-workspace/README.md:7,24` and `references/absorption-roadmap.md` Decision 1, across **19 surfaces** in `docs/`, both wiki trees, `cogni-help` and `cogni-workspace`.

- Records the AC-4 decision as **Decision 5** in the roadmap: `concept-four-layer-architecture.md` is **retained in reduced form**. The descriptive Orchestration / Data / Output groupings survive; the total-order dependency claim and the Foundation rung do not. Filename and frontmatter `id:` are unchanged, so all 31 inbound references keep resolving.
- Adds `cogni-workspace/tests/test-layering-claim-reconciled.sh` — nothing in the repo caught a partial fix before this.
- Marks the roadmap's "Known remaining contradictions" table reconciled, and records the **nine locations it omitted**.

## The issue's first acceptance criterion is vacuous

Both greps it names return **zero on the untouched base** — the prior PR had already removed them:

```
git grep -i "every other cogni-x plugin depends"   ->  0
git grep -i "no upward dependencies"               ->  0
```

An item phrased as those greps is satisfied by a no-op diff and can never fail. The surviving assertions use different wording, so the gating literals were re-derived from what was actually red on base: `every other plugin depends` (6 hits), `foundation layer` (8 in-scope of 11), `higher layers depend`, `depends on nothing`, `foundation for all`. Both original literals are still enforced by the new guard — case L2 plants each one, proving the scanner catches the phrase. L2 does **not** prove a literal is safe from being *reworded*: it reads its needles from the same `FORBIDDEN` constant it plants from, so a substitution changes both sides and the case stays green. The count floor (now 14) is what stops an entry being dropped unnoticed.

## Nine locations the inventory missed

The roadmap table listed 8 paths and said the set "does not need re-deriving". It did. All nine below carried the same claim and were present at the roadmap's own base:

| Path | How it was missed |
|---|---|
| `docs/ecosystem-overview.md:13`, `:17` | A `### Foundation` layer-group **heading** with cogni-workspace as sole occupant, plus the cell beneath it. Rewriting only the cell would have left the framing standing structurally — so the heading is now `### Workspace Infrastructure`. |
| `docs/architecture/er-diagram.md:9` | The total-order sentence above the ASCII diagram; the table named only `:22`. |
| `cogni-help/skills/guide/references/plugin-catalog.md:240`, `:248` | `**Foundation for**: All other plugins` |
| `cogni-help/skills/teach/.../tour-install-to-infographic.md:80` | Course prose |
| `cogni-help/skills/workflow/.../install-to-infographic.md:23` | Workflow prose |
| `arch-er-diagram.md:15-17` (both trees) | `## Four architectural layers` + total-order sentence |
| `workflow-install-to-infographic.md:42` (both trees) | Wiki workflow prose |
| `plugin-cogni-workspace.md:45` (both trees) | `Foundation for all 13 other plugins.` — **two paragraphs below** the `:21` alias the table did name, so fixing the alias alone would have left the claim intact |
| `cogni-workspace/skills/ask/SKILL.md:72` | The worked example quoting the model |

## Review round 2 — the four unwaived majors

The automated verdict returned NEEDS_REVISION with four unwaived majors. All four
are fixed in `afc67d30`; two further defects surfaced while fixing them.

| Finding | Fix |
|---|---|
| `docs/workflows/install-to-infographic.md:43`, `:65` — named by the contract, zero diff vs base | Both rewritten to the scope framing. This is the tutorial the `cogni-help` workflow template links to at its closing line, so a reader crossed from a reconciled sentence into an unreconciled one. |
| Mutation recipe was a no-op and proved a false property | Retargeted at L4 (see **Mutation recipe** above); guard header and this body corrected. |
| `plugin-cogni-workspace.md:17` (both trees) — hyphenated `Foundation-layer plugin`, 4 lines above the fixed `:21` | Rewritten in both trees, byte-identical. The derived one-liner at `wiki/wiki/index.md:52` carried it too — **not named in the verdict** — and is fixed with it. |
| `tour-install-to-infographic.md:34-38` (+ `:42`, `:52`) — retired four-tier taxonomy 46 lines above the fixed `:80` | Replaced with the committed horizontal/vertical split. Roster totals 13 against `marketplace.json`; cogni-help is named as a cross-cutting utility, not a rung, per the concept page's own *Plugins outside the groups*. |

**Two defects found while widening the guard:**

1. **A candidate literal caught a deliberately-surviving line.** `is the shared
   foundation` also matches `manage-workspace/SKILL.md:23`, a waived, in-scope-of-
   nothing survivor. Narrowed to `cogni-workspace is the shared foundation`.
2. **The scan read the filesystem, not the repository.** It walked git-ignored
   skill eval workspaces (`*-workspace/`) and nested worktree checkouts of this
   same repo, so L1's verdict depended on a developer's local state — green in
   CI, where none of that exists, red on a working machine for reasons no reader
   could act on. `grep_hits` now enumerates **tracked** files inside a git work
   tree and falls back to a recursive grep for the synthetic fixtures. This is why
   the original 7/7 measurement was accurate in CI yet unreproducible locally.

`FORBIDDEN` gained five literals (9 → 14, floor raised to match). L1 verified red
on reintroducing either new phrasing and green on restore.

**Waived major deferred, not dropped:** the `.claude-plugin/` manifests are the
claim's upstream source and remain out of scope under contract item 1. Filed as
#1376. The guard excludes `.claude-plugin/` **explicitly**, with a header note to
remove the exclusion when that issue lands — so it is a recorded gap, not silent
green.

## Deliberately not touched

| Path | Why |
|---|---|
| `cogni-visual/libraries/{excalidraw,svg}-patterns.md` | ASCII-art fill labels in diagram legends, unrelated to the claim |
| `wiki/log.md` (both trees) | Dated ingest log — rewriting history is not reconciliation |
| `wiki/pages/lint-2026-04-20.md` | Dated lint note, and root-tree-only — editing it would break the per-page parity assertion |
| `plugin-cogni-help.md:18-20` | "Depends on every other plugin … is depended on by nothing" is accurate *about cogni-help*, and stays true under the reduced form |
| 18 `Data layer` / `Output layer` aliases (9 pages × 2 trees) | Valid under the retained form; only the replace-instead option would touch them — see Open question 1 |
| Stale roster names in `arch-er-diagram.md` | 6 lines name `cogni-consulting` / `cogni-research`; only 2 sit in the rewrite region. Fixing 2 of 6 would leave the file internally inconsistent, and sweeping all 6 is separate roster-drift work. Fixed only where a whole self-contained block was rewritten (the concept page, the `ask` example), which end up fully consistent. |

## Two-tree handling

Both wiki trees are **hand-edited identically**. `scripts/release-bundle-wiki.sh` is deliberately not used — it is a one-way `rsync -a --delete` meant only for pre-publish, and its own docstring says inter-release drift is acceptable; running it would sweep unrelated drift.

Parity is asserted **per touched page, never tree-wide**. The trees legitimately differ (root 179 pages, bundled 178 — `lint-2026-04-20.md` is root-only), so a tree-wide assertion would be red on arrival and would pressure someone into running that sync.

## The new guard

`cogni-workspace/tests/test-layering-claim-reconciled.sh`, modeled on its sibling `test-wiki-namespace-sync.sh` (same `PASS:`/`FAIL:` label shape the mutation harness requires, L-prefixed case ids, bash-3.2 portable, stdlib-only, no network).

| Case | Asserts |
|---|---|
| L1 | the real repo asserts no retired layering claim |
| L2 | every one of the nine literals is caught when planted |
| L3 | a literal under an excluded path is **not** flagged |
| L4 | a touched page differing across trees fails, and is named |
| L5 | a page outside `PAGE_PARITY` may differ without failing |
| L6 | liveness floor — a missing tree fails rather than reporting clean |
| L7 | the real trees agree on every page this change touched |

Both real-repo cases were proven falsifiable, not just green: reintroducing the claim into `docs/ecosystem-overview.md` turns **L1 red**, and appending a line to one copy of `arch-er-diagram.md` turns **L7 red**. Both restored to green.

## Test plan

- [x] `bash cogni-workspace/tests/test-layering-claim-reconciled.sh` — 7/7 pass, exit 0
- [x] `python3 scripts/run-plugin-tests.py` — **all 111 suites pass**; the new suite is CI-discovered
- [x] `git grep -i "every other plugin depends"` → 0 · `"no upward dependencies"` → 0 · `"every other cogni-x plugin depends"` → 0
- [x] `git grep -i "foundation layer"` → only `cogni-visual/libraries/` (×2) and the roadmap's own inventory
- [x] `python3 scripts/check-version-bump.py` → 13 scanned, 0 touched, 0 violations
- [x] `python3 scripts/check-breadcrumbs.py` → clean (`ask/SKILL.md` is touched)
- [x] `cmp` clean across both trees for all four touched pages
- [x] Concept-page `id:` unchanged — 31 inbound references still resolve
- [x] Mermaid `Foundation` subgraph **id** unchanged; only its display label changed, so every edge still resolves

## Mutation recipe

```
bash mutation-check.sh --root . --file cogni-workspace/tests/test-layering-claim-reconciled.sh --expr 's/if ! cmp -s /if cmp -s /' --test cogni-workspace/tests/test-layering-claim-reconciled.sh --case L4
```

Inverting the parity comparison must turn **L4** red. The expression matches
exactly **1** line (verified: `re.subn` returns 1), the replacement is disjoint
from the pattern it replaces, and L4 asserts that two touched pages differing
across the trees fails — so inverting `cmp` makes a differing pair compare equal
and the case cannot stay green. Verified red on mutation, green on restore; L7
flips with it.

The earlier recipe in this PR targeted `L2` via the `FORBIDDEN` constant and was
a no-op twice over: the `^`-anchored expression matched **zero** lines (the
literal sits inside a multi-line assignment, never alone on a line), and even the
corrected form leaves L2 green by construction, for the reason given above.


## Process notes

Two steps of the resolve pipeline were deviated from, recorded here rather than left silent:

1. **Step 4c.5 (plan-refiner) was folded into an expanded Step 4d.** Its characteristic value classes — forgotten label registrations, help-text updates, idempotency holes, stray version bumps — are all N/A for a prose reconciliation, and four independent passes had already swept the target set. Step 4d then passed all six checks: 19 files exist, 19 cited anchors match, 1 file new, parent dir present, branch unique.
2. **Steps 6.4 / 6.4b (simplify passes) were assessed, not dispatched.** `/simplify` is code-only against a 19-file prose diff plus one new suite already modeled on its sibling. `skill-simplifier`'s gate did match `ask/SKILL.md`, but the change there is a single blockquote line (+45 chars) and Step 6.5's whole-file review found no length or duplication finding — the editor would have been a contractual no-op.

Step 6.5 (`skill-quality-reviewer` on `ask/SKILL.md`) returned **pass** with no auto-fixable items and no structural issues.

`origin/main` moved twice during this run (`78d6e39c` → `28e37bce` → `cf2d03d1`). All measurements were re-taken at `cf2d03d1`; the second move was PR #1367 landing CI-only files and changed none of the gating counts.

No version bump — the post-merge workflow owns it.

## Open questions

1. **(genuine) AC 4 — reduce the taxonomy, or replace it?** This PR records "retained in reduced form" as the conservative, reversible default: it deletes only what committed evidence falsifies and leaves the 18 `Data layer` / `Output layer` aliases valid and untouched. Adopting an explicit horizontal/vertical vocabulary as the documented architecture instead — rewriting the concept page wholesale plus those 18 aliases across 9 pages × 2 trees — is an architecture-owner call, not one an autonomous author should invent. Reversal costs no more later than it would have here.

2. **(genuine) AC 2 — the generator is in another repository.** "Any layering wording emitted by a `cogni-docs` generator is fixed at the generator, not in its output" is not landable here: `cogni-docs` ships from `cogni-work/managed-service` and there is no `cogni-docs/` directory in this repo. `docs/plugin-guide/cogni-workspace.md` is generator output and is hand-corrected so readers stop seeing a falsified claim, but a regeneration pass could reintroduce it in that one file until the generator changes — a companion issue is needed there. One nuance in our favour: `doc-generate`'s `## Dependencies` template emits only a heading and a table and specifies no lead-in prose, so the offending sentence at `README.md:212` was hand-written debris inside a generator-owned section — **deleting** it is regeneration-stable and needed no `cogni-docs` change at all.

3. **(avoidable)** AC 1 was vacuous as filed — resolved without asking by re-deriving the gating literals from what was measured red on base.

---

## Blocked

**Not handed off to the merger.** `check-preflight.sh` exited non-zero, so this PR carries no `svc:needs-review` and stays draft. Full detail in [the preflight comment](https://github.com/cogni-work/insight-wave/pull/1373#issuecomment-5280975373).

**The one violation:** `frontmatter — 8 offender(s) in cogni-workspace`. **All 8 are pre-existing; zero introduced by this branch** (8 on this branch, 8 on a pristine `origin/main`, empty set difference). The only file this PR touches, `skills/ask/SKILL.md`, offends on line 3 (`description-cap`) — frontmatter this PR never edited; the change here is one blockquote at line 72.

The `frontmatter` arm is armed by the diff touching any `SKILL.md`, then scans plugin-wide and gates on standing drift. In the same run the `breadcrumbs` arm marked its 10 offenders "standing drift, not introduced here; surfaced, not gating". Scoping frontmatter the same way would unblock this.

**This PR's own diff is green:** 111/111 test suites pass, version-bump clean, breadcrumbs clean on the touched set, and the new guard's 7 cases pass with L1 and L7 proven falsifiable.

**To unblock:** clear the 8 pre-existing offenders in a separate cogni-workspace frontmatter-hygiene PR, or scope the frontmatter arm to the touched set.

