### PR TITLE
Clear all 8 frontmatter-schema offenders in cogni-workspace

### DIFF
--- a/cogni-workspace/skills/ask/SKILL.md
+++ b/cogni-workspace/skills/ask/SKILL.md
@@ -2,12 +2,10 @@
 name: ask
 description: >-
   Answer a question about the insight-wave plugin ecosystem by reading the
-  bundled insight-wave wiki — never from memory. The wiki ships with cogni-workspace
-  and lives at ${CLAUDE_PLUGIN_ROOT}/wiki/. Reads wiki/wiki/index.md first to
-  find relevant pages, then reads only those pages, then synthesizes a grounded
-  answer with [[wikilink]] citations. Use this skill whenever the user asks about
-  insight-wave plugins, skills, agents, conventions, architecture, workflows, or
-  cross-cutting concepts. Trigger phrases include "ask the wiki", "ask insight-wave",
+  bundled insight-wave wiki — never from memory. Use this skill whenever the
+  user asks about insight-wave plugins, skills, agents, conventions,
+  architecture, workflows, or cross-cutting concepts. Trigger phrases include
+  "ask the wiki", "ask insight-wave",
   "what does cogni-X do", "how does claims propagation work", "which plugin
   generates IS/DOES/MEANS", "what is the agent model strategy", "how do plugins
   share data", "what's the difference between cogni-narrative and cogni-copywriting",

--- a/cogni-workspace/skills/install-mcp/SKILL.md
+++ b/cogni-workspace/skills/install-mcp/SKILL.md
@@ -13,7 +13,6 @@ description: >-
   its MCP installation step (step 5), when workspace-status reports MCP servers
   as not loaded and the user wants to fix it, or when a rendering skill
   (render-big-picture, story-to-web) fails because its MCP dependency is missing.
-version: 0.1.0
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion, ToolSearch
 ---
 

--- a/cogni-workspace/skills/manage-themes/SKILL.md
+++ b/cogni-workspace/skills/manage-themes/SKILL.md
@@ -1,25 +1,19 @@
 ---
 name: manage-themes
 description: >-
-  Manage visual design themes for the workspace — import themes from Claude
-  Design handoff bundles (the recommended authoring path), or extract from live
-  websites (via claude-in-chrome), PowerPoint templates, or presets, then store
-  and apply them to all visual outputs (slides, documents, diagrams, reports).
-  Also audits and improves existing themes: contrast/accessibility checks,
-  palette harmony, typography pairing, and completeness review. Use this skill
-  whenever the user mentions themes, brand colors, visual identity, extracting
-  styles, or wants consistent look-and-feel across outputs. Also triggers when
-  the user wants to review, audit, fix, or improve a theme — e.g., "my theme
-  feels off", "check contrast", "improve my colors". Also triggers when the
-  user needs help choosing or building a theme — e.g., "what theme for my
-  brand?", "help me pick a theme", "I need a visual identity for my startup".
-  Even if the user just says "make it match our brand", "use our company
-  colors", or "grab the style from that site", this skill applies. Also
-  triggers on "brand guidelines", "design system", "brand identity", or
-  "visual standards", or when the user wants to "author tokens", "build a
-  tiered theme system", "deepen a theme", "match the cogni-work pattern", or
-  has a Claude Design bundle URL (api.anthropic.com/v1/design/h/...) to import.
-version: 0.5.0
+  Manage visual design themes for the workspace — create themes from Claude
+  Design bundles, live websites, PowerPoint templates, or presets, audit and
+  improve existing ones, and apply them across all visual outputs. Use this
+  skill whenever the user mentions themes, brand colors, visual identity, or
+  extracting styles, wants a consistent look-and-feel across outputs, or wants
+  to review, audit, fix, improve, choose, or build a theme. Trigger phrases
+  include "my theme feels off", "check contrast", "improve my colors", "what
+  theme for my brand?", "help me pick a theme", "I need a visual identity for
+  my startup", "make it match our brand", "use our company colors", "grab the
+  style from that site", "brand guidelines", "design system", "brand identity",
+  "visual standards", "author tokens", "build a tiered theme system", "deepen a
+  theme", and "match the cogni-work pattern". Also triggers on a Claude Design
+  bundle URL (api.anthropic.com/v1/design/h/...) to import.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, Skill, mcp__claude-in-chrome__navigate, mcp__claude-in-chrome__read_page, mcp__claude-in-chrome__computer, mcp__claude-in-chrome__tabs_create_mcp, mcp__claude-in-chrome__tabs_context_mcp, mcp__claude-in-chrome__get_page_text
 ---
 

--- a/cogni-workspace/skills/manage-themes/SKILL.md
+++ b/cogni-workspace/skills/manage-themes/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: manage-themes
 description: >-
-  Manage visual design themes for the workspace — create themes from Claude
-  Design bundles, live websites, PowerPoint templates, or presets, audit and
-  improve existing ones, and apply them across all visual outputs. Use this
-  skill whenever the user mentions themes, brand colors, visual identity, or
-  extracting styles, wants a consistent look-and-feel across outputs, or wants
-  to review, audit, fix, improve, choose, or build a theme. Trigger phrases
-  include "my theme feels off", "check contrast", "improve my colors", "what
+  Create, audit, improve, and apply visual design themes for the workspace —
+  sourced from Claude Design bundles, live websites, PowerPoint templates, or
+  presets. Audits cover contrast and accessibility, palette harmony, typography
+  pairing, and completeness. Use this skill whenever the user mentions themes,
+  brand colors, visual identity, or extracting styles, wants a consistent
+  look-and-feel across outputs, or wants to review, fix, choose, or build a
+  theme. Trigger phrases include "my theme feels off", "check contrast",
+  "improve my colors", "what
   theme for my brand?", "help me pick a theme", "I need a visual identity for
   my startup", "make it match our brand", "use our company colors", "grab the
   style from that site", "brand guidelines", "design system", "brand identity",
   "visual standards", "author tokens", "build a tiered theme system", "deepen a
   theme", and "match the cogni-work pattern". Also triggers on a Claude Design
-  bundle URL (api.anthropic.com/v1/design/h/...) to import.
+  bundle URL (api.anthropic.com/v1/design/h/...).
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, Skill, mcp__claude-in-chrome__navigate, mcp__claude-in-chrome__read_page, mcp__claude-in-chrome__computer, mcp__claude-in-chrome__tabs_create_mcp, mcp__claude-in-chrome__tabs_context_mcp, mcp__claude-in-chrome__get_page_text
 ---
 

--- a/cogni-workspace/skills/manage-workspace/SKILL.md
+++ b/cogni-workspace/skills/manage-workspace/SKILL.md
@@ -12,7 +12,6 @@ description: >-
   needs to catch up. Even if the user just says "new project", "start fresh",
   "add a plugin", "wire up my workspace", or "my plugins can't find each other",
   this skill applies.
-version: 0.4.0
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion
 ---
 

--- a/cogni-workspace/skills/pick-theme/SKILL.md
+++ b/cogni-workspace/skills/pick-theme/SKILL.md
@@ -13,7 +13,6 @@ description: >-
   Also triggers on "apply a theme", "use this theme", or "theme my output".
   This is the single standard entry point for theme selection across the
   insight-wave marketplace.
-version: 0.2.0
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion
 ---
 

--- a/cogni-workspace/skills/workspace-dashboard/SKILL.md
+++ b/cogni-workspace/skills/workspace-dashboard/SKILL.md
@@ -11,7 +11,6 @@ description: |
   even if they don't say "dashboard". This is the visual sibling of
   `workspace-status` (which is a text-based health diagnostic): pick this skill
   when the user wants to *see* the configuration, not diagnose it.
-version: 0.1.0
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Skill, AskUserQuestion
 ---
 

--- a/cogni-workspace/skills/workspace-status/SKILL.md
+++ b/cogni-workspace/skills/workspace-status/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: workspace-status
 description: "Diagnose and report on the health of an insight-wave workspace. Use this skill whenever the user mentions workspace status, health, diagnostics, or troubleshooting — including check workspace, is my workspace ok, something broke, why isn't my plugin working, diagnose workspace, verify workspace, or any situation where understanding the workspace state would help resolve a problem. Even if the user doesn't explicitly say status, trigger this skill when they describe symptoms that suggest a misconfigured workspace (missing env vars, plugins not found, themes not loading). This is the first skill to reach for when debugging workspace issues."
-version: 0.2.0
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion, Skill, ToolSearch
 ---
 


### PR DESCRIPTION
## Why

`check-frontmatter.sh cogni-workspace` reported 8 offenders on `main`, all pre-existing — none introduced by any open PR. They only surface when a PR happens to touch one of those files, so they gate unrelated work at random. This clears every one at the source.

**No exemption is recorded.** `cogni-workspace/scripts/frontmatter-allowlist.txt` is not created; the gate now reports `allowlisted: 0`.

## Decision per offender

| File | Check | Call |
|---|---|---|
| `skills/ask/SKILL.md` | description-cap 1091 | Fix → **865** |
| `skills/manage-themes/SKILL.md` | description-cap 1343 | Fix → **982** |
| `skills/install-mcp`, `manage-themes`, `manage-workspace`, `pick-theme`, `workspace-dashboard`, `workspace-status` | unknown-key `version` | Drop the key |

### description-cap — pruned into the body

The 1024-char cap is a real platform constraint: over it, the description is silently truncated, degrading the triggering it exists for. An exemption buys nothing.

- **`ask`** — removed the mechanism sentences (wiki path, index-first read order, citation format). They duplicated the body's self-contained-read paragraph and Workflow steps 1–5. A description buys triggering, not explanation.
- **`manage-themes`** — folded four `Also triggers …` clauses into one enumerated list and rewrote the opening sentence to lead with its verb list rather than restate it mid-description. The audit dimensions (accessibility, palette harmony, typography pairing, completeness) are **kept** — an earlier pass cut them, but they were inside the old cap and therefore visible to the router, so the budget was recovered from non-trigger prose instead. What left is mechanism vocabulary (claude-in-chrome extraction, the authoring-path aside, the visual-output list), body-covered verbatim under Prerequisites and Operations 6/10.

**All 27 quoted trigger phrases survive** — 10 in `ask`, 17 in `manage-themes` — verified by diffing the YAML-*folded* description before/after, not the raw line wrap.

### unknown-key `version` — dropped, not exempted

Checked whether it was load-bearing before deleting:

- Nothing in the repo reads a per-skill frontmatter `version`. The only SKILL.md frontmatter parser is `cogni-workspace/scripts/check-skill-names.sh`, which extracts `name` alone.
- No doc mandates it. The canonical authoring template in `docs/contributing/plugin-development.md` specifies exactly `name` / `description` / `allowed-tools`.
- It appeared in 8 of ~110 skills — vestigial, not a house convention.

An allowlist entry would have pinned dead metadata in place against the repo's own documented template.

### Net effect on routing

The cap was already truncating these descriptions on `main`, so this is a repair, not just hygiene. `manage-themes` was silently losing its last 319 chars — nine trigger phrases the router never saw: `"brand guidelines"`, `"design system"`, `"brand identity"`, `"visual standards"`, `"author tokens"`, `"build a tiered theme system"`, `"deepen a theme"`, `"match the cogni-work pattern"`, and the Claude Design bundle URL. All nine are now inside the cap. Word-level diff against `main` confirms no matching vocabulary is lost.

`ask` was losing only its closing caveat sentence — no trigger phrases.

## Verification

`check-frontmatter.sh cogni-workspace` → `clean: true, count: 0, allowlisted: 0`, **exit 0**.

Deleting frontmatter lines shifts line numbers under the ratcheting breadcrumb baseline, so the surrounding guards were re-run rather than assumed:

| Guard | Exit |
|---|---|
| `scripts/check-breadcrumbs.py` | 0 |
| `cogni-workspace/scripts/check-skill-names.sh` | 0 |
| `scripts/check-version-bump.py` | 0 (13 scanned, 0 touched) |
| `scripts/check-external-dispatch.py` | 0 |
| `scripts/check-plugin-inventory.py` | 0 |
| `scripts/run-plugin-tests.py --filter cogni-workspace` | 0 (5/5 suites) |

No version bumped — the post-merge workflow owns that.

## Deliberately out of scope

- `cogni-copywriting/skills/copy-json` and `copy-reader` carry the same dead `version:` key. Different plugin, and they don't gate cogni-workspace work — worth a follow-up rather than widening this PR across a plugin boundary.
- `skills/manage-themes/SKILL.md` lines 89 and 126 read `Deprecated (since v0.5.0)`, now referencing a version the file no longer carries. The deprecation semantic survives; only the anchor is gone. Left as a body decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

