### PR TITLE
cogni-copywriting: repair copy-reader dispatch

### DIFF
--- a/cogni-copywriting/agents/reader.md
+++ b/cogni-copywriting/agents/reader.md
@@ -10,6 +10,12 @@ description: >-
   strategy with executive and legal personas."
 tools:
   - Read
+  - Write
+  - Edit
+  - Bash
+  - Task
+  - TodoWrite
+  - TodoRead
   - Skill
 ---
 

--- a/cogni-copywriting/agents/reader.md
+++ b/cogni-copywriting/agents/reader.md
@@ -42,7 +42,7 @@ Invoke the reader skill using the Skill tool with args parameter.
 
 <example>
 <invoke name="Skill">
-  <parameter name="skill">cogni-copywriting:reader</parameter>
+  <parameter name="skill">cogni-copywriting:copy-reader</parameter>
   <parameter name="args">FILE_PATH={{FILE_PATH}} PERSONAS={{PERSONAS}} AUTO_IMPROVE={{AUTO_IMPROVE}}</parameter>
 </invoke>
 </example>

--- a/cogni-copywriting/agents/reader.md
+++ b/cogni-copywriting/agents/reader.md
@@ -15,7 +15,6 @@ tools:
   - Bash
   - Task
   - TodoWrite
-  - TodoRead
   - Skill
 ---
 

--- a/cogni-copywriting/agents/reader.md
+++ b/cogni-copywriting/agents/reader.md
@@ -2,7 +2,15 @@
 name: reader
 model: sonnet
 color: cyan
-description: Review documents through parallel stakeholder persona Q&A simulation with synthesized feedback.
+description: >-
+  Use this agent when a markdown document needs stakeholder review through
+  parallel persona Q&A and synthesized feedback. Typical triggers include
+  requests to review a proposal as executive, technical, legal, marketing, or
+  end-user stakeholders; for example, dispatch it when asked to "review this
+  strategy with executive and legal personas."
+tools:
+  - Read
+  - Skill
 ---
 
 # Reader Agent (Orchestrator)

--- a/cogni-copywriting/skills/copy-json/SKILL.md
+++ b/cogni-copywriting/skills/copy-json/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: copy-json
-version: 1.0
 description: Adapter skill that polishes text fields inside JSON files by extracting them, delegating to the copywriter skill for polishing, and writing the polished text back. Use when the user wants to polish, improve, or copywrite text inside a JSON file — plugin descriptions, IS/DOES/MEANS propositions, category names, claim statements, or any string fields in structured JSON data. Triggers include "polish JSON", "copywrite marketplace.json", "improve descriptions in plugin.json", "polish fields in JSON", or any /copywrite invocation targeting a .json file with --fields.
 allowed-tools: Read, Write, Edit, Bash, Skill
 ---

--- a/cogni-copywriting/skills/copy-reader/SKILL.md
+++ b/cogni-copywriting/skills/copy-reader/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: copy-reader
-version: 1.0
 description: This skill should be used when the user wants to review a document from different stakeholder perspectives, simulate how different audiences would read a document, or get multi-perspective feedback before distribution. Common triggers include "review document as stakeholder", "stakeholder review", "reader review", "read as executive", "review from technical perspective", "does this document work for [audience]", "get feedback on this document", "what would [role] think of this", "check if this is ready for stakeholders", or "simulate different readers".
 allowed-tools: Read, Write, Edit, Bash, Task, TodoWrite, TodoRead
 ---

--- a/cogni-copywriting/skills/copy-reader/SKILL.md
+++ b/cogni-copywriting/skills/copy-reader/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: copy-reader
 description: This skill should be used when the user wants to review a document from different stakeholder perspectives, simulate how different audiences would read a document, or get multi-perspective feedback before distribution. Common triggers include "review document as stakeholder", "stakeholder review", "reader review", "read as executive", "review from technical perspective", "does this document work for [audience]", "get feedback on this document", "what would [role] think of this", "check if this is ready for stakeholders", or "simulate different readers".
-allowed-tools: Read, Write, Edit, Bash, Task, TodoWrite, TodoRead
+allowed-tools: Read, Write, Edit, Bash, Task, TodoWrite
 ---
 
 # Reader Skill

--- a/cogni-copywriting/skills/copywriter/SKILL.md
+++ b/cogni-copywriting/skills/copywriter/SKILL.md
@@ -85,6 +85,7 @@ These apply even in `--scope=tone` because they are readability essentials, not 
 - `framework` (optional): bluf | pyramid | scqa | star | psb | fab | inverted-pyramid
 - `impact_level` (optional): standard | high
 - `MODE` (optional): standard | sales (default: standard)
+- `review_mode` (optional): reader | automated | skip (default: automated) — selects the Step 4 review path
 - `AUDIENCE` (optional): expert | mixed | lay (default: mixed) — tunes audience-aware disciplines such as acronym expansion depth
 - `TARGET_LANG` (optional): de | en | fr | it | pl | nl | es — when set, runs a translate-then-polish two-pass flow (see Step 2.5). When unset, the skill polishes in the source language only. Translation requires EN or DE on one end of the pair (the pivot); direct non-EN/DE pairs (e.g. fr↔it) are rejected — see pre-check #5.
 
@@ -258,6 +259,8 @@ Args: FILE_PATH={{output_path}} PERSONAS={{stakeholders}} AUTO_IMPROVE=true
 
 The reader skill runs parallel multi-persona Q&A, synthesizes feedback, and applies one auto-improvement loop directly to the document. Use for reports, proposals, executive summaries, and briefs.
 
+Resolve `{{stakeholders}}` from the user's explicit persona list when one is given; otherwise take the audience defaults from the Option B table below.
+
 **Option B — Automated Checklist Review (lighter weight):**
 
 Load stakeholder review profiles from `references/10-stakeholder-review/`. Default stakeholders by audience:
@@ -272,7 +275,7 @@ Load stakeholder review profiles from `references/10-stakeholder-review/`. Defau
 
 Evaluate against each stakeholder's 5 weighted criteria. Aggregate feedback, prioritize (3+ stakeholders = CRITICAL, 2 = HIGH, 1 = OPTIONAL), and apply CRITICAL/HIGH improvements. Load `references/10-stakeholder-review/synthesis-guidelines.md` for conflict resolution patterns.
 
-**Review mode parameter:** `reader` (Option A), `automated` (default, Option B), or `skip`.
+Which option runs is set by the `review_mode` parameter resolved in Step 1: `reader` selects Option A, `automated` (the default) selects Option B, and `skip` bypasses this step.
 
 Review enhances quality but never blocks delivery — if review fails, continue to Step 5 with the document as-is.
 

--- a/cogni-copywriting/skills/copywriter/SKILL.md
+++ b/cogni-copywriting/skills/copywriter/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: copywriter
-description: Polish, rewrite, or create business documents (memos, briefs, reports, proposals, one-pagers, executive summaries, emails, blog posts, business letters) using professional messaging frameworks (BLUF, McKinsey Pyramid, SCQA, STAR, PSB, FAB) and persuasion techniques (number plays, power words, rhetorical devices). Use this skill when the user asks to polish a document, improve writing, make something more readable, restructure a brief, apply BLUF or Pyramid Principle, rewrite for executives, strengthen messaging, create a proposal, write a one-pager, clean up a report, compress a document to minimum length without losing facts, shorten a synthesis for circulation, tighten a document while keeping every citation and number, or apply any named messaging framework. Also handles German documents (Wolf Schneider style), arc-aware narrative polishing (cogni-narrative arcs with arc_id), and IS/DOES/MEANS sales messaging. Even simple requests like "make this better" about a markdown file should trigger this skill.
-allowed-tools: Read, Write, Edit, Bash, TodoWrite
+description: Polish, rewrite, or create business documents (memos, briefs, reports, proposals, one-pagers, executive summaries, emails, blog posts, business letters) using professional messaging frameworks (BLUF, McKinsey Pyramid, SCQA, STAR, PSB, FAB) and persuasion techniques (number plays, power words, rhetorical devices). Use this skill when the user asks to polish a document, improve writing, make something more readable, restructure a brief, apply BLUF or Pyramid Principle, rewrite for executives, strengthen messaging, create a proposal, write a one-pager, clean up a report, compress a document to minimum length without losing facts, shorten a synthesis for circulation, tighten a document while keeping every citation and number, or apply any named messaging framework. Handles German documents (Wolf Schneider style), arc-aware narrative polishing (cogni-narrative arcs with arc_id), and IS/DOES/MEANS sales messaging. Simple requests like "make this better" about a markdown file should trigger this skill.
+allowed-tools: Read, Write, Edit, Bash, TodoWrite, Skill
 ---
 
 # Copywriter Skill
@@ -105,13 +105,13 @@ These apply even in `--scope=tone` because they are readability essentials, not 
 1. Resolve `source_lang` via the existing detector in Step 3 (`--lang` → workspace config → content analysis).
 2. If `source_lang == TARGET_LANG`, log "source language already matches target — skipping translation pass" and fall through to standard polish. **Also unset the translation scope override below** so the user's explicit `--scope` is honoured (a user invoking `--scope=full` on a same-language doc expects Step 2 to run normally).
 3. **Arc-mode gate.** Determine the document's arc: use frontmatter `arc_id` if present; otherwise, if the H2 headings match a known in-scope arc pattern (per `arc-preservation.md` detection), use that `arc_id`. If neither yields an arc, skip this gate (proceed as a non-arc translation). When an arc is identified:
-   - If the arc is **not** one of `corporate-visions`, `jtbd-portfolio` → abort (coverage), **regardless of language**, with: "Arc-mode translation currently covers corporate-visions and jtbd-portfolio; arc `{arc_id}` is future expansion (tracked under #255)." Do not modify the file.
+   - If the arc is **not** one of `corporate-visions`, `jtbd-portfolio` → abort (coverage), **regardless of language**, with: "Arc-mode translation currently covers corporate-visions and jtbd-portfolio; arc `{arc_id}` is not yet supported." Do not modify the file.
    - Else (the arc is in scope) **and** at least one of `source_lang`/`TARGET_LANG` is in `{en, de}` → **allow**: set `arc_mode = true` and proceed. The arc-element and bridge headings will be **substituted** (not freely translated) in Step 2.5. This covers en↔de, en/de→fr/it/pl/nl/es, and the fr/it/pl/nl/es→en/de reverse.
    - Else (the arc is in scope but **neither** end is in `{en, de}` — e.g. a French source with `TARGET_LANG=it`) → do **not** abort here; fall through to pre-check #4 (accept-set) and #5 (pivot guard), which emits the correct direct-non-EN/DE message.
    - If `TARGET_LANG` is not in the accept-set at all → do **not** abort here; fall through to pre-check #4, which emits the correct "not a supported language" message.
-   (Arc-mode translation pivots on EN/DE for these two arcs across `{de,en,fr,it,pl,nl,es}`; the FR/IT/PL/NL/ES coverage is Slice 3 of #255. The remaining 9 arcs — any language — and direct non-EN/DE pairs stay blocking here.)
+   (Arc-mode translation pivots on EN/DE for these two arcs across `{de,en,fr,it,pl,nl,es}`. The remaining 9 arcs — any language — and direct non-EN/DE pairs stay blocking here.)
 4. **Accept-set check.** Accept only `de`, `en`, `fr`, `it`, `pl`, `nl`, `es`. Any other value: abort with "TARGET_LANG=`{value}` is not a supported language. Supported: de, en, fr, it, pl, nl, es."
-5. **Pivot guard.** Translation pivots on EN or DE. If **neither** `source_lang` **nor** `TARGET_LANG` is in `{en, de}` (e.g. a French source with `TARGET_LANG=it`), abort with: "Direct {source_lang}→{TARGET_LANG} translation is not supported — every direction must include English or German on one end. Pivot via EN or DE (translate to en/de first, then to the final language), or follow #255 for direct non-EN/DE pairs (Phase 3)." Do not modify the file.
+5. **Pivot guard.** Translation pivots on EN or DE. If **neither** `source_lang` **nor** `TARGET_LANG` is in `{en, de}` (e.g. a French source with `TARGET_LANG=it`), abort with: "Direct {source_lang}→{TARGET_LANG} translation is not supported — every direction must include English or German on one end. Pivot via EN or DE: translate to en/de first, then to the final language." Do not modify the file.
 
 **Pre-check order:** resolve source (1) → no-op (2) → arc gate (3) → accept-set (4) → pivot guard (5). The arc and accept-set messages are the most actionable, so they win when multiple conditions hold.
 
@@ -252,7 +252,7 @@ Skip if `skip_review: true`, or for informal deliverables (emails, casual memos)
 **Option A — Interactive Reader Skill (recommended for formal deliverables):**
 
 ```text
-Skill: cogni-copywriting:reader
+Skill: cogni-copywriting:copy-reader
 Args: FILE_PATH={{output_path}} PERSONAS={{stakeholders}} AUTO_IMPROVE=true
 ```
 

--- a/cogni-copywriting/skills/copywriter/references/00-index.md
+++ b/cogni-copywriting/skills/copywriter/references/00-index.md
@@ -224,7 +224,7 @@ IF user asks about markdown syntax:
 
 ```
 IF review_mode = reader:
-  Delegate to cogni-copywriting:reader skill (handles its own reference loading)
+  Delegate to cogni-copywriting:copy-reader skill (handles its own reference loading)
 
 IF review_mode = automated OR review not explicitly skipped:
   LOAD: 10-stakeholder-review/{perspective}-review.md (for each selected stakeholder)

--- a/cogni-copywriting/skills/copywriter/references/workflow/step-by-step-guide.md
+++ b/cogni-copywriting/skills/copywriter/references/workflow/step-by-step-guide.md
@@ -373,7 +373,7 @@ Before proceeding, verify:
 If `review_mode: reader`:
 
 ```text
-Delegate to: cogni-copywriting:reader
+Delegate to: cogni-copywriting:copy-reader
 Args: FILE_PATH={{output_path}} PERSONAS={{stakeholders}} AUTO_IMPROVE=true
 ```
 


### PR DESCRIPTION
Refs #1380.
Closes #1382.

## Summary

- Declare `Skill` in the copywriter skill's allowed tools.
- Replace every stale `cogni-copywriting:reader` skill target with the registered `cogni-copywriting:copy-reader` slug.
- Keep the copywriter workflow references and reader agent aligned with the executable dispatch.
- Remove pre-existing maintainer-history breadcrumbs surfaced by the required skill-quality pass, without changing translation behavior.
- Remove the two unsupported per-skill `version: 1.0` keys absorbed from #1382.

## Scope decisions

This draft PR addresses the functional dispatch defect and absorbs the two mechanical copywriting metadata fixes from #1382 so the touched plugin clears the handoff preflight. The remaining cross-plugin description-cap work stays tracked in #1381, so this PR references rather than closes #1380. No plugin manifest versions, manifests, allowlists, tests, or guard implementations are changed.

## Test plan

- [x] Candidate commit contains zero `cogni-copywriting:reader` skill-target occurrences.
- [x] Copywriting frontmatter gate reports `clean: true`, `count: 0`, `allowlisted: 0`.
- [x] Knowledge, trends, and claims frontmatter findings match `origin/main` and are tracked in #1381 (`allowlisted: 0`).
- [x] `python3 scripts/check-breadcrumbs.py`
- [x] `python3 scripts/check-external-dispatch.py`
- [x] `python3 scripts/check-plugin-inventory.py`
- [x] `python3 scripts/check-version-bump.py` (`status: ok`, non-degraded)
- [x] `python3 scripts/run-plugin-tests.py` — 113/113 suites passed after the final prose fix.
- [ ] `bash cogni-workspace/scripts/check-skill-names.sh` — reproduces the two unrelated duplicate-name findings from `origin/main` (`cogni-issues`, `troubleshoot`); this change introduces neither.

## Review notes

- The deterministic skill-length check reports the pre-existing `copywriter` body at 34,827 characters against its 30,000-character advisory budget. This focused change did not introduce the architecture debt and reduced the body from the 34,944-character base while preserving all behavior; broader progressive-disclosure work remains outside this PR.
- The strict token-scope preflight reported the runner's fixed GitHub CLI OAuth credential as over-scoped (`gist`, `read:org`, `workflow`) and exited 0 through the configured opt-out.

## Follow-up issues

- #1381 — Compact remaining frontmatter descriptions to the schema cap.

## Plan record

- https://github.com/cogni-work/insight-wave/issues/1380#issuecomment-5301287382
