### PR TITLE
wiki: name adopting plugins for retired-plugin prose in both page trees

### DIFF
--- a/cogni-workspace/references/wiki-tree-reconciliation.md
+++ b/cogni-workspace/references/wiki-tree-reconciliation.md
@@ -215,6 +215,55 @@ Both `.cogni-wiki/config.json` files — closed by Decision 1.
 **Reversing it** and running a blanket sync destroys the group-B sections and cannot be
 recovered from the bundled tree afterwards.
 
+### Extension — the same rule applied to bare prose names
+
+*Carried out in issue #1426.*
+
+The pass above reached only references shaped as `[[wikilink]]`s or `related:` frontmatter — the
+mechanically detectable set. A **bare** plugin name in prose carries no wrapper, so the wikilink
+resolvers behind W4/W5 never saw that class and the suites stayed green with it fully present. The
+same rule — name the adopting plugin and the relocated skill — now applies to bare prose too.
+
+**The surface is the two-tree intersection of `wiki/wiki/pages/*.md`, non-recursive.** Measured at
+the time of the sweep: 150 pages in the intersection, all 150 byte-identical; 25 of them carried a
+bare retired name. Everything else is outside the surface **structurally, with no exclusion list**:
+
+- `index.md`, `log.md` and `overview.md` fall out by **depth** — they sit at `wiki/wiki/` level.
+- `lint-2026-04-20.md` falls out because it is the only **root-only** page (and Decision 5 freezes it).
+- The 7 pages of Decision 4 fall out because they are **bundled-only** — the very property that
+  decision is about.
+
+A surface with no exclusion entries cannot be widened by accident, which matters here: the
+substring-matching `is_excluded()` in `tests/test-layering-claim-reconciled.sh` turns one loose
+fragment into a repo-wide exemption. It also self-heals — when #1402 rules, the held pages enter or
+leave the surface with no guard edit.
+
+**Adopters used.** `cogni-narrative` and `cogni-copywriting` → cogni-workspace, citing its
+`narrative` and `copywriter` skills (`audit-copywriter` was deleted, not adopted, and is never cited
+as live). `cogni-research` → cogni-knowledge. `cogni-consulting` → cogni-consult, **but not as a
+rename**: several pages described the retired plugin's *phase-gated* architecture, which
+cogni-consult does not have, so those were rewritten against the live model (action fields as WBS
+containers, a per-deliverable design-thinking loop, `consult-project.json`) rather than
+substituted. `cogni-wiki` had zero bare occurrences in the surface.
+
+**Five claims were false, not merely stale**, and were corrected as content: cogni-knowledge ships
+no `hooks/` (the four that do are cogni-consult, cogni-portfolio, cogni-visual, cogni-workspace);
+the "no `scripts/`" census named plugins whose code now lives in cogni-workspace, which has one —
+only cogni-marketing and cogni-website lack it; cogni-knowledge's entity vocabulary is not
+SubQuestion/Context/Source/ReportClaim; the `portfolio_path` frontmatter edge had no cogni-consult
+consumer at all; and the `canvas-{slug}.md` bridge row named a file no plugin emits — removed per
+Decision 6 rather than repointed.
+
+**`cogni-claims/` paths are preserved deliberately.** Per `cogni-workspace/CLAUDE.md`, the
+discriminator is the colon: a `cogni-claims:` dispatch token is rewritten, a `cogni-claims/` path is
+not. All 8 surviving occurrences in the surface (4 per tree) are paths. Two of them share a line
+with a rewritten `cogni-research` token.
+
+**`cogni-docs` and `cogni-service` are not retired** — they are live plugins hosted in a different
+marketplace, already allowlisted as `EXTRA_ALLOWED` in `tests/test-wiki-namespace-sync.sh`. They are
+out of scope here, and any future roster-derived scan needs that same allowance or it reports false
+positives on them.
+
 ## Decision 4 — the 7 bundled-only pages are held pending a maintainer ruling
 
 *Recorded, not executed. Carried out in issue #1402.*
@@ -342,6 +391,11 @@ Kept as a permanent inventory so the set stays auditable rather than being redis
 | `ecosystem-command-reference` names a retired command surface | held with the page above | #1402 |
 | Sync script destroys bundle-only content | closed — refuses by default; `--force` is the opt-in | #1403 |
 | This record and its guard are unregistered in the plugin guide | closed — `cogni-workspace/CLAUDE.md` names both under `## Wiki Trees` | #1404 |
+| Bare prose plugin names are invisible to every resolver | swept over the two-tree `pages/*.md` intersection; no guard yet, so a future retirement can reintroduce the class silently | #1426, guard in #1438 |
+| The 5 bundled-only pages still name retired plugins | held with the pages themselves — editing them would pre-decide the ruling | #1402, sweep in #1440 |
+| `index.md` and `overview.md` carry the same bare-name class | outside the swept surface by depth; needs its own decision, since the two `index.md` copies diverge by design and a TOC of deleted pages is a Decision-6 removal, not a rename | #1439 |
+| The generated `docs/` mirror repeats the dead `portfolio_path` edge | open — cogni-docs ships from a separate repo, so the fix is correct-the-output plus an upstream filing, never a local regeneration | #1441 |
+| Two `consulting-project.json` residues name a manifest no plugin writes | open — outside the page surface (`troubleshoot/known-issues.md`, `docs/contributing/`) | #1442 |
 
 ## Deliberately left standing
 

--- a/cogni-workspace/tests/test-layering-claim-reconciled.sh
+++ b/cogni-workspace/tests/test-layering-claim-reconciled.sh
@@ -159,6 +159,12 @@ cogni-visual/libraries/
 
 # Pages that must stay byte-identical between the two wiki trees. Scoped to what
 # this reconciliation touched — see the header on why this is not tree-wide.
+#
+# plugin-cogni-portfolio.md joins the list with the bare-prose sweep: it carried
+# four off-roster names across two lines, both copies were rewritten, and unlike
+# its siblings here it had no byte-identity arm of its own. Until the
+# roster-derived body scan lands with its two per-tree arms, this entry is the
+# only thing that would catch a one-tree-only regression on that page.
 PAGE_PARITY='plugin-cogni-workspace.md
 workflow-install-to-infographic.md
 arch-er-diagram.md
@@ -166,7 +172,8 @@ concept-four-layer-architecture.md
 workflow-portfolio-to-website.md
 workflow-content-pipeline.md
 workflow-portfolio-to-pitch.md
-workflow-trends-to-solutions.md'
+workflow-trends-to-solutions.md
+plugin-cogni-portfolio.md'
 
 # ---------------------------------------------------------------------------
 # The checkers. Fixture cases and the real-repo cases drive these same two

--- a/cogni-workspace/wiki/wiki/pages/arch-design-philosophy.md
+++ b/cogni-workspace/wiki/wiki/pages/arch-design-philosophy.md
@@ -19,11 +19,11 @@ The architectural principles that recur across insight-wave plugins. Reading the
 - **[[concept-slug-based-lookups]]** — every cross-plugin reference uses kebab-case slugs derived at creation time. Slugs are both file names and identifiers. cogni-portfolio's double-dash convention (`feature--market`) marks paired entities.
 - **[[concept-brief-based-rendering]]** — cogni-visual splits content specification (briefs) from rendering. Briefs travel as YAML-frontmatter markdown; rendering agents are swapped without invalidating briefs.
 - **[[concept-quality-gates]]** — entity-producing plugins gate on three layers (structural validation, quality assessment, stakeholder review) before downstream generation runs.
-- **[[concept-orchestrator-pattern]]** — cogni-consulting tracks engagement state and dispatches; it does not produce content. Most phase gates are advisory; the Develop proposition gate is the deliberate exception.
+- **[[concept-orchestrator-pattern]]** — cogni-consult tracks engagement state across action fields and dispatches; it does not produce content itself. Most gates are advisory; the personas gate on a fresh deliverable is the deliberate exception.
 
 ## Why these principles work together
 
-Data isolation gives each plugin a clean local context to test against. Progressive disclosure keeps that context loadable. Slug-based lookups make cross-plugin references stable across renames and reorganization. Brief-based rendering decouples evolution of content pipelines from rendering pipelines. Quality gates push detection of bad upstream work to the cheapest possible point. The orchestrator pattern keeps cogni-consulting from becoming a god-object that knows every other plugin's internals.
+Data isolation gives each plugin a clean local context to test against. Progressive disclosure keeps that context loadable. Slug-based lookups make cross-plugin references stable across renames and reorganization. Brief-based rendering decouples evolution of content pipelines from rendering pipelines. Quality gates push detection of bad upstream work to the cheapest possible point. The orchestrator pattern keeps cogni-consult from becoming a god-object that knows every other plugin's internals.
 
 The combination is what makes the ecosystem horizontally scalable: a new plugin can consume cogni-portfolio output by reading `portfolio-context.json` without any change to cogni-portfolio.
 

--- a/cogni-workspace/wiki/wiki/pages/arch-er-diagram.md
+++ b/cogni-workspace/wiki/wiki/pages/arch-er-diagram.md
@@ -17,9 +17,9 @@ The cross-plugin entity model and how data flows between plugins. Every arrow is
 cogni-workspace is the horizontal layer owning shared workspace state; the business plugins are vertical, each keeping its own project lifecycle. The role groupings below are descriptive, not a dependency ordering. See [[concept-four-layer-architecture]] for the full mapping.
 
 - **Horizontal** — cogni-workspace (themes, env vars, vault config)
-- **Orchestration** — cogni-consulting (engagement state, phase dispatch)
-- **Data** — cogni-portfolio, cogni-trends, cogni-research (each owns a knowledge domain)
-- **Output** — cogni-narrative, cogni-copywriting, cogni-visual, cogni-sales, cogni-marketing (transform data-layer content into deliverables)
+- **Orchestration** — cogni-consult (engagement state, action-field dispatch)
+- **Data** — cogni-portfolio, cogni-trends, cogni-knowledge (each owns a knowledge domain)
+- **Output** — cogni-visual, cogni-sales, cogni-marketing, cogni-website (transform data-layer content into deliverables)
 
 ## Entity types per plugin
 
@@ -27,11 +27,11 @@ Each data-layer plugin owns a specialized domain with its own persistent entitie
 
 - cogni-portfolio: Product, Feature, Market, Proposition, Solution, Package, Competitor, Customer (JSON in project dir)
 - cogni-trends: TipsProject, TrendCandidate, TrendReport, InvestmentTheme, SolutionTemplate, Catalog (JSON + YAML)
-- cogni-research: SubQuestion, Context, Source, ReportClaim (markdown with YAML frontmatter, Obsidian-browsable)
+- cogni-knowledge: sub-questions in `plan.json`, source / concept / question pages under `wiki/`, `pre_extracted_claims:` frontmatter, `citation-manifest.json` (markdown with YAML frontmatter, Obsidian-browsable)
 - cogni-workspace: ClaimRecord, DeviationRecord, ResolutionRecord (JSON in the project-local `cogni-claims/` store — the directory name is historical)
-- cogni-narrative, cogni-visual, cogni-marketing, cogni-sales, cogni-consulting, cogni-workspace also have their own entity types
+- cogni-visual, cogni-marketing, cogni-sales and cogni-consult also have their own entity types
 
-cogni-copywriting deliberately has no persistent entities — it modifies documents in place and detects `arc_id` frontmatter for arc-aware polishing.
+cogni-workspace's `copywriter` skill deliberately has no persistent entities — it modifies documents in place and detects `arc_id` frontmatter for arc-aware polishing.
 
 ## Bridge files
 
@@ -41,11 +41,11 @@ The bidirectional bridge between cogni-portfolio and cogni-trends is the most co
 
 ## YAML frontmatter contracts
 
-Lighter than bridge files: a downstream plugin reads specific frontmatter fields from upstream files. `arc_id` (cogni-narrative → cogni-copywriting/cogni-visual), `theme_path` (cogni-workspace → cogni-visual — see [[concept-theme-inheritance]]), `portfolio_path` (cogni-portfolio → cogni-consulting), `arc_type` (cogni-visual internal mapping for rendering agents).
+Lighter than bridge files: a downstream plugin reads specific frontmatter fields from upstream files. `arc_id` (cogni-workspace's `narrative` skill → its `copywriter` skill and cogni-visual), `theme_path` (cogni-workspace → cogni-visual — see [[concept-theme-inheritance]]), `portfolio_path` (cogni-portfolio → cogni-sales, cogni-marketing, cogni-trends), `arc_type` (cogni-visual internal mapping for rendering agents).
 
 ## Data isolation in practice
 
-The diagram shows many arrows but each is read-only. cogni-workspace reads source URLs from cogni-research entity files but never writes back. cogni-portfolio's proposition-generator reads trend-bridge enrichments from `portfolio-opportunities.json` but never modifies cogni-trends files. The boundary is the bridge file or frontmatter field — everything on each side is private to the owning plugin. See [[concept-data-isolation]].
+The diagram shows many arrows but each is read-only. cogni-workspace reads source URLs from cogni-knowledge entity files but never writes back. cogni-portfolio's proposition-generator reads trend-bridge enrichments from `portfolio-opportunities.json` but never modifies cogni-trends files. The boundary is the bridge file or frontmatter field — everything on each side is private to the owning plugin. See [[concept-data-isolation]].
 
 ## Claim lifecycle
 

--- a/cogni-workspace/wiki/wiki/pages/arch-plugin-anatomy.md
+++ b/cogni-workspace/wiki/wiki/pages/arch-plugin-anatomy.md
@@ -29,14 +29,14 @@ How insight-wave plugins are structured on disk. Every plugin follows the same s
 └── README.md                     User-facing introduction
 ```
 
-Not every plugin uses every directory. cogni-narrative has no `scripts/`, only four plugins ship `hooks/`, cogni-visual has `libraries/` instead of per-skill `references/`.
+Not every plugin uses every directory. cogni-marketing has no `scripts/`, only four plugins ship `hooks/`, cogni-visual has `libraries/` instead of per-skill `references/`.
 
 ## The four file kinds
 
 - **`plugin.json`** — name, version, description, author, license, keywords. The description is read by marketplace tooling, so it's one or two sentences about what the plugin does, not why it exists.
 - **`SKILL.md`** — YAML frontmatter (`name`, `description`, `allowed-tools`) followed by the system prompt body. The description field is the trigger specification — it determines when Claude Code activates this skill — so it lists explicit trigger phrases including multilingual variants when relevant.
 - **`agents/{name}.md`** — frontmatter (`name`, `description`, `model`, `color`, `tools`) plus the agent's system prompt. Models are picked per role — see [[concept-agent-model-strategy]]. Tools are narrower than a skill's tool set because agents do bounded tasks.
-- **`hooks/hooks.json` + scripts** — `PreToolUse`/`PostToolUse`/`Stop` matchers binding regex tool patterns to bash scripts. cogni-research uses these to block direct entity writes and cap review iterations.
+- **`hooks/hooks.json` + scripts** — `PreToolUse`/`SessionStart`/`SubagentStart` matchers binding regex tool or agent-name patterns to bash scripts. cogni-portfolio and cogni-visual use a `PreToolUse` matcher to auto-start the Excalidraw canvas before any `mcp__excalidraw__*` call; cogni-consult uses `SubagentStart` to inject engagement context into its own subagents.
 
 ## Naming conventions
 

--- a/cogni-workspace/wiki/wiki/pages/concept-agent-model-strategy.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-agent-model-strategy.md
@@ -18,14 +18,14 @@ Agents pick model tiers by role across insight-wave, with cost-per-task as the d
 |------|-------|-----------|
 | Orchestration | sonnet (skill context) | Phase dispatch, sub-question generation |
 | Research | sonnet | Web research, section researchers, deep researchers |
-| Heavy synthesis | opus | Demanding rewrites (cogni-copywriting), 60-candidate scoring (cogni-trends) |
+| Heavy synthesis | opus | Demanding rewrites (the `copywriter` skill of cogni-workspace), 60-candidate scoring (cogni-trends) |
 | Quality assessment | haiku | High-volume rubric evaluation (3-5 dimensions per entity) |
 | Content generation | sonnet | Narrative writers, report writers, content writers |
 
 ## Why each pick
 
 - **sonnet** is the default for anything that needs solid reasoning at moderate volume — research, synthesis, content generation.
-- **opus** comes out for the hard cases: demanding rewrites where tone subtleties matter (cogni-copywriting), or multi-axis scoring across many candidates (cogni-trends scoring 60 candidates).
+- **opus** comes out for the hard cases: demanding rewrites where tone subtleties matter (the `copywriter` skill of cogni-workspace), or multi-axis scoring across many candidates (cogni-trends scoring 60 candidates).
 - **haiku** is the workhorse for high-volume rubric evaluation. The [[concept-quality-gates]] pattern fires haiku assessors across many entities and many dimensions; sonnet would be cost-prohibitive at that scale.
 
 ## Cost telemetry

--- a/cogni-workspace/wiki/wiki/pages/concept-bridge-files.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-bridge-files.md
@@ -21,8 +21,7 @@ Bridge files are explicit JSON exports written by one plugin and read by another
 | `portfolio-opportunities.json` | cogni-trends | cogni-portfolio | Ranked growth opportunities from trend analysis |
 | `tips-value-model.json` | cogni-trends | cogni-portfolio | Solution templates, TIPS paths, BR scores for trends-bridge import |
 | `claims.json` | various | cogni-workspace | Claim records with source URLs submitted for verification |
-| `consulting-project.json` | cogni-consulting | (internal) | Engagement config, phase state, plugin path references |
-| `canvas-{slug}.md` | cogni-consulting | cogni-portfolio | Lean Canvas sections for entity extraction |
+| `consult-project.json` | cogni-consult | (internal) | Engagement config, action-field and deliverable state, plugin path references |
 
 ## Why bridges, not direct imports
 

--- a/cogni-workspace/wiki/wiki/pages/concept-brief-based-rendering.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-brief-based-rendering.md
@@ -15,11 +15,11 @@ cogni-visual separates content specification from rendering. Between the compose
 ## The pipeline
 
 ```
-cogni-narrative → cogni-copywriting → cogni-visual
-(compose)         (polish)            (visualize)
+cogni-workspace `narrative` → cogni-workspace `copywriter` → cogni-visual
+(compose)                     (polish)                       (visualize)
 ```
 
-A brief sits between cogni-copywriting's output and cogni-visual's rendering agents.
+A brief sits between the `copywriter` skill's output and cogni-visual's rendering agents.
 
 ## What a brief specifies vs hides
 

--- a/cogni-workspace/wiki/wiki/pages/concept-claims-propagation.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-claims-propagation.md
@@ -2,7 +2,7 @@
 id: concept-claims-propagation
 title: Claims propagation (auto-log, verify, cascade)
 type: concept
-tags: [cogni-workspace, claims, propagation, source-lineage, cogni-research, cogni-portfolio, cogni-trends]
+tags: [cogni-workspace, claims, propagation, source-lineage, cogni-knowledge, cogni-portfolio, cogni-trends]
 created: 2026-04-17
 updated: 2026-04-20
 sources:
@@ -11,11 +11,11 @@ sources:
 status: stable
 ---
 
-Claims propagation is the cross-plugin pattern that turns sourced assertions into a verifiable, self-correcting knowledge graph. Any data-layer plugin that produces claims (cogni-research, cogni-portfolio, cogni-trends) writes them to the shared `cogni-claims/` claim store; verification corrections cascade back to entity files and downstream consumers.
+Claims propagation is the cross-plugin pattern that turns sourced assertions into a verifiable, self-correcting knowledge graph. Any data-layer plugin that produces claims (cogni-knowledge, cogni-portfolio, cogni-trends) writes them to the shared `cogni-claims/` claim store; verification corrections cascade back to entity files and downstream consumers.
 
 ## The four steps
 
-1. **Auto-log on creation.** Research agents append claim records to `cogni-claims/claims.json` as they generate sourced assertions. Each record carries `entity_ref` provenance (the plugin entity the claim came from), `source_url`, and the asserted text. cogni-portfolio uses `scripts/append-claim.sh` for this; cogni-research's report agents auto-log via the same pattern.
+1. **Auto-log on creation.** Research agents append claim records to `cogni-claims/claims.json` as they generate sourced assertions. Each record carries `entity_ref` provenance (the plugin entity the claim came from), `source_url`, and the asserted text. cogni-portfolio uses `scripts/append-claim.sh` for this; cogni-knowledge's ingest agents auto-log via the same pattern.
 2. **Verify in cogni-workspace.** The `cogni-workspace:claims` skill walks unverified claims, groups them by source URL, and dispatches one `claim-verifier` agent per URL — that agent does the WebFetch and detects deviations between each claim and what the source actually says. Verdicts: verified / deviated / resolved (see [[concept-claim-lifecycle]]).
 3. **Propagate corrections back.** When a claim is marked deviated and the user resolves it (by accepting a corrected version or removing the assertion), the correction propagates to the originating entity file via the `entity_ref` pointer.
 4. **Cascade staleness downstream.** Entities that depend on the corrected entity get marked stale via `propagated_at` timestamps. Downstream skills (e.g., proposition-generator reading a corrected feature) detect stale dependencies and either refresh or warn.
@@ -26,7 +26,7 @@ cogni-workspace owns verification logic but never generates claims itself — th
 
 ## Where it shows up most
 
-- cogni-research's `verify-report` skill is the heaviest user — every ReportClaim in a research draft becomes a claim record.
+- cogni-knowledge scores a draft's citations against claims already on its wiki via `knowledge-verify`, which is a zero-network consistency check rather than live-source verification — so the heaviest users of this store are cogni-portfolio and cogni-trends.
 - cogni-portfolio's `portfolio-verify` skill verifies web-sourced claims in proposition entities.
 - cogni-trends's `trend-report-revisor` reads claim verdicts to decide which evidence to replace.
 

--- a/cogni-workspace/wiki/wiki/pages/concept-data-model-patterns.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-data-model-patterns.md
@@ -18,7 +18,7 @@ Entity slugs are kebab-case, derived from the entity name at creation time, and 
 
 ## Project directory layout
 
-Every project sits at `{plugin}/{project-slug}/` with a manifest at the root. cogni-portfolio uses `portfolio.json`, cogni-trends uses `tips-project.json`, cogni-research uses `project.md` with frontmatter, cogni-consulting uses `consulting-project.json`. The manifest is the lightweight index — full entity content lives in subdirectories and is loaded only when needed (see [[concept-progressive-disclosure]]).
+Every project sits at `{plugin}/{project-slug}/` with a manifest at the root. cogni-portfolio uses `portfolio.json`, cogni-trends uses `tips-project.json`, cogni-knowledge uses `.cogni-knowledge/binding.json`, cogni-consult uses `consult-project.json`. The manifest is the lightweight index — full entity content lives in subdirectories and is loaded only when needed (see [[concept-progressive-disclosure]]).
 
 ## The Feature × Market join
 
@@ -48,6 +48,6 @@ These three are the substrate of [[concept-claims-propagation]] — when a claim
 
 ## Obsidian-browsability
 
-All entity outputs are markdown with YAML frontmatter. This means the user can open the project directory in Obsidian and browse the entire knowledge graph natively — no custom tooling needed. This is one reason cogni-research, cogni-narrative, cogni-marketing, and cogni-trends all default to markdown-with-frontmatter rather than pure JSON.
+All entity outputs are markdown with YAML frontmatter. This means the user can open the project directory in Obsidian and browse the entire knowledge graph natively — no custom tooling needed. This is one reason cogni-knowledge, cogni-marketing, cogni-trends, and cogni-workspace's `narrative` skill all default to markdown-with-frontmatter rather than pure JSON.
 
 **Source**: [insight-wave/CLAUDE.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/CLAUDE.md)

--- a/cogni-workspace/wiki/wiki/pages/concept-four-layer-architecture.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-four-layer-architecture.md
@@ -18,8 +18,7 @@ horizontal   cogni-workspace
 vertical     Orchestration   cogni-consult
              Data            cogni-portfolio  cogni-trends
                              cogni-knowledge
-             Output          cogni-narrative  cogni-copywriting
-                             cogni-visual     cogni-sales
+             Output          cogni-visual     cogni-sales
                              cogni-marketing  cogni-website
 ```
 
@@ -27,8 +26,8 @@ vertical     Orchestration   cogni-consult
 
 - **Horizontal** (cogni-workspace) — shared infrastructure: themes, environment variables, Obsidian vault configuration, MCP server installation. Every plugin that produces visual HTML output reads theme files from cogni-workspace. No plugin writes to cogni-workspace except through `pick-theme` and `manage-workspace`. It also owns the cross-plugin claim-verification gate: verification state across all sourced assertions.
 - **Data** — each plugin owns a specialized knowledge domain. cogni-portfolio (products, markets, propositions, competitors). cogni-trends (TIPS paths, solution templates, catalogs). cogni-knowledge (sub-questions, contexts, sources, claims).
-- **Output** — cogni-narrative, cogni-copywriting, cogni-visual, cogni-sales, cogni-marketing, cogni-website. Transforms data-group content into deliverables (narratives, polished docs, slides/HTML/infographics, sales pitches, marketing campaigns, customer websites). Consumes but does not produce data-group entities.
-- **Orchestration** (cogni-consult) — manages engagement state. Dispatches to data and output plugins at phase-appropriate moments without producing content itself. See [[concept-orchestrator-pattern]].
+- **Output** — cogni-visual, cogni-sales, cogni-marketing, cogni-website. Transforms data-group content into deliverables (slides/HTML/infographics, sales pitches, marketing campaigns, customer websites). Consumes but does not produce data-group entities. Narrative shaping and prose polish belong to this group in function but ship as the `narrative` and `copywriter` skills of the horizontal cogni-workspace, not as plugins of their own.
+- **Orchestration** (cogni-consult) — manages engagement state. Dispatches to data and output plugins as each action field's deliverables require, without producing content itself. See [[concept-orchestrator-pattern]].
 
 ## Why these groups
 

--- a/cogni-workspace/wiki/wiki/pages/concept-multilingual-support.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-multilingual-support.md
@@ -30,9 +30,9 @@ This matters because downstream rendering (cogni-visual, cogni-website, document
 
 ## Per-market authority sources
 
-Authority sources are curated per market in two files:
-- `cogni-research/references/market-sources.json`
-- `cogni-trends/references/region-authority-sources.json`
+Authority sources are canonical in one registry, with per-plugin operational overlays:
+- `cogni-workspace/references/supported-markets-registry.json` — canonical, read via `cogni-workspace/scripts/get-market-config.py`
+- `cogni-trends/skills/trend-research/references/region-authority-sources.json` — the trends overlay (`site_searches[]` per Smarter Service dimension)
 
 Default authority sources by market:
 - **DACH**: fraunhofer.de, bitkom.org, vdma.org, destatis.de, handelsblatt.com
@@ -50,8 +50,8 @@ Per-language section header mappings live in `references/section-headers-de.md` 
 
 ## Plugins most affected
 
-- cogni-research, cogni-trends — language-aware web research and authority weighting
-- cogni-narrative, cogni-copywriting, cogni-marketing — language-aware writing tone
+- cogni-knowledge, cogni-trends — language-aware web research and authority weighting
+- cogni-marketing, and the `narrative` and `copywriter` skills of cogni-workspace — language-aware writing tone
 - cogni-visual, cogni-website — language-aware text rendering and section headers
 
 **Source**: [insight-wave/CLAUDE.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/CLAUDE.md)

--- a/cogni-workspace/wiki/wiki/pages/concept-orchestrator-pattern.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-orchestrator-pattern.md
@@ -1,8 +1,8 @@
 ---
 id: concept-orchestrator-pattern
-title: Orchestrator pattern (cogni-consulting tracks, never produces)
+title: Orchestrator pattern (cogni-consult tracks, never produces)
 type: concept
-tags: [architecture, orchestration, cogni-consulting, phase-gates]
+tags: [architecture, orchestration, cogni-consult, action-fields]
 created: 2026-04-17
 updated: 2026-04-17
 sources:
@@ -10,33 +10,37 @@ sources:
 status: stable
 ---
 
-cogni-consulting does not produce content. It tracks engagement state and dispatches to plugins that produce content. This is the central design principle of the orchestration layer.
+cogni-consult does not produce content. It tracks engagement state and dispatches to plugins that produce content. This is the central design principle of the orchestration layer.
 
 ## The split
 
-cogni-consulting knows:
-- Which phase an engagement is in (Discover, Define, Develop, Deliver)
-- Which plugins have completed their work
-- Which phase transitions are ready
-- Where to find the outputs (path references in `consulting-project.json`)
+cogni-consult knows:
+- Which action fields the engagement's key question decomposes into (3–6, derived at scoping)
+- Which deliverable inside a field is next, and which design-thinking stage it has reached
+- Which deliverables have landed
+- Where to find the outputs (path references in `consult-project.json`)
 
-cogni-consulting does not know:
-- How to run a research report — that's cogni-research
+cogni-consult does not know:
+- How to run research — that's the bound cogni-knowledge base
 - How to generate a value model — that's cogni-trends
 - How to produce propositions — that's cogni-portfolio
 
 ## How dispatch works
 
-When cogni-consulting runs the Discover phase, it instructs the user to invoke `cogni-research:research-report`, `cogni-trends:trend-scout`, and `cogni-portfolio:portfolio-scan`. It stores the output paths. When the Define phase begins, it reads those paths to verify completion and then dispatches to `cogni-workspace:claims` for claim verification.
+Work is organized by **action field**, not by a global phase. Scoping derives 3–6 action fields from the key question, every deliverable lives inside exactly one field, and progress is tracked per deliverable rather than per engagement-wide stage. There are no phase folders and no fixed Discover/Define/Develop/Deliver sequence.
 
-From cogni-consulting's CLAUDE.md: "Orchestrator, not producer — manages engagement state; content work done by existing plugins."
+Each deliverable runs its own design-thinking loop — empathize → define → ideate → prototype → test — and dispatches outward at the points where it needs content it does not own. Research is the clearest case: one cogni-knowledge base is bound to the engagement at setup (`plugin_refs.knowledge_base`), every deliverable's research runs through that base, and the syntheses land under `action-fields/<field-slug>/research/<topic-slug>.md`. Because the same base is reused, research compounds across deliverables instead of being re-fetched for each one.
 
-## Warn-not-block phase gates
+From cogni-consult's CLAUDE.md: "Orchestrator, not producer — manages engagement state; content work dispatches to existing plugins."
 
-Most phase gates are advisory. The orchestrator warns that Discover is incomplete but allows the consultant to proceed anyway. The exception is the Develop proposition [[concept-quality-gates]], which blocks by default because downstream deliverables built on unverified propositions carry compounded error.
+## Gates are advisory, with one deliberate exception
+
+The design-thinking loop's own quality gates are advisory — structural validation, the acting-persona challenge and the framework-adherence review all report rather than block, so an auto-walk never deadlocks. See [[concept-quality-gates]].
+
+The exception is the **personas gate**. Stakeholder personas are seeded from the engagement scope before the first design-thinking deliverable can start, and that seed is a gate rather than a suggestion: a not-yet-started deliverable is hard-blocked until it is satisfied. It clears when a persona carries `source: scope-seeded`, or when the `personas/.gate-waiver` marker records an explicit decision that no external stakeholder is worth modelling — the two setup-default advisors do not satisfy it. The reason this one blocks where the others warn is the reason quality gates exist at all: a deliverable built with no stakeholder to answer to carries compounded error downstream.
 
 ## Why this works
 
-Path references are stored in `consulting-project.json` as relative paths. The engagement never copies data from other plugins — it only remembers where to find it. This is [[concept-data-isolation]] applied at the orchestration level: cogni-consulting can be reasoned about, tested, and modified without touching any data-layer plugin.
+Path references are stored in `consult-project.json` as relative paths. The engagement never copies data from other plugins — it only remembers where to find it. This is [[concept-data-isolation]] applied at the orchestration level: cogni-consult can be reasoned about, tested, and modified without touching any data-layer plugin.
 
 **Source**: [docs/architecture/design-philosophy.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/docs/architecture/design-philosophy.md)

--- a/cogni-workspace/wiki/wiki/pages/concept-progressive-disclosure.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-progressive-disclosure.md
@@ -14,7 +14,7 @@ Skills and agents load reference material only at the step that needs it, never 
 
 ## Where it shows up
 
-cogni-visual, cogni-portfolio, cogni-research, and cogni-consulting apply this consistently. cogni-visual's CLAUDE.md states it directly: "Reference files are read only at the step that needs them, not all at once."
+cogni-visual, cogni-portfolio, cogni-knowledge, and cogni-consult apply this consistently. cogni-visual's CLAUDE.md states it directly: "Reference files are read only at the step that needs them, not all at once."
 
 A typical research-report pipeline:
 

--- a/cogni-workspace/wiki/wiki/pages/concept-quality-gates.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-quality-gates.md
@@ -31,6 +31,6 @@ Quality assessors run on haiku because the workload is high-volume rubric evalua
 
 ## Most prominent in cogni-portfolio
 
-cogni-portfolio is the cleanest reference implementation. cogni-trends and cogni-research apply variations. The orchestrator-level decision to *block* vs *warn* is the [[concept-orchestrator-pattern]]'s "warn-not-block" exception — most phase gates are advisory but the Develop proposition gate blocks.
+cogni-portfolio is the cleanest reference implementation. cogni-trends and cogni-knowledge apply variations. The orchestrator-level decision to *block* vs *warn* is the [[concept-orchestrator-pattern]]'s "warn-not-block" exception — most gates are advisory, but cogni-consult's personas gate blocks a fresh deliverable from opening.
 
 **Source**: [insight-wave/CLAUDE.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/CLAUDE.md) (see also [design-philosophy.md](https://github.com/cogni-work/insight-wave/blob/main/docs/architecture/design-philosophy.md))

--- a/cogni-workspace/wiki/wiki/pages/concept-script-output-format.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-script-output-format.md
@@ -28,7 +28,7 @@ All scripts are bash + python3 standard library. **No pip dependencies, no npm d
 
 ## Where it appears
 
-Every plugin with a `scripts/` directory follows this. cogni-narrative, cogni-copywriting, cogni-marketing and cogni-website have no `scripts/` directory at all, but every plugin that has one uses this format universally. Hook scripts in `hooks/` follow the same convention even though they signal via exit code rather than stdout.
+Every plugin with a `scripts/` directory follows this. cogni-marketing and cogni-website have no `scripts/` directory at all, but every plugin that has one uses this format universally. Hook scripts in `hooks/` follow the same convention even though they signal via exit code rather than stdout.
 
 ## Implications for new code
 

--- a/cogni-workspace/wiki/wiki/pages/concept-slug-based-lookups.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-slug-based-lookups.md
@@ -18,11 +18,11 @@ All cross-plugin references use kebab-case slug identifiers. Slugs are derived f
 cloud-monitoring--mid-market-saas-dach    cogni-portfolio proposition (paired entity)
 automotive-ai-predictive-maintenance-abc12345  cogni-trends trend
 siemens-manufacturing-pitch              cogni-sales pitch
-acme-market-entry                        cogni-consulting engagement
+acme-market-entry                        cogni-consult engagement
 claim-550e8400-e29b-41d4-a716            cogni-workspace claim (UUID-v4 slug)
 ```
 
-Slugs serve as both the file name and the cross-plugin identifier. When cogni-consulting stores a reference to a cogni-portfolio project, it stores the project slug, not an internal ID. When cogni-trends exports a bridge file referencing a portfolio feature, it uses the feature slug.
+Slugs serve as both the file name and the cross-plugin identifier. cogni-consult files each deliverable's research under `action-fields/<field-slug>/research/<topic-slug>.md`, addressing the action field and the topic by slug rather than by an internal ID. When cogni-trends exports a bridge file referencing a portfolio feature, it uses the feature slug.
 
 ## The double-dash convention
 

--- a/cogni-workspace/wiki/wiki/pages/concept-theme-inheritance.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-theme-inheritance.md
@@ -23,7 +23,7 @@ All visual plugins read their theme from cogni-workspace. There's no per-plugin 
 - **cogni-visual** — every render agent (slides, infographic, storyboard, web) reads the theme.
 - **cogni-website** — site-assembler generates the shared CSS stylesheet from the theme; page-generator and hero-renderer interpolate variables.
 - **cogni-portfolio** — the portfolio dashboard reads the theme for its HTML output.
-- **cogni-trends, cogni-marketing, cogni-research** — dashboards pull the same theme for visual consistency.
+- **cogni-trends, cogni-marketing** — dashboards pull the same theme for visual consistency.
 
 ## Why centralize themes
 

--- a/cogni-workspace/wiki/wiki/pages/plugin-cogni-marketing.md
+++ b/cogni-workspace/wiki/wiki/pages/plugin-cogni-marketing.md
@@ -41,6 +41,6 @@ Configurable per project. The setup skill discovers cogni-trends and cogni-portf
 
 ## Integration
 
-Upstream: cogni-trends (TIPS investment themes as GTM paths), cogni-portfolio (propositions, customer profiles, competitor analysis). Downstream: cogni-narrative (content arcs), cogni-copywriting (polish), cogni-visual (brief preparation for slides, infographics), cogni-website (landing page content).
+Upstream: cogni-trends (TIPS investment themes as GTM paths), cogni-portfolio (propositions, customer profiles, competitor analysis). Downstream: cogni-workspace (content arcs via its `narrative` skill, polish via `copywriter`), cogni-visual (brief preparation for slides, infographics), cogni-website (landing page content).
 
 **Source**: [cogni-marketing README](https://github.com/cogni-work/insight-wave/blob/main/cogni-marketing/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-marketing.md)

--- a/cogni-workspace/wiki/wiki/pages/plugin-cogni-portfolio.md
+++ b/cogni-workspace/wiki/wiki/pages/plugin-cogni-portfolio.md
@@ -18,7 +18,7 @@ cogni-portfolio gives B2B companies a structured way to build market-specific me
 
 ## Layer
 
-[[concept-four-layer-architecture|Data layer]]. The most central data plugin — feeds cogni-sales (Why Change), cogni-marketing (content), cogni-website (site), cogni-narrative (pitch arcs), cogni-consulting (Develop phase).
+[[concept-four-layer-architecture|Data layer]]. The most central data plugin — feeds cogni-sales (Why Change), cogni-marketing (content), cogni-website (site), cogni-workspace (pitch arcs via its `narrative` skill), cogni-consult (action-field deliverables).
 
 ## Core data model
 
@@ -42,6 +42,6 @@ Three-layer pipeline ([[concept-quality-gates]]) blocks downstream generation. F
 
 ## Integration
 
-Upstream: cogni-trends (`portfolio-opportunities.json`, `tips-value-model.json`), cogni-consulting (lean canvas), document-skills (file readers). Downstream: cogni-workspace (auto-logged claims), cogni-sales, cogni-marketing, cogni-website, cogni-narrative. The bidirectional cogni-trends integration is the most complex single integration in the ecosystem — see [[concept-trends-portfolio-bridge]].
+Upstream: cogni-trends (`portfolio-opportunities.json`, `tips-value-model.json`), document-skills (file readers). Downstream: cogni-workspace (auto-logged claims; pitch arcs via its `narrative` skill), cogni-sales, cogni-marketing, cogni-website. The bidirectional cogni-trends integration is the most complex single integration in the ecosystem — see [[concept-trends-portfolio-bridge]].
 
 **Source**: [cogni-portfolio README](https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-portfolio.md)

--- a/cogni-workspace/wiki/wiki/pages/plugin-cogni-sales.md
+++ b/cogni-workspace/wiki/wiki/pages/plugin-cogni-sales.md
@@ -34,7 +34,7 @@ The Corporate Visions arc structures every pitch as **Why Change → Why Now →
 - **Why You** — differentiate against the buyer's likely alternatives
 - **Why Pay** — justify investment with quantified business case
 
-The arc is implemented as a structural template in cogni-narrative; cogni-sales dispatches narrative composition and then renders to slide + proposal deliverables.
+The arc is implemented as a structural template in cogni-workspace's `narrative` skill; cogni-sales dispatches narrative composition and then renders to slide + proposal deliverables.
 
 ## Two pitch types
 
@@ -43,10 +43,10 @@ The arc is implemented as a structural template in cogni-narrative; cogni-sales 
 
 ## Outputs
 
-`sales-presentation.md` (slide narrative) and `sales-proposal.md` (long-form proposal). Both pass through cogni-copywriting for Power Positions polish before final rendering.
+`sales-presentation.md` (slide narrative) and `sales-proposal.md` (long-form proposal). Both pass through cogni-workspace's `copywriter` skill for Power Positions polish before final rendering.
 
 ## Integration
 
-Upstream: cogni-portfolio (Feature × Market propositions, customer profiles, competitor analysis), cogni-trends (optional TIPS enrichment for Why Now urgency). Downstream: cogni-narrative (Why Change arc composition), cogni-copywriting (polish), cogni-visual (slide rendering), cogni-workspace (auto-logged sourced claims in pitches).
+Upstream: cogni-portfolio (Feature × Market propositions, customer profiles, competitor analysis), cogni-trends (optional TIPS enrichment for Why Now urgency). Downstream: cogni-workspace (Why Change arc composition via `narrative`, polish via `copywriter`, auto-logged sourced claims in pitches), cogni-visual (slide rendering).
 
 **Source**: [cogni-sales README](https://github.com/cogni-work/insight-wave/blob/main/cogni-sales/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-sales.md)

--- a/cogni-workspace/wiki/wiki/pages/plugin-cogni-trends.md
+++ b/cogni-workspace/wiki/wiki/pages/plugin-cogni-trends.md
@@ -48,6 +48,6 @@ Trend candidates must come from web-sourced signals — never padded with LLM tr
 
 ## Integration
 
-Upstream: cogni-portfolio (`portfolio-context.json`). Downstream: cogni-portfolio (`portfolio-opportunities.json`, `tips-value-model.json`), cogni-marketing (TIPS strategic themes feeding GTM paths), cogni-workspace (auto-logged claims), cogni-narrative (trend reports). The bidirectional cogni-portfolio integration is documented in [[concept-trends-portfolio-bridge]].
+Upstream: cogni-portfolio (`portfolio-context.json`). Downstream: cogni-portfolio (`portfolio-opportunities.json`, `tips-value-model.json`), cogni-marketing (TIPS strategic themes feeding GTM paths), cogni-workspace (auto-logged claims; trend-report arcs via its `narrative` skill). The bidirectional cogni-portfolio integration is documented in [[concept-trends-portfolio-bridge]].
 
 **Source**: [cogni-trends README](https://github.com/cogni-work/insight-wave/blob/main/cogni-trends/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-trends.md)

--- a/cogni-workspace/wiki/wiki/pages/plugin-cogni-visual.md
+++ b/cogni-workspace/wiki/wiki/pages/plugin-cogni-visual.md
@@ -48,6 +48,6 @@ Three MCP servers — see [[concept-mcp-server-map]]:
 
 ## Integration
 
-Upstream: cogni-narrative (narratives with `arc_id`), cogni-copywriting (polished docs), any plugin producing text deliverables (cogni-research, cogni-trends, cogni-portfolio, cogni-marketing, cogni-sales). Downstream: terminal — produces final visual deliverables that humans consume.
+Upstream: cogni-workspace (narratives with `arc_id` from its `narrative` skill, polished docs from `copywriter`), any plugin producing text deliverables (cogni-knowledge, cogni-trends, cogni-portfolio, cogni-marketing, cogni-sales). Downstream: terminal — produces final visual deliverables that humans consume.
 
 **Source**: [cogni-visual README](https://github.com/cogni-work/insight-wave/blob/main/cogni-visual/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-visual.md)

--- a/cogni-workspace/wiki/wiki/pages/plugin-cogni-website.md
+++ b/cogni-workspace/wiki/wiki/pages/plugin-cogni-website.md
@@ -24,7 +24,7 @@ Assembles multi-page customer websites from portfolio, marketing, trend, and res
 
 | Skill | Purpose |
 |-------|---------|
-| `cogni-website:website-setup` | Initialize project; discover content from cogni-portfolio, cogni-marketing, cogni-trends, cogni-research; pick theme |
+| `cogni-website:website-setup` | Initialize project; discover content from cogni-portfolio, cogni-marketing, cogni-trends, cogni-knowledge; pick theme |
 | `cogni-website:website-plan` | Plan site structure interactively — discover content, propose pages, map content to sections |
 | `cogni-website:website-build` | Build the static site — orchestrate CSS generation, parallel page generation, hero rendering, sitemap |
 | `cogni-website:website-preview` | Preview generated website in browser via claude-in-chrome; validate links; report structural issues |
@@ -45,6 +45,6 @@ The setup skill walks every other insight-wave plugin's project directories and 
 
 ## Integration
 
-Upstream: cogni-portfolio (propositions, capabilities pages), cogni-marketing (thought-leadership, demand-gen), cogni-trends (trend reports), cogni-research (whitepapers), cogni-workspace (theme). Downstream: deployable static site (terminal output).
+Upstream: cogni-portfolio (propositions, capabilities pages), cogni-marketing (thought-leadership, demand-gen), cogni-trends (trend reports), cogni-knowledge (wiki syntheses), cogni-workspace (theme). Downstream: deployable static site (terminal output).
 
 **Source**: [cogni-website README](https://github.com/cogni-work/insight-wave/blob/main/cogni-website/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-website.md)

--- a/cogni-workspace/wiki/wiki/pages/skill-cogni-trends-trend-report.md
+++ b/cogni-workspace/wiki/wiki/pages/skill-cogni-trends-trend-report.md
@@ -13,7 +13,7 @@ related: [plugin-cogni-trends]
 
 > One of the skills inside [[plugin-cogni-trends]].
 
-Generate a strategic TIPS trend report organized around investment themes (Handlungsfelder) with inline citations and verifiable claims. The user selects a report-level narrative arc from cogni-narrative's 7 story arcs (corporate-visions, technology-futures, competitive-intelligence, strategic-foresight, industry-transformation, trend-panorama, theme-thesis) — the arc frames the executive summary, bridge paragraphs between themes, and a synthesis closing section that bind investment themes into one cohesive narrative.
+Generate a strategic TIPS trend report organized around investment themes (Handlungsfelder) with inline citations and verifiable claims. The user selects a report-level narrative arc from the 7 story arcs of cogni-workspace's `narrative` skill (corporate-visions, technology-futures, competitive-intelligence, strategic-foresight, industry-transformation, trend-panorama, theme-thesis) — the arc frames the executive summary, bridge paragraphs between themes, and a synthesis closing section that bind investment themes into one cohesive narrative.
 
 **Source**: `cogni-trends:trend-report`
 ([SKILL.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/cogni-trends/skills/trend-report/SKILL.md))

--- a/cogni-workspace/wiki/wiki/pages/skill-cogni-website-website-setup.md
+++ b/cogni-workspace/wiki/wiki/pages/skill-cogni-website-website-setup.md
@@ -13,7 +13,7 @@ related: [plugin-cogni-website]
 
 > One of the skills inside [[plugin-cogni-website]].
 
-This skill initializes a cogni-website project by discovering content sources from cogni-portfolio, cogni-marketing, cogni-trends, and cogni-research, selecting a theme, and scaffolding the project directory. It should be triggered when the user mentions creating a website, starting a new website project, setting up a website, "build me a website", "company website", "customer website", "generate a website", "website setup", "Website erstellen", "Homepage erstellen", "Internetauftritt", "Webseite generieren", "online presence", "web presence", or wants to turn portfolio content into a web presence — even without saying "setup" explicitly.
+This skill initializes a cogni-website project by discovering content sources from cogni-portfolio, cogni-marketing, cogni-trends, and cogni-knowledge, selecting a theme, and scaffolding the project directory. It should be triggered when the user mentions creating a website, starting a new website project, setting up a website, "build me a website", "company website", "customer website", "generate a website", "website setup", "Website erstellen", "Homepage erstellen", "Internetauftritt", "Webseite generieren", "online presence", "web presence", or wants to turn portfolio content into a web presence — even without saying "setup" explicitly.
 
 **Source**: `cogni-website:website-setup`
 ([SKILL.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/cogni-website/skills/website-setup/SKILL.md))

--- a/cogni-workspace/wiki/wiki/pages/workflow-content-pipeline.md
+++ b/cogni-workspace/wiki/wiki/pages/workflow-content-pipeline.md
@@ -18,9 +18,9 @@ The end-to-end content production pipeline — from strategy to channel-ready de
 ```
 cogni-marketing (setup + content generation)
    ↓ raw content pieces
-cogni-narrative (story arc shaping, long-form only)
+cogni-workspace `narrative` (story arc shaping, long-form only)
    ↓ narrative with arc_id
-cogni-copywriting (polish, arc-aware)
+cogni-workspace `copywriter` (polish, arc-aware)
    ↓ polished prose
 cogni-visual (slides / web rendering, brief-driven)
 ```

--- a/wiki/wiki/pages/arch-design-philosophy.md
+++ b/wiki/wiki/pages/arch-design-philosophy.md
@@ -19,11 +19,11 @@ The architectural principles that recur across insight-wave plugins. Reading the
 - **[[concept-slug-based-lookups]]** — every cross-plugin reference uses kebab-case slugs derived at creation time. Slugs are both file names and identifiers. cogni-portfolio's double-dash convention (`feature--market`) marks paired entities.
 - **[[concept-brief-based-rendering]]** — cogni-visual splits content specification (briefs) from rendering. Briefs travel as YAML-frontmatter markdown; rendering agents are swapped without invalidating briefs.
 - **[[concept-quality-gates]]** — entity-producing plugins gate on three layers (structural validation, quality assessment, stakeholder review) before downstream generation runs.
-- **[[concept-orchestrator-pattern]]** — cogni-consulting tracks engagement state and dispatches; it does not produce content. Most phase gates are advisory; the Develop proposition gate is the deliberate exception.
+- **[[concept-orchestrator-pattern]]** — cogni-consult tracks engagement state across action fields and dispatches; it does not produce content itself. Most gates are advisory; the personas gate on a fresh deliverable is the deliberate exception.
 
 ## Why these principles work together
 
-Data isolation gives each plugin a clean local context to test against. Progressive disclosure keeps that context loadable. Slug-based lookups make cross-plugin references stable across renames and reorganization. Brief-based rendering decouples evolution of content pipelines from rendering pipelines. Quality gates push detection of bad upstream work to the cheapest possible point. The orchestrator pattern keeps cogni-consulting from becoming a god-object that knows every other plugin's internals.
+Data isolation gives each plugin a clean local context to test against. Progressive disclosure keeps that context loadable. Slug-based lookups make cross-plugin references stable across renames and reorganization. Brief-based rendering decouples evolution of content pipelines from rendering pipelines. Quality gates push detection of bad upstream work to the cheapest possible point. The orchestrator pattern keeps cogni-consult from becoming a god-object that knows every other plugin's internals.
 
 The combination is what makes the ecosystem horizontally scalable: a new plugin can consume cogni-portfolio output by reading `portfolio-context.json` without any change to cogni-portfolio.
 

--- a/wiki/wiki/pages/arch-er-diagram.md
+++ b/wiki/wiki/pages/arch-er-diagram.md
@@ -17,9 +17,9 @@ The cross-plugin entity model and how data flows between plugins. Every arrow is
 cogni-workspace is the horizontal layer owning shared workspace state; the business plugins are vertical, each keeping its own project lifecycle. The role groupings below are descriptive, not a dependency ordering. See [[concept-four-layer-architecture]] for the full mapping.
 
 - **Horizontal** — cogni-workspace (themes, env vars, vault config)
-- **Orchestration** — cogni-consulting (engagement state, phase dispatch)
-- **Data** — cogni-portfolio, cogni-trends, cogni-research (each owns a knowledge domain)
-- **Output** — cogni-narrative, cogni-copywriting, cogni-visual, cogni-sales, cogni-marketing (transform data-layer content into deliverables)
+- **Orchestration** — cogni-consult (engagement state, action-field dispatch)
+- **Data** — cogni-portfolio, cogni-trends, cogni-knowledge (each owns a knowledge domain)
+- **Output** — cogni-visual, cogni-sales, cogni-marketing, cogni-website (transform data-layer content into deliverables)
 
 ## Entity types per plugin
 
@@ -27,11 +27,11 @@ Each data-layer plugin owns a specialized domain with its own persistent entitie
 
 - cogni-portfolio: Product, Feature, Market, Proposition, Solution, Package, Competitor, Customer (JSON in project dir)
 - cogni-trends: TipsProject, TrendCandidate, TrendReport, InvestmentTheme, SolutionTemplate, Catalog (JSON + YAML)
-- cogni-research: SubQuestion, Context, Source, ReportClaim (markdown with YAML frontmatter, Obsidian-browsable)
+- cogni-knowledge: sub-questions in `plan.json`, source / concept / question pages under `wiki/`, `pre_extracted_claims:` frontmatter, `citation-manifest.json` (markdown with YAML frontmatter, Obsidian-browsable)
 - cogni-workspace: ClaimRecord, DeviationRecord, ResolutionRecord (JSON in the project-local `cogni-claims/` store — the directory name is historical)
-- cogni-narrative, cogni-visual, cogni-marketing, cogni-sales, cogni-consulting, cogni-workspace also have their own entity types
+- cogni-visual, cogni-marketing, cogni-sales and cogni-consult also have their own entity types
 
-cogni-copywriting deliberately has no persistent entities — it modifies documents in place and detects `arc_id` frontmatter for arc-aware polishing.
+cogni-workspace's `copywriter` skill deliberately has no persistent entities — it modifies documents in place and detects `arc_id` frontmatter for arc-aware polishing.
 
 ## Bridge files
 
@@ -41,11 +41,11 @@ The bidirectional bridge between cogni-portfolio and cogni-trends is the most co
 
 ## YAML frontmatter contracts
 
-Lighter than bridge files: a downstream plugin reads specific frontmatter fields from upstream files. `arc_id` (cogni-narrative → cogni-copywriting/cogni-visual), `theme_path` (cogni-workspace → cogni-visual — see [[concept-theme-inheritance]]), `portfolio_path` (cogni-portfolio → cogni-consulting), `arc_type` (cogni-visual internal mapping for rendering agents).
+Lighter than bridge files: a downstream plugin reads specific frontmatter fields from upstream files. `arc_id` (cogni-workspace's `narrative` skill → its `copywriter` skill and cogni-visual), `theme_path` (cogni-workspace → cogni-visual — see [[concept-theme-inheritance]]), `portfolio_path` (cogni-portfolio → cogni-sales, cogni-marketing, cogni-trends), `arc_type` (cogni-visual internal mapping for rendering agents).
 
 ## Data isolation in practice
 
-The diagram shows many arrows but each is read-only. cogni-workspace reads source URLs from cogni-research entity files but never writes back. cogni-portfolio's proposition-generator reads trend-bridge enrichments from `portfolio-opportunities.json` but never modifies cogni-trends files. The boundary is the bridge file or frontmatter field — everything on each side is private to the owning plugin. See [[concept-data-isolation]].
+The diagram shows many arrows but each is read-only. cogni-workspace reads source URLs from cogni-knowledge entity files but never writes back. cogni-portfolio's proposition-generator reads trend-bridge enrichments from `portfolio-opportunities.json` but never modifies cogni-trends files. The boundary is the bridge file or frontmatter field — everything on each side is private to the owning plugin. See [[concept-data-isolation]].
 
 ## Claim lifecycle
 

--- a/wiki/wiki/pages/arch-plugin-anatomy.md
+++ b/wiki/wiki/pages/arch-plugin-anatomy.md
@@ -29,14 +29,14 @@ How insight-wave plugins are structured on disk. Every plugin follows the same s
 └── README.md                     User-facing introduction
 ```
 
-Not every plugin uses every directory. cogni-narrative has no `scripts/`, only four plugins ship `hooks/`, cogni-visual has `libraries/` instead of per-skill `references/`.
+Not every plugin uses every directory. cogni-marketing has no `scripts/`, only four plugins ship `hooks/`, cogni-visual has `libraries/` instead of per-skill `references/`.
 
 ## The four file kinds
 
 - **`plugin.json`** — name, version, description, author, license, keywords. The description is read by marketplace tooling, so it's one or two sentences about what the plugin does, not why it exists.
 - **`SKILL.md`** — YAML frontmatter (`name`, `description`, `allowed-tools`) followed by the system prompt body. The description field is the trigger specification — it determines when Claude Code activates this skill — so it lists explicit trigger phrases including multilingual variants when relevant.
 - **`agents/{name}.md`** — frontmatter (`name`, `description`, `model`, `color`, `tools`) plus the agent's system prompt. Models are picked per role — see [[concept-agent-model-strategy]]. Tools are narrower than a skill's tool set because agents do bounded tasks.
-- **`hooks/hooks.json` + scripts** — `PreToolUse`/`PostToolUse`/`Stop` matchers binding regex tool patterns to bash scripts. cogni-research uses these to block direct entity writes and cap review iterations.
+- **`hooks/hooks.json` + scripts** — `PreToolUse`/`SessionStart`/`SubagentStart` matchers binding regex tool or agent-name patterns to bash scripts. cogni-portfolio and cogni-visual use a `PreToolUse` matcher to auto-start the Excalidraw canvas before any `mcp__excalidraw__*` call; cogni-consult uses `SubagentStart` to inject engagement context into its own subagents.
 
 ## Naming conventions
 

--- a/wiki/wiki/pages/concept-agent-model-strategy.md
+++ b/wiki/wiki/pages/concept-agent-model-strategy.md
@@ -18,14 +18,14 @@ Agents pick model tiers by role across insight-wave, with cost-per-task as the d
 |------|-------|-----------|
 | Orchestration | sonnet (skill context) | Phase dispatch, sub-question generation |
 | Research | sonnet | Web research, section researchers, deep researchers |
-| Heavy synthesis | opus | Demanding rewrites (cogni-copywriting), 60-candidate scoring (cogni-trends) |
+| Heavy synthesis | opus | Demanding rewrites (the `copywriter` skill of cogni-workspace), 60-candidate scoring (cogni-trends) |
 | Quality assessment | haiku | High-volume rubric evaluation (3-5 dimensions per entity) |
 | Content generation | sonnet | Narrative writers, report writers, content writers |
 
 ## Why each pick
 
 - **sonnet** is the default for anything that needs solid reasoning at moderate volume — research, synthesis, content generation.
-- **opus** comes out for the hard cases: demanding rewrites where tone subtleties matter (cogni-copywriting), or multi-axis scoring across many candidates (cogni-trends scoring 60 candidates).
+- **opus** comes out for the hard cases: demanding rewrites where tone subtleties matter (the `copywriter` skill of cogni-workspace), or multi-axis scoring across many candidates (cogni-trends scoring 60 candidates).
 - **haiku** is the workhorse for high-volume rubric evaluation. The [[concept-quality-gates]] pattern fires haiku assessors across many entities and many dimensions; sonnet would be cost-prohibitive at that scale.
 
 ## Cost telemetry

--- a/wiki/wiki/pages/concept-bridge-files.md
+++ b/wiki/wiki/pages/concept-bridge-files.md
@@ -21,8 +21,7 @@ Bridge files are explicit JSON exports written by one plugin and read by another
 | `portfolio-opportunities.json` | cogni-trends | cogni-portfolio | Ranked growth opportunities from trend analysis |
 | `tips-value-model.json` | cogni-trends | cogni-portfolio | Solution templates, TIPS paths, BR scores for trends-bridge import |
 | `claims.json` | various | cogni-workspace | Claim records with source URLs submitted for verification |
-| `consulting-project.json` | cogni-consulting | (internal) | Engagement config, phase state, plugin path references |
-| `canvas-{slug}.md` | cogni-consulting | cogni-portfolio | Lean Canvas sections for entity extraction |
+| `consult-project.json` | cogni-consult | (internal) | Engagement config, action-field and deliverable state, plugin path references |
 
 ## Why bridges, not direct imports
 

--- a/wiki/wiki/pages/concept-brief-based-rendering.md
+++ b/wiki/wiki/pages/concept-brief-based-rendering.md
@@ -15,11 +15,11 @@ cogni-visual separates content specification from rendering. Between the compose
 ## The pipeline
 
 ```
-cogni-narrative → cogni-copywriting → cogni-visual
-(compose)         (polish)            (visualize)
+cogni-workspace `narrative` → cogni-workspace `copywriter` → cogni-visual
+(compose)                     (polish)                       (visualize)
 ```
 
-A brief sits between cogni-copywriting's output and cogni-visual's rendering agents.
+A brief sits between the `copywriter` skill's output and cogni-visual's rendering agents.
 
 ## What a brief specifies vs hides
 

--- a/wiki/wiki/pages/concept-claims-propagation.md
+++ b/wiki/wiki/pages/concept-claims-propagation.md
@@ -2,7 +2,7 @@
 id: concept-claims-propagation
 title: Claims propagation (auto-log, verify, cascade)
 type: concept
-tags: [cogni-workspace, claims, propagation, source-lineage, cogni-research, cogni-portfolio, cogni-trends]
+tags: [cogni-workspace, claims, propagation, source-lineage, cogni-knowledge, cogni-portfolio, cogni-trends]
 created: 2026-04-17
 updated: 2026-04-20
 sources:
@@ -11,11 +11,11 @@ sources:
 status: stable
 ---
 
-Claims propagation is the cross-plugin pattern that turns sourced assertions into a verifiable, self-correcting knowledge graph. Any data-layer plugin that produces claims (cogni-research, cogni-portfolio, cogni-trends) writes them to the shared `cogni-claims/` claim store; verification corrections cascade back to entity files and downstream consumers.
+Claims propagation is the cross-plugin pattern that turns sourced assertions into a verifiable, self-correcting knowledge graph. Any data-layer plugin that produces claims (cogni-knowledge, cogni-portfolio, cogni-trends) writes them to the shared `cogni-claims/` claim store; verification corrections cascade back to entity files and downstream consumers.
 
 ## The four steps
 
-1. **Auto-log on creation.** Research agents append claim records to `cogni-claims/claims.json` as they generate sourced assertions. Each record carries `entity_ref` provenance (the plugin entity the claim came from), `source_url`, and the asserted text. cogni-portfolio uses `scripts/append-claim.sh` for this; cogni-research's report agents auto-log via the same pattern.
+1. **Auto-log on creation.** Research agents append claim records to `cogni-claims/claims.json` as they generate sourced assertions. Each record carries `entity_ref` provenance (the plugin entity the claim came from), `source_url`, and the asserted text. cogni-portfolio uses `scripts/append-claim.sh` for this; cogni-knowledge's ingest agents auto-log via the same pattern.
 2. **Verify in cogni-workspace.** The `cogni-workspace:claims` skill walks unverified claims, groups them by source URL, and dispatches one `claim-verifier` agent per URL — that agent does the WebFetch and detects deviations between each claim and what the source actually says. Verdicts: verified / deviated / resolved (see [[concept-claim-lifecycle]]).
 3. **Propagate corrections back.** When a claim is marked deviated and the user resolves it (by accepting a corrected version or removing the assertion), the correction propagates to the originating entity file via the `entity_ref` pointer.
 4. **Cascade staleness downstream.** Entities that depend on the corrected entity get marked stale via `propagated_at` timestamps. Downstream skills (e.g., proposition-generator reading a corrected feature) detect stale dependencies and either refresh or warn.
@@ -26,7 +26,7 @@ cogni-workspace owns verification logic but never generates claims itself — th
 
 ## Where it shows up most
 
-- cogni-research's `verify-report` skill is the heaviest user — every ReportClaim in a research draft becomes a claim record.
+- cogni-knowledge scores a draft's citations against claims already on its wiki via `knowledge-verify`, which is a zero-network consistency check rather than live-source verification — so the heaviest users of this store are cogni-portfolio and cogni-trends.
 - cogni-portfolio's `portfolio-verify` skill verifies web-sourced claims in proposition entities.
 - cogni-trends's `trend-report-revisor` reads claim verdicts to decide which evidence to replace.
 

--- a/wiki/wiki/pages/concept-data-model-patterns.md
+++ b/wiki/wiki/pages/concept-data-model-patterns.md
@@ -18,7 +18,7 @@ Entity slugs are kebab-case, derived from the entity name at creation time, and 
 
 ## Project directory layout
 
-Every project sits at `{plugin}/{project-slug}/` with a manifest at the root. cogni-portfolio uses `portfolio.json`, cogni-trends uses `tips-project.json`, cogni-research uses `project.md` with frontmatter, cogni-consulting uses `consulting-project.json`. The manifest is the lightweight index — full entity content lives in subdirectories and is loaded only when needed (see [[concept-progressive-disclosure]]).
+Every project sits at `{plugin}/{project-slug}/` with a manifest at the root. cogni-portfolio uses `portfolio.json`, cogni-trends uses `tips-project.json`, cogni-knowledge uses `.cogni-knowledge/binding.json`, cogni-consult uses `consult-project.json`. The manifest is the lightweight index — full entity content lives in subdirectories and is loaded only when needed (see [[concept-progressive-disclosure]]).
 
 ## The Feature × Market join
 
@@ -48,6 +48,6 @@ These three are the substrate of [[concept-claims-propagation]] — when a claim
 
 ## Obsidian-browsability
 
-All entity outputs are markdown with YAML frontmatter. This means the user can open the project directory in Obsidian and browse the entire knowledge graph natively — no custom tooling needed. This is one reason cogni-research, cogni-narrative, cogni-marketing, and cogni-trends all default to markdown-with-frontmatter rather than pure JSON.
+All entity outputs are markdown with YAML frontmatter. This means the user can open the project directory in Obsidian and browse the entire knowledge graph natively — no custom tooling needed. This is one reason cogni-knowledge, cogni-marketing, cogni-trends, and cogni-workspace's `narrative` skill all default to markdown-with-frontmatter rather than pure JSON.
 
 **Source**: [insight-wave/CLAUDE.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/CLAUDE.md)

--- a/wiki/wiki/pages/concept-four-layer-architecture.md
+++ b/wiki/wiki/pages/concept-four-layer-architecture.md
@@ -18,8 +18,7 @@ horizontal   cogni-workspace
 vertical     Orchestration   cogni-consult
              Data            cogni-portfolio  cogni-trends
                              cogni-knowledge
-             Output          cogni-narrative  cogni-copywriting
-                             cogni-visual     cogni-sales
+             Output          cogni-visual     cogni-sales
                              cogni-marketing  cogni-website
 ```
 
@@ -27,8 +26,8 @@ vertical     Orchestration   cogni-consult
 
 - **Horizontal** (cogni-workspace) — shared infrastructure: themes, environment variables, Obsidian vault configuration, MCP server installation. Every plugin that produces visual HTML output reads theme files from cogni-workspace. No plugin writes to cogni-workspace except through `pick-theme` and `manage-workspace`. It also owns the cross-plugin claim-verification gate: verification state across all sourced assertions.
 - **Data** — each plugin owns a specialized knowledge domain. cogni-portfolio (products, markets, propositions, competitors). cogni-trends (TIPS paths, solution templates, catalogs). cogni-knowledge (sub-questions, contexts, sources, claims).
-- **Output** — cogni-narrative, cogni-copywriting, cogni-visual, cogni-sales, cogni-marketing, cogni-website. Transforms data-group content into deliverables (narratives, polished docs, slides/HTML/infographics, sales pitches, marketing campaigns, customer websites). Consumes but does not produce data-group entities.
-- **Orchestration** (cogni-consult) — manages engagement state. Dispatches to data and output plugins at phase-appropriate moments without producing content itself. See [[concept-orchestrator-pattern]].
+- **Output** — cogni-visual, cogni-sales, cogni-marketing, cogni-website. Transforms data-group content into deliverables (slides/HTML/infographics, sales pitches, marketing campaigns, customer websites). Consumes but does not produce data-group entities. Narrative shaping and prose polish belong to this group in function but ship as the `narrative` and `copywriter` skills of the horizontal cogni-workspace, not as plugins of their own.
+- **Orchestration** (cogni-consult) — manages engagement state. Dispatches to data and output plugins as each action field's deliverables require, without producing content itself. See [[concept-orchestrator-pattern]].
 
 ## Why these groups
 

--- a/wiki/wiki/pages/concept-multilingual-support.md
+++ b/wiki/wiki/pages/concept-multilingual-support.md
@@ -30,9 +30,9 @@ This matters because downstream rendering (cogni-visual, cogni-website, document
 
 ## Per-market authority sources
 
-Authority sources are curated per market in two files:
-- `cogni-research/references/market-sources.json`
-- `cogni-trends/references/region-authority-sources.json`
+Authority sources are canonical in one registry, with per-plugin operational overlays:
+- `cogni-workspace/references/supported-markets-registry.json` — canonical, read via `cogni-workspace/scripts/get-market-config.py`
+- `cogni-trends/skills/trend-research/references/region-authority-sources.json` — the trends overlay (`site_searches[]` per Smarter Service dimension)
 
 Default authority sources by market:
 - **DACH**: fraunhofer.de, bitkom.org, vdma.org, destatis.de, handelsblatt.com
@@ -50,8 +50,8 @@ Per-language section header mappings live in `references/section-headers-de.md` 
 
 ## Plugins most affected
 
-- cogni-research, cogni-trends — language-aware web research and authority weighting
-- cogni-narrative, cogni-copywriting, cogni-marketing — language-aware writing tone
+- cogni-knowledge, cogni-trends — language-aware web research and authority weighting
+- cogni-marketing, and the `narrative` and `copywriter` skills of cogni-workspace — language-aware writing tone
 - cogni-visual, cogni-website — language-aware text rendering and section headers
 
 **Source**: [insight-wave/CLAUDE.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/CLAUDE.md)

--- a/wiki/wiki/pages/concept-orchestrator-pattern.md
+++ b/wiki/wiki/pages/concept-orchestrator-pattern.md
@@ -1,8 +1,8 @@
 ---
 id: concept-orchestrator-pattern
-title: Orchestrator pattern (cogni-consulting tracks, never produces)
+title: Orchestrator pattern (cogni-consult tracks, never produces)
 type: concept
-tags: [architecture, orchestration, cogni-consulting, phase-gates]
+tags: [architecture, orchestration, cogni-consult, action-fields]
 created: 2026-04-17
 updated: 2026-04-17
 sources:
@@ -10,33 +10,37 @@ sources:
 status: stable
 ---
 
-cogni-consulting does not produce content. It tracks engagement state and dispatches to plugins that produce content. This is the central design principle of the orchestration layer.
+cogni-consult does not produce content. It tracks engagement state and dispatches to plugins that produce content. This is the central design principle of the orchestration layer.
 
 ## The split
 
-cogni-consulting knows:
-- Which phase an engagement is in (Discover, Define, Develop, Deliver)
-- Which plugins have completed their work
-- Which phase transitions are ready
-- Where to find the outputs (path references in `consulting-project.json`)
+cogni-consult knows:
+- Which action fields the engagement's key question decomposes into (3–6, derived at scoping)
+- Which deliverable inside a field is next, and which design-thinking stage it has reached
+- Which deliverables have landed
+- Where to find the outputs (path references in `consult-project.json`)
 
-cogni-consulting does not know:
-- How to run a research report — that's cogni-research
+cogni-consult does not know:
+- How to run research — that's the bound cogni-knowledge base
 - How to generate a value model — that's cogni-trends
 - How to produce propositions — that's cogni-portfolio
 
 ## How dispatch works
 
-When cogni-consulting runs the Discover phase, it instructs the user to invoke `cogni-research:research-report`, `cogni-trends:trend-scout`, and `cogni-portfolio:portfolio-scan`. It stores the output paths. When the Define phase begins, it reads those paths to verify completion and then dispatches to `cogni-workspace:claims` for claim verification.
+Work is organized by **action field**, not by a global phase. Scoping derives 3–6 action fields from the key question, every deliverable lives inside exactly one field, and progress is tracked per deliverable rather than per engagement-wide stage. There are no phase folders and no fixed Discover/Define/Develop/Deliver sequence.
 
-From cogni-consulting's CLAUDE.md: "Orchestrator, not producer — manages engagement state; content work done by existing plugins."
+Each deliverable runs its own design-thinking loop — empathize → define → ideate → prototype → test — and dispatches outward at the points where it needs content it does not own. Research is the clearest case: one cogni-knowledge base is bound to the engagement at setup (`plugin_refs.knowledge_base`), every deliverable's research runs through that base, and the syntheses land under `action-fields/<field-slug>/research/<topic-slug>.md`. Because the same base is reused, research compounds across deliverables instead of being re-fetched for each one.
 
-## Warn-not-block phase gates
+From cogni-consult's CLAUDE.md: "Orchestrator, not producer — manages engagement state; content work dispatches to existing plugins."
 
-Most phase gates are advisory. The orchestrator warns that Discover is incomplete but allows the consultant to proceed anyway. The exception is the Develop proposition [[concept-quality-gates]], which blocks by default because downstream deliverables built on unverified propositions carry compounded error.
+## Gates are advisory, with one deliberate exception
+
+The design-thinking loop's own quality gates are advisory — structural validation, the acting-persona challenge and the framework-adherence review all report rather than block, so an auto-walk never deadlocks. See [[concept-quality-gates]].
+
+The exception is the **personas gate**. Stakeholder personas are seeded from the engagement scope before the first design-thinking deliverable can start, and that seed is a gate rather than a suggestion: a not-yet-started deliverable is hard-blocked until it is satisfied. It clears when a persona carries `source: scope-seeded`, or when the `personas/.gate-waiver` marker records an explicit decision that no external stakeholder is worth modelling — the two setup-default advisors do not satisfy it. The reason this one blocks where the others warn is the reason quality gates exist at all: a deliverable built with no stakeholder to answer to carries compounded error downstream.
 
 ## Why this works
 
-Path references are stored in `consulting-project.json` as relative paths. The engagement never copies data from other plugins — it only remembers where to find it. This is [[concept-data-isolation]] applied at the orchestration level: cogni-consulting can be reasoned about, tested, and modified without touching any data-layer plugin.
+Path references are stored in `consult-project.json` as relative paths. The engagement never copies data from other plugins — it only remembers where to find it. This is [[concept-data-isolation]] applied at the orchestration level: cogni-consult can be reasoned about, tested, and modified without touching any data-layer plugin.
 
 **Source**: [docs/architecture/design-philosophy.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/docs/architecture/design-philosophy.md)

--- a/wiki/wiki/pages/concept-progressive-disclosure.md
+++ b/wiki/wiki/pages/concept-progressive-disclosure.md
@@ -14,7 +14,7 @@ Skills and agents load reference material only at the step that needs it, never 
 
 ## Where it shows up
 
-cogni-visual, cogni-portfolio, cogni-research, and cogni-consulting apply this consistently. cogni-visual's CLAUDE.md states it directly: "Reference files are read only at the step that needs them, not all at once."
+cogni-visual, cogni-portfolio, cogni-knowledge, and cogni-consult apply this consistently. cogni-visual's CLAUDE.md states it directly: "Reference files are read only at the step that needs them, not all at once."
 
 A typical research-report pipeline:
 

--- a/wiki/wiki/pages/concept-quality-gates.md
+++ b/wiki/wiki/pages/concept-quality-gates.md
@@ -31,6 +31,6 @@ Quality assessors run on haiku because the workload is high-volume rubric evalua
 
 ## Most prominent in cogni-portfolio
 
-cogni-portfolio is the cleanest reference implementation. cogni-trends and cogni-research apply variations. The orchestrator-level decision to *block* vs *warn* is the [[concept-orchestrator-pattern]]'s "warn-not-block" exception — most phase gates are advisory but the Develop proposition gate blocks.
+cogni-portfolio is the cleanest reference implementation. cogni-trends and cogni-knowledge apply variations. The orchestrator-level decision to *block* vs *warn* is the [[concept-orchestrator-pattern]]'s "warn-not-block" exception — most gates are advisory, but cogni-consult's personas gate blocks a fresh deliverable from opening.
 
 **Source**: [insight-wave/CLAUDE.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/CLAUDE.md) (see also [design-philosophy.md](https://github.com/cogni-work/insight-wave/blob/main/docs/architecture/design-philosophy.md))

--- a/wiki/wiki/pages/concept-script-output-format.md
+++ b/wiki/wiki/pages/concept-script-output-format.md
@@ -28,7 +28,7 @@ All scripts are bash + python3 standard library. **No pip dependencies, no npm d
 
 ## Where it appears
 
-Every plugin with a `scripts/` directory follows this. cogni-narrative, cogni-copywriting, cogni-marketing and cogni-website have no `scripts/` directory at all, but every plugin that has one uses this format universally. Hook scripts in `hooks/` follow the same convention even though they signal via exit code rather than stdout.
+Every plugin with a `scripts/` directory follows this. cogni-marketing and cogni-website have no `scripts/` directory at all, but every plugin that has one uses this format universally. Hook scripts in `hooks/` follow the same convention even though they signal via exit code rather than stdout.
 
 ## Implications for new code
 

--- a/wiki/wiki/pages/concept-slug-based-lookups.md
+++ b/wiki/wiki/pages/concept-slug-based-lookups.md
@@ -18,11 +18,11 @@ All cross-plugin references use kebab-case slug identifiers. Slugs are derived f
 cloud-monitoring--mid-market-saas-dach    cogni-portfolio proposition (paired entity)
 automotive-ai-predictive-maintenance-abc12345  cogni-trends trend
 siemens-manufacturing-pitch              cogni-sales pitch
-acme-market-entry                        cogni-consulting engagement
+acme-market-entry                        cogni-consult engagement
 claim-550e8400-e29b-41d4-a716            cogni-workspace claim (UUID-v4 slug)
 ```
 
-Slugs serve as both the file name and the cross-plugin identifier. When cogni-consulting stores a reference to a cogni-portfolio project, it stores the project slug, not an internal ID. When cogni-trends exports a bridge file referencing a portfolio feature, it uses the feature slug.
+Slugs serve as both the file name and the cross-plugin identifier. cogni-consult files each deliverable's research under `action-fields/<field-slug>/research/<topic-slug>.md`, addressing the action field and the topic by slug rather than by an internal ID. When cogni-trends exports a bridge file referencing a portfolio feature, it uses the feature slug.
 
 ## The double-dash convention
 

--- a/wiki/wiki/pages/concept-theme-inheritance.md
+++ b/wiki/wiki/pages/concept-theme-inheritance.md
@@ -23,7 +23,7 @@ All visual plugins read their theme from cogni-workspace. There's no per-plugin 
 - **cogni-visual** — every render agent (slides, infographic, storyboard, web) reads the theme.
 - **cogni-website** — site-assembler generates the shared CSS stylesheet from the theme; page-generator and hero-renderer interpolate variables.
 - **cogni-portfolio** — the portfolio dashboard reads the theme for its HTML output.
-- **cogni-trends, cogni-marketing, cogni-research** — dashboards pull the same theme for visual consistency.
+- **cogni-trends, cogni-marketing** — dashboards pull the same theme for visual consistency.
 
 ## Why centralize themes
 

--- a/wiki/wiki/pages/plugin-cogni-marketing.md
+++ b/wiki/wiki/pages/plugin-cogni-marketing.md
@@ -41,6 +41,6 @@ Configurable per project. The setup skill discovers cogni-trends and cogni-portf
 
 ## Integration
 
-Upstream: cogni-trends (TIPS investment themes as GTM paths), cogni-portfolio (propositions, customer profiles, competitor analysis). Downstream: cogni-narrative (content arcs), cogni-copywriting (polish), cogni-visual (brief preparation for slides, infographics), cogni-website (landing page content).
+Upstream: cogni-trends (TIPS investment themes as GTM paths), cogni-portfolio (propositions, customer profiles, competitor analysis). Downstream: cogni-workspace (content arcs via its `narrative` skill, polish via `copywriter`), cogni-visual (brief preparation for slides, infographics), cogni-website (landing page content).
 
 **Source**: [cogni-marketing README](https://github.com/cogni-work/insight-wave/blob/main/cogni-marketing/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-marketing.md)

--- a/wiki/wiki/pages/plugin-cogni-portfolio.md
+++ b/wiki/wiki/pages/plugin-cogni-portfolio.md
@@ -18,7 +18,7 @@ cogni-portfolio gives B2B companies a structured way to build market-specific me
 
 ## Layer
 
-[[concept-four-layer-architecture|Data layer]]. The most central data plugin — feeds cogni-sales (Why Change), cogni-marketing (content), cogni-website (site), cogni-narrative (pitch arcs), cogni-consulting (Develop phase).
+[[concept-four-layer-architecture|Data layer]]. The most central data plugin — feeds cogni-sales (Why Change), cogni-marketing (content), cogni-website (site), cogni-workspace (pitch arcs via its `narrative` skill), cogni-consult (action-field deliverables).
 
 ## Core data model
 
@@ -42,6 +42,6 @@ Three-layer pipeline ([[concept-quality-gates]]) blocks downstream generation. F
 
 ## Integration
 
-Upstream: cogni-trends (`portfolio-opportunities.json`, `tips-value-model.json`), cogni-consulting (lean canvas), document-skills (file readers). Downstream: cogni-workspace (auto-logged claims), cogni-sales, cogni-marketing, cogni-website, cogni-narrative. The bidirectional cogni-trends integration is the most complex single integration in the ecosystem — see [[concept-trends-portfolio-bridge]].
+Upstream: cogni-trends (`portfolio-opportunities.json`, `tips-value-model.json`), document-skills (file readers). Downstream: cogni-workspace (auto-logged claims; pitch arcs via its `narrative` skill), cogni-sales, cogni-marketing, cogni-website. The bidirectional cogni-trends integration is the most complex single integration in the ecosystem — see [[concept-trends-portfolio-bridge]].
 
 **Source**: [cogni-portfolio README](https://github.com/cogni-work/insight-wave/blob/main/cogni-portfolio/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-portfolio.md)

--- a/wiki/wiki/pages/plugin-cogni-sales.md
+++ b/wiki/wiki/pages/plugin-cogni-sales.md
@@ -34,7 +34,7 @@ The Corporate Visions arc structures every pitch as **Why Change → Why Now →
 - **Why You** — differentiate against the buyer's likely alternatives
 - **Why Pay** — justify investment with quantified business case
 
-The arc is implemented as a structural template in cogni-narrative; cogni-sales dispatches narrative composition and then renders to slide + proposal deliverables.
+The arc is implemented as a structural template in cogni-workspace's `narrative` skill; cogni-sales dispatches narrative composition and then renders to slide + proposal deliverables.
 
 ## Two pitch types
 
@@ -43,10 +43,10 @@ The arc is implemented as a structural template in cogni-narrative; cogni-sales 
 
 ## Outputs
 
-`sales-presentation.md` (slide narrative) and `sales-proposal.md` (long-form proposal). Both pass through cogni-copywriting for Power Positions polish before final rendering.
+`sales-presentation.md` (slide narrative) and `sales-proposal.md` (long-form proposal). Both pass through cogni-workspace's `copywriter` skill for Power Positions polish before final rendering.
 
 ## Integration
 
-Upstream: cogni-portfolio (Feature × Market propositions, customer profiles, competitor analysis), cogni-trends (optional TIPS enrichment for Why Now urgency). Downstream: cogni-narrative (Why Change arc composition), cogni-copywriting (polish), cogni-visual (slide rendering), cogni-workspace (auto-logged sourced claims in pitches).
+Upstream: cogni-portfolio (Feature × Market propositions, customer profiles, competitor analysis), cogni-trends (optional TIPS enrichment for Why Now urgency). Downstream: cogni-workspace (Why Change arc composition via `narrative`, polish via `copywriter`, auto-logged sourced claims in pitches), cogni-visual (slide rendering).
 
 **Source**: [cogni-sales README](https://github.com/cogni-work/insight-wave/blob/main/cogni-sales/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-sales.md)

--- a/wiki/wiki/pages/plugin-cogni-trends.md
+++ b/wiki/wiki/pages/plugin-cogni-trends.md
@@ -48,6 +48,6 @@ Trend candidates must come from web-sourced signals — never padded with LLM tr
 
 ## Integration
 
-Upstream: cogni-portfolio (`portfolio-context.json`). Downstream: cogni-portfolio (`portfolio-opportunities.json`, `tips-value-model.json`), cogni-marketing (TIPS strategic themes feeding GTM paths), cogni-workspace (auto-logged claims), cogni-narrative (trend reports). The bidirectional cogni-portfolio integration is documented in [[concept-trends-portfolio-bridge]].
+Upstream: cogni-portfolio (`portfolio-context.json`). Downstream: cogni-portfolio (`portfolio-opportunities.json`, `tips-value-model.json`), cogni-marketing (TIPS strategic themes feeding GTM paths), cogni-workspace (auto-logged claims; trend-report arcs via its `narrative` skill). The bidirectional cogni-portfolio integration is documented in [[concept-trends-portfolio-bridge]].
 
 **Source**: [cogni-trends README](https://github.com/cogni-work/insight-wave/blob/main/cogni-trends/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-trends.md)

--- a/wiki/wiki/pages/plugin-cogni-visual.md
+++ b/wiki/wiki/pages/plugin-cogni-visual.md
@@ -48,6 +48,6 @@ Three MCP servers — see [[concept-mcp-server-map]]:
 
 ## Integration
 
-Upstream: cogni-narrative (narratives with `arc_id`), cogni-copywriting (polished docs), any plugin producing text deliverables (cogni-research, cogni-trends, cogni-portfolio, cogni-marketing, cogni-sales). Downstream: terminal — produces final visual deliverables that humans consume.
+Upstream: cogni-workspace (narratives with `arc_id` from its `narrative` skill, polished docs from `copywriter`), any plugin producing text deliverables (cogni-knowledge, cogni-trends, cogni-portfolio, cogni-marketing, cogni-sales). Downstream: terminal — produces final visual deliverables that humans consume.
 
 **Source**: [cogni-visual README](https://github.com/cogni-work/insight-wave/blob/main/cogni-visual/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-visual.md)

--- a/wiki/wiki/pages/plugin-cogni-website.md
+++ b/wiki/wiki/pages/plugin-cogni-website.md
@@ -24,7 +24,7 @@ Assembles multi-page customer websites from portfolio, marketing, trend, and res
 
 | Skill | Purpose |
 |-------|---------|
-| `cogni-website:website-setup` | Initialize project; discover content from cogni-portfolio, cogni-marketing, cogni-trends, cogni-research; pick theme |
+| `cogni-website:website-setup` | Initialize project; discover content from cogni-portfolio, cogni-marketing, cogni-trends, cogni-knowledge; pick theme |
 | `cogni-website:website-plan` | Plan site structure interactively — discover content, propose pages, map content to sections |
 | `cogni-website:website-build` | Build the static site — orchestrate CSS generation, parallel page generation, hero rendering, sitemap |
 | `cogni-website:website-preview` | Preview generated website in browser via claude-in-chrome; validate links; report structural issues |
@@ -45,6 +45,6 @@ The setup skill walks every other insight-wave plugin's project directories and 
 
 ## Integration
 
-Upstream: cogni-portfolio (propositions, capabilities pages), cogni-marketing (thought-leadership, demand-gen), cogni-trends (trend reports), cogni-research (whitepapers), cogni-workspace (theme). Downstream: deployable static site (terminal output).
+Upstream: cogni-portfolio (propositions, capabilities pages), cogni-marketing (thought-leadership, demand-gen), cogni-trends (trend reports), cogni-knowledge (wiki syntheses), cogni-workspace (theme). Downstream: deployable static site (terminal output).
 
 **Source**: [cogni-website README](https://github.com/cogni-work/insight-wave/blob/main/cogni-website/README.md) · [plugin guide](https://github.com/cogni-work/insight-wave/blob/main/docs/plugin-guide/cogni-website.md)

--- a/wiki/wiki/pages/skill-cogni-trends-trend-report.md
+++ b/wiki/wiki/pages/skill-cogni-trends-trend-report.md
@@ -13,7 +13,7 @@ related: [plugin-cogni-trends]
 
 > One of the skills inside [[plugin-cogni-trends]].
 
-Generate a strategic TIPS trend report organized around investment themes (Handlungsfelder) with inline citations and verifiable claims. The user selects a report-level narrative arc from cogni-narrative's 7 story arcs (corporate-visions, technology-futures, competitive-intelligence, strategic-foresight, industry-transformation, trend-panorama, theme-thesis) — the arc frames the executive summary, bridge paragraphs between themes, and a synthesis closing section that bind investment themes into one cohesive narrative.
+Generate a strategic TIPS trend report organized around investment themes (Handlungsfelder) with inline citations and verifiable claims. The user selects a report-level narrative arc from the 7 story arcs of cogni-workspace's `narrative` skill (corporate-visions, technology-futures, competitive-intelligence, strategic-foresight, industry-transformation, trend-panorama, theme-thesis) — the arc frames the executive summary, bridge paragraphs between themes, and a synthesis closing section that bind investment themes into one cohesive narrative.
 
 **Source**: `cogni-trends:trend-report`
 ([SKILL.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/cogni-trends/skills/trend-report/SKILL.md))

--- a/wiki/wiki/pages/skill-cogni-website-website-setup.md
+++ b/wiki/wiki/pages/skill-cogni-website-website-setup.md
@@ -13,7 +13,7 @@ related: [plugin-cogni-website]
 
 > One of the skills inside [[plugin-cogni-website]].
 
-This skill initializes a cogni-website project by discovering content sources from cogni-portfolio, cogni-marketing, cogni-trends, and cogni-research, selecting a theme, and scaffolding the project directory. It should be triggered when the user mentions creating a website, starting a new website project, setting up a website, "build me a website", "company website", "customer website", "generate a website", "website setup", "Website erstellen", "Homepage erstellen", "Internetauftritt", "Webseite generieren", "online presence", "web presence", or wants to turn portfolio content into a web presence — even without saying "setup" explicitly.
+This skill initializes a cogni-website project by discovering content sources from cogni-portfolio, cogni-marketing, cogni-trends, and cogni-knowledge, selecting a theme, and scaffolding the project directory. It should be triggered when the user mentions creating a website, starting a new website project, setting up a website, "build me a website", "company website", "customer website", "generate a website", "website setup", "Website erstellen", "Homepage erstellen", "Internetauftritt", "Webseite generieren", "online presence", "web presence", or wants to turn portfolio content into a web presence — even without saying "setup" explicitly.
 
 **Source**: `cogni-website:website-setup`
 ([SKILL.md on GitHub](https://github.com/cogni-work/insight-wave/blob/main/cogni-website/skills/website-setup/SKILL.md))

--- a/wiki/wiki/pages/workflow-content-pipeline.md
+++ b/wiki/wiki/pages/workflow-content-pipeline.md
@@ -18,9 +18,9 @@ The end-to-end content production pipeline — from strategy to channel-ready de
 ```
 cogni-marketing (setup + content generation)
    ↓ raw content pieces
-cogni-narrative (story arc shaping, long-form only)
+cogni-workspace `narrative` (story arc shaping, long-form only)
    ↓ narrative with arc_id
-cogni-copywriting (polish, arc-aware)
+cogni-workspace `copywriter` (polish, arc-aware)
    ↓ polished prose
 cogni-visual (slides / web rendering, brief-driven)
 ```


### PR DESCRIPTION
Refs #1426.

Sweeps the whole genuine bare-retired-name class over a **declared surface** — the two-tree intersection of `wiki/wiki/pages/*.md` — rewriting each occurrence to name the adopting plugin and the relocated skill (Decision 3 house style), keeping both copies byte-identical. The roster-derived body scan that acceptance criteria (c) and (d) ask for is deferred to #1438; see **Scope decisions** for why, and why it has to land second.

## Why the stated scope was an undercount

The issue's table lists 4 occurrences on 2 pages. Both reproduce, but they undercount twice over: `plugin-cogni-portfolio.md:21` and `:45` each carry **two** stale names, and the class is repo-wide. Measured at the base ref, the intersection is **150 pages, all byte-identical**, of which **25 carried a bare retired name**.

That makes the acceptance criteria as literally written **jointly unsatisfiable**: fixing only the 4 rows leaves the rest standing, and a roster-derived body scan then reports red on an unmodified tree — which criterion (d) treats as falsification. The satisfiable reading, taken here, is that the 4 rows are worked examples rather than the boundary.

## The surface, and why it needs no exclusion list

| Excluded | Why it is out |
|---|---|
| `index.md`, `log.md`, `overview.md` | by **depth** — they sit at `wiki/wiki/` level, not under `pages/` |
| `lint-2026-04-20.md` | the only **root-only** page (also Decision 5 frozen) |
| the 7 Decision-4 pages | **bundled-only** — the property that decision is about |

Zero path-fragment exclusion entries. That matters because `test-layering-claim-reconciled.sh:95-99` records that its substring-matching `is_excluded()` turns one loose fragment into a repo-wide exemption. The boundary also **self-heals**: when #1402 rules, held pages enter or leave the surface with no guard edit.

## cogni-consulting is corrected as content, not renamed

Several pages did not merely name the retired plugin — they described its **phase-gated Double Diamond architecture**, which cogni-consult does not have. cogni-consult is built on action-field WBS containers with a per-deliverable empathize→define→ideate→prototype→test loop and no engagement-level phases; its own skill triggers explicitly disclaim the legacy model. A find-and-replace would have shipped prose asserting Discover/Define/Develop/Deliver phases and a `consulting-project.json` manifest that do not exist.

`concept-orchestrator-pattern.md` is rewritten as a page rather than deleted — the filename is load-bearing for inbound `[[concept-orchestrator-pattern]]` links, and cogni-consult *does* still orchestrate, per deliverable rather than per phase. Its "Orchestrator, not producer" principle survives verbatim and is re-quoted.

## Five claims were false, not stale

Each verified against the live plugin, then rewritten as content:

1. **`arch-plugin-anatomy.md:39`** — "cogni-research uses these [hooks]". cogni-knowledge ships **no** `hooks/`. Exactly four plugins do (cogni-consult, cogni-portfolio, cogni-visual, cogni-workspace), and none of them "blocks direct entity writes or caps review iterations" — the real uses are Excalidraw canvas auto-start and subagent context injection. The same page's L32 "only four plugins ship `hooks/`" was already **correct** and is untouched.
2. **`arch-plugin-anatomy.md:32` + `concept-script-output-format.md:31`** — the "no `scripts/`" census named plugins whose code now lives in cogni-workspace, which *has* one. Verified: only **cogni-marketing and cogni-website** lack it.
3. **`arch-er-diagram.md:30`** — cogni-knowledge's vocabulary is `plan.json` sub-questions, `wiki/sources/*.md`, `pre_extracted_claims:`, `citation-manifest.json` — not SubQuestion/Context/Source/ReportClaim.
4. **`arch-er-diagram.md:44`** — the `portfolio_path` (cogni-portfolio → cogni-consulting) edge has **no** cogni-consult consumer at all; repointed at its real ones (cogni-sales, cogni-marketing, cogni-trends).
5. **`plugin-cogni-portfolio.md:45` + `concept-bridge-files.md:25`** — the `canvas-{slug}.md` "lean canvas" bridge names a file no plugin emits; the Lean Canvas is user-supplied and read by cogni-portfolio's own `portfolio-canvas` skill. Row **removed** per Decision 6.

Two further dead paths were fixed on lines already being touched: `concept-multilingual-support.md`'s two authority-source files (both stale — `cogni-research/` does not exist and the trends overlay moved a level deeper), and `concept-claims-propagation.md:29`'s `verify-report` skill, which exists nowhere; `knowledge-verify` is a zero-network consistency check, a materially different guarantee, so the sentence was rewritten rather than repointed.

## What is deliberately preserved

- **The 8 `cogni-claims/` occurrences** (4 per tree) are on-disk store **paths**, kept per `cogni-workspace/CLAUDE.md`'s colon-vs-slash discriminator. Two share a line with a rewritten `cogni-research` token.
- **`cogni-docs` / `cogni-service`** are live plugins in another marketplace, already allowlisted as `EXTRA_ALLOWED` in `test-wiki-namespace-sync.sh`. Untouched.
- **Frozen history** — both `log.md` copies and `lint-2026-04-20.md` are byte-unchanged (Decision 5).
- **The 7 Decision-4 pages** are byte-unchanged. Note `workflow-consulting-engagement.md:14` is *already compliant* (past tense, asserts no live flow) and must not be "fixed".

## Scope decisions

**The guard is deferred to #1438, and the ordering is forced rather than preferred.** A guard co-shipped with this sweep is red on arrival if any single line is missed in either tree. Landing the sweep first makes the guard PR the instrument that *proves* this one complete, instead of an assertion shipped alongside the thing it asserts. #1438 also records a design constraint found while planning: the guard **must** carry an `EXTRA_ALLOWED` equivalent, or a purely roster-derived scan lands red on four pages including the frozen lint record Decision 5 forbids editing.

**`index.md` / `overview.md` are out** (#1439) — outside the surface by depth, the two `index.md` copies diverge *by design* so no byte-identity criterion protects an edit there, and their `#### cogni-copywriting` sections are a TOC of deleted pages, i.e. a Decision-6 removal rather than a rename.

**No existing suite is touched, so no mutation recipe applies to this PR** — there is nothing in the diff a mutation could neutralise. `PAGE_PARITY` is deliberately left alone: adding 22 page names to a constant owned by a different reconciliation is scope creep, and #1438's guard asserts byte-identity across the whole surface anyway. The guard and its recipe travel together in that PR.

## Verification performed

- [x] All 25 pairs byte-identical after mirroring; the mirror step is **idempotent** (re-running changes nothing) and gated on a per-page precondition that the pair was byte-identical at the base ref — needed because `workflow-content-pipeline.md` is a Decision-3 Group-B "bundled copy wins" page, safe only because #1401 already converged it
- [x] Boundary-aware scan over the 150-page surface: **zero** off-roster bare names survive except the 8 deliberate `cogni-claims/` paths
- [x] `test-wiki-tree-parity.sh`, `test-layering-claim-reconciled.sh`, `test-wiki-namespace-sync.sh` all exit 0 — under **both** `/bin/bash` 3.2.57 and homebrew `bash` 5.x
- [x] `python3 scripts/run-plugin-tests.py --filter cogni-workspace` green
- [x] `check-version-bump.py`: 9 plugins scanned, **0 touched**, 0 violations
- [x] `check-result-line-plainness.py` and `check-breadcrumbs.py` clean
- [x] No new `[[wikilink]]` introduced — because mirroring makes each page byte-identical, a rewritten page may only cite intersection pages, or `test-wiki-tree-parity.sh`'s per-tree resolution arm goes red
- [x] Neither target page introduces any of the 15 `FORBIDDEN` layering literals; both were clean before and after
- [x] Rebased onto `91271f97` after a post-merge auto-bump moved the base mid-run, so the diff does not read that bump in reverse as a version change

## Follow-up issues

- **#1438** — the roster-derived bare-name body scan (acceptance criteria c and d)
- **#1439** — `index.md` / `overview.md`, outside this surface by depth
- **#1440** — the 14 occurrences in the 5 Decision-4 pages, gated on #1402
- **#1441** — the same dead `portfolio_path` edge mirrored in three generated `docs/` files (cogni-docs ships from a separate repo, so this is correct-the-output plus an upstream filing, never a local regeneration)
- **#1442** — two `consulting-project.json` residues naming a manifest no plugin writes

## Open questions

None blocking. One note for the reviewer, since no gate can decide it: the load-bearing risk in this diff is not whether a name was replaced but whether each **rewritten sentence is factually true of the adopting plugin**. Every claim was verified against the live plugin (`cogni-consult/CLAUDE.md`, `cogni-knowledge/CLAUDE.md`, and a `cogni-*/hooks/` and `cogni-*/scripts/` census), and the five corrections above are the cases where verification changed the wording rather than just the name — but a second human read of those five is the highest-value review this PR can get.

## Mutation recipe

The second commit touches a guard (`cogni-workspace/tests/test-layering-claim-reconciled.sh`), adding `plugin-cogni-portfolio.md` to `PAGE_PARITY`. That page carried four off-roster names across two lines and, unlike its siblings in that list, had no byte-identity arm of its own — so until #1438's two per-tree arms land, this entry is the only thing that would catch a one-tree-only regression on it.

The mutation adds `index.md` to `PAGE_PARITY`. `index.md` diverges between the two trees **by design** (Decision 2 / Decision 3 group C), so if case `L7` genuinely reads `PAGE_PARITY` and compares the real trees, it must go red. A `check_parity` stubbed to always pass would leave it green.

```bash
bash "$CLAUDE_PLUGIN_ROOT/scripts/mutation-check.sh" --root . --file cogni-workspace/tests/test-layering-claim-reconciled.sh --expr "s/^plugin-cogni-portfolio\.md'/plugin-cogni-portfolio.md\nindex.md'/m" --test "bash cogni-workspace/tests/test-layering-claim-reconciled.sh" --case L7
```

Replayed: `mutated_result: red`, `restored_result: green`, **`verdict: guard_verified`**. The `/m` modifier is load-bearing — `perl -0pi` slurps the whole file, so the anchored `^` would otherwise hard-error `expr_no_op`.

Separately, the new entry was proven live by direct plant-and-catch: appending a comment to one tree's copy of `plugin-cogni-portfolio.md` reds `FAIL: L7 the real wiki trees agree on every page this change touched`, and restoring the page returns the suite to green.
