### PR TITLE
cogni-portfolio: cut append-claim lock suite from 7.9s to under 2s

### DIFF
--- a/cogni-portfolio/scripts/append-claim.sh
+++ b/cogni-portfolio/scripts/append-claim.sh
@@ -5,6 +5,9 @@
 # Creates cogni-claims/ directory and claims.json if they don't exist.
 # Uses mkdir-based locking (portable across macOS and Linux) to prevent
 # race conditions when agents run in parallel.
+# Env: APPEND_CLAIM_MAX_WAIT — lock-acquire ceiling in 0.1s ticks. Unset means
+# the production default of 30 ticks (3s); tests set a small value so they can
+# drive the timeout path in fractions of a second.
 # Exit codes: 0 = success, 1 = error
 set -euo pipefail
 
@@ -24,7 +27,16 @@ LOCK_DIR="$CLAIMS_DIR/.claims.lock"
 mkdir -p "$CLAIMS_DIR/sources" "$CLAIMS_DIR/history"
 
 # Acquire lock using mkdir (atomic on all POSIX systems)
-MAX_WAIT=30
+MAX_WAIT="${APPEND_CLAIM_MAX_WAIT:-30}"
+# Floor on numeric shape: a malformed override would otherwise make the -ge
+# comparison below a hard error mid-loop. Regex unquoted on purpose — a quoted
+# right-hand side matches literally on bash 3.2, which this repo still targets.
+# The `||` form keeps a non-match from tripping `set -e`.
+[[ "$MAX_WAIT" =~ ^[1-9][0-9]*$ ]] || MAX_WAIT=30
+# Derive the diagnostic's number from the ceiling rather than restating it, so
+# the message can never claim a wait the loop no longer honours.
+TIMEOUT_LABEL="$(( MAX_WAIT / 10 )).$(( MAX_WAIT % 10 ))"
+TIMEOUT_LABEL="${TIMEOUT_LABEL%.0}"
 WAITED=0
 while ! mkdir "$LOCK_DIR" 2>/dev/null; do
   sleep 0.1
@@ -55,7 +67,7 @@ while ! mkdir "$LOCK_DIR" 2>/dev/null; do
         continue
       fi
     fi
-    echo '{"error": "Could not acquire lock on claims.json after 3s"}' >&2
+    echo "{\"error\": \"Could not acquire lock on claims.json after ${TIMEOUT_LABEL}s\"}" >&2
     exit 1
   fi
 done

--- a/cogni-portfolio/tests/test-append-claim-lock.sh
+++ b/cogni-portfolio/tests/test-append-claim-lock.sh
@@ -16,6 +16,17 @@
 #                                             reading leaves a LIVE peer's lock
 #                                             alone; the script times out instead
 #
+# Both cases drive the acquire loop to its ceiling on purpose, so both set
+#   APPEND_CLAIM_MAX_WAIT=3 as a per-invocation prefix — 0.3s each instead of the
+#   production 3s, which is what keeps the whole suite around a second rather than
+#   the ~7.3s it cost when the ceiling was a hardcoded constant. The prefix is
+#   deliberately NOT a suite-level export: run-plugin-tests.py invokes each suite
+#   as a bare `bash <path>`, so each case must carry its own ceiling.
+#   Case 2's asserted stderr literal is the DERIVED form for that ceiling
+#   (`after 0.3s`), not a fixed string — change the ceiling and the literal moves
+#   with it. That coupling is the point: it is what stops the message from
+#   drifting back into restating a number the loop no longer honours.
+#
 # Usage: bash cogni-portfolio/tests/test-append-claim-lock.sh
 # Exits non-zero on any assertion failure.
 #
@@ -39,10 +50,28 @@
 #   exactly once in the fixed script (the read line is `lock_mtime=$(stat ...`,
 #   which does not contain it), so the substitution can never be a no-op.
 #
-#   Only ONE arm is recorded, and the reason is narrower than it may look. An arm
-#   mutating the GNU-first ordering (`s/stat -c %Y/stat -f %m/`) reports a vacuous
-#   guard against the TWO CASES BELOW, because their stub answers unconditionally
-#   and ignores its flags by design — deliberately, so both stay ordering-agnostic.
+#   Second arm — the ceiling-to-message coupling:
+#   bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-portfolio/scripts/append-claim.sh \
+#     --expr 's/APPEND_CLAIM_MAX_WAIT:-30/APPEND_CLAIM_MAX_WAIT_UNUSED:-30/' \
+#     --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' \
+#     --case live-lock-not-swept-on-numeric-stat
+#
+#   The expression redirects the override to a dead variable, so the script
+#   ignores the ceiling the cases set, waits the production 3s and announces
+#   `after 3s` while case 2 asserts the derived `after 0.3s`. That is exactly the
+#   decoupling this arm exists to catch: without it, a message that restates a
+#   constant instead of deriving one stays green. `APPEND_CLAIM_MAX_WAIT:-30`
+#   occurs exactly once (the header names the variable in prose without the
+#   `:-30` default), so the substitution can never be a no-op, and the expression
+#   carries no `^`/`$` anchor so it needs no `/m` under the harness's `perl -0pi`.
+#
+#   The remaining unrecorded arm is the GNU-first ORDERING, and the reason is
+#   narrower than it may look. An arm mutating it (`s/stat -c %Y/stat -f %m/`)
+#   reports a vacuous guard against the TWO CASES BELOW, because their stub answers
+#   unconditionally and ignores its flags by design — deliberately, so both stay
+#   ordering-agnostic.
 #
 #   That is a property of these two cases, NOT a general limit: a flag-aware stub
 #   (`-c` prints an epoch, `-f` prints `%m` and exits 0, simulating GNU) does
@@ -137,7 +166,7 @@ seed_contended_project() {
 case1_dir="$(seed_contended_project stale-non-numeric)"
 case1_stub="$TMPROOT/stub-non-numeric"
 make_stat_stub "$case1_stub" 'echo "%m"'
-case1_out="$(PATH="$case1_stub:$PATH" bash "$SCRIPT" "$case1_dir" '{"id": "claim-1"}' 2>"$TMPROOT/case1.err")"
+case1_out="$(PATH="$case1_stub:$PATH" APPEND_CLAIM_MAX_WAIT=3 bash "$SCRIPT" "$case1_dir" '{"id": "claim-1"}' 2>"$TMPROOT/case1.err")"
 case1_rc=$?
 
 if [ "$case1_rc" -ne 0 ]; then
@@ -154,16 +183,16 @@ fi
 #
 # Without this case a fix that unconditionally sets lock_mtime=0 satisfies case 1
 # while destroying mutual exclusion — every contended lock would read as ancient
-# and get swept out from under a running peer after 3s.
+# and get swept out from under a running peer once the acquire ceiling elapses.
 case2_dir="$(seed_contended_project live-numeric)"
 case2_stub="$TMPROOT/stub-numeric"
 make_stat_stub "$case2_stub" 'date +%s'
-PATH="$case2_stub:$PATH" bash "$SCRIPT" "$case2_dir" '{"id": "claim-2"}' >/dev/null 2>"$TMPROOT/case2.err"
+PATH="$case2_stub:$PATH" APPEND_CLAIM_MAX_WAIT=3 bash "$SCRIPT" "$case2_dir" '{"id": "claim-2"}' >/dev/null 2>"$TMPROOT/case2.err"
 case2_rc=$?
 
 if [ "$case2_rc" -ne 1 ]; then
   fail "live-lock-not-swept-on-numeric-stat" "expected exit 1, got $case2_rc"
-elif ! grep -q 'Could not acquire lock on claims.json after 3s' "$TMPROOT/case2.err"; then
+elif ! grep -q 'Could not acquire lock on claims.json after 0.3s' "$TMPROOT/case2.err"; then
   fail "live-lock-not-swept-on-numeric-stat" "stderr did not carry the timeout error: $(cat "$TMPROOT/case2.err")"
 elif [ ! -d "$case2_dir/cogni-claims/.claims.lock" ]; then
   fail "live-lock-not-swept-on-numeric-stat" "a live peer's lock was swept"

--- a/cogni-portfolio/tests/test-append-claim-lock.sh
+++ b/cogni-portfolio/tests/test-append-claim-lock.sh
@@ -50,7 +50,27 @@
 #   exactly once in the fixed script (the read line is `lock_mtime=$(stat ...`,
 #   which does not contain it), so the substitution can never be a no-op.
 #
-#   Second arm — the ceiling-to-message coupling:
+#   Second arm — the shape floor, case 2's side of it:
+#   bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
+#     --root . \
+#     --file cogni-portfolio/scripts/append-claim.sh \
+#     --expr 's/\^\[0-9\]\+\$/^NOMATCH\$/' \
+#     --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' \
+#     --case live-lock-not-swept-on-numeric-stat
+#
+#   Arm one mutates the floor's ASSIGNMENT and is caught by case 1; this one
+#   mutates the floor's CONDITION and is caught by case 2, which is why both are
+#   recorded rather than one standing in for the other. Replacing the character
+#   class with one that cannot match makes the `||` fire unconditionally, so a
+#   live peer's current-epoch reading is floored to 0, reads as ancient, gets
+#   swept, and the script goes on to append — case 2 sees exit 0 where it demands
+#   exit 1. The pattern's `^` and `$` are ESCAPED, i.e. matched as the literal
+#   characters of the regex text on the floor line, not as anchors — so the
+#   expression needs no `/m` under the harness's `perl -0pi`, which slurps the
+#   whole file. `^[0-9]+$` occurs exactly once (the ceiling's own floor above
+#   reads `^[1-9][0-9]*$`), so the substitution can never be a no-op.
+#
+#   Third arm — the ceiling-to-message coupling:
 #   bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
 #     --root . \
 #     --file cogni-portfolio/scripts/append-claim.sh \


### PR DESCRIPTION
Closes #1431.

Plan record: https://github.com/cogni-work/insight-wave/issues/1431#issuecomment-5318949549

## Summary

The lock suite cost **7.9s wall at 6% CPU**, and 94% of that was sleep. Both of its cases exist to drive `append-claim.sh`'s acquire loop to its ceiling, and that ceiling was a hardcoded `MAX_WAIT=30` x `sleep 0.1`. `scripts/run-plugin-tests.py` runs the suite on every PR, so the whole monorepo paid it on every CI sweep.

- `scripts/append-claim.sh`: `MAX_WAIT` becomes `MAX_WAIT="${APPEND_CLAIM_MAX_WAIT:-30}"`, with a numeric shape floor that returns a malformed override to the production default instead of making the `-ge` comparison a hard error mid-loop. The floor's regex is deliberately **unquoted** — a quoted right-hand side of `=~` matches literally on bash 3.2, which this repo still targets — and the `|| MAX_WAIT=30` form keeps a non-match from tripping `set -e`.
- `scripts/append-claim.sh`: the timeout diagnostic is now **derived** from the ceiling instead of restating it. Under the default it is byte-identical to today's (`... after 3s`); under an override of 3 it correctly reads `... after 0.3s`.
- `tests/test-append-claim-lock.sh`: both cases set `APPEND_CLAIM_MAX_WAIT=3` as a **per-invocation prefix**, so each pays 0.3s instead of 3s. Not a suite-level export: `run-plugin-tests.py` invokes each suite as a bare `bash <path>`, so each case has to carry its own ceiling.
- `tests/test-append-claim-lock.sh`: case 2's stderr assertion moves to the derived literal `after 0.3s`, which is what pins the coupling.

### Why the message change is not optional polish

Parameterising the ceiling on its own would have silently decoupled the diagnostic from the wait. The old message restated `after 3s` — correct only because `30 x 0.1s` happens to equal 3s — and case 2 grepped that literal. Under an override the script would have announced a wait it no longer honoured while the case stayed green: the same class of defect this suite was written to catch. Deriving the label and asserting the derived form makes the coupling the thing the case pins.

## Verification

| Acceptance criterion | Result |
|---|---|
| Suite completes under 2s wall | **1.10s** (was 7.91s); 1.1s inside the sweep |
| Both cases still pin what they pinned | **all three mutation arms replay to `guard_verified`** |
| Default acquire ceiling unchanged with no override | **3s wait, byte-identical message** — verified against a pre-seeded contended lock |
| `run-plugin-tests.py --filter cogni-portfolio` exits 0 | **7/7 suites passed, exit 0** |

Malformed overrides were checked explicitly: `abc`, empty, `0`, `-5` and a trailing-space value all floor to 30 and render `3`. Label arithmetic was verified on **both** bash builds present on this host (3.2.57 and 5.x): `30 -> 3`, `20 -> 2`, `3 -> 0.3`, `1 -> 0.1`, `45 -> 4.5` — the `%.0` trim does not leave a dangling `2.` or `2.0`.

Repo guards run clean on this branch: breadcrumb guard, result-line plainness guard, workflow-YAML guard, and the version-bump gate (0 plugins touched — the post-merge workflow owns the bump).

## Scope decisions

- **In:** the issue's option 1 (parameterised ceiling), plus the message-derivation fix triage identified and the case-2 grep update it forces.
- **Out:** option 2 (running the two cases concurrently). Triage measured it at ~3.5s standalone — above the 2s bar — because it can only remove one of the two ceilings. With option 1 landed it buys a fraction of a second and would cost the subshell failure-counter rework. This is a **rejected alternative, not deferred work**, so no follow-up issue was filed.
- **Out:** any version bump.
- Untouched: the failure counter, the case sequencing, and lines 33-57 of `append-claim.sh` (the stale-lock sweep, including the `lock_mtime=0` the pre-existing mutation arm anchors on).

## Mutation recipe

```
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh --root . --file cogni-portfolio/scripts/append-claim.sh --expr 's/APPEND_CLAIM_MAX_WAIT:-30/APPEND_CLAIM_MAX_WAIT_UNUSED:-30/' --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' --case live-lock-not-swept-on-numeric-stat
```

The expression redirects the override to a dead variable, so the script ignores the ceiling the cases set, waits the production 3s and announces `after 3s` while case 2 asserts the derived `after 0.3s`. `APPEND_CLAIM_MAX_WAIT:-30` occurs exactly once (the header names the variable in prose without the `:-30` default), so the substitution can never be a no-op, and the expression carries no `^`/`$` anchor so it needs no `/m` under the harness's `perl -0pi`. Replayed on this branch: `guard_verified`.

A second arm covers the shape floor's CONDITION — the property case 2 was written for. Arm one below mutates the floor's *assignment* (caught by case 1); this one mutates its *condition* (caught by case 2), which is why both are recorded rather than one standing in for the other:

```
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh --root . --file cogni-portfolio/scripts/append-claim.sh --expr 's/\^\[0-9\]\+\$/^NOMATCH\$/' --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' --case live-lock-not-swept-on-numeric-stat
```

Replacing the character class with one that cannot match makes the `||` fire unconditionally, so a live peer's current-epoch reading floors to 0, reads as ancient, gets swept, and the script appends where case 2 demands exit 1. The pattern's `^` and `$` are escaped — matched as the literal characters of the regex text, not as anchors — so it needs no `/m` under the harness's slurping `perl -0pi`, and `^[0-9]+$` occurs exactly once now that the ceiling's own floor reads `^[1-9][0-9]*$`. Replayed on this branch: `guard_verified`.

The pre-existing arm is unchanged and was replayed on this branch as well:

```
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh --root . --file cogni-portfolio/scripts/append-claim.sh --expr 's/lock_mtime=0/lock_mtime_unused=0/' --test 'bash cogni-portfolio/tests/test-append-claim-lock.sh' --case stale-lock-swept-on-non-numeric-stat
```

Also `guard_verified`.
