### PR TITLE
cogni-workspace: retire dead consulting-project.json advice

### DIFF
--- a/cogni-workspace/references/wiki-tree-reconciliation.md
+++ b/cogni-workspace/references/wiki-tree-reconciliation.md
@@ -405,6 +405,17 @@ per Decision 1. The substantive residual remains 11 lines, per Decision 2 — an
 `wiki/index.md` copies remain different from each other, per Decision 3's group-C rule. None of the
 seven bundled-only pages is edited, promoted or deleted, per Decision 4.
 
+`troubleshoot/SKILL.md` §5's stale-state probe and `troubleshoot/references/known-issues.md`'s
+`Leftover engagement file from a retired consulting plugin` entry both still name
+`consulting-project.json`, deliberately. Neither is a residue: they are detection surfaces, where
+the dead name is the thing being searched for on a user's disk and the thing a reader matches their
+own situation against. Stripping it would leave `/troubleshoot` unable to find or describe the very
+artefact the sweep was about — a documentation fix traded for a functional regression. This is the
+same exemption the neighbouring `Leftover course-progress file` entry already relies on, naming its
+two retired `.claude/*.local.md` files verbatim in both its Symptom line and its `rm -f` remedy. A
+literal zero-hit bar over `cogni-workspace/skills/` is therefore unmeetable by construction, and a
+future sweep should not re-file either occurrence.
+
 ## What guards this
 
 `cogni-workspace/tests/test-wiki-tree-parity.sh` asserts, per tree and never tree-wide: that

--- a/cogni-workspace/references/wiki-tree-reconciliation.md
+++ b/cogni-workspace/references/wiki-tree-reconciliation.md
@@ -395,7 +395,7 @@ Kept as a permanent inventory so the set stays auditable rather than being redis
 | The 5 bundled-only pages still name retired plugins | held with the pages themselves — editing them would pre-decide the ruling | #1402, sweep in #1440 |
 | `index.md` and `overview.md` carry the same bare-name class | outside the swept surface by depth; needs its own decision, since the two `index.md` copies diverge by design and a TOC of deleted pages is a Decision-6 removal, not a rename | #1439 |
 | The generated `docs/` mirror repeats the dead `portfolio_path` edge | open — cogni-docs ships from a separate repo, so the fix is correct-the-output plus an upstream filing, never a local regeneration | #1441 |
-| Two `consulting-project.json` residues name a manifest no plugin writes | open — outside the page surface (`troubleshoot/known-issues.md`, `docs/contributing/`) | #1442 |
+| `consulting-project.json` occurrences name a manifest no plugin writes | closed — the real set was six hits over four files, not two. Both `concept-slug-based-lookups.md` copies were rewritten onto a live `consult-project.json` → `plugin_refs.knowledge_base` slug and pinned by `PAGE_PARITY`; `troubleshoot/known-issues.md` and the `SKILL.md` §5 probe moved from a dead rename to archive-not-rename. The two `docs/contributing/cogni-consult-evaluation.md` hits are accurate cogni-consulting history — a comparison-table cell and a dated run record — so they stand, and are not residues to re-file | #1442 |
 
 ## Deliberately left standing
 

--- a/cogni-workspace/skills/troubleshoot/SKILL.md
+++ b/cogni-workspace/skills/troubleshoot/SKILL.md
@@ -123,7 +123,8 @@ After plugin retirements, orphaned files may linger:
 # Check for retired cogni-diamond / cogni-consulting engagement state.
 # find, not a ** glob: engagement files sit two segments deep
 # ({plugin}/{engagement-slug}/), and ** only recurses where globstar is on.
-find . -type f \( -name 'diamond-project.json' -o -name 'consulting-project.json' \) 2>/dev/null
+# -maxdepth 3 is that same bound, so the walk skips .git, caches and vaults.
+find . -maxdepth 3 -type f \( -name 'diamond-project.json' -o -name 'consulting-project.json' \) 2>/dev/null
 
 # Check for inert course-progress files (the course system is retired)
 ls .claude/cogni-teacher.local.md .claude/cogni-help.local.md 2>/dev/null

--- a/cogni-workspace/skills/troubleshoot/SKILL.md
+++ b/cogni-workspace/skills/troubleshoot/SKILL.md
@@ -117,18 +117,22 @@ cogni-consulting was removed (its source remains in git history); route new cons
 
 ### 5. Stale State Detection
 
-After plugin renames, orphaned files may linger:
+After plugin retirements, orphaned files may linger:
 
 ```bash
-# Check for old cogni-diamond state
-ls **/diamond-project.json 2>/dev/null
+# Check for retired cogni-diamond / cogni-consulting engagement state.
+# find, not a ** glob: engagement files sit two segments deep
+# ({plugin}/{engagement-slug}/), and ** only recurses where globstar is on.
+find . -type f \( -name 'diamond-project.json' -o -name 'consulting-project.json' \) 2>/dev/null
 
 # Check for inert course-progress files (the course system is retired)
 ls .claude/cogni-teacher.local.md .claude/cogni-help.local.md 2>/dev/null
 ```
 
-For a renamed plugin's state file, suggest renaming to the current filename. For
-the course-progress files, suggest deletion — nothing reads them any more.
+For a retired plugin's engagement file, suggest archiving rather than renaming —
+nothing reads either name, and cogni-consult has no import path from them; the
+forward path is to scope a fresh engagement with `/cogni-consult:consult-setup`.
+For the course-progress files, suggest deletion — nothing reads them any more.
 
 ### 6. Common Misconfigurations
 

--- a/cogni-workspace/skills/troubleshoot/references/known-issues.md
+++ b/cogni-workspace/skills/troubleshoot/references/known-issues.md
@@ -19,22 +19,25 @@ rm -f .claude/cogni-teacher.local.md .claude/cogni-help.local.md
 
 ---
 
-## Stale project file after cogni-diamond rename
+## Leftover engagement file from a retired consulting plugin
 
-**Symptom**: Consulting engagement data not found when resuming a project.
+**Symptom**: `diamond-project.json` or `consulting-project.json` is present, but no skill
+finds or resumes the engagement.
 
-**Cause**: Project file still named `diamond-project.json` after the plugin was renamed
-to cogni-consulting.
+**Cause**: Both names belong to retired plugins — cogni-diamond, renamed to
+cogni-consulting, then removed (source for both remains in git history). No surviving
+skill reads either name.
 
-**Fix**: Rename the file:
-```bash
-mv diamond-project.json consulting-project.json
+**Fix**: There is nothing to rename to. cogni-consult keeps its engagements at
+`cogni-consult/{engagement-slug}/consult-project.json` and has no import path from
+either legacy file, so keep the old file as an archive and scope a fresh engagement:
+```
+/cogni-consult:consult-setup
 ```
 
-**Note**: cogni-consulting has been removed — replaced by cogni-consult (its source
-remains in git history). This note only applies to legacy Double Diamond engagement
-data. All new consulting engagements use cogni-consult
-(`consult-project.json`).
+**Note**: renaming a legacy file onto the current name does not migrate it — the
+schemas differ (cogni-consult's WBS is action fields, not Double Diamond phases), and
+nothing would read the result either.
 
 ---
 

--- a/cogni-workspace/tests/test-layering-claim-reconciled.sh
+++ b/cogni-workspace/tests/test-layering-claim-reconciled.sh
@@ -165,6 +165,10 @@ cogni-visual/libraries/
 # its siblings here it had no byte-identity arm of its own. Until the
 # roster-derived body scan lands with its two per-tree arms, this entry is the
 # only thing that would catch a one-tree-only regression on that page.
+#
+# concept-slug-based-lookups.md joins on the same grounds: its shared bullet named a
+# manifest no plugin writes, both copies were rewritten identically, and no other arm
+# here pins the two copies to each other.
 PAGE_PARITY='plugin-cogni-workspace.md
 workflow-install-to-infographic.md
 arch-er-diagram.md
@@ -173,7 +177,8 @@ workflow-portfolio-to-website.md
 workflow-content-pipeline.md
 workflow-portfolio-to-pitch.md
 workflow-trends-to-solutions.md
-plugin-cogni-portfolio.md'
+plugin-cogni-portfolio.md
+concept-slug-based-lookups.md'
 
 # ---------------------------------------------------------------------------
 # The checkers. Fixture cases and the real-repo cases drive these same two

--- a/cogni-workspace/wiki/wiki/pages/concept-slug-based-lookups.md
+++ b/cogni-workspace/wiki/wiki/pages/concept-slug-based-lookups.md
@@ -36,7 +36,7 @@ Claim records use UUID-v4 slugs (`claim-550e8400-...`) rather than name-derived 
 
 Two reasons:
 
-- **Human-readable in cross-plugin references.** When you read `consulting-project.json` and see `portfolio_path: "../cogni-portfolio/acme-market-entry/"`, you know what's there without opening anything.
+- **Human-readable in cross-plugin references.** When you read a cogni-consult engagement's `consult-project.json` and see `plugin_refs.knowledge_base: "dach-cloud-expansion"`, you know which knowledge base it binds without opening anything.
 - **Stable across reorganization.** Numeric IDs require a registry; slugs are the file system. Moving entities between projects only requires updating path references, not rewriting identifiers.
 
 This pattern combines with [[concept-data-isolation]] to make cross-plugin reads predictable and human-debuggable. See also [[concept-naming-conventions]] for the broader naming rules.

--- a/wiki/wiki/pages/concept-slug-based-lookups.md
+++ b/wiki/wiki/pages/concept-slug-based-lookups.md
@@ -36,7 +36,7 @@ Claim records use UUID-v4 slugs (`claim-550e8400-...`) rather than name-derived 
 
 Two reasons:
 
-- **Human-readable in cross-plugin references.** When you read `consulting-project.json` and see `portfolio_path: "../cogni-portfolio/acme-market-entry/"`, you know what's there without opening anything.
+- **Human-readable in cross-plugin references.** When you read a cogni-consult engagement's `consult-project.json` and see `plugin_refs.knowledge_base: "dach-cloud-expansion"`, you know which knowledge base it binds without opening anything.
 - **Stable across reorganization.** Numeric IDs require a registry; slugs are the file system. Moving entities between projects only requires updating path references, not rewriting identifiers.
 
 This pattern combines with [[concept-data-isolation]] to make cross-plugin reads predictable and human-debuggable. See also [[concept-naming-conventions]] for the broader naming rules.


### PR DESCRIPTION
Closes #1442.

## Summary

`consulting-project.json` was the retired cogni-consulting plugin's engagement manifest. `git grep -l 'consulting-project' -- '*/scripts/*' '*/skills/*'` on base returns exactly one file, so nothing live writes or reads that name — every reference to it was inert or actively misleading.

- **`concept-slug-based-lookups.md`, both wiki trees, byte-identically.** The slug-readability bullet asserted two dead things at once: the manifest, and the `portfolio_path` → cogni-consult edge that has zero hits under `cogni-consult/` and is already recorded as false at `wiki-tree-reconciliation.md:253`. Rewritten onto `consult-project.json` + `plugin_refs.knowledge_base: "dach-cloud-expansion"` (`cogni-consult/references/data-model.md:97-99,113`) — a bare slug, which is what this page is actually about. Both copies keep exactly two bullets, so the preceding `Two reasons:` stays true.
- **`troubleshoot/references/known-issues.md`.** The entry told a reader to `mv diamond-project.json consulting-project.json` — producing a file nothing reads, since both endpoints of that migration are retired. Rebuilt on this file's own retired-residue idiom (the neighbouring course-progress entry: nothing reads it, so there is nothing to migrate to). Four entries survive, so `SKILL.md`'s pointer stays live.
- **`troubleshoot/SKILL.md` §5** — the runtime surface that would have regenerated the advice the entry just dropped. Its remedy was "suggest renaming to the current filename"; there is no current filename to rename to, so it is now archive-not-rename with the forward path named.
- **`tests/test-layering-claim-reconciled.sh`.** `concept-slug-based-lookups.md` joins `PAGE_PARITY`. Nothing in CI caught a one-sided edit to this page before.
- **`references/wiki-tree-reconciliation.md`.** Row 398 mislocated the residues and counted two accurate history references as defects. Corrected and closed.

## Why renaming would have been the wrong fix

The obvious edit — swap `consulting-project.json` for `consult-project.json` — is worse than the defect. cogni-consult has no import path from `diamond-project.json`, so the rewrite would assert a migration that does not exist. The schemas differ too: cogni-consult's WBS is action fields, not Double Diamond phases. Archiving is the honest remedy.

## Two of the issue's acceptance criteria do not hold as written

**Criterion 1 is unsatisfiable.** It demands zero `consulting-project.json` hits outside `wiki/wiki/log.md` and `wiki/wiki/pages/lint-2026-04-20.md`. Neither of those files contains the string on base, and the zero-hit demand collides with occurrences that are correct. Meeting it literally would mean falsifying accurate history to quiet a grep.

The corrected bar, which this PR meets: **zero occurrences under either wiki tree**, and every surviving occurrence either accurate history or an accurate description of legacy on-disk data. Five hits survive, all accounted for:

| Occurrence | Why it stands |
|---|---|
| `wiki-tree-reconciliation.md:398` | the record quoting the string it describes |
| `troubleshoot/SKILL.md:124` | a **probe** — it must name the dead file to find it on disk |
| `troubleshoot/references/known-issues.md:24` | the symptom — names legacy data a user may still have |
| `docs/contributing/cogni-consult-evaluation.md:37` | a cell in the `cogni-consulting` column of a comparison table, where that filename is that plugin's real manifest |
| `docs/contributing/cogni-consult-evaluation.md:196` | a dated Session-B run record |

**Criterion 4 rests on a false premise.** It routes the `docs/` occurrence to the generator-output follow-up. But `docs/contributing/cogni-consult-evaluation.md` is hand-authored — no generator markers, cited as a standalone scorecard from `cogni-consult/references/evaluation-criteria.md` — and is outside #1441's declared scope (`docs/er-diagram.md`, `docs/architecture/er-diagram.md`, `docs/architecture/design-philosophy.md`). Neither of the criterion's two routes applies. The file is untouched and the reconciliation row now records why, so a future sweeper does not re-file it.

Criteria 2 and 3 are met as written. On criterion 2 specifically: the issue speculates the entry carries "phase state" wording needing rewording. It does not — that defect was not invented in order to fix it.

## Scope

Widened beyond the issue's two named files, deliberately:

- **The two `concept-slug-based-lookups.md` copies** — missed by the issue's table, and the only occurrences actually wrong about *live* behaviour.
- **`troubleshoot/SKILL.md` §5** — same defect, same skill, and the surface that regenerates it at runtime. Fixing `known-issues.md` alone would leave the residue reachable through `/troubleshoot`.

No maintainer breadcrumbs were introduced into `SKILL.md`; the rationale there is stated semantically. No version bump — the post-merge workflow owns it.

## A defect found during review, not planning

The `SKILL.md` §5 probe was first written as `ls **/diamond-project.json **/consulting-project.json`. `**` only recurses where `globstar` is on, and `/bin/bash` on macOS is 3.2, which has no such option — verified on a fixture, where `**/` matched a one-deep file and silently missed the two-deep one. Engagement state lives two segments deep (`{plugin}/{engagement-slug}/`), exactly where the probe would have missed it, and `2>/dev/null` swallows the evidence. Replaced with `find -type f \( -name … -o -name … \)`, which caught both in the same fixture.

## Test plan

All run on the head commit, in an isolated worktree forked from `origin/main`:

| Check | Result |
|---|---|
| `bash cogni-workspace/tests/test-layering-claim-reconciled.sh` | exit 0 — L7 now also covers the slug page |
| `bash cogni-workspace/tests/test-wiki-tree-parity.sh` | exit 0 (12 cases) |
| `python3 scripts/run-plugin-tests.py --filter cogni-workspace` | exit 0 (10/10) |
| `diff` of the two `concept-slug-based-lookups.md` copies | identical |
| `python3 scripts/check-breadcrumbs.py` | exit 0 |
| `bash …/check-frontmatter.sh cogni-workspace` | exit 0 (26 files, 183 companions, 0 offenders) |
| `python3 scripts/check-result-line-plainness.py` | exit 0 |
| `python3 scripts/check-version-bump.py` | exit 0 — 9 plugins scanned, 0 touched |

Baseline was green on all of these before the change, so any red is this diff's.

## Mutation recipe

```bash
bash ~/.claude/plugins/cache/managed-service/cogni-service/0.0.402/scripts/mutation-check.sh \
  --root . \
  --file wiki/wiki/pages/concept-slug-based-lookups.md \
  --expr 's/dach-cloud-expansion/dach-cloud-expansion-mutant/' \
  --test 'bash cogni-workspace/tests/test-layering-claim-reconciled.sh' \
  --case L7
```

Run from the repo root. Diverging one copy of the newly-pinned page must turn `L7` red — that is what proves the new `PAGE_PARITY` entry is load-bearing rather than decorative. The expression carries no anchors, so it needs no `/m` modifier, and restore is automatic.

**Already run on this branch:** `"mutated_result": "red"`, `"restored_result": "green"`, `"verdict": "guard_verified"`, working tree clean afterwards.

## Open questions

None blocking. One reviewer suggestion was **declined**, and is flagged here rather than silently dropped:

- The skill-quality pass proposed also deleting the `cogni-consulting (archived)` row from §4's cross-plugin dependency table (`SKILL.md:112`). It is a fair observation — the row lists a plugin with no marketplace entry — but it is a different defect class (retired-plugin *names*, already tracked by the #1439/#1440 family) and not a `consulting-project.json` residue. Widening this PR into it would blur a scope boundary the reviewer would rightly question. Left for whoever sweeps that class.