### PR TITLE
cogni-knowledge tests: reachable same-id arms for the three split case ids

### DIFF
--- a/cogni-knowledge/tests/test_plain_result_emitters.sh
+++ b/cogni-knowledge/tests/test_plain_result_emitters.sh
@@ -164,8 +164,19 @@ errors=$((errors + shape_errors))
 if [ "$exercisers" -lt 50 ]; then
   red "FAIL: plain-emit-05 only $exercisers file(s) exercising the emitter contract were found (expected at least 50) — the scan is not reaching them"
   errors=$((errors + 1))
-elif [ "$shape_errors" -eq 0 ]; then
+else
+  green "PASS: plain-emit-05 $exercisers file(s) exercise the emitter contract (floor 50), so the scan is reaching them"
+fi
+
+# plain-emit-06 gates on shape_errors alone rather than chaining off the exercisers
+# floor. As an elif, the state (exercisers >= 50, shape_errors > 0) emitted neither
+# arm, so --case plain-emit-06 could never observe this case go red. The FAIL arm
+# below deliberately does NOT increment errors: the errors=$((errors + shape_errors))
+# fold above already counted them, and counting again would change the failure tally.
+if [ "$shape_errors" -eq 0 ]; then
   green "PASS: plain-emit-06 emitter-defining files are paired and plain — $definers of $exercisers exercising the contract"
+else
+  red "FAIL: plain-emit-06 $shape_errors emitter-defining file(s) are not paired or not plain — see the plain-emit-03/plain-emit-04 lines above"
 fi
 
 # Coverage floor — the shared emitter helper must stay inside the scanned

--- a/cogni-knowledge/tests/test_skill_contracts.sh
+++ b/cogni-knowledge/tests/test_skill_contracts.sh
@@ -267,15 +267,25 @@ DISTILL="$PLUGIN_ROOT/skills/knowledge-distill/SKILL.md"
 DISTILLER="$PLUGIN_ROOT/agents/concept-distiller.md"
 REVIEWER="$PLUGIN_ROOT/agents/wiki-reviewer.md"
 
+_cr_dispatch_hits=0
+_cr_dispatch_detail=""
 for _p in plan:"$PLAN" curate:"$CURATE" fetch:"$FETCH" curator:"$CURATOR" fetcher:"$FETCHER" ingest:"$INGEST" ingester:"$INGESTER" claim-extractor:"$CLAIM_EXTRACTOR" compose:"$COMPOSE" composer:"$COMPOSER" verify:"$VERIFY" verifier:"$VERIFIER" revisor:"$REVISOR" finalize:"$FINALIZE" distill:"$DISTILL" distiller:"$DISTILLER" reviewer:"$REVIEWER"; do
   _cid="${_p%%:*}"; f="${_p#*:}"
   [ -f "$f" ] || continue
   if grep -qE 'Skill\("?(cogni-research:|cogni-workspace:claim)' "$f" 2>/dev/null; then
-    red "FAIL: skill-contracts-82-dispatches-cogni-research-workspace-${_cid} clean-break: $f dispatches a cogni-research/cogni-workspace-claims skill"
-    grep -nE 'Skill\("?(cogni-research:|cogni-workspace:claim)' "$f"
-    errors=$((errors + 1))
+    _cr_dispatch_detail="$_cr_dispatch_detail
+${_cid} ($f):
+$(grep -nE 'Skill\("?(cogni-research:|cogni-workspace:claim)' "$f")"
+    errors=$((errors + 1)); _cr_dispatch_hits=$((_cr_dispatch_hits + 1))
   fi
 done
+
+if [ "$_cr_dispatch_hits" -eq 0 ]; then
+  green "PASS: skill-contracts-82-dispatches-cogni-research-workspace clean-break: no scanned file dispatches a cogni-research/cogni-workspace-claims skill"
+else
+  red "FAIL: skill-contracts-82-dispatches-cogni-research-workspace clean-break: $_cr_dispatch_hits scanned file(s) dispatch a cogni-research/cogni-workspace-claims skill:"
+  printf '%s\n' "$_cr_dispatch_detail" | sed '/^$/d' | sed 's/^/    /'
+fi
 
 # cogni-wiki extension — applies to the v0.0.20 ingest surface, the
 # v0.0.22 compose surface, the v0.0.23 verify surface, and the v0.1.13
@@ -285,18 +295,37 @@ done
 # _wikilib._wiki_lock — an import, not a skill dispatch; knowledge-compose
 # only reads the wiki; the composer/verifier/revisor are read-only against
 # wiki/*; the concept-distiller is read+write-records only, no skill dispatch).
+_wiki_dispatch_hits=0
+_wiki_dispatch_detail=""
 for _p in ingest:"$INGEST" ingester:"$INGESTER" claim-extractor:"$CLAIM_EXTRACTOR" compose:"$COMPOSE" composer:"$COMPOSER" verify:"$VERIFY" verifier:"$VERIFIER" revisor:"$REVISOR" finalize:"$FINALIZE" distill:"$DISTILL" distiller:"$DISTILLER" reviewer:"$REVIEWER" setup:"$SETUP"; do
   _cid="${_p%%:*}"; f="${_p#*:}"
   [ -f "$f" ] || continue
   if grep -qE 'Skill\("?cogni-wiki:' "$f" 2>/dev/null; then
-    red "FAIL: skill-contracts-83-dispatches-cogni-wiki-skill-${_cid} clean-break: $f dispatches a cogni-wiki skill (M6 contract: call helper scripts directly)"
-    grep -nE 'Skill\("?cogni-wiki:' "$f"
-    errors=$((errors + 1))
+    _wiki_dispatch_detail="$_wiki_dispatch_detail
+${_cid} ($f):
+$(grep -nE 'Skill\("?cogni-wiki:' "$f")"
+    errors=$((errors + 1)); _wiki_dispatch_hits=$((_wiki_dispatch_hits + 1))
   fi
 done
 
-if [ $errors -eq 0 ]; then
+if [ "$_wiki_dispatch_hits" -eq 0 ]; then
+  green "PASS: skill-contracts-83-dispatches-cogni-wiki-skill clean-break: no scanned file dispatches a cogni-wiki skill (M6 contract: call helper scripts directly)"
+else
+  red "FAIL: skill-contracts-83-dispatches-cogni-wiki-skill clean-break: $_wiki_dispatch_hits scanned file(s) dispatch a cogni-wiki skill (M6 contract: call helper scripts directly):"
+  printf '%s\n' "$_wiki_dispatch_detail" | sed '/^$/d' | sed 's/^/    /'
+fi
+
+# skill-contracts-84 gates on this case's own predicate — the two dispatch
+# counters above — not on the suite-wide $errors counter it used to read.
+# That counter is incremented by several unrelated earlier checks, so any one of
+# them silenced this case and --case skill-contracts-84-clean-break-no-cogni
+# reported case_not_found instead of a verdict. The FAIL arm deliberately does
+# NOT increment errors: the loops above already counted each offending file.
+_clean_break_hits=$((_cr_dispatch_hits + _wiki_dispatch_hits))
+if [ "$_clean_break_hits" -eq 0 ]; then
   green "PASS: skill-contracts-84-clean-break-no-cogni clean-break — no cogni-research/cogni-workspace-claims/cogni-wiki skill dispatch in new files"
+else
+  red "FAIL: skill-contracts-84-clean-break-no-cogni clean-break — $_clean_break_hits file(s) dispatch a cogni-research/cogni-workspace-claims/cogni-wiki skill (see the skill-contracts-82/83 lines above)"
 fi
 
 # --- wiki-verifier agent honesty bullets ---------------------------------


### PR DESCRIPTION
Refs #1517.

## Summary

Three case ids in cogni-knowledge's test suites are **split**: their `PASS:` and `FAIL:` arms lead with different first tokens. The cogni-service mutation harness matches a case by the first whitespace-delimited token after the label and needs **both** arms to issue a verdict, so a split id is an address it cannot resolve — every guard behind it is unfalsifiable.

- **`plain-emit-05` / `plain-emit-06`** — `test_plain_result_emitters.sh:164-169` shared one `if/elif`. The `if` arm emitted only `FAIL: plain-emit-05`; the `elif` arm only `PASS: plain-emit-06`. Neither id carried both arms, and the state `exercisers >= 50 && shape_errors > 0` emitted **neither**.
- **`skill-contracts-82` / `-83`** — `test_skill_contracts.sh:274` and `:292` emitted per-file suffixed FAIL ids (`...-${_cid}`) inside loops with no PASS arm at all.
- **`skill-contracts-84`** — `test_skill_contracts.sh:298-300` was PASS-only and gated on the **suite-wide `errors` counter**, so any unrelated failure anywhere in the suite silenced it.

Labels and gating only. No assertion predicate moves.

## Evidence — executed, both directions

The issue's `### Constraints` require scope and proof by execution rather than by reading. Everything below was run; both clones were restored clean afterward.

### 1. The harness's own verdict, before and after

```
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
  --root . \
  --file cogni-knowledge/tests/test_plain_result_emitters.sh \
  --expr 's/ -lt 50/ -lt 99999/' \
  --test 'bash cogni-knowledge/tests/test_plain_result_emitters.sh' \
  --case plain-emit-05
```

| | verdict |
|---|---|
| **base** (`6d33cc9f`) | exit 2 — `case_not_found: no 'FAIL: plain-emit-05' and no 'ok:/PASS: plain-emit-05' line in the restored test output. ... Absence of a FAIL line is NOT evidence the case went red, so this is an error rather than a verdict.` |
| **head** | **`guard_verified`** — `mutated_result: red`, `restored_result: green` |

The harness refused to issue a verdict at base. That transition **is** the change.

The same for the re-gated aggregate (`--expr 's/_wiki_dispatch_hits\)\)/_wiki_dispatch_hits + 1))/'`, `--file cogni-knowledge/tests/test_skill_contracts.sh`, `--case skill-contracts-84-clean-break-no-cogni`): **`guard_verified`**, mutated red / restored green.

### 2. The decoupling proof — what separates this from an id rename

Renaming a FAIL id to match its PASS would satisfy the literal acceptance criteria while leaving the guard just as unverifiable, because an unrelated failure would still silence the case. So: break an **unrelated** earlier assertion (`:44`, `assert_grep 'name: knowledge-plan'`) and ask whether `skill-contracts-84` still emits an arm.

| | does `skill-contracts-84` emit any arm? |
|---|---|
| **base** | **0 occurrences — silenced** by the suite-wide `errors` gate |
| **head** | `PASS: skill-contracts-84-clean-break-no-cogni` |

### 3. Arm census

| run | FAIL tokens | PASS tokens |
|---|---|---|
| `test_plain_result_emitters.sh <empty-dir>` @ base | `plain-emit-05`, `-07` | `plain-emit-01`, `-02` |
| clean @ base | *(none)* | `plain-emit-01`, `-02`, `-06`, `-07` |
| clean @ head | *(none)* | `plain-emit-01`, `-02`, **`-05`**, `-06`, `-07` |

`plain-emit-06` appeared in neither arm of the failing run; `plain-emit-05` in neither arm of the clean run. At head `plain-emit-05` prints PASS for the first time. `skill-contracts-82`/`-83`/`-84` all now print PASS on a clean run.

### 4. Green-ness

`bash test_plain_result_emitters.sh` → rc 0 · `bash test_skill_contracts.sh` → rc 0 · `run-plugin-tests.py --filter knowledge` → **78 passed / 0 failed** · `check-result-line-plainness.py` → clean · AC2 `awk … | sort | uniq -d` → empty for both suites.

## Design tension, and how it is resolved

`skill-contracts-82`, `-83` and `-84` overlap: 84's PASS asserts the union of what 82 and 83 each deny. Merging, dropping or renumbering any of them would violate `tests/README.md` rule 3 (never renumber — a renumber silently repoints a `--case` recorded in an older PR body).

**All three ids are retained; none merged, dropped or renumbered, and no new id allocated.** 82 and 83 gain aggregate same-id PASS arms. 84 keeps its id, its text and its meaning — only its **gate** moves, from the suite-wide `errors` counter to the two local dispatch counters. That is a **re-gate, not a repoint**: 84 still asserts exactly "no scanned file dispatches a cogni-research / cogni-workspace-claims / cogni-wiki skill".

The per-file `${_cid}` suffix leaves the id entirely. Each loop now **collects** its offenders during iteration and emits **one** same-id `PASS`/`FAIL` pair after it — the collect-then-pair idiom already resident in this file at `skill-contracts-106` and `-107`. The offending files are still named, with line numbers, in the FAIL body. **No recorded recipe can have depended on the old suffixed tokens** — they existed only on FAIL arms, never appeared in a green baseline, and the harness needs both arms to issue a verdict.

### A regression the quality pass caught, and why the shape above is the right one

The first attempt kept the per-file `red` emission inside the loop and merely moved the discriminator into the message (`clean-break [${_cid}]: ...`). That satisfied AC1 and passed every clean-run check — but it **regressed AC2**, and the reviewer that flagged it was reasoning from `tests/README.md` rule 5, which says in so many words that *"the discriminator belongs in the id, never only in the human-readable message."*

Verified by execution, with two offending files:

| shape | `FAIL:` tokens emitted | AC2 `uniq -d` |
|---|---|---|
| discriminator moved to message | `skill-contracts-83-…` **twice** | **COLLISION** |
| collect-then-pair (shipped) | `skill-contracts-83-…` once | clean |

AC2 requires *"max group size 1"*, so a per-file emission under one stable id falsifies it the moment two files offend — while the base code's per-file *suffix* had kept them unique. Emitting once per case is what satisfies both criteria at the same time, and it is why the shipped shape matches the resident idiom rather than inventing a new one.

Neither new FAIL arm increments `errors`: the loops already counted each offending file, and `:158` already folded `shape_errors` in. Incrementing again would change the failure tally, which would be a behavioural change. Both are commented in place so a later reader does not "fix" them into a double count.

## Scope decisions

- **The issue body's evidence is spent.** Its `## Current behavior` list cites seven `test_question_store.sh` pairs and `test_fetch_cache.sh`; all already carry the case id on both arms (#1498 closed that scope). Those files are untouched. Scope was re-derived against `origin/main` @ `6d33cc9f`.
- **AC2 is already satisfied at base** (0 violations) and is carried here as a **regression guard**, not as work. Three suites repeat a FAIL id, but every repeat is another failure branch of the *same* case — benign, and unchanged.
- **`skill-contracts-81` is NOT defective**, contrary to an exploration note that listed it as FAIL-only. Verified at base: `:234-240` is a well-formed same-id `if/else` (PASS `:235`, FAIL `:237`); `:239` is merely the `errors++` inside its `else`. Untouched.
- **A naive first-token census flags 59 of 78 suites** and is not a valid basis for finding under-coverage. Four benign classes must not be treated as violations: preflight guards that `exit 1` with no PASS arm by design; inverted `if bad; then red; else green` blocks that already share an id; helper-emitted labels passing one `$2` to both arms; and non-cases such as the `probe-green`/`probe-red` fixture strings at `:69-71`, which are byte-compared inside case `plain-emit-01` and would break if edited. It also *misses* `test_concept_store.sh:142`, which emits its FAIL via a bare `echo` — that id already matches its PASS arm and is correctly out of scope.
- **`plain-emit-03` / `-04` are deliberately out of scope** and tracked as **#1575**. They are FAIL-only per-file ids (`:149`, `:152`) inside a loop with no `else`, so neither can ever print green — the same root class, but the `case_slug` suffix makes the id input-dependent, so the fix is a collect-then-pair restructure rather than a suffix strip. The minimal-surgical plan was picked on the smallest-blast-radius tiebreak and this fell outside it.
- **No `plugin.json` version is touched** — the patch bump is applied post-merge.

## Mutation recipe

Both recipes use the **cogni-service** harness from the managed-service marketplace snapshot. `cogni-knowledge/tests/README.md:67-72` states the real harness "ships with the cogni-service managed-service tooling and lives outside this repo" and warns that the same-named `cogni-portfolio/` and `cogni-consult/` scripts "are different, bespoke scripts and are not this harness" — verified: `cogni-portfolio/scripts/mutation-check.sh` carries **zero** `--case` flags, so a recipe naming it cannot run. The invocation shape follows the in-repo convention at `cogni-workspace/tests/test-mcp-declaration-hygiene.sh:81` and `cogni-trends/tests/test-agent-frontmatter-names.sh:51`.

```
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
  --root . \
  --file cogni-knowledge/tests/test_skill_contracts.sh \
  --expr 's/_wiki_dispatch_hits\)\)/_wiki_dispatch_hits + 1))/' \
  --test 'bash cogni-knowledge/tests/test_skill_contracts.sh' \
  --case skill-contracts-84-clean-break-no-cogni
```

```
bash "$HOME/.claude/plugins/marketplaces/managed-service/cogni-service/scripts/mutation-check.sh" \
  --root . \
  --file cogni-knowledge/tests/test_plain_result_emitters.sh \
  --expr 's/ -lt 50/ -lt 99999/' \
  --test 'bash cogni-knowledge/tests/test_plain_result_emitters.sh' \
  --case plain-emit-05
```

Both return `guard_verified`. Each search literal occurs **exactly once** in the post-fix file, so the non-global `s///` is unambiguous: `_wiki_dispatch_hits))` matches only the `_clean_break_hits=$((...))` line (not the initializer, the in-loop `+ 1))` increment, or the `-eq 0` test), and ` -lt 50` only `:164`. Replay them **serially** — the harness holds a per-target lock — and never beside a full test sweep, which reads the files it mutates.

**These recipes are evidence, not gate-satisfaction.** `check-preflight.sh` keys its `mutation-recipe` check on the globs `*/tests/test-*.sh` and `*/scripts/check-*.sh` (hyphen); both changed suites are `test_*.sh` (underscore), so the check reports `not_applicable` to this diff.

## Follow-up issues

- #1575 — `plain-emit-03` / `plain-emit-04` are FAIL-only per-file ids, so neither case can ever report green.
- #1576 — `tests/README.md` states both arms must share an id but never that both must be **reachable**, which is why this shape keeps recurring. Surfaced by the altitude reviewer on this PR; recording the rule (plus the collect-then-pair idiom) is what stops #1575 rediscovering or re-inventing it.

## Token-scope disclosure

`check-token-scope.sh --strict` exits **1** on this runner: `status: over_scoped`, `extra_scopes: [gist, read:org, workflow]` (`forbidden_scopes: [workflow]`). The runner uses the default `gh auth login` OAuth token, whose scope set is fixed by the GitHub CLI OAuth app and cannot be narrowed. Proceeded under the `--allow-overscoped` **flag** per the standing operator decision, and disclosing it here as that decision requires. No environment-variable opt-out was used.

## Open questions

**Should #1517 close on this merge?** This PR links `Refs`, not `Closes`, because `deferred[]` is non-empty (#1575, #1576) and the pipeline fires `--partial` on that condition. But the two readings of the issue disagree, so a human should settle it rather than have the link decide by default:

- **By its own acceptance criteria** — AC1 (arm parity on every converted case), AC2 (FAIL-side uniqueness), AC3 (scope) — #1517 **is** satisfied by this PR. All three are demonstrated above by execution.
- **By its `## Desired behavior` prose** — *"both arms of every case in every cogni-knowledge suite"* — it is **not**, because `plain-emit-03`/`-04` remain (#1575).

I did not resolve this by picking the reading that suits the link. If the ACs are the bar, Refs #1517 on merge; if the prose is, leave it open until #1575 lands.